### PR TITLE
merge the cookie headers sent from HTTP/2 clients

### DIFF
--- a/t/50reverse-proxy-config.t
+++ b/t/50reverse-proxy-config.t
@@ -37,8 +37,8 @@ hosts:
         proxy.reverse.url: http://127.0.0.1:$upstream_port
         proxy.preserve-host: $flag
 EOT
-        my $res = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/echo 2>&1 > /dev/null`;
-        like $res, qr/^x-req-host: 127.0.0.1:@{[ $flag eq 'ON' ? $server->{port} : $upstream_port ]}/im;
+        my $res = `curl --silent http://127.0.0.1:$server->{port}/echo-headers`;
+        like $res, qr/^host: 127.0.0.1:@{[ $flag eq 'ON' ? $server->{port} : $upstream_port ]}$/im;
     };
 
     subtest 'ON' => sub {

--- a/t/50reverse-proxy.t
+++ b/t/50reverse-proxy.t
@@ -141,6 +141,10 @@ sub run_tests_with_conf {
             $out = `nghttp $opt -H':method: POST' -d $huge_file $proto://127.0.0.1:$port/echo`;
             is length($out), $huge_file_size, "$proto://127.0.0.1/echo (mmap-backed, size)";
             is md5_hex($out), $huge_file_md5, "$proto://127.0.0.1/echo (mmap-backed, md5)";
+            subtest 'cookies' => sub {
+                $out = `nghttp $opt -H 'cookie: a=b' -H 'cookie: c=d' $proto://127.0.0.1:$port/echo-headers`;
+                like $out, qr{^cookie: a=b; c=d$}m;
+            };
         };
         subtest 'http' => sub {
             $doit->('http', $port);

--- a/t/50reverse-proxy.t
+++ b/t/50reverse-proxy.t
@@ -112,11 +112,11 @@ sub run_tests_with_conf {
                 like $content, qr{^location: $proto://127.0.0.1:$port/abc\r$}m;
             };
             subtest "x-forwarded ($proto)" => sub {
-                my $resp = `curl --silent --insecure --dump-header /dev/stderr $proto://127.0.0.1:$port/echo 2>&1 > /dev/null`;
-                like $resp, qr/^x-req-x-forwarded-for: 127\.0\.0\.1\r$/mi, "x-forwarded-for";
-                like $resp, qr/^x-req-x-forwarded-proto: $proto\r$/mi, "x-forwarded-proto";
-                $resp = `curl --silent --insecure --header 'X-Forwarded-For: 127.0.0.2' --dump-header /dev/stderr $proto://127.0.0.1:$port/echo 2>&1 > /dev/null`;
-                like $resp, qr/^x-req-x-forwarded-for: 127\.0\.0\.2, 127\.0\.0\.1\r$/mi, "x-forwarded-for (append)";
+                my $resp = `curl --silent --insecure $proto://127.0.0.1:$port/echo-headers`;
+                like $resp, qr/^x-forwarded-for: 127\.0\.0\.1$/mi, "x-forwarded-for";
+                like $resp, qr/^x-forwarded-proto: $proto$/mi, "x-forwarded-proto";
+                $resp = `curl --silent --insecure --header 'X-Forwarded-For: 127.0.0.2' $proto://127.0.0.1:$port/echo-headers`;
+                like $resp, qr/^x-forwarded-for: 127\.0\.0\.2, 127\.0\.0\.1$/mi, "x-forwarded-for (append)";
             };
         };
         $doit->('http', $port);

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -36,9 +36,20 @@ builder {
             [
                 'content-type' => 'text/plain',
                 'content-length' => length $content,
-                map { my $n = lc substr $_, 5; $n =~ tr/_/-/; "x-req-$n" => $env->{$_} } sort grep { /^HTTP_/ } keys %$env,
             ],
             [ $content ],
+        ];
+    };
+    mount "/echo-headers" => sub {
+        my $env = shift;
+        return [
+            200,
+            [
+                'content-type' => 'text/plain',
+            ],
+            [
+                join "\n", map { my $n = lc substr $_, 5; $n =~ tr/_/-/; "$n: $env->{$_}" } sort grep { /^HTTP_/ } keys %$env,
+            ]
         ];
     };
     mount "/redirect" => sub {


### PR DESCRIPTION
quote [Hypertext Transfer Protocol version 2 section 8.1.2.5](http://http2.github.io/http2-spec/index.html#CompressCookie):
> If there are multiple Cookie header fields after decompression, these MUST be concatenated into a single octet string using the two octet delimiter of 0x3B, 0x20 (the ASCII string "; ") before being passed into a non-HTTP/2 context, such as an HTTP/1.1 connection, or a generic HTTP server application. 
