### PR TITLE
gracefully shutdown on SIGTERM

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -248,6 +248,10 @@ struct st_h2o_context_t {
      * pointer to the global configuration
      */
     h2o_globalconf_t *globalconf;
+    /**
+     * flag indicating if shutdown has been requested
+     */
+    int shutdown_requested;
 
     struct {
         /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -265,6 +265,10 @@ struct st_h2o_context_t {
          * idle timeout
          */
         h2o_timeout_t idle_timeout;
+        /**
+         * link-list of h2o_http2_conn_t
+         */
+        h2o_linklist_t _conns;
     } http2;
 
     /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -183,6 +183,10 @@ struct st_h2o_hostconf_t {
     h2o_pathconf_t fallback_path;
 };
 
+typedef struct st_h2o_protocol_callbacks_t {
+    void (*request_shutdown)(h2o_context_t *ctx);
+} h2o_protocol_callbacks_t;
+
 struct st_h2o_globalconf_t {
     /**
      * list of host contexts (h2o_hostconf_t)
@@ -210,6 +214,10 @@ struct st_h2o_globalconf_t {
          * a boolean value indicating whether or not to upgrade to HTTP/2
          */
         int upgrade_to_http2;
+        /**
+         * list of callbacks
+         */
+        h2o_protocol_callbacks_t callbacks;
     } http1;
 
     struct {
@@ -227,6 +235,10 @@ struct st_h2o_globalconf_t {
          * maximum nuber of streams (per connection) to be allowed in IDLE / CLOSED state (used for tracking dependencies).
          */
         size_t max_streams_for_priority;
+        /**
+         * list of callbacks
+         */
+        h2o_protocol_callbacks_t callbacks;
     } http2;
 
     size_t _num_config_slots;
@@ -244,6 +256,10 @@ struct st_h2o_context_t {
      * timeout structure to be used for registering deferred callbacks
      */
     h2o_timeout_t zero_timeout;
+    /**
+     * timeout structure to be used for registering 1-second timeout callbacks
+     */
+    h2o_timeout_t one_sec_timeout;
     /**
      * pointer to the global configuration
      */
@@ -269,6 +285,10 @@ struct st_h2o_context_t {
          * link-list of h2o_http2_conn_t
          */
         h2o_linklist_t _conns;
+        /**
+         * timeout entry used for graceful shutdown
+         */
+        h2o_timeout_entry_t _graceful_shutdown_timeout;
     } http2;
 
     /**
@@ -636,6 +656,10 @@ void h2o_context_init(h2o_context_t *context, h2o_loop_t *loop, h2o_globalconf_t
  * disposes of the resources allocated for the context
  */
 void h2o_context_dispose(h2o_context_t *context);
+/**
+ * requests shutdown to the connections governed by the context
+ */
+void h2o_context_request_shutdown(h2o_context_t *context);
 /**
  * returns current timestamp
  * @param ctx the context

--- a/include/h2o/http1.h
+++ b/include/h2o/http1.h
@@ -29,6 +29,8 @@ extern "C" {
 typedef struct st_h2o_http1_conn_t h2o_http1_conn_t;
 typedef void (*h2o_http1_upgrade_cb)(void *user_data, h2o_socket_t *sock, size_t reqsize);
 
+extern const h2o_protocol_callbacks_t H2O_HTTP1_CALLBACKS;
+
 typedef struct st_h2o_http1_finalostream_t {
     h2o_ostream_t super;
     int sent_headers;

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -36,6 +36,8 @@ typedef struct st_h2o_http2_stream_t h2o_http2_stream_t;
 extern const char *h2o_http2_npn_protocols;
 extern const h2o_iovec_t *h2o_http2_alpn_protocols;
 
+extern const h2o_protocol_callbacks_t H2O_HTTP2_CALLBACKS;
+
 /* connection flow control window + alpha */
 #define H2O_HTTP2_DEFAULT_OUTBUF_SIZE 81920
 
@@ -204,7 +206,11 @@ struct st_h2o_http2_stream_t {
 
 KHASH_MAP_INIT_INT64(h2o_http2_stream_t, h2o_http2_stream_t *)
 
-typedef enum enum_h2o_http2_conn_state_t { H2O_HTTP2_CONN_STATE_OPEN, H2O_HTTP2_CONN_STATE_IS_CLOSING } h2o_http2_conn_state_t;
+typedef enum enum_h2o_http2_conn_state_t {
+    H2O_HTTP2_CONN_STATE_OPEN,        /* accepting new connections */
+    H2O_HTTP2_CONN_STATE_HALF_CLOSED, /* no more accepting new streams */
+    H2O_HTTP2_CONN_STATE_IS_CLOSING   /* nothing should be sent */
+} h2o_http2_conn_state_t;
 
 struct st_h2o_http2_conn_t {
     h2o_conn_t super;

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -220,6 +220,7 @@ struct st_h2o_http2_conn_t {
     /* internal */
     h2o_http2_scheduler_node_t scheduler;
     h2o_http2_conn_state_t state;
+    h2o_linklist_t _conns; /* linklist to h2o_context_t::http2._conns */
     ssize_t (*_read_expect)(h2o_http2_conn_t *conn, const uint8_t *src, size_t len, const char **err_desc);
     h2o_buffer_t *_http1_req_input; /* contains data referred to by original request via HTTP/1.1 */
     h2o_hpack_header_table_t _input_header_table;

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include "h2o.h"
 #include "h2o/configurator.h"
+#include "h2o/http1.h"
 #include "h2o/http2.h"
 
 static void init_pathconf(h2o_pathconf_t *pathconf, h2o_hostconf_t *hostconf)
@@ -81,9 +82,11 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->max_request_entity_size = H2O_DEFAULT_MAX_REQUEST_ENTITY_SIZE;
     config->http1.req_timeout = H2O_DEFAULT_HTTP1_REQ_TIMEOUT;
     config->http1.upgrade_to_http2 = H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2;
+    config->http1.callbacks = H2O_HTTP1_CALLBACKS;
     config->http2.idle_timeout = H2O_DEFAULT_HTTP2_IDLE_TIMEOUT;
     config->http2.max_concurrent_requests_per_connection = H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams;
     config->http2.max_streams_for_priority = 16;
+    config->http2.callbacks = H2O_HTTP2_CALLBACKS;
 
     h2o_configurator__init_core(config);
 }

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -74,6 +74,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     h2o_timeout_init(ctx->loop, &ctx->zero_timeout, 0);
     h2o_timeout_init(ctx->loop, &ctx->http1.req_timeout, config->http1.req_timeout);
     h2o_timeout_init(ctx->loop, &ctx->http2.idle_timeout, config->http2.idle_timeout);
+    h2o_linklist_init_anchor(&ctx->http2._conns);
 
     ctx->_module_configs = h2o_mem_alloc(sizeof(*ctx->_module_configs) * config->_num_config_slots);
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);
@@ -107,6 +108,7 @@ void h2o_context_dispose(h2o_context_t *ctx)
     h2o_timeout_dispose(ctx->loop, &ctx->zero_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http1.req_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http2.idle_timeout);
+    /* what should we do here? assert(!h2o_linklist_is_empty(&ctx->http2._conns); */
 
 #if H2O_USE_LIBUV
     /* make sure the handles released by h2o_timeout_dispose get freed */

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -50,6 +50,10 @@ static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb
 static void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final);
 static void reqread_on_read(h2o_socket_t *sock, int status);
 
+const h2o_protocol_callbacks_t H2O_HTTP1_CALLBACKS = {
+    NULL /* graceful_shutdown (note: nothing special needs to be done for handling graceful shutdown) */
+};
+
 static int is_msie(h2o_req_t *req)
 {
     ssize_t cursor = h2o_find_header(&req->headers, H2O_TOKEN_USER_AGENT, -1);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -321,6 +321,9 @@ static ssize_t fixup_request(h2o_http1_conn_t *conn, struct phr_header *headers,
         /* defaults to keep-alive if >= HTTP/1.1 */
         conn->req.http1_is_persistent = 1;
     }
+    /* disable keep-alive if shutdown is requested */
+    if (conn->req.http1_is_persistent && conn->super.ctx->shutdown_requested)
+        conn->req.http1_is_persistent = 0;
 
     return entity_header_index;
 }

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -199,6 +199,7 @@ static void close_connection_now(h2o_http2_conn_t *conn)
     h2o_http2_scheduler_dispose(&conn->scheduler);
     assert(h2o_linklist_is_empty(&conn->_write.streams_to_proceed));
     assert(!h2o_timeout_is_linked(&conn->_write.timeout_entry));
+    h2o_linklist_unlink(&conn->_conns);
 
     h2o_socket_close(conn->sock);
     free(conn);
@@ -901,6 +902,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_socket_t *sock, str
     conn->peer_settings = H2O_HTTP2_SETTINGS_DEFAULT;
     conn->open_streams = kh_init(h2o_http2_stream_t);
     conn->state = H2O_HTTP2_CONN_STATE_OPEN;
+    h2o_linklist_insert(&ctx->http2._conns, &conn->_conns);
     conn->_read_expect = expect_preface;
     conn->_input_header_table.hpack_capacity = conn->_input_header_table.hpack_max_capacity =
         H2O_HTTP2_SETTINGS_DEFAULT.header_table_size;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -66,23 +66,69 @@ static const h2o_iovec_t SETTINGS_HOST_BIN = {H2O_STRLIT("\x00\x00\x12"     /* f
 
 static __thread h2o_buffer_prototype_t wbuf_buffer_prototype = {{16}, {H2O_HTTP2_DEFAULT_OUTBUF_SIZE}};
 
+static void initiate_graceful_shutdown(h2o_context_t *ctx);
+static void close_connection(h2o_http2_conn_t *conn);
 static void send_stream_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum);
 static ssize_t expect_default(h2o_http2_conn_t *conn, const uint8_t *src, size_t len, const char **err_desc);
 static int do_emit_writereq(h2o_http2_conn_t *conn);
 static void on_read(h2o_socket_t *sock, int status);
 
-static void enqueue_goaway_and_initiate_close(h2o_http2_conn_t *conn, int errnum, h2o_iovec_t additional_data)
+const h2o_protocol_callbacks_t H2O_HTTP2_CALLBACKS = { initiate_graceful_shutdown };
+
+static void enqueue_goaway(h2o_http2_conn_t *conn, int errnum, h2o_iovec_t additional_data)
 {
-    h2o_http2_encode_goaway_frame(&conn->_write.buf, conn->max_processed_stream_id, -errnum, additional_data);
-    h2o_http2_conn_request_write(conn);
-    conn->state = H2O_HTTP2_CONN_STATE_IS_CLOSING;
+    if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING) {
+        /* http2 spec allows sending GOAWAY more than once (for one reason since errors may arise after sending the first one) */
+        h2o_http2_encode_goaway_frame(&conn->_write.buf, conn->max_open_stream_id, errnum, additional_data);
+        h2o_http2_conn_request_write(conn);
+        conn->state = H2O_HTTP2_CONN_STATE_HALF_CLOSED;
+    }
+}
+
+static void graceful_shutdown_resend_goaway(h2o_timeout_entry_t *entry)
+{
+    h2o_context_t *ctx = H2O_STRUCT_FROM_MEMBER(h2o_context_t, http2._graceful_shutdown_timeout, entry);
+    h2o_linklist_t *node;
+
+    for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = node->next) {
+        h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
+        if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED)
+            enqueue_goaway(conn, H2O_HTTP2_ERROR_NONE, (h2o_iovec_t){});
+    }
+}
+
+static void initiate_graceful_shutdown(h2o_context_t *ctx)
+{
+    /* draft-16 6.8
+     * A server that is attempting to gracefully shut down a connection SHOULD send an initial GOAWAY frame with the last stream
+     * identifier set to 231-1 and a NO_ERROR code. This signals to the client that a shutdown is imminent and that no further
+     * requests can be initiated. After waiting at least one round trip time, the server can send another GOAWAY frame with an
+     * updated last stream identifier. This ensures that a connection can be cleanly shut down without losing requests.
+     */
+    h2o_linklist_t *node;
+
+    /* only doit once */
+    if (ctx->http2._graceful_shutdown_timeout.cb != NULL)
+        return;
+    ctx->http2._graceful_shutdown_timeout.cb = graceful_shutdown_resend_goaway;
+
+    for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = node->next) {
+        h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
+        if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED) {
+            h2o_http2_encode_goaway_frame(&conn->_write.buf, INT32_MAX, H2O_HTTP2_ERROR_NONE,
+                                          (h2o_iovec_t){H2O_STRLIT("graceful shutdown")});
+            h2o_http2_conn_request_write(conn);
+        }
+    }
+    h2o_timeout_link(ctx->loop, &ctx->one_sec_timeout, &ctx->http2._graceful_shutdown_timeout);
 }
 
 static void on_idle_timeout(h2o_timeout_entry_t *entry)
 {
     h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _timeout_entry, entry);
 
