### PR TITLE
Fix errors when compiling cpp project against libh2o

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -290,7 +290,7 @@ inline void h2o_vector_reserve(h2o_mempool_t *pool, h2o_vector_t *vector, size_t
 
 inline int h2o_memis(const void *_target, size_t target_len, const void *_test, size_t test_len)
 {
-    const char *target = _target, *test = _test;
+    const char *target = (char *)_target, *test = (char *)_test;
     if (target_len != test_len)
         return 0;
     if (target_len == 0)


### PR DESCRIPTION
I was receiving the following errors when compiling, explicitly typecasting seemed to fix the issue and I now have a working h2o server:

```
In file included from vendor/h2o/include/h2o.h:42:
In file included from vendor/h2o/include/h2o/http1client.h:26:
vendor/h2o/include/h2o/memory.h:293:17: error: cannot initialize a variable of type 'const char *' with an lvalue of
      type 'const void *'
    const char *target = _target, *test = _test;
                ^        ~~~~~~~
vendor/h2o/include/h2o/memory.h:293:36: error: cannot initialize a variable of type 'const char *' with an lvalue of
      type 'const void *'
    const char *target = _target, *test = _test;
                                   ^      ~~~~~
2 errors generated.
```
