### PR TITLE
fix typo: expotential => exponential

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -191,7 +191,7 @@ static void h2o_buffer_dispose(h2o_buffer_t **buffer);
  * @param inbuf - pointer to a pointer pointing to the structure (set *inbuf to NULL to allocate a new buffer)
  * @param min_guarantee minimum number of bytes to reserve
  * @return buffer to which the next data should be stored
- * @note When called against a new buffer, the function returns a buffer twice the size of requested guarantee.  The function uses expotential backoff for already-allocated buffers.
+ * @note When called against a new buffer, the function returns a buffer twice the size of requested guarantee.  The function uses exponential backoff for already-allocated buffers.
  */
 h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **inbuf, size_t min_guarantee);
 /**


### PR DESCRIPTION
fix typo in a comment: expotential => exponential
