### PR TITLE
Introduce pipe-based inter-thread messaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(LIB_SOURCE_FILES
     deps/picohttpparser/picohttpparser.c
 
     lib/common/memory.c
+    lib/common/multithread.c
     lib/common/http1client.c
     lib/common/serverutil.c
     lib/common/socket.c
@@ -81,6 +82,7 @@ SET(UNIT_TEST_SOURCE_FILES
     ${LIB_SOURCE_FILES}
     deps/picotest/picotest.c
     t/00unit/test.c
+    t/00unit/lib/common/multithread.c
     t/00unit/lib/common/serverutil.c
     t/00unit/lib/common/string.c
     t/00unit/lib/common/time.c
@@ -92,6 +94,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/http2/hpack.c
     t/00unit/lib/http2/scheduler.c)
 LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
+    lib/common/multithread.c
     lib/common/serverutil.c
     lib/common/string.c
     lib/common/time.c

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -82,6 +82,9 @@
 		10AA2EA31A88090B004322AC /* url.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EA21A88090B004322AC /* url.c */; };
 		10AA2EA51A8D9999004322AC /* redirect.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EA41A8D9999004322AC /* redirect.c */; };
 		10AA2EA71A8DA93C004322AC /* redirect.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EA61A8DA93C004322AC /* redirect.c */; };
+		10AA2EAA1A8DDC57004322AC /* multithread.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AA2EA91A8DDC57004322AC /* multithread.h */; };
+		10AA2EAC1A8DE0AE004322AC /* multithread.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EAB1A8DE0AE004322AC /* multithread.c */; };
+		10AA2EAE1A8E22DA004322AC /* multithread.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EAD1A8E22DA004322AC /* multithread.c */; };
 		10BA72AA19AAD6300059392A /* stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 10BA72A919AAD6300059392A /* stream.c */; };
 		10D0903A19F0A51C0043D458 /* memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D0903919F0A51C0043D458 /* memory.h */; };
 		10D0903E19F0A8190043D458 /* socket.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D0903D19F0A8190043D458 /* socket.h */; };
@@ -289,6 +292,9 @@
 		10AA2EA41A8D9999004322AC /* redirect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = redirect.c; sourceTree = "<group>"; };
 		10AA2EA61A8DA93C004322AC /* redirect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = redirect.c; sourceTree = "<group>"; };
 		10AA2EA81A8DAFD4004322AC /* 50redirect.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 50redirect.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		10AA2EA91A8DDC57004322AC /* multithread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = multithread.h; sourceTree = "<group>"; };
+		10AA2EAB1A8DE0AE004322AC /* multithread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = multithread.c; sourceTree = "<group>"; };
+		10AA2EAD1A8E22DA004322AC /* multithread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = multithread.c; sourceTree = "<group>"; };
 		10BA72A919AAD6300059392A /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
 		10D0903919F0A51C0043D458 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		10D0903D19F0A8190043D458 /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket.h; sourceTree = "<group>"; };
@@ -408,6 +414,7 @@
 				10AA2E951A80A612004322AC /* time.c */,
 				1065E6F819BEBAC600686E72 /* timeout.c */,
 				10AA2EA01A88082E004322AC /* url.c */,
+				10AA2EAB1A8DE0AE004322AC /* multithread.c */,
 			);
 			path = common;
 			sourceTree = "<group>";
