### PR TITLE
introduce shared-memory cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ ENDIF (WSLAY_FOUND)
 SET(LIB_SOURCE_FILES
     deps/picohttpparser/picohttpparser.c
     lib/access_log.c
+    lib/cache.c
     lib/chunked.c
     lib/context.c
     lib/config.c
@@ -70,6 +71,7 @@ SET(UNIT_TEST_SOURCE_FILES
     deps/picotest/picotest.c
     t/00unit/test.c
     t/00unit/lib/http2/hpack.c
+    t/00unit/lib/cache.c
     t/00unit/lib/file.c
     t/00unit/lib/mimemap.c
     t/00unit/lib/proxy.c
@@ -77,6 +79,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/string.c)
 LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/http2/hpack.c
+    lib/cache.c
     lib/file.c
     lib/mimemap.c
     lib/proxy.c

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		104B9A281A4A5139009EEE64 /* serverutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 104B9A271A4A5139009EEE64 /* serverutil.c */; };
 		104B9A2A1A4AA9BF009EEE64 /* serverutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 104B9A241A4A4FEE009EEE64 /* serverutil.c */; };
 		104B9A2D1A4BE029009EEE64 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 104B9A2C1A4BE029009EEE64 /* version.h */; };
+		104B9A371A5A39A5009EEE64 /* cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 104B9A361A5A39A5009EEE64 /* cache.c */; };
+		104B9A381A5A3BB1009EEE64 /* cache.h in Headers */ = {isa = PBXBuildFile; fileRef = 104B9A341A5A3417009EEE64 /* cache.h */; };
+		104B9A3A1A5A5AB9009EEE64 /* cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 104B9A391A5A5AB9009EEE64 /* cache.c */; };
 		105534BE1A3B8F7700627ECB /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = 105534BD1A3B8F7700627ECB /* file.c */; };
 		105534C11A3B911300627ECB /* hpack.c in Sources */ = {isa = PBXBuildFile; fileRef = 105534C01A3B911300627ECB /* hpack.c */; };
 		105534C31A3B917000627ECB /* mimemap.c in Sources */ = {isa = PBXBuildFile; fileRef = 105534C21A3B917000627ECB /* mimemap.c */; };
@@ -196,6 +199,9 @@
 		104B9A311A59D7A2009EEE64 /* 40running-user.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40running-user.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		104B9A321A59E27A009EEE64 /* 40ssl-cipher-suite.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40ssl-cipher-suite.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		104B9A331A59E594009EEE64 /* 01cxx-compile.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "01cxx-compile.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		104B9A341A5A3417009EEE64 /* cache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cache.h; sourceTree = "<group>"; };
+		104B9A361A5A39A5009EEE64 /* cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cache.c; sourceTree = "<group>"; };
+		104B9A391A5A5AB9009EEE64 /* cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cache.c; sourceTree = "<group>"; };
 		105534BD1A3B8F7700627ECB /* file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = file.c; sourceTree = "<group>"; };
 		105534C01A3B911300627ECB /* hpack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hpack.c; sourceTree = "<group>"; };
 		105534C21A3B917000627ECB /* mimemap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mimemap.c; sourceTree = "<group>"; };
@@ -368,6 +374,7 @@
 			isa = PBXGroup;
 			children = (
 				105534BF1A3B90E600627ECB /* http2 */,
+				104B9A391A5A5AB9009EEE64 /* cache.c */,
 				105534BD1A3B8F7700627ECB /* file.c */,
 				105534C21A3B917000627ECB /* mimemap.c */,
 				105534C81A3BB41C00627ECB /* proxy.c */,
