### PR TITLE
fix access-log failing to log headers when specified using uppercase letters

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		10AA2EA91A8DDC57004322AC /* multithread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = multithread.h; sourceTree = "<group>"; };
 		10AA2EAB1A8DE0AE004322AC /* multithread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = multithread.c; sourceTree = "<group>"; };
 		10AA2EAD1A8E22DA004322AC /* multithread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = multithread.c; sourceTree = "<group>"; };
+		10AA2EB11A931409004322AC /* 50access-log.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50access-log.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10BA72A919AAD6300059392A /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
 		10D0903919F0A51C0043D458 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		10D0903D19F0A8190043D458 /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket.h; sourceTree = "<group>"; };
@@ -721,6 +722,7 @@
 				104B9A311A59D7A2009EEE64 /* 40running-user.t */,
 				104B9A321A59E27A009EEE64 /* 40ssl-cipher-suite.t */,
 				104B9A221A47BBA1009EEE64 /* 40unix-socket.t */,
+				10AA2EB11A931409004322AC /* 50access-log.t */,
 				104B9A541A60773E009EEE64 /* 50expires.t */,
 				105534F61A460EF600627ECB /* 50file-config.t */,
 				105534F71A460F2E00627ECB /* 50mimemap.t */,

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+sub doit {
+    my ($testname, $getcurlopts, $format, $expected) = @_;
+
+    subtest $testname => sub {
+        unlink "$tempdir/access_log";
+
+        my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[ DOC_ROOT ]}
+    access-log:
+      format: "$format"
+      path: $tempdir/access_log
+EOT
+
+        system("curl --silent @{[$getcurlopts->($server)]} > /dev/null");
+
+        my $log = do {
+            open my $fh, "<", "$tempdir/access_log"
+                or die "failed to open access_log:$!";
+            join "", <$fh>;
+        };
+
+        like $log, $expected;
+    };
+}
+
+doit(
+    "custom-log",
+    sub {
+        my $server = shift;
+        "--referer http://example.com/ http://127.0.0.1:$server->{port}/";
+    },
+    '%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"',
+    qr{^127\.0\.0\.1 - - \[[0-9]{2}/[A-Z][a-z]{2}/20[0-9]{2}:[0-9]{2}:[0-9]{2}:[0-9]{2} [+\-][0-9]{4}\] "GET / HTTP/1\.1" 200 6 "http://example.com/" "curl/.*"\n$},
+);
+
+done_testing;


### PR DESCRIPTION
lib/handler/access_log.c should lowercase the supplied header names, or it is impossible to log the header when the specified name includes a upper-case character (e.g. `%{User-agent}i`).

relates to #36 