### PR TITLE
Fix issues found by h2spec v0.0.6

### DIFF
--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -27,6 +27,7 @@ extern "C" {
 #endif
 
 #include <assert.h>
+#include <stdint.h>
 #include "khash.h"
 #include "./http2/scheduler.h"
 
@@ -304,7 +305,7 @@ void h2o_http2_stream_proceed(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream
 
 /* misc */
 static void h2o_http2_window_init(h2o_http2_window_t *window, const h2o_http2_settings_t *peer_settings);
-static void h2o_http2_window_update(h2o_http2_window_t *window, ssize_t delta);
+static int h2o_http2_window_update(h2o_http2_window_t *window, ssize_t delta);
 static ssize_t h2o_http2_window_get_window(h2o_http2_window_t *window);
 static void h2o_http2_window_consume_window(h2o_http2_window_t *window, size_t bytes);
 
@@ -414,9 +415,13 @@ inline void h2o_http2_window_init(h2o_http2_window_t *window, const h2o_http2_se
     window->_avail = peer_settings->initial_window_size;
 }
 
-inline void h2o_http2_window_update(h2o_http2_window_t *window, ssize_t delta)
+inline int h2o_http2_window_update(h2o_http2_window_t *window, ssize_t delta)
 {
-    window->_avail += delta;
+    size_t v = window->_avail + delta;
+    if (v > INT32_MAX)
+        return -1;
+    window->_avail = v;
+    return 0;
 }
 
 inline ssize_t h2o_http2_window_get_window(h2o_http2_window_t *window)

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -294,14 +294,16 @@ static void request_gathered_write(h2o_http2_conn_t *conn)
     }
 }
 
-static void update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta)
+static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta)
 {
     ssize_t cur = h2o_http2_window_get_window(&stream->output_window);
-    h2o_http2_window_update(&stream->output_window, delta);
+    if (h2o_http2_window_update(&stream->output_window, delta) != 0)
+        return -1;
     if (cur <= 0 && h2o_http2_window_get_window(&stream->output_window) > 0 && h2o_http2_stream_has_pending_data(stream)) {
         assert(!h2o_linklist_is_linked(&stream->_refs.link));
         h2o_http2_scheduler_activate(&stream->_refs.scheduler);
     }
+    return 0;
 }
 
 static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, const uint8_t *src, size_t len,
@@ -645,7 +647,11 @@ static int handle_window_update_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t 
     } else if (!is_idle_stream_id(conn, frame->stream_id)) {
         h2o_http2_stream_t *stream = h2o_http2_conn_get_stream(conn, frame->stream_id);
         if (stream != NULL) {
-            update_stream_output_window(stream, payload.window_size_increment);
+            if (update_stream_output_window(stream, payload.window_size_increment) != 0) {
+                h2o_http2_stream_reset(conn, stream);
+                send_stream_error(conn, frame->stream_id, H2O_HTTP2_ERROR_FLOW_CONTROL);
+                return 0;
+            }
         }
     } else {
         *err_desc = "invaild stream id in WINDOW_UPDATE frame";

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -638,7 +638,10 @@ static int handle_window_update_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t 
     }
 
     if (frame->stream_id == 0) {
-        h2o_http2_window_update(&conn->_write.window, payload.window_size_increment);
+        if (h2o_http2_window_update(&conn->_write.window, payload.window_size_increment) != 0) {
+            *err_desc = "flow control window overflow";
+            return H2O_HTTP2_ERROR_FLOW_CONTROL;
+        }
     } else if (!is_idle_stream_id(conn, frame->stream_id)) {
         h2o_http2_stream_t *stream = h2o_http2_conn_get_stream(conn, frame->stream_id);
         if (stream != NULL) {


### PR DESCRIPTION
Fixes behaviors found by h2spec v0.0.6 not conforming to the HTTP/2 spec., with https://github.com/summerwind/h2spec/pull/19 being the only exception.