### PR TITLE
based default thread count on getconf NPROCESSORS_ONLIN Fixes #24

### DIFF
--- a/include/h2o/serverutil.h
+++ b/include/h2o/serverutil.h
@@ -80,4 +80,9 @@ ssize_t h2o_server_starter_get_fds(int **_fds);
  */
 int h2o_read_command(const char *cmd, char **argv, h2o_buffer_t **resp, int *child_status);
 
+/**
+ * Gets the maximum number of threads the system supports
+ */
+size_t h2o_sys_thread_count();
+
 #endif

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -187,3 +187,13 @@ Exit:
 
     return ret;
 }
+
+size_t h2o_sys_thread_count () {
+#if  defined(__APPLE__) && defined(__MACH__) || defined(__linux__)
+  size_t sys_thread_count = sysconf(_SC_NPROCESSORS_ONLN);
+#else
+  size_t sys_thread_count = 1;
+#endif
+  return sys_thread_count > 1 ? sys_thread_count : 1;
+}
+


### PR DESCRIPTION
This uses sysconf to get the value of the number of online processing cores.  This works in both OSX 10.8.5 and Linux 3.13.0-36-generic, but it doesn't look there's Windows support that we have to worry about?

I'm not sure that sysconf could mess up an return a negative number, and we can't initialize the static config with a runtime function, so we initialize the static struct to 1, and only reassign if the sysconf value if it's greater.

You can check this value from the command line via `getconf NPROCESSORS_ONLN`.  We use this value by default (as long as it's above 1), unless you have set a value in your config file, which takes precedent.  Not sure if we should be using max procs minus one?