### PR TITLE
Add 'Host' header to OCSP request

### DIFF
--- a/share/h2o/fetch-ocsp-response
+++ b/share/h2o/fetch-ocsp-response
@@ -73,6 +73,7 @@ my $ocsp_uri = run_openssl("x509 -in $cert_fn -noout -ocsp_uri");
 chomp $ocsp_uri;
 die "failed to extract ocsp URI from $cert_fn\n"
     if $ocsp_uri !~ m{^https?://};
+my($ocsp_host) = $ocsp_uri =~ m{^https?://([^/:]+)};
 
 # save issuer certificate
 if (! defined $issuer_fn) {
@@ -86,7 +87,7 @@ if (! defined $issuer_fn) {
 # obtain response (without verification)
 print STDERR "sending OCSP request to $ocsp_uri\n";
 my $resp = run_openssl(
-    "ocsp -issuer $issuer_fn -cert $cert_fn -url $ocsp_uri -noverify -respout $tempdir/resp.der " . join(' ', @ARGV),
+    "ocsp -issuer $issuer_fn -cert $cert_fn -url $ocsp_uri -header Host $ocsp_host -noverify -respout $tempdir/resp.der " . join(' ', @ARGV),
     1,
 );
 print STDERR $resp;

--- a/t/90live-fetch-ocsp-response.t
+++ b/t/90live-fetch-ocsp-response.t
@@ -12,6 +12,7 @@ my @HOSTS = qw(
     www.cybertrust.ne.jp
     www.comodo.com
     www.godaddy.com
+    www.startssl.com
 );
 
 for my $host (@HOSTS) {


### PR DESCRIPTION
Some OCSP responder (eg: www.startssl.com) requires HTTP `Host` header.

```
sending OCSP request to http://ocsp.startssl.com/sub/class4/server/ca
Error querying OCSP responsder
140192127325856:error:27076072:OCSP routines:PARSE_HTTP_LINE1:server response error:ocsp_ht.c:250:Code=400,Reason=Bad Request
OpenSSL exitted abnormally: openssl ocsp -issuer /tmp/a0m9_V78bN/issuer.crt -cert /tmp/4nKFjVVJ1H -url http://ocsp.startssl.com/sub/class4/server/ca -noverify -respout /tmp/a0m9_V78bN/resp.der :    not ok 2 - fetch-ocsp-response exitted with status:19200
    #   Failed test 'fetch-ocsp-response exitted with status:19200'
    #   at t/90live-fetch-ocsp-response.t line 48.
    1..2
    # Looks like you failed 1 test of 2.
not ok 6 - www.startssl.com
```