@@ -446,6 +453,7 @@
 		104B9A4D1A5FAA7B009EEE64 /* common */ = {
 			isa = PBXGroup;
 			children = (
+				10AA2EAD1A8E22DA004322AC /* multithread.c */,
 				104B9A271A4A5139009EEE64 /* serverutil.c */,
 				105534C61A3BB29100627ECB /* string.c */,
 				10AA2E981A81F68A004322AC /* time.c */,
@@ -630,6 +638,7 @@
 				10AA2E9E1A8807CF004322AC /* url.h */,
 				107923A319A3215F00C52AD6 /* websocket.h */,
 				104B9A2C1A4BE029009EEE64 /* version.h */,
+				10AA2EA91A8DDC57004322AC /* multithread.h */,
 			);
 			path = h2o;
 			sourceTree = "<group>";
@@ -775,6 +784,7 @@
 				105534EB1A42A87E00627ECB /* _templates.c.h in Headers */,
 				1079236A19A3210E00C52AD6 /* khash.h in Headers */,
 				105534D81A3C791B00627ECB /* configurator.h in Headers */,
+				10AA2EAA1A8DDC57004322AC /* multithread.h in Headers */,
 				10AA2E9F1A8807CF004322AC /* url.h in Headers */,
 				107923A619A3215F00C52AD6 /* http2.h in Headers */,
 				107923A719A3215F00C52AD6 /* token.h in Headers */,
@@ -982,6 +992,7 @@
 				10AA2EA11A88082E004322AC /* url.c in Sources */,
 				10EC2A381A0B4DC70083514F /* socketpool.c in Sources */,
 				1079239619A3210E00C52AD6 /* picohttpparser.c in Sources */,
+				10AA2EAC1A8DE0AE004322AC /* multithread.c in Sources */,
 				1065E6F919BEBAC600686E72 /* timeout.c in Sources */,
 				10F4180519CA75C500B6E31A /* configurator.c in Sources */,
 				104B9A461A5F608A009EEE64 /* serverutil.c in Sources */,
@@ -1046,6 +1057,7 @@
 				1079244719A3265C00C52AD6 /* http1.c in Sources */,
 				1079244819A3265C00C52AD6 /* connection.c in Sources */,
 				1079244119A3264300C52AD6 /* picohttpparser.c in Sources */,
+				10AA2EAE1A8E22DA004322AC /* multithread.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -404,8 +404,9 @@
 		104B9A4A1A5FA7E5009EEE64 /* common */ = {
 			isa = PBXGroup;
 			children = (
-				107923BA19A3217300C52AD6 /* memory.c */,
 				10D0905419F102C70043D458 /* http1client.c */,
+				107923BA19A3217300C52AD6 /* memory.c */,
+				10AA2EAB1A8DE0AE004322AC /* multithread.c */,
 				104B9A241A4A4FEE009EEE64 /* serverutil.c */,
 				101788B119B561AA0084C6D8 /* socket.c */,
 				1065E70919BF18A600686E72 /* socket */,
@@ -414,7 +415,6 @@
 				10AA2E951A80A612004322AC /* time.c */,
 				1065E6F819BEBAC600686E72 /* timeout.c */,
 				10AA2EA01A88082E004322AC /* url.c */,
-				10AA2EAB1A8DE0AE004322AC /* multithread.c */,
 			);
 			path = common;
 			sourceTree = "<group>";
@@ -627,6 +627,7 @@
 				10E299541A67E5F600701AA6 /* http2 */,
 				10D0904219F0BA780043D458 /* linklist.h */,
 				10D0903919F0A51C0043D458 /* memory.h */,
+				10AA2EA91A8DDC57004322AC /* multithread.h */,
 				104B9A231A4A4FAF009EEE64 /* serverutil.h */,
 				10D0903F19F0B90A0043D458 /* socket */,
 				10D0903D19F0A8190043D458 /* socket.h */,
@@ -638,7 +639,6 @@
 				10AA2E9E1A8807CF004322AC /* url.h */,
 				107923A319A3215F00C52AD6 /* websocket.h */,
 				104B9A2C1A4BE029009EEE64 /* version.h */,
-				10AA2EA91A8DDC57004322AC /* multithread.h */,
 			);
 			path = h2o;
 			sourceTree = "<group>";

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -39,6 +39,7 @@ extern "C" {
 #include "h2o/linklist.h"
 #include "h2o/http1client.h"
 #include "h2o/memory.h"
+#include "h2o/multithread.h"
 #include "h2o/socket.h"
 #include "h2o/string_.h"
 #include "h2o/time_.h"
@@ -267,6 +268,10 @@ struct st_h2o_context_t {
      * pointer to the global configuration
      */
     h2o_globalconf_t *globalconf;
+    /**
+     * queue for receiving messages from other contexts
+     */
+    h2o_multithread_queue_t *queue;
     /**
      * flag indicating if shutdown has been requested
      */

--- a/include/h2o/linklist.h
+++ b/include/h2o/linklist.h
@@ -54,10 +54,14 @@ static int h2o_linklist_is_empty(h2o_linklist_t *anchor);
 static int h2o_linklist_is_linked(h2o_linklist_t *node);
 /**
  * inserts a node to the linked list
- * @param pos insert position; the node will be inserted before pos (or NULL in case *head is NULL)
+ * @param pos insert position; the node will be inserted before pos
  * @param node the node to be inserted
  */
 static void h2o_linklist_insert(h2o_linklist_t *pos, h2o_linklist_t *node);
+/**
+ * inserts all the elements of list before pos (list becomes empty)
+ */
+static void h2o_linklist_insert_list(h2o_linklist_t *pos, h2o_linklist_t *list);
 /**
  * unlinks a node from the linked list
  */
@@ -88,6 +92,17 @@ inline void h2o_linklist_insert(h2o_linklist_t *pos, h2o_linklist_t *node)
     node->next = pos;
     node->prev->next = node;
     node->next->prev = node;
+}
+
+inline void h2o_linklist_insert_list(h2o_linklist_t *pos, h2o_linklist_t *list)
+{
+    if(h2o_linklist_is_empty(list))
+        return;
+    list->next->prev = pos->prev;
+    list->prev->next = pos;
+    pos->prev->next = list->next;
+    pos->prev = list->prev;
+    h2o_linklist_init_anchor(list);
 }
 
 inline void h2o_linklist_unlink(h2o_linklist_t *node)

--- a/include/h2o/serverutil.h
+++ b/include/h2o/serverutil.h
@@ -43,23 +43,6 @@
  * equivalent of signal(3)
  */
 void h2o_set_signal_handler(int signo, void (*cb)(int signo));
-/**
- * a signal handler that does nothing
- */
-void h2o_noop_signal_handler(int signo);
-
-/**
- * initializes the given signal to be used for waking up other threads
- */
-void h2o_thread_initialize_signal_for_notification(int signo);
-/**
- * notifies a thread
- */
-void h2o_thread_notify(pthread_t tid);
-/**
- * returns if the running thread has received a notification (and clears the flag)
- */
-int h2o_thread_is_notified(void);
 
 /**
  * equiv. to setuidgid of djb

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -90,6 +90,8 @@ static void init_async(h2o_multithread_queue_t *queue, h2o_loop_t *loop)
         perror("pipe");
         abort();
     }
+    fcntl(fds[0], F_SETFD, FD_CLOEXEC);
+    fcntl(fds[1], F_SETFD, FD_CLOEXEC);
     fcntl(fds[1], F_SETFL, O_NONBLOCK);
     queue->async.write = fds[1];
     queue->async.read = h2o_evloop_socket_create(loop, fds[0], NULL, 0, 0);

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <assert.h>
+#include <pthread.h>
+#include "h2o/multithread.h"
+
+struct st_h2o_multithread_queue_t {
+    uv_async_t async;
+    pthread_mutex_t mutex;
+    struct {
+        h2o_linklist_t active;
+        h2o_linklist_t inactive;
+    } receivers;
+};
+
+static void queue_cb(h2o_multithread_queue_t *queue)
+{
+    pthread_mutex_lock(&queue->mutex);
+
+    while (!h2o_linklist_is_empty(&queue->receivers.active)) {
+        h2o_multithread_receiver_t *receiver =
+            H2O_STRUCT_FROM_MEMBER(h2o_multithread_receiver_t, _link, queue->receivers.active.next);
+        /* detach all the messages from the receiver */
+        h2o_linklist_t messages;
+        h2o_linklist_init_anchor(&messages);
+        h2o_linklist_insert_list(&messages, &receiver->_messages);
+        /* relink the receiver to the inactive list */
+        h2o_linklist_unlink(&receiver->_link);
+        h2o_linklist_insert(&queue->receivers.inactive, &receiver->_link);
+
+        /* dispatch the messages */
+        pthread_mutex_unlock(&queue->mutex);
+        receiver->cb(receiver, &messages);
+        assert(h2o_linklist_is_empty(&messages));
+        pthread_mutex_lock(&queue->mutex);
+    }
+
+    pthread_mutex_unlock(&queue->mutex);
+}
+
+h2o_multithread_queue_t *h2o_multithread_create_queue(h2o_loop_t *loop)
+{
+    h2o_multithread_queue_t *queue = malloc(sizeof(*queue));
+    *queue = (h2o_multithread_queue_t){loop};
+
+    uv_async_init(loop, &queue->async, (void *)queue_cb);
+    pthread_mutex_init(&queue->mutex, NULL);
+    h2o_linklist_init_anchor(&queue->receivers.active);
+    h2o_linklist_init_anchor(&queue->receivers.inactive);
+
+    return queue;
+}
+
+void h2o_multithread_destroy_queue(h2o_multithread_queue_t *queue)
+{
+    assert(h2o_linklist_is_empty(&queue->receivers.active));
+    assert(h2o_linklist_is_empty(&queue->receivers.inactive));
+    uv_close((uv_handle_t *)&queue->async, (void *)free);
+    pthread_mutex_destroy(&queue->mutex);
+}
+
+void h2o_multithread_register_receiver(h2o_multithread_queue_t *queue, h2o_multithread_receiver_t *receiver,
+                                       h2o_multithread_receiver_cb cb)
+{
+    receiver->queue = queue;
+    receiver->_link = (h2o_linklist_t){};
+    h2o_linklist_init_anchor(&receiver->_messages);
+    receiver->cb = cb;
+
+    h2o_linklist_insert(&queue->receivers.inactive, &receiver->_link);
+}
+
+void h2o_multithread_unregister_receiver(h2o_multithread_queue_t *queue, h2o_multithread_receiver_t *receiver)
+{
+    assert(queue == receiver->queue);
+    assert(h2o_linklist_is_empty(&receiver->_messages));
+    h2o_linklist_unlink(&receiver->_link);
+}
+
+void h2o_multithread_send_message(h2o_multithread_receiver_t *receiver, h2o_multithread_message_t *message)
+{
+    int do_send = 0;
+
+    assert(!h2o_linklist_is_linked(&message->link));
+
+    pthread_mutex_lock(&receiver->queue->mutex);
+    if (h2o_linklist_is_empty(&receiver->_messages)) {
+        h2o_linklist_unlink(&receiver->_link);
+        h2o_linklist_insert(&receiver->queue->receivers.active, &receiver->_link);
+        do_send = 1;
+    }
+    h2o_linklist_insert(&receiver->_messages, &message->link);
+    pthread_mutex_unlock(&receiver->queue->mutex);
+
+    if (do_send)
+        uv_async_send(&receiver->queue->async);
+}

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -47,43 +47,6 @@ void h2o_set_signal_handler(int signo, void (*cb)(int signo))
     sigaction(signo, &action, NULL);
 }
 
