### PR TITLE
Add netinet/in.h for IPPROTO_TCP.

### DIFF
--- a/lib/socketpool.c
+++ b/lib/socketpool.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <netinet/in.h>
 #include "h2o/linklist.h"
 #include "h2o/socketpool.h"
 #include "h2o/string_.h"


### PR DESCRIPTION
Fixes build on NetBSD.

Signed-off-by: Thomas Klausner wiz@NetBSD.org
