### PR TITLE
implement parser for name-value pairs

### DIFF
--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -83,7 +83,7 @@ size_t h2o_strstr(const char *haysack, size_t haysack_len, const char *needle, s
 /**
  *
  */
-const char *h2o_next_token(h2o_iovec_t *iter, int separator, size_t *element_len);
+const char *h2o_next_token(h2o_iovec_t *iter, int separator, size_t *element_len, h2o_iovec_t *value);
 /**
  * tests if string needle exists within a separator-separated string (for handling "#rule" of RFC 2616)
  */

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -83,11 +83,11 @@ size_t h2o_strstr(const char *haysack, size_t haysack_len, const char *needle, s
 /**
  *
  */
-const char *h2o_next_token(const char *elements, size_t elements_len, size_t *element_len, const char *cur);
+const char *h2o_next_token(h2o_iovec_t *iter, int separator, size_t *element_len);
 /**
- * tests if string needle exists within a comma-separated string (for handling "#rule" of RFC 2616)
+ * tests if string needle exists within a separator-separated string (for handling "#rule" of RFC 2616)
  */
-int h2o_contains_token(const char *haysack, size_t haysack_len, const char *needle, size_t needle_len);
+int h2o_contains_token(const char *haysack, size_t haysack_len, const char *needle, size_t needle_len, int separator);
 /**
  * removes "..", ".", decodes %xx from a path representation
  * @param pool memory pool to be used in case the path contained references to directories

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -213,7 +213,7 @@ static void on_head(h2o_socket_t *sock, int status)
     for (i = 0; i != num_headers; ++i) {
         h2o_strtolower((char *)headers[i].name, headers[i].name_len);
         if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("connection"))) {
-            if (h2o_contains_token(headers[i].value, headers[i].value_len, H2O_STRLIT("keep-alive"))) {
+            if (h2o_contains_token(headers[i].value, headers[i].value_len, H2O_STRLIT("keep-alive"), ',')) {
                 client->_can_keepalive = 1;
             } else {
                 client->_can_keepalive = 0;

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -148,7 +148,7 @@ static struct st_h2o_sendfile_generator_t *create_generator(h2o_req_t *req, cons
         ssize_t header_index;
         if ((header_index = h2o_find_header(&req->headers, H2O_TOKEN_ACCEPT_ENCODING, -1)) != -1 &&
             h2o_contains_token(req->headers.entries[header_index].value.base, req->headers.entries[header_index].value.len,
-                               H2O_STRLIT("gzip"))) {
+                               H2O_STRLIT("gzip"), ',')) {
             char *gzpath = h2o_mem_alloc_pool(&req->pool, path_len + 4);
             memcpy(gzpath, path, path_len);
             strcpy(gzpath + path_len, ".gz");

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -315,10 +315,10 @@ static ssize_t fixup_request(h2o_http1_conn_t *conn, struct phr_header *headers,
     /* setup persistent flag (and upgrade info) */
     if (connection.base != NULL) {
         /* TODO contains_token function can be faster */
-        if (h2o_contains_token(connection.base, connection.len, H2O_STRLIT("keep-alive"))) {
+        if (h2o_contains_token(connection.base, connection.len, H2O_STRLIT("keep-alive"), ',')) {
             conn->req.http1_is_persistent = 1;
         }
-        if (upgrade.base != NULL && h2o_contains_token(connection.base, connection.len, H2O_STRLIT("upgrade"))) {
+        if (upgrade.base != NULL && h2o_contains_token(connection.base, connection.len, H2O_STRLIT("upgrade"), ',')) {
             conn->req.upgrade = upgrade;
         }
     } else if (conn->req.version >= 0x101) {

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1011,7 +1011,7 @@ int h2o_http2_handle_upgrade(h2o_req_t *req)
     connection_index = h2o_find_header(&req->headers, H2O_TOKEN_CONNECTION, -1);
     assert(connection_index != -1);
     if (!h2o_contains_token(req->headers.entries[connection_index].value.base, req->headers.entries[connection_index].value.len,
-                            H2O_STRLIT("http2-settings"))) {
+                            H2O_STRLIT("http2-settings"), ',')) {
         goto Error;
     }
 


### PR DESCRIPTION
As suggested in by @igrigorik in https://github.com/h2o/h2o/pull/133#issuecomment-72927404 application developers may want to set attributes against each URL being pushed.

In case of an application server requesting the reverse proxy to do so, we would need to use a name-value paired response header like `X-Server-Push: URL=http://server/pushed.css; PRIORITY=256`.

This PR implements such parser by extending the existing tokenizer (for headers like `Cache-Control`).