-void h2o_noop_signal_handler(int signo)
-{
-}
-
-static int thread_notify_signo;
-static __thread volatile sig_atomic_t thread_notified = 0;
-
-static void on_thread_notify_sig(int signo)
-{
-    thread_notified = 1;
-}
-
-void h2o_thread_initialize_signal_for_notification(int signo)
-{
-    sigset_t mask;
-
-    h2o_set_signal_handler(signo, on_thread_notify_sig);
-    pthread_sigmask(SIG_BLOCK, NULL, &mask);
-    sigdelset(&mask, signo);
-    pthread_sigmask(SIG_SETMASK, &mask, NULL);
-
-    thread_notify_signo = signo;
-}
-
-void h2o_thread_notify(pthread_t tid)
-{
-    assert(thread_notify_signo != 0);
-    pthread_kill(tid, thread_notify_signo);
-}
-
-int h2o_thread_is_notified(void)
-{
-    int ret = thread_notified != 0;
-    thread_notified = 0;
-    return ret;
-}
-
 int h2o_setuidgid(struct passwd *passwd)
 {
     if (setgid(passwd->pw_gid) != 0) {

--- a/lib/common/socket/evloop/select.c.h
+++ b/lib/common/socket/evloop/select.c.h
@@ -151,7 +151,8 @@ static void evloop_do_on_socket_close(struct st_h2o_evloop_socket_t *sock)
     struct st_h2o_evloop_select_t *loop = (struct st_h2o_evloop_select_t *)sock->loop;
     if (sock->fd == -1)
         return;
-    assert(loop->socks[sock->fd] != NULL);
+    if (loop->socks[sock->fd] == NULL)
+        return;
     DEBUG_LOG("clearing READ/WRITE for fd: %d\n", sock->fd);
     FD_CLR(sock->fd, &loop->readfds);
     FD_CLR(sock->fd, &loop->writefds);

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -73,6 +73,8 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     ctx->globalconf = config;
     h2o_timeout_init(ctx->loop, &ctx->zero_timeout, 0);
     h2o_timeout_init(ctx->loop, &ctx->one_sec_timeout, 1000);
+    ctx->queue = h2o_multithread_create_queue(loop);
+
     h2o_timeout_init(ctx->loop, &ctx->http1.req_timeout, config->http1.req_timeout);
     h2o_timeout_init(ctx->loop, &ctx->http2.idle_timeout, config->http2.idle_timeout);
     h2o_linklist_init_anchor(&ctx->http2._conns);
@@ -111,6 +113,8 @@ void h2o_context_dispose(h2o_context_t *ctx)
     h2o_timeout_dispose(ctx->loop, &ctx->http1.req_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http2.idle_timeout);
 /* what should we do here? assert(!h2o_linklist_is_empty(&ctx->http2._conns); */
+
+    h2o_multithread_destroy_queue(ctx->queue);
 
 #if H2O_USE_LIBUV
     /* make sure the handles released by h2o_timeout_dispose get freed */

--- a/src/main.c
+++ b/src/main.c
@@ -259,7 +259,7 @@ static void *ocsp_updater_thread(void *_ssl_conf)
 
     assert(ssl_conf->ocsp_stapling.interval != 0);
 
-    while (!h2o_thread_is_notified()) {
+    while (1) {
         /* sleep until next_at */
         if ((now = time(NULL)) < next_at) {
             time_t sleep_secs = next_at - now;

--- a/t/00unit/lib/common/multithread.c
+++ b/t/00unit/lib/common/multithread.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2014 DeNA Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <stdlib.h>
+#include "../../test.h"
+#include "../../../../lib/common/multithread.c"
+
+struct st_thread_t {
+    h2o_loop_t *loop;
+    h2o_multithread_queue_t *queue;
+};
+
+struct {
+    h2o_loop_t *loop;
+    h2o_multithread_queue_t *queue;
+    h2o_multithread_receiver_t pong_receiver;
+    h2o_multithread_receiver_t exit_receiver;
+    int received_exit;
+} main_thread;
+
+struct {
+    h2o_loop_t *loop;
+    h2o_multithread_queue_t *queue;
+    h2o_multithread_receiver_t ping_receiver;
+    size_t num_ping_received;
+    int should_exit;
+} worker_thread;
+
+static void send_empty_message(h2o_multithread_receiver_t *receiver)
+{
+    h2o_multithread_message_t *message = h2o_mem_alloc(sizeof(*message));
+    *message = (h2o_multithread_message_t){};
+    h2o_multithread_send_message(receiver, message);
+}
+
+static void pop_empty_message(h2o_linklist_t *list)
+{
+    h2o_multithread_message_t *message = H2O_STRUCT_FROM_MEMBER(h2o_multithread_message_t, link, list->next);
+    h2o_linklist_unlink(&message->link);
+    free(message);
+}
+
+static void on_ping(h2o_multithread_receiver_t *receiver, h2o_linklist_t *list)
+{
+    while (!h2o_linklist_is_empty(list)) {
+        pop_empty_message(list);
+        if (++worker_thread.num_ping_received < 100) {
+            send_empty_message(&main_thread.pong_receiver);
+        } else {
+            send_empty_message(&main_thread.exit_receiver);
+            worker_thread.should_exit = 1;
+        }
+    }
+}
+
+static void on_pong(h2o_multithread_receiver_t *receiver, h2o_linklist_t *list)
+{
+    while (!h2o_linklist_is_empty(list)) {
+        pop_empty_message(list);
+        send_empty_message(&worker_thread.ping_receiver);
+    }
+}
+
+static void on_exit(h2o_multithread_receiver_t *receiver, h2o_linklist_t *list)
+{
+    while (!h2o_linklist_is_empty(list))
+        pop_empty_message(list);
+    main_thread.received_exit = 1;
+}
+
+#if H2O_USE_LIBUV
+static h2o_loop_t *create_loop(void)
+{
+    h2o_loop_t *loop = h2o_mem_alloc(sizeof(*loop));
+    uv_loop_init(loop);
+    return loop;
+}
+
+static void destroy_loop(h2o_loop_t *loop)
+{
+    uv_run(loop, UV_RUN_NOWAIT);
+    uv_loop_close(loop);
+    free(loop);
+}
+#endif
+
+static void *worker_main(void *_unused)
+{
+    while (!worker_thread.should_exit) {
+#if H2O_USE_LIBUV
+        uv_run(worker_thread.loop, UV_RUN_ONCE);
+#else
+        h2o_evloop_run(worker_thread.loop);
+#endif
+    }
+
+    return NULL;
+}
+
+void test_lib__multithread_c(void)
+{
+    pthread_t tid;
+
+    main_thread.loop = create_loop();
+    main_thread.queue = h2o_multithread_create_queue(main_thread.loop);
+    h2o_multithread_register_receiver(main_thread.queue, &main_thread.pong_receiver, on_pong);
+    h2o_multithread_register_receiver(main_thread.queue, &main_thread.exit_receiver, on_exit);
+    worker_thread.loop = create_loop();
+    worker_thread.queue = h2o_multithread_create_queue(worker_thread.loop);
+    h2o_multithread_register_receiver(worker_thread.queue, &worker_thread.ping_receiver, on_ping);
+
+    pthread_create(&tid, NULL, worker_main, NULL);
+
+    /* send first message */
+    send_empty_message(&worker_thread.ping_receiver);
+
+    while (!main_thread.received_exit) {
+#if H2O_USE_LIBUV
+        uv_run(main_thread.loop, UV_RUN_ONCE);
+#else
+        h2o_evloop_run(main_thread.loop);
+#endif
+    }
+
+    h2o_multithread_unregister_receiver(worker_thread.queue, &worker_thread.ping_receiver);
+    h2o_multithread_destroy_queue(worker_thread.queue);
+    destroy_loop(worker_thread.loop);
+    h2o_multithread_unregister_receiver(main_thread.queue, &main_thread.pong_receiver);
+    h2o_multithread_unregister_receiver(main_thread.queue, &main_thread.exit_receiver);
+    h2o_multithread_destroy_queue(main_thread.queue);
+    destroy_loop(main_thread.loop);
+
+    ok(1);
+}

--- a/t/00unit/lib/common/multithread.c
+++ b/t/00unit/lib/common/multithread.c
@@ -100,6 +100,9 @@ static void destroy_loop(h2o_loop_t *loop)
     uv_loop_close(loop);
     free(loop);
 }
+#else
+#define create_loop h2o_evloop_create
+#define destroy_loop(loop) (0) /* FIXME */
 #endif
 
 static void *worker_main(void *_unused)

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -141,6 +141,7 @@ int main(int argc, char **argv)
         test_loop = h2o_evloop_create();
 #endif
 
+        subtest("lib/common/multithread.c", test_lib__multithread_c);
         subtest("lib/t/test.c/loopback", test_loopback);
         subtest("lib/file.c", test_lib__file_c);
         subtest("lib/proxy.c", test_lib__proxy_c);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -48,6 +48,7 @@ extern h2o_loop_t *test_loop;
 
 char *sha1sum(const void *src, size_t len);
 
+void test_lib__multithread_c(void);
 void test_lib__serverutil_c(void);
 void test_lib__string_c(void);
 void test_lib__time_c(void);


### PR DESCRIPTION
At the moment H2O uses signals for notifying other threads, however it cannot be used for general purpose (e.g. sharing a prefixed number of connections upstream, or using a dedicated thread for communicating with memcached (#120)), as it has TOCTOU issues.

There are two options to fix the problem, one is to use platform-dependent features like `signalfd` to integrate signal handling with poll-based event loop; the other is to switch to `pipe` based messaging.

This PR uses the latter approach (which can be optimized in case of linux by using `eventfd`).