### PR TITLE
implement max_connections

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -346,6 +346,10 @@ typedef struct st_h2o_global_configuration_t {
      * H2O accepts at most 256 requests over HTTP/2, but internally limits the number of in-flight requests to the value specified by this property in order to limit the resources allocated to a single connection.
      */
     size_t http2_max_concurrent_requests_per_connection;
+    /**
+     * an optional callback called when a connection is being closed
+     */
+    void (*close_cb)(h2o_context_t *ctx);
 } h2o_global_configuration_t;
 
 /**

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -52,6 +52,8 @@ static void close_connection(h2o_http1_conn_t *conn)
     free(conn->_req_entity_reader);
     if (conn->sock != NULL)
         h2o_socket_close(conn->sock);
+    if (conn->super.ctx->global_config->close_cb != NULL)
+        conn->super.ctx->global_config->close_cb(conn->super.ctx);
     free(conn);
 }
 

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -188,6 +188,8 @@ static void close_connection_now(h2o_http2_conn_t *conn)
     assert(! h2o_timeout_is_linked(&conn->_write.timeout_entry));
 
     h2o_socket_close(conn->sock);
+    if (conn->super.ctx->global_config->close_cb != NULL)
+        conn->super.ctx->global_config->close_cb(conn->super.ctx);
     free(conn);
 }
 

--- a/lib/socket/evloop/epoll.c.h
+++ b/lib/socket/evloop/epoll.c.h
@@ -100,10 +100,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
         return -1;
 
     /* poll */
-    while (
-        (nevents = epoll_wait(loop->ep, events, sizeof(events) / sizeof(events[0]), get_max_wait(&loop->super))) == -1
-        && errno == EINTR)
-        ;
+    nevents = epoll_wait(loop->ep, events, sizeof(events) / sizeof(events[0]), get_max_wait(&loop->super));
     update_now(&loop->super);
     if (nevents == -1)
         return -1;

--- a/lib/socket/evloop/kqueue.c.h
+++ b/lib/socket/evloop/kqueue.c.h
@@ -97,6 +97,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
     struct st_h2o_socket_loop_kqueue_t *loop = (struct st_h2o_socket_loop_kqueue_t*)_loop;
     struct kevent changelist[64], events[128];
     int nchanges, nevents, i;
+    int32_t max_wait;
     struct timespec ts;
 
     /* collect (and update) status */
@@ -104,12 +105,10 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
         return -1;
 
     /* poll */
-    do {
-        int32_t max_wait = get_max_wait(&loop->super);
-        ts.tv_sec = max_wait / 1000;
-        ts.tv_nsec = max_wait % 1000 * 1000 * 1000;
-    } while ((nevents = kevent(loop->kq, changelist, nchanges, events, sizeof(events) / sizeof(events[0]), &ts)) == -1
-        && errno == EINTR);
+    max_wait = get_max_wait(&loop->super);
+    ts.tv_sec = max_wait / 1000;
+    ts.tv_nsec = max_wait % 1000 * 1000 * 1000;
+    nevents = kevent(loop->kq, changelist, nchanges, events, sizeof(events) / sizeof(events[0]), &ts);
     update_now(&loop->super);
     if (nevents == -1)
         return -1;

