### PR TITLE
Internally keep header names lower-cased

### DIFF
--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -71,7 +71,8 @@ typedef struct st_h2o_hpack_header_table_t {
 } h2o_hpack_header_table_t;
 
 void h2o_hpack_dispose_header_table(h2o_hpack_header_table_t *header_table);
-int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_table, const uint8_t *src, size_t len);
+int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_table, const uint8_t *src, size_t len,
+                            const char **err_desc, int *err_is_stream_level);
 size_t h2o_hpack_encode_string(uint8_t *dst, const char *s, size_t len);
 int h2o_hpack_flatten_headers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id, size_t max_frame_size,
                               h2o_res_t *res, h2o_timestamp_t *ts, const h2o_iovec_t *server_name);

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -56,6 +56,10 @@ h2o_iovec_t h2o_strdup_slashed(h2o_mem_pool_t *pool, const char *s, size_t len);
  */
 static int h2o_tolower(int ch);
 /**
+ * tr/A-Z/a-z/
+ */
+static void h2o_strtolower(char *s, size_t len);
+/**
  * tests if target string (target_len bytes long) is equal to test string (test_len bytes long) after being converted to lower-case
  */
 static int h2o_lcstris(const char *target, size_t target_len, const char *test, size_t test_len);
@@ -125,6 +129,12 @@ int h2o__lcstris_core(const char *target, const char *test, size_t test_len);
 inline int h2o_tolower(int ch)
 {
     return 'A' <= ch && ch <= 'Z' ? ch + 0x20 : ch;
+}
+
+inline void h2o_strtolower(char *s, size_t len)
+{
+    for (; len != 0; ++s, --len)
+        *s = h2o_tolower(*s);
 }
 
 inline int h2o_lcstris(const char *target, size_t target_len, const char *test, size_t test_len)

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -206,13 +206,14 @@ static void on_head(h2o_socket_t *sock, int status)
     reader = on_body_until_close;
     client->_can_keepalive = minor_version >= 1;
     for (i = 0; i != num_headers; ++i) {
-        if (h2o_lcstris(headers[i].name, headers[i].name_len, H2O_STRLIT("connection"))) {
+        h2o_strtolower((char *)headers[i].name, headers[i].name_len);
+        if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("connection"))) {
             if (h2o_contains_token(headers[i].value, headers[i].value_len, H2O_STRLIT("keep-alive"))) {
                 client->_can_keepalive = 1;
             } else {
                 client->_can_keepalive = 0;
             }
-        } else if (h2o_lcstris(headers[i].name, headers[i].name_len, H2O_STRLIT("transfer-encoding"))) {
+        } else if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("transfer-encoding"))) {
             if (h2o_memis(headers[i].value, headers[i].value_len, H2O_STRLIT("chunked"))) {
                 /* precond: _body_decoder.chunked is zero-filled */
                 client->_body_decoder.chunked.decoder.consume_trailer = 1;
@@ -223,7 +224,7 @@ static void on_head(h2o_socket_t *sock, int status)
                 on_error_before_head(client, "unexpected type of transfer-encoding");
                 return;
             }
-        } else if (h2o_lcstris(headers[i].name, headers[i].name_len, H2O_STRLIT("content-length"))) {
+        } else if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("content-length"))) {
             if ((client->_body_decoder.content_length.bytesleft = h2o_strtosize(headers[i].value, headers[i].value_len)) ==
                 SIZE_MAX) {
                 on_error_before_head(client, "invalid content-length");

--- a/lib/core/headers.c
+++ b/lib/core/headers.c
@@ -52,7 +52,7 @@ ssize_t h2o_find_header_by_str(const h2o_headers_t *headers, const char *name, s
 {
     for (++cursor; cursor < headers->size; ++cursor) {
         h2o_header_t *t = headers->entries + cursor;
-        if (h2o_lcstris(t->name->base, t->name->len, name, name_len)) {
+        if (h2o_memis(t->name->base, t->name->len, name, name_len)) {
             return cursor;
         }
     }

--- a/lib/core/token_table.h
+++ b/lib/core/token_table.h
@@ -83,285 +83,285 @@ const h2o_token_t *h2o_lookup_token(const char *name, size_t len)
 {
     switch (len) {
     case 3:
-        switch (h2o_tolower(name[2])) {
+        switch (name[2]) {
         case 'a':
-            if (h2o__lcstris_core(name, "vi", 2))
+            if (memcmp(name, "vi", 2) == 0)
                 return H2O_TOKEN_VIA;
             break;
         case 'e':
-            if (h2o__lcstris_core(name, "ag", 2))
+            if (memcmp(name, "ag", 2) == 0)
                 return H2O_TOKEN_AGE;
             break;
         }
         break;
     case 4:
-        switch (h2o_tolower(name[3])) {
+        switch (name[3]) {
         case 'e':
-            if (h2o__lcstris_core(name, "dat", 3))
+            if (memcmp(name, "dat", 3) == 0)
                 return H2O_TOKEN_DATE;
             break;
         case 'g':
-            if (h2o__lcstris_core(name, "eta", 3))
+            if (memcmp(name, "eta", 3) == 0)
                 return H2O_TOKEN_ETAG;
             break;
         case 'k':
-            if (h2o__lcstris_core(name, "lin", 3))
+            if (memcmp(name, "lin", 3) == 0)
                 return H2O_TOKEN_LINK;
             break;
         case 'm':
-            if (h2o__lcstris_core(name, "fro", 3))
+            if (memcmp(name, "fro", 3) == 0)
                 return H2O_TOKEN_FROM;
             break;
         case 't':
-            if (h2o__lcstris_core(name, "hos", 3))
+            if (memcmp(name, "hos", 3) == 0)
                 return H2O_TOKEN_HOST;
             break;
         case 'y':
-            if (h2o__lcstris_core(name, "var", 3))
+            if (memcmp(name, "var", 3) == 0)
                 return H2O_TOKEN_VARY;
             break;
         }
         break;
     case 5:
-        switch (h2o_tolower(name[4])) {
+        switch (name[4]) {
         case 'e':
-            if (h2o__lcstris_core(name, "rang", 4))
+            if (memcmp(name, "rang", 4) == 0)
                 return H2O_TOKEN_RANGE;
             break;
         case 'h':
-            if (h2o__lcstris_core(name, ":pat", 4))
+            if (memcmp(name, ":pat", 4) == 0)
                 return H2O_TOKEN_PATH;
             break;
         case 'w':
-            if (h2o__lcstris_core(name, "allo", 4))
+            if (memcmp(name, "allo", 4) == 0)
                 return H2O_TOKEN_ALLOW;
             break;
         }
         break;
     case 6:
-        switch (h2o_tolower(name[5])) {
+        switch (name[5]) {
         case 'e':
-            if (h2o__lcstris_core(name, "cooki", 5))
+            if (memcmp(name, "cooki", 5) == 0)
                 return H2O_TOKEN_COOKIE;
             break;
         case 'r':
-            if (h2o__lcstris_core(name, "serve", 5))
+            if (memcmp(name, "serve", 5) == 0)
                 return H2O_TOKEN_SERVER;
             break;
         case 't':
-            if (h2o__lcstris_core(name, "accep", 5))
+            if (memcmp(name, "accep", 5) == 0)
                 return H2O_TOKEN_ACCEPT;
-            if (h2o__lcstris_core(name, "expec", 5))
+            if (memcmp(name, "expec", 5) == 0)
                 return H2O_TOKEN_EXPECT;
             break;
         }
         break;
     case 7:
-        switch (h2o_tolower(name[6])) {
+        switch (name[6]) {
         case 'd':
-            if (h2o__lcstris_core(name, ":metho", 6))
+            if (memcmp(name, ":metho", 6) == 0)
                 return H2O_TOKEN_METHOD;
             break;
         case 'e':
-            if (h2o__lcstris_core(name, ":schem", 6))
+            if (memcmp(name, ":schem", 6) == 0)
                 return H2O_TOKEN_SCHEME;
-            if (h2o__lcstris_core(name, "upgrad", 6))
+            if (memcmp(name, "upgrad", 6) == 0)
                 return H2O_TOKEN_UPGRADE;
             break;
         case 'h':
-            if (h2o__lcstris_core(name, "refres", 6))
+            if (memcmp(name, "refres", 6) == 0)
                 return H2O_TOKEN_REFRESH;
             break;
         case 'r':
-            if (h2o__lcstris_core(name, "refere", 6))
+            if (memcmp(name, "refere", 6) == 0)
                 return H2O_TOKEN_REFERER;
             break;
         case 's':
-            if (h2o__lcstris_core(name, ":statu", 6))
+            if (memcmp(name, ":statu", 6) == 0)
                 return H2O_TOKEN_STATUS;
-            if (h2o__lcstris_core(name, "expire", 6))
+            if (memcmp(name, "expire", 6) == 0)
                 return H2O_TOKEN_EXPIRES;
             break;
         }
         break;
     case 8:
-        switch (h2o_tolower(name[7])) {
+        switch (name[7]) {
         case 'e':
-            if (h2o__lcstris_core(name, "if-rang", 7))
+            if (memcmp(name, "if-rang", 7) == 0)
                 return H2O_TOKEN_IF_RANGE;
             break;
         case 'h':
-            if (h2o__lcstris_core(name, "if-matc", 7))
+            if (memcmp(name, "if-matc", 7) == 0)
                 return H2O_TOKEN_IF_MATCH;
             break;
         case 'n':
-            if (h2o__lcstris_core(name, "locatio", 7))
+            if (memcmp(name, "locatio", 7) == 0)
                 return H2O_TOKEN_LOCATION;
             break;
         }
         break;
     case 10:
-        switch (h2o_tolower(name[9])) {
+        switch (name[9]) {
         case 'e':
-            if (h2o__lcstris_core(name, "set-cooki", 9))
+            if (memcmp(name, "set-cooki", 9) == 0)
                 return H2O_TOKEN_SET_COOKIE;
             break;
         case 'n':
-            if (h2o__lcstris_core(name, "connectio", 9))
+            if (memcmp(name, "connectio", 9) == 0)
                 return H2O_TOKEN_CONNECTION;
             break;
         case 't':
-            if (h2o__lcstris_core(name, "user-agen", 9))
+            if (memcmp(name, "user-agen", 9) == 0)
                 return H2O_TOKEN_USER_AGENT;
             break;
         case 'y':
-            if (h2o__lcstris_core(name, ":authorit", 9))
+            if (memcmp(name, ":authorit", 9) == 0)
                 return H2O_TOKEN_AUTHORITY;
             break;
         }
         break;
     case 11:
-        switch (h2o_tolower(name[10])) {
+        switch (name[10]) {
         case 'r':
-            if (h2o__lcstris_core(name, "retry-afte", 10))
+            if (memcmp(name, "retry-afte", 10) == 0)
                 return H2O_TOKEN_RETRY_AFTER;
             break;
         }
         break;
     case 12:
-        switch (h2o_tolower(name[11])) {
+        switch (name[11]) {
         case 'e':
-            if (h2o__lcstris_core(name, "content-typ", 11))
+            if (memcmp(name, "content-typ", 11) == 0)
                 return H2O_TOKEN_CONTENT_TYPE;
             break;
         case 's':
-            if (h2o__lcstris_core(name, "max-forward", 11))
+            if (memcmp(name, "max-forward", 11) == 0)
                 return H2O_TOKEN_MAX_FORWARDS;
             break;
         }
         break;
     case 13:
-        switch (h2o_tolower(name[12])) {
+        switch (name[12]) {
         case 'd':
-            if (h2o__lcstris_core(name, "last-modifie", 12))
+            if (memcmp(name, "last-modifie", 12) == 0)
                 return H2O_TOKEN_LAST_MODIFIED;
             break;
         case 'e':
-            if (h2o__lcstris_core(name, "content-rang", 12))
+            if (memcmp(name, "content-rang", 12) == 0)
                 return H2O_TOKEN_CONTENT_RANGE;
             break;
         case 'h':
-            if (h2o__lcstris_core(name, "if-none-matc", 12))
+            if (memcmp(name, "if-none-matc", 12) == 0)
                 return H2O_TOKEN_IF_NONE_MATCH;
             break;
         case 'l':
-            if (h2o__lcstris_core(name, "cache-contro", 12))
+            if (memcmp(name, "cache-contro", 12) == 0)
                 return H2O_TOKEN_CACHE_CONTROL;
-            if (h2o__lcstris_core(name, "x-reproxy-ur", 12))
+            if (memcmp(name, "x-reproxy-ur", 12) == 0)
                 return H2O_TOKEN_X_REPROXY_URL;
             break;
         case 'n':
-            if (h2o__lcstris_core(name, "authorizatio", 12))
+            if (memcmp(name, "authorizatio", 12) == 0)
                 return H2O_TOKEN_AUTHORIZATION;
             break;
         case 's':
-            if (h2o__lcstris_core(name, "accept-range", 12))
+            if (memcmp(name, "accept-range", 12) == 0)
                 return H2O_TOKEN_ACCEPT_RANGES;
             break;
         }
         break;
     case 14:
-        switch (h2o_tolower(name[13])) {
+        switch (name[13]) {
         case 'h':
-            if (h2o__lcstris_core(name, "content-lengt", 13))
+            if (memcmp(name, "content-lengt", 13) == 0)
                 return H2O_TOKEN_CONTENT_LENGTH;
             break;
         case 's':
-            if (h2o__lcstris_core(name, "http2-setting", 13))
+            if (memcmp(name, "http2-setting", 13) == 0)
                 return H2O_TOKEN_HTTP2_SETTINGS;
             break;
         case 't':
-            if (h2o__lcstris_core(name, "accept-charse", 13))
+            if (memcmp(name, "accept-charse", 13) == 0)
                 return H2O_TOKEN_ACCEPT_CHARSET;
             break;
         }
         break;
     case 15:
-        switch (h2o_tolower(name[14])) {
+        switch (name[14]) {
         case 'e':
-            if (h2o__lcstris_core(name, "accept-languag", 14))
+            if (memcmp(name, "accept-languag", 14) == 0)
                 return H2O_TOKEN_ACCEPT_LANGUAGE;
             break;
         case 'g':
-            if (h2o__lcstris_core(name, "accept-encodin", 14))
+            if (memcmp(name, "accept-encodin", 14) == 0)
                 return H2O_TOKEN_ACCEPT_ENCODING;
             break;
         }
         break;
     case 16:
-        switch (h2o_tolower(name[15])) {
+        switch (name[15]) {
         case 'e':
-            if (h2o__lcstris_core(name, "content-languag", 15))
+            if (memcmp(name, "content-languag", 15) == 0)
                 return H2O_TOKEN_CONTENT_LANGUAGE;
-            if (h2o__lcstris_core(name, "www-authenticat", 15))
+            if (memcmp(name, "www-authenticat", 15) == 0)
                 return H2O_TOKEN_WWW_AUTHENTICATE;
             break;
         case 'g':
-            if (h2o__lcstris_core(name, "content-encodin", 15))
+            if (memcmp(name, "content-encodin", 15) == 0)
                 return H2O_TOKEN_CONTENT_ENCODING;
             break;
         case 'n':
-            if (h2o__lcstris_core(name, "content-locatio", 15))
+            if (memcmp(name, "content-locatio", 15) == 0)
                 return H2O_TOKEN_CONTENT_LOCATION;
             break;
         }
         break;
     case 17:
-        switch (h2o_tolower(name[16])) {
+        switch (name[16]) {
         case 'e':
-            if (h2o__lcstris_core(name, "if-modified-sinc", 16))
+            if (memcmp(name, "if-modified-sinc", 16) == 0)
                 return H2O_TOKEN_IF_MODIFIED_SINCE;
             break;
         case 'g':
-            if (h2o__lcstris_core(name, "transfer-encodin", 16))
+            if (memcmp(name, "transfer-encodin", 16) == 0)
                 return H2O_TOKEN_TRANSFER_ENCODING;
             break;
         }
         break;
     case 18:
-        switch (h2o_tolower(name[17])) {
+        switch (name[17]) {
         case 'e':
-            if (h2o__lcstris_core(name, "proxy-authenticat", 17))
+            if (memcmp(name, "proxy-authenticat", 17) == 0)
                 return H2O_TOKEN_PROXY_AUTHENTICATE;
             break;
         }
         break;
     case 19:
-        switch (h2o_tolower(name[18])) {
+        switch (name[18]) {
         case 'e':
-            if (h2o__lcstris_core(name, "if-unmodified-sinc", 18))
+            if (memcmp(name, "if-unmodified-sinc", 18) == 0)
                 return H2O_TOKEN_IF_UNMODIFIED_SINCE;
             break;
         case 'n':
-            if (h2o__lcstris_core(name, "content-dispositio", 18))
+            if (memcmp(name, "content-dispositio", 18) == 0)
                 return H2O_TOKEN_CONTENT_DISPOSITION;
-            if (h2o__lcstris_core(name, "proxy-authorizatio", 18))
+            if (memcmp(name, "proxy-authorizatio", 18) == 0)
                 return H2O_TOKEN_PROXY_AUTHORIZATION;
             break;
         }
         break;
     case 25:
-        switch (h2o_tolower(name[24])) {
+        switch (name[24]) {
         case 'y':
-            if (h2o__lcstris_core(name, "strict-transport-securit", 24))
+            if (memcmp(name, "strict-transport-securit", 24) == 0)
                 return H2O_TOKEN_STRICT_TRANSPORT_SECURITY;
             break;
         }
         break;
     case 27:
-        switch (h2o_tolower(name[26])) {
+        switch (name[26]) {
         case 'n':
-            if (h2o__lcstris_core(name, "access-control-allow-origi", 26))
+            if (memcmp(name, "access-control-allow-origi", 26) == 0)
                 return H2O_TOKEN_ACCESS_CONTROL_ALLOW_ORIGIN;
             break;
         }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -223,8 +223,10 @@ static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, const 
         size_t i;
         h2o_vector_reserve(pool, (h2o_vector_t *)headers, sizeof(h2o_header_t), len);
         for (i = 0; i != len; ++i) {
-            const h2o_token_t *name_token = h2o_lookup_token(src[i].name, src[i].name_len);
-            if (name_token != NULL) {
+            const h2o_token_t *name_token;
+            /* convert to lower-case in-place */
+            h2o_strtolower((char *)src[i].name, src[i].name_len);
+            if ((name_token = h2o_lookup_token(src[i].name, src[i].name_len)) != NULL) {
                 if (name_token->is_init_header_special) {
                     if (name_token == H2O_TOKEN_HOST) {
                         host->base = (char *)src[i].value;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -237,10 +237,19 @@ static void update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delt
 static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, const uint8_t *src, size_t len,
                                    const char **err_desc)
 {
+    int ret, err_is_stream_level;
+
     assert(stream->state == H2O_HTTP2_STREAM_STATE_RECV_HEADERS);
 
-    if (h2o_hpack_parse_headers(&stream->req, &conn->_input_header_table, src, len) != 0)
-        return H2O_HTTP2_ERROR_COMPRESSION;
+    if ((ret = h2o_hpack_parse_headers(&stream->req, &conn->_input_header_table, src, len, err_desc, &err_is_stream_level)) != 0) {
+        if (err_is_stream_level) {
+            send_stream_error(conn, stream->stream_id, ret);
+            h2o_http2_stream_reset(conn, stream);
+            return 0;
+        } else {
+            return ret;
+        }
+    }
 
     /* handle the request */
     conn->_read_expect = expect_default;
@@ -252,7 +261,7 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
         }
     } else {
         send_stream_error(conn, stream->stream_id, H2O_HTTP2_ERROR_ENHANCE_YOUR_CALM);
-        h2o_http2_stream_close(conn, stream);
+        h2o_http2_stream_reset(conn, stream);
     }
 
     return 0;

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -221,26 +221,28 @@ static struct st_h2o_hpack_header_table_entry_t *header_table_add(h2o_hpack_head
 }
 
 static int decode_header(h2o_mem_pool_t *pool, struct st_h2o_decode_header_result_t *result,
-                         h2o_hpack_header_table_t *hpack_header_table, const uint8_t **const src, const uint8_t *src_end)
+                         h2o_hpack_header_table_t *hpack_header_table, const uint8_t **const src, const uint8_t *src_end,
+                         const char **err_desc)
 {
     int32_t index = 0;
     int value_is_indexed = 0, do_index = 0;
 
+Redo:
     if (*src == src_end)
-        return -1;
+        return H2O_HTTP2_ERROR_COMPRESSION;
 
     /* determine the mode and handle accordingly */
     if (**src >= 128) {
         /* indexed header field representation */
         if ((index = decode_int(src, src_end, 7)) <= 0)
-            return -1;
+            return H2O_HTTP2_ERROR_COMPRESSION;
         value_is_indexed = 1;
     } else if (**src >= 64) {
         /* literal header field with incremental handling */
         if (**src == 64) {
             ++*src;
         } else if ((index = decode_int(src, src_end, 6)) <= 0) {
-            return -1;
+            return H2O_HTTP2_ERROR_COMPRESSION;
         }
         do_index = 1;
     } else if (**src < 32) {
@@ -248,21 +250,22 @@ static int decode_header(h2o_mem_pool_t *pool, struct st_h2o_decode_header_resul
         if ((**src & 0xf) == 0) {
             ++*src;
         } else if ((index = decode_int(src, src_end, 4)) <= 0) {
-            return -1;
+            return H2O_HTTP2_ERROR_COMPRESSION;
         }
     } else {
         /* size update */
-        if ((index = decode_int(src, src_end, 5)) < 0) {
-            return -1;
+        int new_apacity;
+        if ((new_apacity = decode_int(src, src_end, 5)) < 0) {
+            return H2O_HTTP2_ERROR_COMPRESSION;
         }
-        if (index > hpack_header_table->hpack_max_capacity) {
-            return -1;
+        if (new_apacity > hpack_header_table->hpack_max_capacity) {
+            return H2O_HTTP2_ERROR_COMPRESSION;
         }
-        hpack_header_table->hpack_capacity = index;
+        hpack_header_table->hpack_capacity = new_apacity;
         while (hpack_header_table->num_entries != 0 && hpack_header_table->hpack_size > hpack_header_table->hpack_capacity) {
             header_table_evict_one(hpack_header_table);
         }
-        return -2;
+        goto Redo;
     }
 
     /* determine the header */
@@ -283,13 +286,13 @@ static int decode_header(h2o_mem_pool_t *pool, struct st_h2o_decode_header_resul
                 h2o_mem_link_shared(pool, result->value);
             }
         } else {
-            return -1;
+            return H2O_HTTP2_ERROR_COMPRESSION;
         }
     } else {
         /* non-existing name */
         const h2o_token_t *name_token;
         if ((result->name = decode_string(pool, src, src_end)) == NULL)
-            return -1;
+            return H2O_HTTP2_ERROR_COMPRESSION;
         /* predefined header names should be interned */
         if ((name_token = h2o_lookup_token(result->name->base, result->name->len)) != NULL)
             result->name = (h2o_iovec_t *)&name_token->buf;
@@ -298,7 +301,7 @@ static int decode_header(h2o_mem_pool_t *pool, struct st_h2o_decode_header_resul
     /* determine the value (if necessary) */
     if (!value_is_indexed) {
         if ((result->value = decode_string(pool, src, src_end)) == NULL)
-            return -1;
+            return H2O_HTTP2_ERROR_COMPRESSION;
     }
 
     /* add the decoded header to the header table if necessary */
@@ -365,19 +368,18 @@ void h2o_hpack_dispose_header_table(h2o_hpack_header_table_t *header_table)
     free(header_table->entries);
 }
 
-int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_table, const uint8_t *src, size_t len)
+int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_table, const uint8_t *src, size_t len,
+                            const char **err_desc, int *err_is_stream_level)
 {
     const uint8_t *src_end = src + len;
     int allow_pseudo = 1;
 
     while (src != src_end) {
         struct st_h2o_decode_header_result_t r;
-        int ret = decode_header(&req->pool, &r, header_table, &src, src_end);
+        int ret = decode_header(&req->pool, &r, header_table, &src, src_end, err_desc);
         if (ret != 0) {
-            if (ret == -2)
-                continue; /* size update */
-            else
-                return -1;
+            *err_is_stream_level = 0;
+            return ret;
         }
         if (r.name->base[0] == ':') {
             if (allow_pseudo) {
@@ -385,25 +387,25 @@ int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_tab
                 if (r.name == &H2O_TOKEN_AUTHORITY->buf) {
                     /* FIXME should we perform this check? */
                     if (req->authority.base != NULL)
-                        return -1;
+                        goto StreamLevelProcotolError;
                     req->authority = *r.value;
                 } else if (r.name == &H2O_TOKEN_METHOD->buf) {
                     if (req->method.base != NULL)
-                        return -1;
+                        goto StreamLevelProcotolError;
                     req->method = *r.value;
                 } else if (r.name == &H2O_TOKEN_PATH->buf) {
                     if (req->path.base != NULL)
-                        return -1;
+                        goto StreamLevelProcotolError;
                     req->path = *r.value;
                 } else if (r.name == &H2O_TOKEN_SCHEME->buf) {
                     if (req->scheme.base != NULL)
-                        return -1;
+                        goto StreamLevelProcotolError;
                     req->scheme = *r.value;
                 } else {
-                    return -1;
+                    goto StreamLevelProcotolError;
                 }
             } else {
-                return -1;
+                goto StreamLevelProcotolError;
             }
         } else {
             allow_pseudo = 0;
@@ -412,8 +414,8 @@ int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_tab
                     /* ignore (draft 15 8.1.2.6 says: a server MAY send an HTTP response prior to closing or resetting the stream if
                      * content-length and the actual length differs) */
                 } else if (r.name == &H2O_TOKEN_TRANSFER_ENCODING->buf) {
-                    fprintf(stderr, "Transfer-Encoding is not supported in HTTP/2");
-                    return -1;
+                    /* Transfer-Encoding is not supported in HTTP/2 */
+                    goto StreamLevelProcotolError;
                 } else {
                     h2o_add_header(&req->pool, &req->headers, H2O_STRUCT_FROM_MEMBER(h2o_token_t, buf, r.name), r.value->base,
                                    r.value->len);
@@ -425,6 +427,10 @@ int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_tab
     }
 
     return 0;
+
+StreamLevelProcotolError:
+    *err_is_stream_level = 1;
+    return H2O_HTTP2_ERROR_PROTOCOL;
 }
 
 static uint8_t *encode_int(uint8_t *dst, uint32_t value, size_t prefix_bits)

--- a/misc/tokens.pl
+++ b/misc/tokens.pl
@@ -103,13 +103,13 @@ const h2o_token_t *h2o_lookup_token(const char *name, size_t len)
     switch (len) {
 ? for my $len (uniq sort { $a <=> $b } map { length $_->[0] } @$tokens) {
     case <?= $len ?>:
-        switch (h2o_tolower(name[<?= $len - 1 ?>])) {
+        switch (name[<?= $len - 1 ?>]) {
 ?  my @tokens_of_len = grep { length($_->[0]) == $len } @$tokens;
 ?  for my $end (uniq sort map { substr($_->[0], length($_->[0]) - 1) } @tokens_of_len) {
         case '<?= $end ?>':
 ?   my @tokens_of_end = grep { substr($_->[0], length($_->[0]) - 1) eq $end } @tokens_of_len;
 ?   for my $token (@tokens_of_end) {
-            if (h2o__lcstris_core(name, "<?= substr($token->[0], 0, length($token->[0]) - 1) ?>", <?= length($token->[0]) - 1 ?>))
+            if (memcmp(name, "<?= substr($token->[0], 0, length($token->[0]) - 1) ?>", <?= length($token->[0]) - 1 ?>) == 0)
                 return <?= normalize_name($token->[0]) ?>;
 ?   }
             break;

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -27,7 +27,8 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     h2o_hpack_header_table_t header_table;
     h2o_req_t req;
     h2o_iovec_t in;
-    int r;
+    int r, err_is_stream_level;
+    const char *err_desc;
 
     memset(&header_table, 0, sizeof(header_table));
     header_table.hpack_capacity = 4096;
@@ -35,7 +36,7 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     memset(&req, 0, sizeof(req));
     h2o_mem_init_pool(&req.pool);
     in = first_req;
-    r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len);
+    r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len, &err_desc, &err_is_stream_level);
     ok(r == 0);
     ok(req.authority.len == 15);
     ok(memcmp(req.authority.base, H2O_STRLIT("www.example.com")) == 0);
@@ -52,7 +53,7 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     memset(&req, 0, sizeof(req));
     h2o_mem_init_pool(&req.pool);
     in = second_req;
-    r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len);
+    r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len, &err_desc, &err_is_stream_level);
     ok(r == 0);
     ok(req.authority.len == 15);
     ok(memcmp(req.authority.base, H2O_STRLIT("www.example.com")) == 0);
@@ -71,7 +72,7 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     memset(&req, 0, sizeof(req));
     h2o_mem_init_pool(&req.pool);
     in = third_req;
-    r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len);
+    r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len, &err_desc, &err_is_stream_level);
     ok(r == 0);
     ok(req.authority.len == 15);
     ok(memcmp(req.authority.base, H2O_STRLIT("www.example.com")) == 0);
@@ -107,6 +108,8 @@ static void check_flatten(h2o_hpack_header_table_t *header_table, h2o_res_t *res
 void test_lib__http2__hpack(void)
 {
     h2o_mem_pool_t pool;
+    const char *err_desc;
+
     h2o_mem_init_pool(&pool);
 
     note("decode_int");
@@ -158,7 +161,7 @@ void test_lib__http2__hpack(void)
         in = h2o_iovec_init(
             H2O_STRLIT("\x40\x0a\x63\x75\x73\x74\x6f\x6d\x2d\x6b\x65\x79\x0d\x63\x75\x73\x74\x6f\x6d\x2d\x68\x65\x61\x64\x65\x72"));
         const uint8_t *p = (const uint8_t *)in.base;
-        r = decode_header(&pool, &result, &header_table, &p, p + in.len);
+        r = decode_header(&pool, &result, &header_table, &p, p + in.len, &err_desc);
         ok(r == 0);
         ok(result.name->len == 10);
         ok(strcmp(result.name->base, "custom-key") == 0);
@@ -179,7 +182,7 @@ void test_lib__http2__hpack(void)
         header_table.hpack_capacity = 4096;
         in = h2o_iovec_init(H2O_STRLIT("\x04\x0c\x2f\x73\x61\x6d\x70\x6c\x65\x2f\x70\x61\x74\x68"));
         const uint8_t *p = (const uint8_t *)in.base;
-        r = decode_header(&pool, &result, &header_table, &p, p + in.len);
+        r = decode_header(&pool, &result, &header_table, &p, p + in.len, &err_desc);
         ok(r == 0);
         ok(result.name == &H2O_TOKEN_PATH->buf);
         ok(result.value->len == 12);
@@ -199,7 +202,7 @@ void test_lib__http2__hpack(void)
         header_table.hpack_capacity = 4096;
         in = h2o_iovec_init(H2O_STRLIT("\x10\x08\x70\x61\x73\x73\x77\x6f\x72\x64\x06\x73\x65\x63\x72\x65\x74"));
         const uint8_t *p = (const uint8_t *)in.base;
-        r = decode_header(&pool, &result, &header_table, &p, p + in.len);
+        r = decode_header(&pool, &result, &header_table, &p, p + in.len, &err_desc);
         ok(r == 0);
         ok(result.name->len == 8);
         ok(strcmp(result.name->base, "password") == 0);
@@ -220,7 +223,7 @@ void test_lib__http2__hpack(void)
         header_table.hpack_capacity = 4096;
         in = h2o_iovec_init(H2O_STRLIT("\x82"));
         const uint8_t *p = (const uint8_t *)in.base;
-        r = decode_header(&pool, &result, &header_table, &p, p + in.len);
+        r = decode_header(&pool, &result, &header_table, &p, p + in.len, &err_desc);
         ok(r == 0);
         ok(result.name == &H2O_TOKEN_METHOD->buf);
         ok(result.value->len == 3);

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -63,7 +63,7 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     ok(req.scheme.len == 4);
     ok(memcmp(req.scheme.base, H2O_STRLIT("http")) == 0);
     ok(req.headers.size == 1);
-    ok(h2o_lcstris(req.headers.entries[0].name->base, req.headers.entries[0].name->len, H2O_STRLIT("cache-control")));
+    ok(h2o_memis(req.headers.entries[0].name->base, req.headers.entries[0].name->len, H2O_STRLIT("cache-control")));
     ok(h2o_lcstris(req.headers.entries[0].value.base, req.headers.entries[0].value.len, H2O_STRLIT("no-cache")));
 
     h2o_mem_clear_pool(&req.pool);
@@ -82,7 +82,7 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     ok(req.scheme.len == 5);
     ok(memcmp(req.scheme.base, H2O_STRLIT("https")) == 0);
     ok(req.headers.size == 1);
-    ok(h2o_lcstris(req.headers.entries[0].name->base, req.headers.entries[0].name->len, H2O_STRLIT("custom-key")));
+    ok(h2o_memis(req.headers.entries[0].name->base, req.headers.entries[0].name->len, H2O_STRLIT("custom-key")));
     ok(h2o_lcstris(req.headers.entries[0].value.base, req.headers.entries[0].value.len, H2O_STRLIT("custom-value")));
 
     h2o_hpack_dispose_header_table(&header_table);


### PR DESCRIPTION
Considering the fact that [HTTP2 spec. states that header names must be lower-cased](http://http2.github.io/http2-spec/#rfc.section.8.1.2), for simplicity and performance we should better use lower-cased names internally.