### PR TITLE
Send remote address, used protocol and incoming host header to upstream

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -762,6 +762,7 @@ void h2o_file_register_configurator(h2o_globalconf_t *conf);
 typedef struct st_h2o_proxy_config_vars_t {
     uint64_t io_timeout;
     int use_keepalive;
+    int preserve_host;
     uint64_t keepalive_timeout;
 } h2o_proxy_config_vars_t;
 
@@ -774,12 +775,12 @@ typedef struct st_h2o_proxy_location_t {
 /**
  * delegates the request to given server, rewriting the path as specified
  */
-int h2o_proxy_send(h2o_req_t *req, h2o_http1client_ctx_t *client_ctx, h2o_proxy_location_t *upstream);
+int h2o_proxy_send(h2o_req_t *req, h2o_http1client_ctx_t *client_ctx, h2o_proxy_location_t *upstream, int preserve_host);
 /**
  * delegates the request to given server, rewriting the path as specified
  */
 int h2o_proxy_send_with_pool(h2o_req_t *req, h2o_http1client_ctx_t *client_ctx, h2o_proxy_location_t *upstream,
-                             h2o_socketpool_t *sockpool);
+                             h2o_socketpool_t *sockpool, int preserve_host);
 /**
  * registers the reverse proxy handler to the context
  */

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -51,6 +51,16 @@ static int on_config_keepalive(h2o_configurator_command_t *cmd, h2o_configurator
     return 0;
 }
 
+static int on_config_preserve_host(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct proxy_configurator_t *self = (void *)cmd->configurator;
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    self->vars->preserve_host = (int)ret;
+    return 0;
+}
+
 static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
@@ -118,6 +128,11 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
                                         H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_keepalive, "boolean flag (ON/OFF) indicating whether or not to use persistent\n"
                                                          "connections to upstream (default: OFF)");
+    h2o_configurator_define_command(&c->super, "proxy.preserve_host",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_preserve_host, "boolean flag (ON/OFF) indicating whether or not to pass Host header\n"
+                                                         "from imcoming request to upstream (default: OFF)");
     h2o_configurator_define_command(&c->super, "proxy.timeout.io",
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
                                         H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,


### PR DESCRIPTION
I added the following functions in order to pass some information about the original request to a upstream server.

- add X-Forwarded-For and X-Forwarded-Proto to request header.
- add proxy.preserve_host directive. To send Host header from client to upstream

X-Forwarded-For and X-Forwarded-Proto are de-facto standard for identifying the original request. Many application servers and middlewares support these header.