--- a/lib/socket/evloop/select.c.h
+++ b/lib/socket/evloop/select.c.h
@@ -80,24 +80,22 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
 {
     struct st_h2o_evloop_select_t *loop = (struct st_h2o_evloop_select_t*)_loop;
     fd_set rfds, wfds;
+    int32_t max_wait;
     struct timeval timeout;
     int fd, ret;
 
     /* update status */
     update_fdset(loop);
 
-    /* call select */
-    do {
-        /* calc timeout */
-        int32_t max_wait = get_max_wait(&loop->super);
-        timeout.tv_sec = max_wait / 1000;
-        timeout.tv_usec = max_wait % 1000 * 1000;
-        /* set fds */
-        memcpy(&rfds, &loop->readfds, sizeof(rfds));
-        memcpy(&wfds, &loop->writefds, sizeof(wfds));
-        /* call */
-        ret = select(loop->max_fd + 1, &rfds, &wfds, NULL, &timeout);
-    } while (ret == -1 && errno == EINTR);
+    /* calc timeout */
+    max_wait = get_max_wait(&loop->super);
+    timeout.tv_sec = max_wait / 1000;
+    timeout.tv_usec = max_wait % 1000 * 1000;
+    /* set fds */
+    memcpy(&rfds, &loop->readfds, sizeof(rfds));
+    memcpy(&wfds, &loop->writefds, sizeof(wfds));
+    /* call */
+    ret = select(loop->max_fd + 1, &rfds, &wfds, NULL, &timeout);
     update_now(&loop->super);
     if (ret == -1)
         return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -36,77 +36,63 @@
 # define EX_CONFIG 78
 #endif
 
-struct port_configurator_t {
-    h2o_configurator_t super;
-    unsigned short port;
-    int fd;
+struct config_t {
+    h2o_global_configuration_t global_config;
+    unsigned short listen_port;
+    int listen_fd;
+    unsigned max_connections;
+    unsigned num_threads;
+    pthread_t *thread_ids;
+    struct {
+        /* unused buffers exist to avoid false sharing of the cache line */
+        char _unused1[32];
+        unsigned num_connections; /* should use atomic functions to update the value */
+        char _unused2[32];
+    } state;
+    h2o_configurator_t port_configurator;
+    h2o_configurator_t max_connections_configurator;
+    h2o_configurator_t num_threads_configurator;
 };
 
 static int on_config_port(h2o_configurator_t *_conf, void *ctx, const char *config_file, yoml_t *config_node)
 {
-    struct port_configurator_t *conf = (void*)_conf;
-    return h2o_config_scanf(&conf->super, config_file, config_node, "%hu", &conf->port);
-}
-
-static void on_config_port_accept(h2o_socket_t *listener, int status)
-{
-    h2o_context_t *ctx = listener->data;
-    h2o_socket_t *sock;
-
-    if (status == -1) {
-        return;
-    }
-
-    if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
-        return;
-    }
-    h2o_http1_accept(ctx, sock);
+    struct config_t *conf = H2O_STRUCT_FROM_MEMBER(struct config_t, port_configurator, _conf);
+    return h2o_config_scanf(&conf->port_configurator, config_file, config_node, "%hu", &conf->listen_port);
 }
 
 static int on_config_port_complete(h2o_configurator_t *_conf, void *_global_config)
 {
-    struct port_configurator_t *conf = (void*)_conf;
+    struct config_t *conf = H2O_STRUCT_FROM_MEMBER(struct config_t, port_configurator, _conf);
     struct sockaddr_in addr;
     int reuseaddr_flag = 1;
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = htonl(0);
-    addr.sin_port = htons(conf->port);
+    addr.sin_port = htons(conf->listen_port);
 
-    if ((conf->fd = socket(AF_INET, SOCK_STREAM, 0)) == -1
-        || setsockopt(conf->fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr_flag, sizeof(reuseaddr_flag)) != 0
-        || bind(conf->fd, (struct sockaddr*)&addr, sizeof(addr)) != 0
-        || listen(conf->fd, SOMAXCONN) != 0) {
-        fprintf(stderr, "failed to listen to port %hu:%s\n", conf->port, strerror(errno));
+    if ((conf->listen_fd = socket(AF_INET, SOCK_STREAM, 0)) == -1
+        || setsockopt(conf->listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr_flag, sizeof(reuseaddr_flag)) != 0
+        || bind(conf->listen_fd, (struct sockaddr*)&addr, sizeof(addr)) != 0
+        || listen(conf->listen_fd, SOMAXCONN) != 0) {
+        fprintf(stderr, "failed to listen to port %hu:%s\n", conf->listen_port, strerror(errno));
         return -1;
     }
 
     return 0;
 }
 
-static int on_config_port_context_create(h2o_configurator_t *_conf, h2o_context_t *ctx)
+static int on_config_max_connections(h2o_configurator_t *_conf, void *ctx, const char *config_file, yoml_t *config_node)
 {
-    struct port_configurator_t *conf = (void*)_conf;
-    h2o_socket_t *sock;
-
-    /* FIXME use dup to support multithread? */
-    sock = h2o_evloop_socket_create(ctx->loop, conf->fd, H2O_SOCKET_FLAG_IS_ACCEPT);
-    sock->data = ctx;
-    h2o_socket_read_start(sock, on_config_port_accept);
-
-    return 0;
+    struct config_t *conf = H2O_STRUCT_FROM_MEMBER(struct config_t, max_connections_configurator, _conf);
+    return h2o_config_scanf(&conf->max_connections_configurator, config_file, config_node, "%u", &conf->max_connections);
 }
 
-struct num_threads_configurator_t {
-    h2o_configurator_t super;
-    unsigned num_threads;
-};
 
 static int on_config_num_threads(h2o_configurator_t *_conf, void *ctx, const char *config_file, yoml_t *config_node)
 {
-    struct num_threads_configurator_t *conf = (void*)_conf;
-    return h2o_config_scanf(&conf->super, config_file, config_node, "%u", &conf->num_threads);
+    struct config_t *conf = H2O_STRUCT_FROM_MEMBER(struct config_t, num_threads_configurator, _conf);
+    return h2o_config_scanf(&conf->num_threads_configurator, config_file, config_node, "%u", &conf->num_threads);
 }
 
 static void usage_print_directives(h2o_linklist_t *configurators)
@@ -170,27 +156,100 @@ yoml_t *load_config(const char *fn)
     return yoml;
 }
 
-static void setup_signal_handlers(void)
+static void signal_ignore_cb(int signo)
 {
-    struct sigaction sa;
-
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_handler = SIG_IGN;
-    sigemptyset(&sa.sa_mask);
-    sigaction(SIGPIPE, &sa, NULL);
 }
 
-static void *run_loop(void *_config)
+static void setup_signal_handlers(void)
 {
-    h2o_global_configuration_t *config = _config;
+    struct sigaction action;
+    sigset_t mask;
+
+    /* ignore SIGPIPE */
+    memset(&action, 0, sizeof(action));
+    sigemptyset(&action.sa_mask);
+    action.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &action, NULL);
+
+    /* accept SIGCONT (so that we could use the signal to interrupt blocking syscalls like epoll) */
+    memset(&action, 0, sizeof(action));
+    sigemptyset(&action.sa_mask);
+    action.sa_handler = signal_ignore_cb;
+    sigaction(SIGCONT, &action, NULL);
+    /* and make sure SIGCONT is delivered */
+    pthread_sigmask(SIG_BLOCK, NULL, &mask);
+    sigdelset(&mask, SIGCONT);
+    pthread_sigmask(SIG_SETMASK, &mask, NULL);
+}
+
+static void on_close(h2o_context_t *ctx)
+{
+    struct config_t *conf = H2O_STRUCT_FROM_MEMBER(struct config_t, global_config, ctx->global_config);
+    unsigned prev_num_connections = __sync_fetch_and_sub(&conf->state.num_connections, 1);
+
+    if (conf->num_threads != 1) {
+        if (prev_num_connections == conf->max_connections) {
+            /* ready to accept new connections.  wake up the threads! */
+            pthread_t self_tid = pthread_self();
+            unsigned i;
+            for (i = 0; i != conf->num_threads; ++i) {
+                if (conf->thread_ids[i] != self_tid)
+                    pthread_kill(conf->thread_ids[i], SIGCONT);
+            }
+        }
+    }
+}
+
+static void on_accept(h2o_socket_t *listener, int status)
+{
+    h2o_context_t *ctx = listener->data;
+    struct config_t *conf = H2O_STRUCT_FROM_MEMBER(struct config_t, global_config, ctx->global_config);
+    int num_accepts = 16;
+
+    if (status == -1) {
+        return;
+    }
+
+    do {
+        h2o_socket_t *sock;
+        if (conf->state.num_connections >= conf->max_connections)
+            break;
+        if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
+            break;
+        }
+        __sync_add_and_fetch(&conf->state.num_connections, 1);
+        h2o_http1_accept(ctx, sock);
+    } while (--num_accepts != 0);
+}
+
+
+static void *run_loop(void *_conf)
+{
+    struct config_t *conf = _conf;
     h2o_evloop_t *loop;
     h2o_context_t ctx;
+    h2o_socket_t *listener;
 
+    /* setup loop and context */
     loop = h2o_evloop_create();
-    h2o_context_init(&ctx, loop, config);
+    h2o_context_init(&ctx, loop, &conf->global_config);
 
-    while (1)
+    listener = h2o_evloop_socket_create(ctx.loop, conf->listen_fd, H2O_SOCKET_FLAG_IS_ACCEPT);
+    listener->data = &ctx;
+
+    /* the main loop */
+    while (1) {
+        /* start / stop trying to accept new connections */
+        if (conf->state.num_connections < conf->max_connections) {
+            if (! h2o_socket_is_reading(listener))
+                h2o_socket_read_start(listener, on_accept);
+        } else {
+            if (h2o_socket_is_reading(listener))
+                h2o_socket_read_stop(listener);
+        }
+        /* run the loop once */
         h2o_evloop_run(loop);
+    }
 
     return NULL;
 }