@@ -484,6 +491,7 @@
 		1079239F19A3215F00C52AD6 /* h2o */ = {
 			isa = PBXGroup;
 			children = (
+				104B9A341A5A3417009EEE64 /* cache.h */,
 				105534D71A3C785000627ECB /* configurator.h */,
 				107923A019A3215F00C52AD6 /* http1.h */,
 				10D0905619F102DA0043D458 /* http1client.h */,
@@ -515,6 +523,7 @@
 			isa = PBXGroup;
 			children = (
 				101B670B19ADD3380084A351 /* access_log.c */,
+				104B9A361A5A39A5009EEE64 /* cache.c */,
 				107923AE19A3217300C52AD6 /* chunked.c */,
 				105534EE1A440FC800627ECB /* config.c */,
 				10F4180419CA75C500B6E31A /* configurator.c */,
@@ -649,6 +658,7 @@
 				10EC2A361A0B4D370083514F /* socketpool.h in Headers */,
 				105534EB1A42A87E00627ECB /* _templates.c.h in Headers */,
 				1079236A19A3210E00C52AD6 /* khash.h in Headers */,
+				104B9A381A5A3BB1009EEE64 /* cache.h in Headers */,
 				105534D81A3C791B00627ECB /* configurator.h in Headers */,
 				107923A619A3215F00C52AD6 /* http2.h in Headers */,
 				107923A719A3215F00C52AD6 /* token.h in Headers */,
@@ -848,6 +858,7 @@
 				107923CD19A3217300C52AD6 /* memory.c in Sources */,
 				107923CC19A3217300C52AD6 /* context.c in Sources */,
 				107923C519A3217300C52AD6 /* http1.c in Sources */,
+				104B9A371A5A39A5009EEE64 /* cache.c in Sources */,
 				10EC2A381A0B4DC70083514F /* socketpool.c in Sources */,
 				1079239619A3210E00C52AD6 /* picohttpparser.c in Sources */,
 				1065E6F919BEBAC600686E72 /* timeout.c in Sources */,
@@ -892,6 +903,7 @@
 				1079244B19A3266700C52AD6 /* context.c in Sources */,
 				1079244C19A3266700C52AD6 /* memory.c in Sources */,
 				105534C71A3BB29100627ECB /* string.c in Sources */,
+				104B9A3A1A5A5AB9009EEE64 /* cache.c in Sources */,
 				1079244E19A3266700C52AD6 /* request.c in Sources */,
 				10D0907019F494CC0043D458 /* test.c in Sources */,
 				105534C11A3B911300627ECB /* hpack.c in Sources */,

--- a/include/h2o/cache.h
+++ b/include/h2o/cache.h
@@ -39,7 +39,9 @@ typedef struct st_h2o_cache_ref_t {
     h2o_cache_key_t key;
     h2o_iovec_t data;
     uint64_t at;
-    h2o_linklist_t _link;
+    int _requested_early_update;
+    h2o_linklist_t _lru_link;
+    h2o_linklist_t _age_link;
     size_t _refcnt;
 } h2o_cache_ref_t;
 

--- a/lib/cache.c
+++ b/lib/cache.c
@@ -158,12 +158,13 @@ h2o_cache_ref_t *h2o_cache_fetch(h2o_cache_t *cache, h2o_iovec_t key, uint64_t n
         ref->_requested_early_update = 1;
         goto NotFound;
     }
-    /* move the entry to the top of LRU, and return */
+    /* move the entry to the top of LRU */
     pthread_mutex_lock(&cache->link.mutex);
     h2o_linklist_unlink(&ref->_lru_link);
     h2o_linklist_insert(&cache->link.lru, &ref->_lru_link);
-    __sync_fetch_and_add(&ref->_refcnt, 1);
     pthread_mutex_unlock(&cache->link.mutex);
+
+    __sync_fetch_and_add(&ref->_refcnt, 1);
 
     /* unlock and return the found entry */
     pthread_rwlock_unlock(&cache->rwlock);

--- a/lib/cache.c
+++ b/lib/cache.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2014 DeNA Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <assert.h>
+#include <pthread.h>
+#include "khash.h"
+#include "h2o/cache.h"
+#include "h2o/linklist.h"
+#include "h2o/memory.h"
+
+static h2o_cache_hashcode_t get_keyhash(h2o_cache_ref_t *ref);
+static int is_equal(h2o_cache_ref_t *x, h2o_cache_ref_t *y);
+
+KHASH_INIT(cache, h2o_cache_ref_t *, char, 0, get_keyhash, is_equal)
+
+struct st_h2o_cache_t {
+    pthread_mutex_t lock;
+    khash_t(cache) *table;
+    size_t size;
+    h2o_linklist_t lru;
+    size_t capacity;
+    uint64_t duration;
+    void (*destroy_cb)(h2o_iovec_t value);
+};
+
+static h2o_cache_hashcode_t calchash(const char *s, size_t l)
+{
+    h2o_cache_hashcode_t h = 0;
+    for (; l != 0; --l)
+        h = (h << 5) - h + *(unsigned char*)s;
+    return h;
+}
+
+static h2o_cache_hashcode_t get_keyhash(h2o_cache_ref_t *ref)
+{
+    return ref->key.hash;
+}
+
+static int is_equal(h2o_cache_ref_t *x, h2o_cache_ref_t *y)
+{
+    return x->key.vec.len == y->key.vec.len && memcmp(x->key.vec.base, y->key.vec.base, x->key.vec.len) == 0;
+}
+
+static void erase_ref(h2o_cache_t *cache, khiter_t iter)
+{
+    h2o_cache_ref_t *ref = kh_key(cache->table, iter);
+
+    kh_del(cache, cache->table, iter);
+    h2o_linklist_unlink(&ref->_link);
+    cache->size -= ref->data.len;
+
+    h2o_cache_release(cache, ref);
+}
+
+h2o_cache_t *h2o_cache_create(size_t capacity, uint64_t duration, void (*destroy_cb)(h2o_iovec_t value))
+{
+    h2o_cache_t *cache = h2o_mem_alloc(sizeof(*cache));
+
+    pthread_mutex_init(&cache->lock, NULL);
+    cache->table = kh_init(cache);
+    cache->size = 0;
+    h2o_linklist_init_anchor(&cache->lru);
+    cache->capacity = capacity;
+    cache->duration = duration;
+    cache->destroy_cb = destroy_cb;
+
+    return cache;
+}
+
+void h2o_cache_destroy(h2o_cache_t *cache)
+{
+    h2o_cache_clear(cache, 0);
+
+    assert(kh_size(cache->table) == 0);
+
+    kh_destroy(cache, cache->table);
+    pthread_mutex_destroy(&cache->lock);
+    free(cache);
+}
+
+void h2o_cache_clear(h2o_cache_t *cache, uint64_t now)
+{
+    khiter_t iter;
+
+    pthread_mutex_lock(&cache->lock);
+
+	for (iter = kh_begin(cache->table); iter != kh_end(cache->table); ++iter) {
+        if (kh_exist(cache->table, iter)) {
+            h2o_cache_ref_t *ref = kh_key(cache->table, iter);
+            if (now == 0 || ref->at + cache->duration < now)
+                erase_ref(cache, iter);
+        }
+    }
+
+    pthread_mutex_unlock(&cache->lock);
+}
+
+h2o_cache_ref_t *h2o_cache_fetch(h2o_cache_t *cache, h2o_iovec_t key, uint64_t now)
+{
+    h2o_cache_key_t search_key = { key, calchash(key.base, key.len) };
+    khiter_t iter;
+    uint64_t expires;
+    h2o_cache_ref_t *ref;
+
+    pthread_mutex_lock(&cache->lock);
+
+    if ((iter = kh_get(cache, cache->table, (void*)&search_key)) == kh_end(cache->table))
+        goto NotFound;
+
+    /* found */
+    ref = kh_key(cache->table, iter);
+    expires = ref->at + cache->duration;
+    if (expires < now) {
+        /* request update (add some delta to `at` so that not all clients would need to update the entry) */
+        if (now - expires <= 10)
+            ref->at += 20;
+        goto NotFound;
+    }
+    /* move the entry to the top of LRU, and return */
+    h2o_linklist_unlink(&ref->_link);
+    h2o_linklist_insert(&cache->lru, &ref->_link);
+    __sync_fetch_and_add(&ref->_refcnt, 1);
+
+    /* unlock and return the found entry */
+    pthread_mutex_unlock(&cache->lock);
+    return ref;
+
+NotFound:
+    pthread_mutex_unlock(&cache->lock);
+
+    /* prepare new ref and return */
+    ref = h2o_mem_alloc(sizeof(*ref) + key.len);
+    ref->key.vec.base = (void*)(ref + 1);
+    ref->key.vec.len = key.len;
+    ref->key.hash = search_key.hash;
+    ref->data = (h2o_iovec_t){};
+    ref->at = 0;
+    ref->_link = (h2o_linklist_t){};
+    ref->_refcnt = 1;
+    memcpy(ref->key.vec.base, key.base, key.len);
+
+    return ref;
+}
+
+void h2o_cache_release(h2o_cache_t *cache, h2o_cache_ref_t *ref)
+{
+    if (__sync_fetch_and_sub(&ref->_refcnt, 1) == 1) {
+        cache->destroy_cb(ref->data);
+        free(ref);
+    }
+}
+
+void h2o_cache_update(h2o_cache_t *cache, h2o_cache_ref_t *ref, uint64_t now)
+{
+    khiter_t iter;
+
+    assert(ref->_refcnt == 1);
+    assert(! h2o_linklist_is_linked(&ref->_link));
+
+    pthread_mutex_lock(&cache->lock);
+
+    /* look for existing entry */
+    iter = kh_get(cache, cache->table, ref);
+
+    /* if delete is requested, doit, and return */
+    if (ref->data.base == NULL) {
+        if (iter != kh_end(cache->table)) {
+            erase_ref(cache, iter);
+        }
+        pthread_mutex_unlock(&cache->lock);
+        h2o_cache_release(cache, ref);
+        return;
+    }
+
+    /* update */
+    if (iter == kh_end(cache->table)) {
+        int unused;
+        /* attach the entry to cache */
+        ref->at = now;
+        kh_put(cache, cache->table, ref, &unused);
+        h2o_linklist_insert(&cache->lru, &ref->_link);
+    } else {
+        /* swap with the existing entry */
+        h2o_cache_ref_t *old = kh_key(cache->table, iter);
+        kh_key(cache->table, iter) = ref;
+        h2o_linklist_insert(&old->_link, &ref->_link);
+        h2o_linklist_unlink(&old->_link);
+        cache->size = cache->size - old->data.len + ref->data.len;
+        ref->at = now;
+        h2o_cache_release(cache, old);
+    }
+
+    /* purge if the cache has become too large */
+    while (cache->capacity < cache->size) {
+        h2o_cache_ref_t *old;
+        assert(! h2o_linklist_is_empty(&cache->lru));
+        old = H2O_STRUCT_FROM_MEMBER(h2o_cache_ref_t, _link, cache->lru.next);
+        erase_ref(cache, kh_get(cache, cache->table, old));
+    }
+
+    pthread_mutex_unlock(&cache->lock);
+}

--- a/t/00unit/lib/cache.c
+++ b/t/00unit/lib/cache.c
@@ -48,7 +48,7 @@ void test_lib__cache_c(void)
     h2o_cache_release(cache, ref);
 
     /* proceed 1001ms */
-    now += 1001;
+    now += 999;
 
     /* should fail to fetch "key" */
     ref = h2o_cache_fetch(cache, key, now);

--- a/t/00unit/lib/cache.c
+++ b/t/00unit/lib/cache.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014 DeNA Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "../test.h"
+#include "../../../lib/cache.c"
+
+static size_t bytes_destroyed;
+
+static void on_destroy(h2o_iovec_t vec)
+{
+    bytes_destroyed += vec.len;
+}
+
+void test_lib__cache_c(void)
+{
+    h2o_cache_t *cache = h2o_cache_create(1024, 1000, on_destroy);
+    uint64_t now = 0;
+    h2o_iovec_t key = { H2O_STRLIT("key") };
+    h2o_cache_ref_t *ref, *ref2;
+
+    /* set "key" => "value" */
+    ref = h2o_cache_fetch(cache, key, now);
+    ok(ref->data.base == NULL);
+    ref->data = h2o_iovec_init(H2O_STRLIT("value"));
+    h2o_cache_update(cache, ref, now);
+
+    /* fetch "key" */
+    ref = h2o_cache_fetch(cache, key, now);
+    ok(h2o_memis(ref->data.base, ref->data.len, H2O_STRLIT("value")));
+    h2o_cache_release(cache, ref);
+
+    /* proceed 1001ms */
+    now += 1001;
+
+    /* should fail to fetch "key" */
+    ref = h2o_cache_fetch(cache, key, now);
+    ok(ref->data.base == NULL);
+
+    /* refetch should succeed */
+    ref2 = h2o_cache_fetch(cache, key, now);
+    ok(h2o_memis(ref2->data.base, ref2->data.len, H2O_STRLIT("value")));
+    h2o_cache_release(cache, ref2);
+
+    /* set "key" to "value2" */
+    ref->data = h2o_iovec_init(H2O_STRLIT("value2"));
+    h2o_cache_update(cache, ref, now);
+
+    /* fetch */
+    ref = h2o_cache_fetch(cache, key, now);
+    ok(h2o_memis(ref->data.base, ref->data.len, H2O_STRLIT("value2")));
+    h2o_cache_release(cache, ref);
+
+    ok(bytes_destroyed == 5);
+
+    h2o_cache_destroy(cache);
+
+    ok(bytes_destroyed == 11);
+}

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -123,7 +123,8 @@ static void test_loopback(void)
 int main(int argc, char **argv)
 {
     { /* library tests */
-        subtest("lib/server_starter.c", test_lib__serverutil_c);
+        subtest("lib/cache.c", test_lib__cache_c);
+        subtest("lib/serverutil.c", test_lib__serverutil_c);
         subtest("lib/string.c", test_lib__string_c);
         subtest("lib/http2/hpack.c", test_lib__http2__hpack);
         subtest("lib/mimemap.c", test_lib__mimemap_c);


### PR DESCRIPTION
This PR implements a tiny in-memory cache, suitable for caching open files etc.

It has so far been not merged to master as there has been no practical use case.  However this might be desirable if we are to let users define server-push URL mapping files for statically served content using the file handler (#137).