### PR TITLE
fix `bytes_read` becoming incorrect when response is not received at once

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -286,7 +286,7 @@ static void on_head(h2o_socket_t *sock, int status)
     }
 
     h2o_buffer_consume(&client->super.sock->input, rlen);
-    client->super.sock->bytes_read -= rlen;
+    client->super.sock->bytes_read = client->super.sock->input->size;
 
     client->_timeout.cb = on_body_timeout;
     h2o_socket_read_start(sock, reader);


### PR DESCRIPTION
The bug may lead to internal state corruption, as it may set `h2o_socket_buffer_prototype._initial_buf.size` to a non-zero value (happens when the HTTP response from upstream is received in multiple number of packets, and if the last packet did not contain any response body).