-    enqueue_goaway_and_initiate_close(conn, H2O_HTTP2_ERROR_INTERNAL, h2o_iovec_init(H2O_STRLIT("idle timeout")));
+    enqueue_goaway(conn, H2O_HTTP2_ERROR_NONE, h2o_iovec_init(H2O_STRLIT("idle timeout")));
+    close_connection(conn);
 }
 
 static void update_idle_timeout(h2o_http2_conn_t *conn)
@@ -174,7 +220,7 @@ void h2o_http2_conn_unregister_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t
         break;
     }
 
-    if (conn->state != H2O_HTTP2_CONN_STATE_IS_CLOSING) {
+    if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING) {
         run_pending_requests(conn);
         update_idle_timeout(conn);
     }
@@ -205,7 +251,7 @@ static void close_connection_now(h2o_http2_conn_t *conn)
     free(conn);
 }
 
-static void close_connection(h2o_http2_conn_t *conn)
+void close_connection(h2o_http2_conn_t *conn)
 {
     conn->state = H2O_HTTP2_CONN_STATE_IS_CLOSING;
 
@@ -219,7 +265,7 @@ static void close_connection(h2o_http2_conn_t *conn)
 void send_stream_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum)
 {
     assert(stream_id != 0);
-    assert(conn->state != H2O_HTTP2_CONN_STATE_IS_CLOSING);
+    assert(conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING);
 
     h2o_http2_encode_rst_stream_frame(&conn->_write.buf, stream_id, -errnum);
     h2o_http2_conn_request_write(conn);
@@ -227,7 +273,7 @@ void send_stream_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum)
 
 static void request_gathered_write(h2o_http2_conn_t *conn)
 {
-    assert(conn->state != H2O_HTTP2_CONN_STATE_IS_CLOSING);
+    assert(conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING);
     if (conn->_write.buf_in_flight == NULL) {
         if (!h2o_timeout_is_linked(&conn->_write.timeout_entry))
             h2o_timeout_link(conn->super.ctx->loop, &conn->super.ctx->zero_timeout, &conn->_write.timeout_entry);
@@ -293,11 +339,14 @@ static ssize_t expect_continuation_of_headers(h2o_http2_conn_t *conn, const uint
 
     if ((ret = h2o_http2_decode_frame(&frame, src, len, &H2O_HTTP2_SETTINGS_HOST, err_desc)) < 0)
         return ret;
-
     if (frame.type != H2O_HTTP2_FRAME_TYPE_CONTINUATION) {
         *err_desc = "expected CONTINUATION frame";
         return H2O_HTTP2_ERROR_PROTOCOL;
     }
+
+    if (conn->state >= H2O_HTTP2_CONN_STATE_HALF_CLOSED)
+        return 0;
+
     if (frame.stream_id != conn->max_open_stream_id ||
         (stream = h2o_http2_conn_get_stream(conn, conn->max_open_stream_id)) == NULL ||
         stream->state != H2O_HTTP2_STREAM_STATE_RECV_HEADERS) {
@@ -389,6 +438,9 @@ static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, c
     if ((ret = h2o_http2_decode_data_payload(&payload, frame, err_desc)) != 0)
         return ret;
 
+    if (conn->state >= H2O_HTTP2_CONN_STATE_HALF_CLOSED)
+        return 0;
+
     stream = h2o_http2_conn_get_stream(conn, frame->stream_id);
 
     /* save the input in the request body buffer, or send error (and close the stream) */
@@ -443,6 +495,9 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
         *err_desc = "invalid stream id in HEADERS frame";
         return H2O_HTTP2_ERROR_PROTOCOL;
     }
+
+    if (conn->state >= H2O_HTTP2_CONN_STATE_HALF_CLOSED)
+        return 0;
 
     /* adjust state */
     conn->_read_expect = expect_continuation_of_headers;
@@ -706,7 +761,7 @@ static void parse_input(h2o_http2_conn_t *conn)
         perform_early_exit = 1;
 
     /* handle the input */
-    while (conn->state != H2O_HTTP2_CONN_STATE_IS_CLOSING && conn->sock->input->size != 0) {
+    while (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING && conn->sock->input->size != 0) {
         if (perform_early_exit == 1 && conn->num_responding_streams == http2_max_concurrent_requests_per_connection)
             goto EarlyExit;
         /* process a frame */
@@ -716,8 +771,8 @@ static void parse_input(h2o_http2_conn_t *conn)
             break;
         } else if (ret < 0) {
             if (ret != H2O_HTTP2_ERROR_PROTOCOL_CLOSE_IMMEDIATELY) {
-                enqueue_goaway_and_initiate_close(
-                    conn, (int)ret, err_desc != NULL ? (h2o_iovec_t){(char *)err_desc, strlen(err_desc)} : (h2o_iovec_t){});
+                enqueue_goaway(conn, (int)ret,
+                               err_desc != NULL ? (h2o_iovec_t){(char *)err_desc, strlen(err_desc)} : (h2o_iovec_t){});
             }
             close_connection(conn);
             return;
@@ -813,7 +868,7 @@ static void on_write_complete(h2o_socket_t *sock, int status)
     assert(conn->_write.buf_in_flight == NULL);
 
     /* call the proceed callback of the streams that have been flushed (while unlinking them from the list) */
-    if (status == 0 && conn->state == H2O_HTTP2_CONN_STATE_OPEN) {
+    if (status == 0 && conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING) {
         while (!h2o_linklist_is_empty(&conn->_write.streams_to_proceed)) {
             h2o_http2_stream_t *stream =
                 H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _refs.link, conn->_write.streams_to_proceed.next);
@@ -828,7 +883,15 @@ static void on_write_complete(h2o_socket_t *sock, int status)
         return;
 
     /* close the connection if necessary */
-    if (conn->state == H2O_HTTP2_CONN_STATE_IS_CLOSING) {
+    switch (conn->state) {
+    case H2O_HTTP2_CONN_STATE_OPEN:
+        break;
+    case H2O_HTTP2_CONN_STATE_HALF_CLOSED:
+        if (conn->num_responding_streams != 0)
+            break;
+        conn->state = H2O_HTTP2_CONN_STATE_IS_CLOSING;
+        /* fall-thru */
+    case H2O_HTTP2_CONN_STATE_IS_CLOSING:
         close_connection_now(conn);
         return;
     }
@@ -867,7 +930,7 @@ int do_emit_writereq(h2o_http2_conn_t *conn)
     assert(conn->_write.buf_in_flight == NULL);
 
     /* push DATA frames */
-    if (conn->state == H2O_HTTP2_CONN_STATE_OPEN && h2o_http2_conn_get_buffer_window(conn) > 0)
+    if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING && h2o_http2_conn_get_buffer_window(conn) > 0)
         h2o_http2_scheduler_run(&conn->scheduler, emit_writereq_of_openref, conn);
 
     if (conn->_write.buf->size == 0)

--- a/lib/http2/frame.c
+++ b/lib/http2/frame.c
@@ -98,7 +98,7 @@ void h2o_http2_encode_goaway_frame(h2o_buffer_t **buf, uint32_t last_stream_id, 
 {
     uint8_t *dst = allocate_frame(buf, 8 + additional_data.len, H2O_HTTP2_FRAME_TYPE_GOAWAY, 0, 0);
     dst = encode32u(dst, last_stream_id);
-    dst = encode32u(dst, errnum);
+    dst = encode32u(dst, (uint32_t)-errnum);
     memcpy(dst, additional_data.base, additional_data.len);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1039,11 +1039,12 @@ static void *run_loop(void *_unused)
         h2o_evloop_run(loop);
     }
 
-    /* shutdown requested, close the listeners and continue running the loop */
+    /* shutdown requested, close the listeners, notify the protocol handlers, and continue running the loop */
     for (i = 0; i != conf.num_listeners; ++i) {
         h2o_socket_close(listeners[i].sock);
         listeners[i].sock = NULL;
     }
+    h2o_context_request_shutdown(&ctx);
     while (1)
         h2o_evloop_run(loop);
 


### PR DESCRIPTION
The server should gracefully shutdown the connection and exit when receiving SIGTERM.

The PR is implemented as follows:
* core
 * the server immediately closes the listening sockets when receiving SIGTERM
 * the server exits with status code zero once all the connections get closed
* http1
 * after receiving SIGTERM, all the HTTP/1 responses will have `Connection: close` set
 * persistent connections will eventually get closed as the idle timeout expires or after handling the next request (since it would contain the `Connection: close` header)
* http2
 * GOAWAY (stream_id=INT32_MAX) is sent for every stream when SIGTERM is received
 * after one second, the server stops accepting new requests, and sends GOAWAY with `last_stream_id` set to the last stream ID that has been handled
 * after then, incoming DATA / HEADERS / CONITUATION frames are ignored
 * the connection gets closed when all responding streams are closed