### PR TITLE
Mark functions either noreturn or returns_nonnull

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -34,13 +34,23 @@ extern "C" {
 
 #define H2O_STRUCT_FROM_MEMBER(s, m, p) ((s *)((char *)(p)-offsetof(s, m)))
 
-#if defined(__clang__) || defined(__GNUC__) && (__GNUC__ > 2 || __GNUC__ == 2 && __GNUC_MINOR__ >= 5)
+#ifdef __GNUC__
+#define H2O_GNUC_VERSION (__GNUC__ << 16) | (__GNUC__MINOR__ << 8) | __GNUC_PATCHLEVEL__
+#else
+#define H2O_GNUC_VERSION 0
+#endif
+
+#if __STDC_VERSION__ >= 201112L
+#define H2O_NORETURN _Noreturn
+#elif defined(__clang__) || defined(__GNUC__) && H2O_GNUC_VERSION >= 0x20500
+// noreturn was not defined before gcc 2.5
 #define H2O_NORETURN __attribute__((noreturn))
 #else
 #define H2O_NORETURN
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if !defined(__clang__) && defined(__GNUC__) && H2O_GNUC_VERSION >= 0x40802
+// returns_nonnull was seemingly not defined before gcc 4.8.2
 #define H2O_RETURNS_NONNULL __attribute__((returns_nonnull))
 #else
 #define H2O_RETURNS_NONNULL

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -35,7 +35,7 @@ extern "C" {
 #define H2O_STRUCT_FROM_MEMBER(s, m, p) ((s *)((char *)(p)-offsetof(s, m)))
 
 #ifdef __GNUC__
-#define H2O_GNUC_VERSION (__GNUC__ << 16) | (__GNUC__MINOR__ << 8) | __GNUC_PATCHLEVEL__
+#define H2O_GNUC_VERSION ((__GNUC__ << 16) | (__GNUC__MINOR__ << 8) | __GNUC_PATCHLEVEL__)
 #else
 #define H2O_GNUC_VERSION 0
 #endif

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -34,6 +34,18 @@ extern "C" {
 
 #define H2O_STRUCT_FROM_MEMBER(s, m, p) ((s *)((char *)(p)-offsetof(s, m)))
 
+#if defined(__clang__) || defined(__GNUC__) && (__GNUC__ > 2 || __GNUC__ == 2 && __GNUC_MINOR__ >= 5)
+#define H2O_NORETURN __attribute__((noreturn))
+#else
+#define H2O_NORETURN
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#define H2O_RETURNS_NONNULL __attribute__((returns_nonnull))
+#else
+#define H2O_RETURNS_NONNULL
+#endif
+
 typedef struct st_h2o_buffer_prototype_t h2o_buffer_prototype_t;
 
 /**
@@ -116,7 +128,7 @@ typedef H2O_VECTOR(void) h2o_vector_t;
 /**
  * prints an error message and aborts
  */
-void h2o_fatal(const char *msg);
+H2O_NORETURN void h2o_fatal(const char *msg);
 
 /**
  * constructor for h2o_iovec_t
@@ -125,7 +137,7 @@ static h2o_iovec_t h2o_iovec_init(const void *base, size_t len);
 /**
  * wrapper of malloc; allocates given size of memory or dies if impossible
  */
-static void *h2o_mem_alloc(size_t sz);
+H2O_RETURNS_NONNULL static void *h2o_mem_alloc(size_t sz);
 /**
  * warpper of realloc; reallocs the given chunk or dies if impossible
  */


### PR DESCRIPTION
to silence 4 null pointer warnings from static
analysis #107

Also, `_Noreturn` [seems to be](http://stackoverflow.com/a/21646860/1027966) part of C11, and [MSVS has](http://msdn.microsoft.com/en-us/library/k6ktzx3s.aspx) `__declspec(noreturn)`. Not sure we want C11 features or if the M$ thing id C++ only?  Closing #108 in favor of this.