### PR TITLE
add new media type(application/json) to default media types

### DIFF
--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -63,7 +63,7 @@ h2o_mimemap_t *h2o_mimemap_create()
     { /* setup the tiny default */
         static const char *default_types[] = {"txt", "text/plain", "html", "text/html", "gif", "image/gif", "png", "image/png",
                                               "jpg", "image/jpeg", "jpeg", "image/jpeg", "css", "text/css", "js",
-                                              "application/javascript", NULL};
+                                              "application/javascript", "json", "application/json", NULL};
         const char **p;
         for (p = default_types; *p != NULL; p += 2)
             h2o_mimemap_set_type(mimemap, p[0], p[1]);


### PR DESCRIPTION

According to [RFC4627](http://www.rfc-editor.org/rfc/rfc4627.txt), `application/json` is appropriate for JSON.