### PR TITLE
Do not send Vary header if the client is MSIE

### DIFF
--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -88,6 +88,10 @@ void h2o_time2str_log(char *buf, time_t time);
  */
 const char *h2o_get_filext(const char *path, size_t len);
 /**
+ * returns the offset of given substring or SIZE_MAX if not found
+ */
+size_t h2o_strstr(const char *haysack, size_t haysack_len, const char *needle, size_t needle_len);
+/**
  *
  */
 const char *h2o_next_token(const char *elements, size_t elements_len, size_t *element_len, const char *cur);

--- a/lib/common/string.c
+++ b/lib/common/string.c
@@ -311,6 +311,20 @@ const char *h2o_get_filext(const char *path, size_t len)
     return NULL;
 }
 
+size_t h2o_strstr(const char *haysack, size_t haysack_len, const char *needle, size_t needle_len)
+{
+    /* TODO optimize */
+    if (haysack_len >= needle_len) {
+        size_t off, max = haysack_len - needle_len;
+        if (needle_len == 0)
+            return 0;
+        for (off = 0; off != max; ++off)
+            if (haysack[off] == needle[0] && memcmp(haysack + off + 1, needle + 1, needle_len - 1) == 0)
+                return off;
+    }
+    return SIZE_MAX;
+}
+
 /* note: returns a zero-width match as well */
 const char *h2o_next_token(const char *elements, size_t elements_len, size_t *element_len, const char *cur)
 {

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -55,7 +55,8 @@ static int is_msie(h2o_req_t *req)
     ssize_t cursor = h2o_find_header(&req->headers, H2O_TOKEN_USER_AGENT, -1);
     if (cursor == -1)
         return 0;
-    if (h2o_strstr(req->headers.entries[cursor].value.base, req->headers.entries[cursor].value.len, H2O_STRLIT("; MSIE ")) == SIZE_MAX)
+    if (h2o_strstr(req->headers.entries[cursor].value.base, req->headers.entries[cursor].value.len, H2O_STRLIT("; MSIE ")) ==
+        SIZE_MAX)
         return 0;
     return 1;
 }
@@ -542,7 +543,7 @@ static size_t flatten_headers(char *buf, h2o_req_t *req, const char *connection)
                  * - https://www.igvita.com/2013/05/01/deploying-webp-via-accept-content-negotiation/
                  */
                 if (is_msie(req)) {
-                    static h2o_header_t cache_control_private = { &H2O_TOKEN_CACHE_CONTROL->buf, { H2O_STRLIT("private") } };
+                    static h2o_header_t cache_control_private = {&H2O_TOKEN_CACHE_CONTROL->buf, {H2O_STRLIT("private")}};
                     header = &cache_control_private;
                 }
             }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -50,6 +50,16 @@ static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb
 static void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final);
 static void reqread_on_read(h2o_socket_t *sock, int status);
 
+static int is_msie(h2o_req_t *req)
+{
+    ssize_t cursor = h2o_find_header(&req->headers, H2O_TOKEN_USER_AGENT, -1);
+    if (cursor == -1)
+        return 0;
+    if (h2o_strstr(req->headers.entries[cursor].value.base, req->headers.entries[cursor].value.len, H2O_STRLIT("; MSIE ")) == SIZE_MAX)
+        return 0;
+    return 1;
+}
+
 static void init_request(h2o_http1_conn_t *conn, int reinit)
 {
     if (reinit)
@@ -493,7 +503,7 @@ static size_t flatten_headers_estimate_size(h2o_req_t *req, size_t server_name_a
 {
     size_t len = sizeof("HTTP/1.1  \r\ndate: \r\nserver: \r\nconnection: \r\ncontent-length: \r\n\r\n") + 3 +
                  strlen(req->res.reason) + H2O_TIMESTR_RFC1123_LEN + server_name_and_connection_len +
-                 sizeof("18446744073709551615") - 1;
+                 sizeof("18446744073709551615") - 1 + sizeof("cache-control: private") - 1;
     const h2o_header_t *header, *end;
 
     for (header = req->res.headers.entries, end = header + req->res.headers.size; header != end; ++header)
@@ -523,8 +533,19 @@ static size_t flatten_headers(char *buf, h2o_req_t *req, const char *connection)
     }
 
     { /* flatten the normal headers */
-        const h2o_header_t *header = req->res.headers.entries, *end = header + req->res.headers.size;
-        for (; header != end; ++header) {
+        size_t i;
+        for (i = 0; i != req->res.headers.size; ++i) {
+            const h2o_header_t *header = req->res.headers.entries + i;
+            if (header->name == &H2O_TOKEN_VARY->buf) {
+                /* replace Vary with Cache-Control: private; see the following URLs to understand why this is necessary
+                 * - http://blogs.msdn.com/b/ieinternals/archive/2009/06/17/vary-header-prevents-caching-in-ie.aspx
+                 * - https://www.igvita.com/2013/05/01/deploying-webp-via-accept-content-negotiation/
+                 */
+                if (is_msie(req)) {
+                    static h2o_header_t cache_control_private = { &H2O_TOKEN_CACHE_CONTROL->buf, { H2O_STRLIT("private") } };
+                    header = &cache_control_private;
+                }
+            }
             memcpy(dst, header->name->base, header->name->len);
             dst += header->name->len;
             *dst++ = ':';

--- a/t/50file-config.t
+++ b/t/50file-config.t
@@ -68,6 +68,21 @@ EOT
     $doit->("ON", q{--header "Accept-Encoding: gzip, deflate"}, $gz_len);
     $doit->("ON", q{--header "Accept-Encoding: deflate, gzip"}, $gz_len);
     $doit->("ON", q{--header "Accept-Encoding: deflate"}, $orig_len);
+
+    subtest 'MSIE-workaround' => sub {
+        my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir:       t/assets/doc_root
+        file.send-gzip: ON
+EOT
+        my $resp = `curl --silent --dump-header /dev/stderr --user-agent "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)" --header "Accept-Encoding: gzip" http://127.0.0.1:$server->{port}/ 2>&1 > /dev/null`;
+        like $resp, qr/^content-length:\s*$gz_len\r$/im, "length is as expected";
+        like $resp, qr/^cache-control:.*private.*\r$/im, "cache-control: private";
+        unlike $resp, qr/^vary:/im, "no vary";
+    };
 };
 
 subtest 'dir-listing' => sub {


### PR DESCRIPTION
source:
- https://www.igvita.com/2013/05/01/deploying-webp-via-accept-content-negotiation/
- http://blogs.msdn.com/b/ieinternals/archive/2009/06/17/vary-header-prevents-caching-in-ie.aspx
- http://blogs.msdn.com/b/ie/archive/2010/07/14/caching-improvements-in-internet-explorer-9.aspx