### PR TITLE
simplify the proxy configuration (remove `proxy.keepalive`)

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 		10AA2EAB1A8DE0AE004322AC /* multithread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = multithread.c; sourceTree = "<group>"; };
 		10AA2EAD1A8E22DA004322AC /* multithread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = multithread.c; sourceTree = "<group>"; };
 		10AA2EB11A931409004322AC /* 50access-log.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50access-log.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		10AA2EB21A9479B4004322AC /* 50reverse-proxy-upstream-down.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50reverse-proxy-upstream-down.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10BA72A919AAD6300059392A /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
 		10D0903919F0A51C0043D458 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		10D0903D19F0A8190043D458 /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket.h; sourceTree = "<group>"; };
@@ -730,6 +731,7 @@
 				10AA2EA81A8DAFD4004322AC /* 50redirect.t */,
 				105534F91A460F4200627ECB /* 50reverse-proxy.t */,
 				104C65021A6DF36B000AC190 /* 50reverse-proxy-config.t */,
+				10AA2EB21A9479B4004322AC /* 50reverse-proxy-upstream-down.t */,
 				104B9A2B1A4BBDA4009EEE64 /* 50server-starter.t */,
 				105534FA1A460F4200627ECB /* 50sni.t */,
 				105534FE1A46134A00627ECB /* 80issues61.t */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -826,9 +826,8 @@ void h2o_file_register_configurator(h2o_globalconf_t *conf);
 
 typedef struct st_h2o_proxy_config_vars_t {
     uint64_t io_timeout;
-    int use_keepalive;
     int preserve_host;
-    uint64_t keepalive_timeout;
+    uint64_t keepalive_timeout; /* in milliseconds; set to zero to disable keepalive */
 } h2o_proxy_config_vars_t;
 
 typedef struct st_h2o_proxy_location_t {

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -409,6 +409,8 @@ h2o_http1client_t *h2o_http1client_connect_with_pool(h2o_http1client_ctx_t *ctx,
     h2o_http1client_t *client = create_client(ctx, pool, cb);
     client->sockpool.pool = sockpool;
     client->sockpool.connect_req = h2o_socketpool_connect(sockpool, ctx->loop, ctx->zero_timeout, on_pool_connect, client);
+    client->_timeout.cb = on_connect_timeout;
+    h2o_timeout_link(ctx->loop, ctx->io_timeout, &client->_timeout);
     return client;
 }
 

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -41,16 +41,6 @@ static int on_config_timeout_keepalive(h2o_configurator_command_t *cmd, h2o_conf
     return h2o_configurator_scanf(cmd, node, "%" PRIu64, &self->vars->keepalive_timeout);
 }
 
-static int on_config_keepalive(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    struct proxy_configurator_t *self = (void *)cmd->configurator;
-    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
-    if (ret == -1)
-        return -1;
-    self->vars->use_keepalive = (int)ret;
-    return 0;
-}
-
 static int on_config_preserve_host(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
@@ -123,11 +113,6 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
                                     H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR |
                                         H2O_CONFIGURATOR_FLAG_DEFERRED,
                                     on_config_reverse_url, "upstream URL (only HTTP is suppported)");
-    h2o_configurator_define_command(&c->super, "proxy.keepalive",
-                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
-                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
-                                    on_config_keepalive, "boolean flag (ON/OFF) indicating whether or not to use persistent\n"
-                                                         "connections to upstream (default: OFF)");
     h2o_configurator_define_command(&c->super, "proxy.preserve-host",
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
                                         H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
@@ -140,5 +125,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "proxy.timeout.keepalive",
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
                                         H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
-                                    on_config_timeout_keepalive, "timeout for idle conncections (in milliseconds, default: 2000)");
+                                    on_config_timeout_keepalive,
+                                    "timeout for idle conncections (set to zero to disable persistent connections\n"
+                                    "upstream; in milliseconds, default: 2000)");
 }

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -473,7 +473,7 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, const char *host
     self->upstream.host = h2o_strdup(NULL, host, SIZE_MAX);
     self->upstream.port = port;
     self->upstream.path = h2o_strdup(NULL, real_path, SIZE_MAX);
-    if (config->use_keepalive) {
+    if (config->keepalive_timeout != 0) {
         self->sockpool = h2o_mem_alloc(sizeof(*self->sockpool));
         h2o_socketpool_init(self->sockpool, host, port, SIZE_MAX /* FIXME */);
     }

--- a/t/50reverse-proxy-upstream-down.t
+++ b/t/50reverse-proxy-upstream-down.t
@@ -16,7 +16,8 @@ hosts:
     paths:
       /:
         proxy.reverse.url: http://127.0.0.1:$upstream_port
-@{[ $persistent ? "" : "proxy.timeout.keepalive: 2000" ]}
+        proxy.timeout.io: 2000
+@{[ $persistent ? "" : "proxy.timeout.keepalive: 0" ]}
 EOT
     my $port = $server->{port};
     my $res = `curl --max-time 5 --silent --dump-header /dev/stderr http://127.0.0.1:$port/ 2>&1 > /dev/null`;

--- a/t/50reverse-proxy-upstream-down.t
+++ b/t/50reverse-proxy-upstream-down.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+# should return 502 in case of upstream error
+subtest 'upstream-down' => sub {
+    plan skip_all => 'curl not found'
+        unless prog_exists('curl');
+    my $upstream_port = empty_port();
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+    my $port = $server->{port};
+    my $res = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$port/ 2>&1 > /dev/null`;
+    like $res, qr{^HTTP/1\.1 502 }, "502 response on upstream error";
+};
+
+done_testing();

--- a/t/50reverse-proxy.t
+++ b/t/50reverse-proxy.t
@@ -44,23 +44,6 @@ EOT
     ok ! check_port($upstream_port), "upstream should be down now";
 }
 
-# should return 502 in case of upstream error
-subtest 'upstream-down' => sub {
-    plan skip_all => 'curl not found'
-        unless prog_exists('curl');
-    my $upstream_port = empty_port();
-    my $server = spawn_h2o(<< "EOT");
-hosts:
-  default:
-    paths:
-      /:
-        proxy.reverse.url: http://127.0.0.1:$upstream_port
-EOT
-    my $port = $server->{port};
-    my $res = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$port/ 2>&1 > /dev/null`;
-    like $res, qr{^HTTP/1\.1 502 }, "502 response on upstream error";
-};
-
 sub spawn_upstream {
     my ($port, @extra) = @_;
     spawn_server(

--- a/t/50reverse-proxy.t
+++ b/t/50reverse-proxy.t
@@ -38,7 +38,7 @@ hosts:
     paths:
       /:
         proxy.reverse.url: http://127.0.0.1:$upstream_port
-        proxy.keepalive: @{[ $h2o_keepalive ? "ON" : "OFF" ]}
+@{[ $h2o_keepalive ? "" : "        proxy.timeout.keepalive: 0" ]}
 EOT
     };
     ok ! check_port($upstream_port), "upstream should be down now";


### PR DESCRIPTION
This PR does the following:
* removes the `proxy.keepalive` configuration directive
* the upstream connections become non-persistent if `proxy.keepalive.timeout: 0`
* upstream connections by default are persistent, since the dafault value of `proxy.keepalive.timeout` is `2000` (in milliseconds)