### PR TITLE
[http2] fix assertion failure in hpack encoder

### DIFF
--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -493,7 +493,7 @@ static size_t encode_huffman(uint8_t *_dst, const uint8_t *src, size_t len)
             bits <<= 8;
             bits_left += 8;
             if (dst == dst_end) {
-                return -1;
+                return 0;
             }
         }
     }

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -36,6 +36,7 @@ builder {
             [
                 'content-type' => 'text/plain',
                 'content-length' => length $content,
+                'foo' => '*', # test for issue #185
             ],
             [ $content ],
         ];


### PR DESCRIPTION
The encoder emits an assertion failure in case the header value is expected to become equal to or longer after being huffman encoded, as the huffman encoding function returns an unexpected value (in such case the function should have return zero whereas it actually returns -1).

The PR fixes the issue in response to #185.