### PR TITLE
Send `Via` header to upstream server

### DIFF
--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -178,10 +178,16 @@ static h2o_iovec_t build_request(h2o_req_t *req, h2o_proxy_location_t *upstream,
     }
     if (cookie_buf.len != 0) {
         RESERVE(sizeof("cookie: ") - 1 + cookie_buf.len);
-        offset += sprintf(buf.base + offset, "cookie: %.*s\r\n", (int)cookie_buf.len, cookie_buf.base);
+        APPEND_STRLIT("cookie: ");
+        APPEND(cookie_buf.base, cookie_buf.len);
+        buf.base[offset++] = '\r';
+        buf.base[offset++] = '\n';
     }
     RESERVE(sizeof("x-forwarded-proto: ") - 1 + req->scheme->name.len);
-    offset += sprintf(buf.base + offset, "x-forwarded-proto: %.*s\r\n", (int)req->scheme->name.len, req->scheme->name.base);
+    APPEND_STRLIT("x-forwarded-proto: ");
+    APPEND(req->scheme->name.base, req->scheme->name.len);
+    buf.base[offset++] = '\r';
+    buf.base[offset++] = '\n';
     if (remote_addr_len != SIZE_MAX) {
         if (x_forwarded_for != NULL) {
             RESERVE(sizeof("x-forwarded-for: , ") - 1 + x_forwarded_for->value.len + remote_addr_len);
@@ -189,7 +195,10 @@ static h2o_iovec_t build_request(h2o_req_t *req, h2o_proxy_location_t *upstream,
                               x_forwarded_for->value.base, (int)remote_addr_len, remote_addr);
         } else {
             RESERVE(sizeof("x-forwarded-for: ") - 1 + remote_addr_len);
-            offset += sprintf(buf.base + offset, "x-forwarded-for: %.*s\r\n", (int)remote_addr_len, remote_addr);
+            APPEND_STRLIT("x-forwarded-for: ");
+            APPEND(remote_addr, remote_addr_len);
+            buf.base[offset++] = '\r';
+            buf.base[offset++] = '\n';
         }
     }
     buf.base[offset++] = '\r';

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -201,8 +201,14 @@ static h2o_iovec_t build_request(h2o_req_t *req, h2o_proxy_location_t *upstream,
             buf.base[offset++] = '\n';
         }
     }
-    buf.base[offset++] = '\r';
-    buf.base[offset++] = '\n';
+    RESERVE(sizeof("via: 1.255 ") - 1 + req->authority.len);
+    if (req->version < 0x200) {
+        offset += sprintf(buf.base + offset, "via: 1.%3d ", (int)(req->version & 0xff));
+    } else {
+        APPEND_STRLIT("via: 2 ");
+    }
+    APPEND(req->authority.base, req->authority.len);
+    APPEND_STRLIT("\r\n\r\n");
 
 #undef RESERVE
 #undef APPEND

--- a/t/50reverse-proxy.t
+++ b/t/50reverse-proxy.t
@@ -98,8 +98,10 @@ sub run_tests_with_conf {
                 my $resp = `curl --silent --insecure $proto://127.0.0.1:$port/echo-headers`;
                 like $resp, qr/^x-forwarded-for: 127\.0\.0\.1$/mi, "x-forwarded-for";
                 like $resp, qr/^x-forwarded-proto: $proto$/mi, "x-forwarded-proto";
-                $resp = `curl --silent --insecure --header 'X-Forwarded-For: 127.0.0.2' $proto://127.0.0.1:$port/echo-headers`;
+                like $resp, qr/^via: 1\.1 127\.0\.0\.1:$port$/mi, "via";
+                $resp = `curl --silent --insecure --header 'X-Forwarded-For: 127.0.0.2' --header 'Via: 2 example.com' $proto://127.0.0.1:$port/echo-headers`;
                 like $resp, qr/^x-forwarded-for: 127\.0\.0\.2, 127\.0\.0\.1$/mi, "x-forwarded-for (append)";
+                like $resp, qr/^via: 2 example.com, 1\.1 127\.0\.0\.1:$port$/mi, "via (append)";
             };
         };
         $doit->('http', $port);


### PR DESCRIPTION
As suggested by @tatsuhiro-t and @Lukasa in tweets: http://twitter.com/tatsuhiro_t/status/569886046982316032 and http://twitter.com/Lukasaoz/status/569972529571495936.

The header emitted looks like: `via: 2 127.0.0.1.xip.io:8081` (RFC 7230 suggests that `HTTP/` portion of the protocol be removed).