@@ -202,31 +261,40 @@ int main(int argc, char **argv)
         { "help", no_argument, NULL, 'h' },
         { NULL, 0, NULL, 0 }
     };
-    static const char *post_configurator_desc[] = {
+
+    static const char *port_configurator_desc[] = {
         "TCP port number to which the server should listen (mandatory)",
         NULL
-    };
-    static struct port_configurator_t port_configurator = {
-        { {}, "port", post_configurator_desc, NULL, on_config_port, on_config_port_complete, on_config_port_context_create },
-        0
     };
     static const char *num_threads_configurator_desc[] = {
         "number of worker threads (default: 1)",
         NULL
     };
-    static struct num_threads_configurator_t num_threads_configurator = {
-        { {}, "num-threads", num_threads_configurator_desc, NULL, on_config_num_threads, NULL, NULL },
-        1 /* default number of threads is 1 */
+    static const char *max_connections_configurator_desc[] = {
+        "max connections (default: 1024)",
+        NULL
+    };
+    static struct config_t config = {
+        {}, /* global_config */
+        0, /* listen_port */
+        -1, /* listen_fd */
+        1024, /* max_connections */
+        1, /* num_threads */
+        NULL, /* thread_ids */
+        {}, /* state */
+        { {}, "port", port_configurator_desc, NULL, on_config_port, on_config_port_complete, NULL },
+        { {}, "max-connections", max_connections_configurator_desc, NULL, on_config_max_connections, NULL, NULL },
+        { {}, "num-threads", num_threads_configurator_desc, NULL, on_config_num_threads, NULL, NULL }
     };
 
     const char *config_file = "h2o.conf";
     int opt_ch;
     yoml_t *config_yoml;
-    h2o_global_configuration_t config;
-
-    h2o_config_init(&config);
-    h2o_linklist_insert(&config.global_configurators, &port_configurator.super._link);
-    h2o_linklist_insert(&config.global_configurators, &num_threads_configurator.super._link);
+    h2o_config_init(&config.global_config);
+    config.global_config.close_cb = on_close;
+    h2o_linklist_insert(&config.global_config.global_configurators, &config.port_configurator._link);
+    h2o_linklist_insert(&config.global_config.global_configurators, &config.max_connections_configurator._link);
+    h2o_linklist_insert(&config.global_config.global_configurators, &config.num_threads_configurator._link);
 
     /* parse options */
     while ((opt_ch = getopt_long(argc, argv, "c:h", longopts, NULL)) != -1) {
@@ -235,7 +303,7 @@ int main(int argc, char **argv)
             config_file = optarg;
             break;
         case 'h':
-            usage(&config);
+            usage(&config.global_config);
             exit(0);
             break;
         default:
@@ -249,22 +317,22 @@ int main(int argc, char **argv)
     /* configure */
     if ((config_yoml = load_config(config_file)) == NULL)
         exit(EX_CONFIG);
-    if (h2o_config_configure(&config, config_file, config_yoml) != 0)
+    if (h2o_config_configure(&config.global_config, config_file, config_yoml) != 0)
         exit(EX_CONFIG);
     yoml_free(config_yoml);
 
     setup_signal_handlers();
 
-    if (num_threads_configurator.num_threads <= 1) {
+    if (config.num_threads <= 1) {
         run_loop(&config);
     } else {
-        pthread_t *tids = alloca(sizeof(pthread_t) * num_threads_configurator.num_threads);
+        config.thread_ids = alloca(sizeof(pthread_t) * config.num_threads);
         unsigned i;
-        for (i = 0; i != num_threads_configurator.num_threads; ++i) {
-            pthread_create(tids + i, NULL, run_loop, &config);
+        for (i = 0; i != config.num_threads; ++i) {
+            pthread_create(config.thread_ids + i, NULL, run_loop, &config);
         }
-        for (i = 0; i < num_threads_configurator.num_threads; ++i) {
-            pthread_join(tids[i], NULL);
+        for (i = 0; i < config.num_threads; ++i) {
+            pthread_join(config.thread_ids[i], NULL);
         }
     }
 


### PR DESCRIPTION
This PR tackles #20 by doing the following:
- add configuration directive `max-connections`
- observes the number of connections
- starts / stops accepting new connections by checking the number of connections
  - uses `pthread_kill` to exit from blocking call to `epoll` et. al. when it is necessary to start accepting new connections
- accepts at max. 16 new connections per loop
  - may improve performance when non-persistent connections are used, though we need to apply things like DATAREADY and read-before-select as well  (#15)
