### PR TITLE
fixed invalid somaxconn value.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@
 #include "h2o/serverutil.h"
 
 /* simply use a large value, and let the kernel clip it to the internal max */
-#define H2O_SOMAXCONN (65536)
+#define H2O_SOMAXCONN (65535)
 
 struct listener_ssl_config_t {
     H2O_VECTOR(h2o_iovec_t) hostnames;


### PR DESCRIPTION
type of somaxconn is unsigned short in kernel. So a maximum value is not 65536 but 65535.

## FYI

https://github.com/torvalds/linux/commit/5f671d6b4ec3e6d66c2a868738af2cdea09e7509