### PR TITLE
Fixed abort when ./h2o -h

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
     h2o_context_t ctx;
 
     /* parse options */
-    while ((opt_ch = getopt_long(argc, argv, "c:h:", longopts, NULL)) != -1) {
+    while ((opt_ch = getopt_long(argc, argv, "c:h", longopts, NULL)) != -1) {
         switch (opt_ch) {
         case 'c':
             conf_fn = optarg;


### PR DESCRIPTION
``` zsh
% ./h2o -h
./h2o: option requires an argument -- 'h'
h2o: /home/kimoto/projects/h2o/src/main.c:160: main: Assertion `0' failed.
zsh: abort (core dumped)  ./h2o -h
```
