### PR TITLE
Include for using macros related to 'wait'

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/un.h>
+#include <sys/wait.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>


### PR DESCRIPTION
This patch fixes #123 issue.
I confirmed that building h2o is successful after applying this patch on FreeBSD 10.1.
