### PR TITLE
add support for reverse proxing to unix socket

### DIFF
--- a/examples/libh2o/socket-client.c
+++ b/examples/libh2o/socket-client.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
         goto Exit;
     }
 
-    if ((sock = h2o_socket_connect(loop, res->ai_addr, res->ai_addrlen, on_connect)) == NULL) {
+    if ((sock = h2o_socket_connect(loop, res->ai_addr, res->ai_addrlen, IPPROTO_TCP, on_connect)) == NULL) {
         fprintf(stderr, "failed to create socket:%s\n", strerror(errno));
         goto Exit;
     }

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -85,7 +85,7 @@ void h2o_socket_close(h2o_socket_t *sock);
 /**
  * connects to peer
  */
-h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, h2o_socket_cb cb);
+h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, int proto, h2o_socket_cb cb);
 /**
  * writes given data to socket
  * @param sock the socket

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -96,6 +96,10 @@ h2o_buf_t h2o_normalize_path(h2o_mempool_t *pool, const char *path, size_t len);
  */
 int h2o_parse_url(h2o_mempool_t *pool, const char *url, char **scheme, char **host, uint16_t *port, char **path);
 /**
+ * parses unix socket path
+ */
+int h2o_parse_unix(h2o_mempool_t *pool, const char *unix_path, char **socket_path, char **path);
+/**
  * HTML-escapes a string
  * @param pool memory pool
  * @param src source string

--- a/lib/socket/evloop.c.h
+++ b/lib/socket/evloop.c.h
@@ -339,12 +339,12 @@ h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *_listener)
     return sock;
 }
 
-h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, h2o_socket_cb cb)
+h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, int proto, h2o_socket_cb cb)
 {
     int fd;
     struct st_h2o_evloop_socket_t *sock;
 
-    if ((fd = socket(addr->sa_family, SOCK_STREAM, IPPROTO_TCP)) == -1)
+    if ((fd = socket(addr->sa_family, SOCK_STREAM, proto)) == -1)
         return NULL;
     if (! (connect(fd, addr, addrlen) == 0 || errno == EINPROGRESS)) {
         close(fd);

--- a/lib/socket/uv-binding.c.h
+++ b/lib/socket/uv-binding.c.h
@@ -149,10 +149,15 @@ static void on_connect(uv_connect_t *conn, int status)
     cb(&sock->super, status);
 }
 
-h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, h2o_socket_cb cb)
+h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, int proto, h2o_socket_cb cb)
 {
     struct st_h2o_uv_socket_t *sock;
     uv_tcp_t *tcp = h2o_malloc(sizeof(*tcp));
+
+    // TODO: support unix domain socket with libuv
+    if (addr->sa_family == AF_UNIX) {
+        assert(!"unix domain socket is not supported when libuv is used");
+    }
 
     if (uv_tcp_init(loop, tcp) != 0) {
         free(tcp);

--- a/lib/string.c
+++ b/lib/string.c
@@ -500,6 +500,35 @@ int h2o_parse_url(h2o_mempool_t *pool, const char *url, char **scheme, char **ho
     return 0;
 }
 
+int h2o_parse_unix(h2o_mempool_t *pool, const char *unix_path, char **socket_path, char **path)
+{
+    const char *ux_start, *ux_end;
+
+    /* check scheme */
+    if (strncmp(unix_path, "unix:", sizeof("unix:") - 1) != 0) {
+        return -1;
+    }
+
+    /* skip scheme */
+    ux_start = unix_path + sizeof("unix:") - 1;
+
+    /* locate the end of unix socket path */
+    if ((ux_end = strchr(ux_start, ':')) != NULL) {
+        *path = (char*)++ux_end;
+        if (**path != '/') {
+            return -1;
+        }
+    } else {
+        return -1;
+    }
+
+    /* parse socket path */
+    *socket_path = h2o_strdup(pool, ux_start, ux_end - 1 - ux_start).base;
+
+    /* success */
+    return 0;
+}
+
 h2o_buf_t h2o_htmlescape(h2o_mempool_t *pool, const char *src, size_t len)
 {
     const char *s, *end = src + len;


### PR DESCRIPTION
I added support for reverse proxing to unix socket. `h2o`'s reverse proxing to unix socket is twice faster than its reverse proxing to tcp-port.

```bash
$ ab -k -n 10000 -c 500 "http://127.0.0.1:8081/tcp" 2>&1 | grep "Requests per second:"
Requests per second:    8923.78 [#/sec] (mean)
$ ab -k -n 10000 -c 500 "http://127.0.0.1:8081/unix" 2>&1 | grep "Requests per second:"
Requests per second:    16566.69 [#/sec] (mean)
$
```

The followings are configurations for this benchmark.

## h2o.conf

```yaml
listen:
  port: 8081
hosts:
  default:
    paths:
      /tcp:
        proxy.reverse.url: http://127.0.0.1/
      /unix:
        proxy.reverse.path: unix:/tmp/nginx.sock:/
```

## nginx.conf

```nginx
worker_processes 1; 

events {
    worker_connections 1024;
}


http {
    include       mime.types;
    default_type  application/octet-stream;

    sendfile        on;

    keepalive_timeout  65;

    server {
        listen 80;
        root   html;
    }

    server {
        listen unix:/tmp/nginx.sock;
        root   html;
    }

}
```
