### PR TITLE
Internal redirect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ SET(LIB_SOURCE_FILES
     lib/core/configurator.c
     lib/core/context.c
     lib/core/headers.c
+    lib/core/proxy.c
     lib/core/request.c
     lib/core/token.c
     lib/core/util.c
@@ -88,9 +89,9 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/common/time.c
     t/00unit/lib/common/url.c
     t/00unit/lib/core/headers.c
+    t/00unit/lib/core/proxy.c
     t/00unit/lib/handler/file.c
     t/00unit/lib/handler/mimemap.c
-    t/00unit/lib/handler/proxy.c
     t/00unit/lib/http2/hpack.c
     t/00unit/lib/http2/scheduler.c)
 LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
@@ -100,9 +101,9 @@ LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/common/time.c
     lib/common/url.c
     lib/core/headers.c
+    lib/core/proxy.c
     lib/handler/file.c
     lib/handler/mimemap.c
-    lib/handler/proxy.c
     lib/http2/hpack.c
     lib/http2/scheduler.c)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,13 @@ SET(LIB_SOURCE_FILES
     lib/handler/mimemap.c
     lib/handler/proxy.c
     lib/handler/redirect.c
+    lib/handler/reproxy.c
     lib/handler/configurator/access_log.c
     lib/handler/configurator/expires.c
     lib/handler/configurator/file.c
     lib/handler/configurator/proxy.c
     lib/handler/configurator/redirect.c
+    lib/handler/configurator/reproxy.c
 
     lib/http1.c
 

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		10AA2EBB1A9EEDF8004322AC /* proxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = proxy.c; sourceTree = "<group>"; };
 		10AA2EC11AA0402E004322AC /* reproxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = reproxy.c; sourceTree = "<group>"; };
 		10AA2EC31AA0403A004322AC /* reproxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = reproxy.c; sourceTree = "<group>"; };
+		10AA2EC61AA05598004322AC /* upstream.psgi */ = {isa = PBXFileReference; lastKnownFileType = text; path = upstream.psgi; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10BA72A919AAD6300059392A /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
 		10D0903919F0A51C0043D458 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		10D0903D19F0A8190043D458 /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket.h; sourceTree = "<group>"; };
@@ -699,6 +700,14 @@
 			path = examples;
 			sourceTree = "<group>";
 		};
+		10AA2EC51AA0557A004322AC /* assets */ = {
+			isa = PBXGroup;
+			children = (
+				10AA2EC61AA05598004322AC /* upstream.psgi */,
+			);
+			path = assets;
+			sourceTree = "<group>";
+		};
 		10BF213E1A087CDF008F7129 /* libh2o */ = {
 			isa = PBXGroup;
 			children = (
@@ -747,6 +756,7 @@
 				105534FA1A460F4200627ECB /* 50sni.t */,
 				105534FE1A46134A00627ECB /* 80issues61.t */,
 				104B9A451A5D1004009EEE64 /* 90live-fetch-ocsp-response.t */,
+				10AA2EC51AA0557A004322AC /* assets */,
 				105534FB1A460F4200627ECB /* Util.pm */,
 			);
 			path = t;

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		10AA2EAE1A8E22DA004322AC /* multithread.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EAD1A8E22DA004322AC /* multithread.c */; };
 		10AA2EB71A970EFC004322AC /* http2_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AA2EB61A970EFC004322AC /* http2_internal.h */; };
 		10AA2EB91A971280004322AC /* http2_scheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AA2EB81A971280004322AC /* http2_scheduler.h */; };
+		10AA2EBC1A9EEDF8004322AC /* proxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EBB1A9EEDF8004322AC /* proxy.c */; };
 		10BA72AA19AAD6300059392A /* stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 10BA72A919AAD6300059392A /* stream.c */; };
 		10D0903A19F0A51C0043D458 /* memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D0903919F0A51C0043D458 /* memory.h */; };
 		10D0903E19F0A8190043D458 /* socket.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D0903D19F0A8190043D458 /* socket.h */; };
@@ -299,6 +300,7 @@
 		10AA2EB31A94B66D004322AC /* 40virtual-host.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40virtual-host.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10AA2EB61A970EFC004322AC /* http2_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http2_internal.h; sourceTree = "<group>"; };
 		10AA2EB81A971280004322AC /* http2_scheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http2_scheduler.h; sourceTree = "<group>"; };
+		10AA2EBB1A9EEDF8004322AC /* proxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = proxy.c; sourceTree = "<group>"; };
 		10BA72A919AAD6300059392A /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
 		10D0903919F0A51C0043D458 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		10D0903D19F0A8190043D458 /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket.h; sourceTree = "<group>"; };
@@ -445,6 +447,7 @@
 				10F4180419CA75C500B6E31A /* configurator.c */,
 				107923B919A3217300C52AD6 /* context.c */,
 				107923B019A3217300C52AD6 /* headers.c */,
+				10AA2EBB1A9EEDF8004322AC /* proxy.c */,
 				107923BC19A3217300C52AD6 /* request.c */,
 				107923BF19A3217300C52AD6 /* token.c */,
 				1079245319A32C0800C52AD6 /* token_table.h */,
@@ -469,6 +472,7 @@
 			isa = PBXGroup;
 			children = (
 				104B9A471A5F9472009EEE64 /* headers.c */,
+				105534C81A3BB41C00627ECB /* proxy.c */,
 			);
 			path = core;
 			sourceTree = "<group>";
@@ -478,7 +482,6 @@
 			children = (
 				105534BD1A3B8F7700627ECB /* file.c */,
 				105534C21A3B917000627ECB /* mimemap.c */,
-				105534C81A3BB41C00627ECB /* proxy.c */,
 			);
 			path = handler;
 			sourceTree = "<group>";
@@ -977,6 +980,7 @@
 				101788B219B561AA0084C6D8 /* socket.c in Sources */,
 				10D0905519F102C70043D458 /* http1client.c in Sources */,
 				107923D219A3217300C52AD6 /* token.c in Sources */,
+				10AA2EBC1A9EEDF8004322AC /* proxy.c in Sources */,
 				104B9A511A5FB096009EEE64 /* expires.c in Sources */,
 				105534DB1A3C7A5400627ECB /* access_log.c in Sources */,
 				107923CE19A3217300C52AD6 /* mimemap.c in Sources */,

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		10AA2EB71A970EFC004322AC /* http2_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AA2EB61A970EFC004322AC /* http2_internal.h */; };
 		10AA2EB91A971280004322AC /* http2_scheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AA2EB81A971280004322AC /* http2_scheduler.h */; };
 		10AA2EBC1A9EEDF8004322AC /* proxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EBB1A9EEDF8004322AC /* proxy.c */; };
+		10AA2EC21AA0402E004322AC /* reproxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EC11AA0402E004322AC /* reproxy.c */; };
+		10AA2EC41AA0403A004322AC /* reproxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EC31AA0403A004322AC /* reproxy.c */; };
 		10BA72AA19AAD6300059392A /* stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 10BA72A919AAD6300059392A /* stream.c */; };
 		10D0903A19F0A51C0043D458 /* memory.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D0903919F0A51C0043D458 /* memory.h */; };
 		10D0903E19F0A8190043D458 /* socket.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D0903D19F0A8190043D458 /* socket.h */; };
@@ -301,6 +303,8 @@
 		10AA2EB61A970EFC004322AC /* http2_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http2_internal.h; sourceTree = "<group>"; };
 		10AA2EB81A971280004322AC /* http2_scheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http2_scheduler.h; sourceTree = "<group>"; };
 		10AA2EBB1A9EEDF8004322AC /* proxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = proxy.c; sourceTree = "<group>"; };
+		10AA2EC11AA0402E004322AC /* reproxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = reproxy.c; sourceTree = "<group>"; };
+		10AA2EC31AA0403A004322AC /* reproxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = reproxy.c; sourceTree = "<group>"; };
 		10BA72A919AAD6300059392A /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
 		10D0903919F0A51C0043D458 /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		10D0903D19F0A8190043D458 /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket.h; sourceTree = "<group>"; };
@@ -436,6 +440,7 @@
 				107923BB19A3217300C52AD6 /* mimemap.c */,
 				10D0907219F633B00043D458 /* proxy.c */,
 				10AA2EA41A8D9999004322AC /* redirect.c */,
+				10AA2EC31AA0403A004322AC /* reproxy.c */,
 			);
 			path = handler;
 			sourceTree = "<group>";
@@ -524,6 +529,7 @@
 				105534DC1A3C7AA900627ECB /* file.c */,
 				105534DE1A3C7B9800627ECB /* proxy.c */,
 				10AA2EA61A8DA93C004322AC /* redirect.c */,
+				10AA2EC11AA0402E004322AC /* reproxy.c */,
 			);
 			path = configurator;
 			sourceTree = "<group>";
@@ -989,11 +995,13 @@
 				107923C319A3217300C52AD6 /* file.c in Sources */,
 				107923CD19A3217300C52AD6 /* memory.c in Sources */,
 				107923CC19A3217300C52AD6 /* context.c in Sources */,
+				10AA2EC21AA0402E004322AC /* reproxy.c in Sources */,
 				107923C519A3217300C52AD6 /* http1.c in Sources */,
 				10AA2EA71A8DA93C004322AC /* redirect.c in Sources */,
 				10AA2EA11A88082E004322AC /* url.c in Sources */,
 				10EC2A381A0B4DC70083514F /* socketpool.c in Sources */,
 				1079239619A3210E00C52AD6 /* picohttpparser.c in Sources */,
+				10AA2EC41AA0403A004322AC /* reproxy.c in Sources */,
 				10AA2EAC1A8DE0AE004322AC /* multithread.c in Sources */,
 				1065E6F919BEBAC600686E72 /* timeout.c in Sources */,
 				10F4180519CA75C500B6E31A /* configurator.c in Sources */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -681,6 +681,11 @@ void h2o_process_request(h2o_req_t *req);
 void h2o_reprocess_request(h2o_req_t *req, h2o_iovec_t method, const h2o_url_scheme_t *scheme, h2o_iovec_t authority,
                            h2o_iovec_t path, h2o_req_overrides_t *overrides, int is_delegated);
 /**
+ * calls h2o_reprocess_request using zero_timeout callback
+ */
+void h2o_reprocess_request_deferred(h2o_req_t *req, h2o_iovec_t method, const h2o_url_scheme_t *scheme, h2o_iovec_t authority,
+                                    h2o_iovec_t path, h2o_req_overrides_t *overrides, int is_delegated);
+/**
  * called by handlers to set the generator
  * @param req the request
  * @param generator the generator

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -553,11 +553,20 @@ struct st_h2o_req_t {
      * number of bytes sent by the generator (excluding headers)
      */
     size_t bytes_sent;
+
+    /* flags */
+
     /**
      * whether or not the connection is persistent.
      * Applications should set this flag to zero in case the connection cannot be kept keep-alive (due to an error etc.)
      */
-    int http1_is_persistent;
+    char http1_is_persistent;
+    /**
+     * whether if the response has been delegated (i.e. reproxied).
+     * For delegated responses, redirect responses would be handled internally.
+     */
+    char res_is_delegated;
+
     /**
      * absolute paths to be pushed (using HTTP/2 server push)
      */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -945,6 +945,19 @@ h2o_redirect_handler_t *h2o_redirect_register(h2o_pathconf_t *pathconf, int stat
  */
 void h2o_redirect_register_configurator(h2o_globalconf_t *conf);
 
+/* lib/handler/reproxy.c */
+
+typedef struct st_h2o_reproxy_handler_t h2o_reproxy_handler_t;
+
+/**
+ * registers the reproxy filter
+ */
+void h2o_reproxy_register(h2o_pathconf_t *pathconf);
+/**
+ * registers the configurator
+ */
+void h2o_reproxy_register_configurator(h2o_globalconf_t *conf);
+
 /* inline defs */
 
 inline void h2o_proceed_response(h2o_req_t *req)

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -439,6 +439,10 @@ struct st_h2o_conn_t {
 
 typedef struct st_h2o_req_overrides_t {
     /**
+     * specific client context (or NULL)
+     */
+    h2o_http1client_ctx_t *client_ctx;
+    /**
      * socketpool to be used when connecting to upstream (or NULL)
      */
     h2o_socketpool_t *socketpool;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -678,7 +678,8 @@ void h2o_process_request(h2o_req_t *req);
 /**
  * reprocesses a request once more (used for internal redirection)
  */
-void h2o_reprocess_request(h2o_req_t *req);
+void h2o_reprocess_request(h2o_req_t *req, h2o_iovec_t method, const h2o_url_scheme_t *scheme, h2o_iovec_t authority,
+                           h2o_iovec_t path, h2o_req_overrides_t *overrides, int is_delegated);
 /**
  * called by handlers to set the generator
  * @param req the request

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -608,6 +608,10 @@ void h2o_dispose_request(h2o_req_t *req);
  */
 void h2o_process_request(h2o_req_t *req);
 /**
+ * reprocesses a request once more (used for internal redirection)
+ */
+void h2o_reprocess_request(h2o_req_t *req);
+/**
  * called by handlers to set the generator
  * @param req the request
  * @param generator the generator

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -481,6 +481,10 @@ struct st_h2o_req_t {
      */
     struct {
         /**
+         * scheme (http, https, etc.)
+         */
+        const h2o_url_scheme_t *scheme;
+        /**
          * authority (a.k.a. the Host header; the value is supplemented if missing before the handlers are being called)
          */
         h2o_iovec_t authority;
@@ -501,6 +505,10 @@ struct st_h2o_req_t {
      * the path context
      */
     h2o_pathconf_t *pathconf;
+    /**
+     * scheme (http, https, etc.)
+     */
+    const h2o_url_scheme_t *scheme;
     /**
      * authority (of the processing request)
      */
@@ -525,10 +533,6 @@ struct st_h2o_req_t {
      * overrides (maybe NULL)
      */
     h2o_req_overrides_t *overrides;
-    /**
-     * scheme (http, https, etc.)
-     */
-    const h2o_url_scheme_t *scheme;
     /**
      * the HTTP version (represented as 0xMMmm (M=major, m=minor))
      */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -426,30 +426,50 @@ struct st_h2o_req_t {
      */
     h2o_conn_t *conn;
     /**
+     * the request sent by the client (as is)
+     */
+    struct {
+        /**
+         * authority (a.k.a. the Host header; the value is supplemented if missing before the handlers are being called)
+         */
+        h2o_iovec_t authority;
+        /**
+         * method
+         */
+        h2o_iovec_t method;
+        /**
+         * abs-path of the request (unmodified)
+         */
+        h2o_iovec_t path;
+        /**
+         * offset of '?' within path, or SIZE_MAX if not found
+         */
+        size_t query_at;
+    } input;
+    /**
      * the path context
      */
     h2o_pathconf_t *pathconf;
     /**
-     * authority (a.k.a. the Host header; the value is supplemented if missing before the handlers are being called)
+     * authority (of the processing request)
      */
     h2o_iovec_t authority;
     /**
-     * HTTP method
-     * This is a non-terminated string of method_len bytes long.
+     * method (of the processing request)
      */
     h2o_iovec_t method;
     /**
-     * abs-path of the request (unmodified)
+     * abs-path of the processing request
      */
     h2o_iovec_t path;
-    /**
-     * abs-path of the request (normalized, only guaranteed to be non-NULL for non-fallback handler)
-     */
-    h2o_iovec_t path_normalized;
     /**
      * offset of '?' within path, or SIZE_MAX if not found
      */
     size_t query_at;
+    /**
+     * normalized path of the processing request (i.e. no "." or "..", no query)
+     */
+    h2o_iovec_t path_normalized;
     /**
      * scheme (http, https, etc.)
      */

--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -69,6 +69,10 @@ const char *h2o_url_parse_hostport(const char *s, size_t len, h2o_iovec_t *host,
  */
 h2o_iovec_t h2o_url_resolve(h2o_mem_pool_t *pool, const h2o_url_t *base, const h2o_url_t *relative, h2o_url_t *dest);
 /**
+ * resolves the path part of the URL (both the arguments are modified; the result is h2o_concat(*base, *relative))
+ */
+void h2o_url_resolve_path(h2o_iovec_t *base, h2o_iovec_t *relative);
+/**
  * stringifies the URL
  */
 static h2o_iovec_t h2o_url_stringify(h2o_mem_pool_t *pool, const h2o_url_t *url);

--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -72,6 +72,10 @@ h2o_iovec_t h2o_url_resolve(h2o_mem_pool_t *pool, const h2o_url_t *base, const h
  * stringifies the URL
  */
 static h2o_iovec_t h2o_url_stringify(h2o_mem_pool_t *pool, const h2o_url_t *url);
+/**
+ * copies a URL object (null-terminates all the string elements)
+ */
+void h2o_url_copy(h2o_mem_pool_t *pool, h2o_url_t *dest, const h2o_url_t *src);
 
 /* inline definitions */
 

--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -322,3 +322,12 @@ Build:
 
     return ret;
 }
+
+void h2o_url_copy(h2o_mem_pool_t *pool, h2o_url_t *dest, const h2o_url_t *src)
+{
+    dest->scheme = src->scheme;
+    dest->authority = h2o_strdup(pool, src->authority.base, src->authority.len);
+    dest->host = h2o_strdup(pool, src->host.base, src->host.len);
+    dest->path = h2o_strdup(pool, src->path.base, src->path.len);
+    dest->_port = src->_port;
+}

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -89,6 +89,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http1.upgrade_to_http2 = H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2;
     config->http1.callbacks = H2O_HTTP1_CALLBACKS;
     config->http2.idle_timeout = H2O_DEFAULT_HTTP2_IDLE_TIMEOUT;
+    config->proxy.io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
     config->http2.max_concurrent_requests_per_connection = H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams;
     config->http2.max_streams_for_priority = 16;
     config->http2.callbacks = H2O_HTTP2_CALLBACKS;

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -78,6 +78,10 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     h2o_timeout_init(ctx->loop, &ctx->http1.req_timeout, config->http1.req_timeout);
     h2o_timeout_init(ctx->loop, &ctx->http2.idle_timeout, config->http2.idle_timeout);
     h2o_linklist_init_anchor(&ctx->http2._conns);
+    ctx->proxy.client_ctx.loop = loop;
+    h2o_timeout_init(ctx->loop, &ctx->proxy.io_timeout, config->proxy.io_timeout);
+    ctx->proxy.client_ctx.io_timeout = &ctx->proxy.io_timeout;
+    ctx->proxy.client_ctx.zero_timeout = &ctx->zero_timeout;
 
     ctx->_module_configs = h2o_mem_alloc(sizeof(*ctx->_module_configs) * config->_num_config_slots);
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);
@@ -112,6 +116,7 @@ void h2o_context_dispose(h2o_context_t *ctx)
     h2o_timeout_dispose(ctx->loop, &ctx->one_sec_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http1.req_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http2.idle_timeout);
+    h2o_timeout_dispose(ctx->loop, &ctx->proxy.io_timeout);
     /* what should we do here? assert(!h2o_linklist_is_empty(&ctx->http2._conns); */
 
     h2o_multithread_destroy_queue(ctx->queue);

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -179,7 +179,7 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive)
         buf.base[offset++] = '\r';
         buf.base[offset++] = '\n';
     }
-    FLATTEN_PREFIXED_VALUE("x-forwarded-proto: ", req->scheme->name, 0);
+    FLATTEN_PREFIXED_VALUE("x-forwarded-proto: ", req->input.scheme->name, 0);
     buf.base[offset++] = '\r';
     buf.base[offset++] = '\n';
     if (remote_addr_len != SIZE_MAX) {
@@ -350,7 +350,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                 if (req->overrides != NULL && req->overrides->location_rewrite.match != NULL) {
                     value =
                         rewrite_location(&req->pool, headers[i].value, headers[i].value_len, req->overrides->location_rewrite.match,
-                                         req->scheme, req->input.authority, req->overrides->location_rewrite.path_prefix);
+                                         req->input.scheme, req->input.authority, req->overrides->location_rewrite.path_prefix);
                     if (value.base != NULL)
                         goto AddHeader;
                 }
@@ -360,7 +360,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                     if (h2o_url_parse_hostport(req->input.authority.base, req->input.authority.len, &url_parsed.host,
                                                &url_parsed._port) != NULL) {
                         url_parsed = (h2o_url_t){
-                            req->scheme,          /* scheme */
+                            req->input.scheme,    /* scheme */
                             req->input.authority, /* authority */
                             {},                   /* host */
                             req->path_normalized, /* path */

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -1,0 +1,472 @@
+/*
+ * Copyright (c) 2014,2015 DeNA Co., Ltd., Kazuho Oku, Masahiro Nagano
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include "picohttpparser.h"
+#include "h2o.h"
+#include "h2o/http1client.h"
+
+struct rp_generator_t {
+    h2o_generator_t super;
+    h2o_req_t *src_req;
+    h2o_http1client_t *client;
+    struct {
+        h2o_iovec_t bufs[2]; /* first buf is the request line and headers, the second is the POST content */
+        int is_head;
+    } up_req;
+    h2o_buffer_t *last_content_before_send;
+    h2o_buffer_t *buf_sending;
+};
+
+static h2o_iovec_t rewrite_location(h2o_mem_pool_t *pool, const char *location, size_t location_len, h2o_url_t *match,
+                                    const h2o_url_scheme_t *req_scheme, h2o_iovec_t req_authority, h2o_iovec_t req_basepath)
+{
+    h2o_url_t loc_parsed;
+
+    if (h2o_url_parse(location, location_len, &loc_parsed) != 0)
+        goto NoRewrite;
+    if (loc_parsed.scheme != &H2O_URL_SCHEME_HTTP)
+        goto NoRewrite;
+    if (!h2o_lcstris(loc_parsed.host.base, loc_parsed.host.len, match->host.base, match->host.len))
+        goto NoRewrite;
+    if (h2o_url_get_port(&loc_parsed) != h2o_url_get_port(match))
+        goto NoRewrite;
+    if (loc_parsed.path.len < match->path.len)
+        goto NoRewrite;
+    if (memcmp(loc_parsed.path.base, match->path.base, match->path.len) != 0)
+        goto NoRewrite;
+
+    return h2o_concat(pool, req_scheme->name, h2o_iovec_init(H2O_STRLIT("://")), req_authority, req_basepath,
+                      h2o_iovec_init(loc_parsed.path.base + match->path.len, loc_parsed.path.len - match->path.len));
+
+NoRewrite:
+    return (h2o_iovec_t){};
+}
+
+static h2o_iovec_t build_request_merge_headers(h2o_mem_pool_t *pool, h2o_iovec_t merged, h2o_iovec_t added, int seperator)
+{
+    if (added.len == 0)
+        return merged;
+    if (merged.len == 0)
+        return added;
+
+    size_t newlen = merged.len + 2 + added.len;
+    char *buf = h2o_mem_alloc_pool(pool, newlen);
+    memcpy(buf, merged.base, merged.len);
+    buf[merged.len] = seperator;
+    buf[merged.len + 1] = ' ';
+    memcpy(buf + merged.len + 2, added.base, added.len);
+    merged.base = buf;
+    merged.len = newlen;
+    return merged;
+}
+
+static h2o_iovec_t build_request(h2o_req_t *req, int keepalive)
+{
+    h2o_iovec_t buf;
+    size_t offset = 0, remote_addr_len = SIZE_MAX;
+    char remote_addr[NI_MAXHOST];
+    h2o_iovec_t cookie_buf = {}, xff_buf = {}, via_buf = {};
+
+    /* for x-f-f */
+    if (req->conn->peername.addr != NULL)
+        remote_addr_len = h2o_socket_getnumerichost(req->conn->peername.addr, req->conn->peername.len, remote_addr);
+
+    /* build response */
+    buf.len = req->method.len + req->path.len + req->authority.len + 512;
+    buf.base = h2o_mem_alloc_pool(&req->pool, buf.len);
+
+#define RESERVE(sz)                                                                                                                \
+    do {                                                                                                                           \
+        if (offset + sz + 4 /* for "\r\n\r\n" */ > buf.len) {                                                                      \
+            buf.len *= 2;                                                                                                          \
+            char *newp = h2o_mem_alloc_pool(&req->pool, buf.len);                                                                  \
+            memcpy(newp, buf.base, offset);                                                                                        \
+            buf.base = newp;                                                                                                       \
+        }                                                                                                                          \
+    } while (0)
+#define APPEND(s, l)                                                                                                               \
+    do {                                                                                                                           \
+        memcpy(buf.base + offset, (s), (l));                                                                                       \
+        offset += (l);                                                                                                             \
+    } while (0)
+#define APPEND_STRLIT(lit) APPEND((lit), sizeof(lit) - 1)
+#define FLATTEN_PREFIXED_VALUE(prefix, value, add_size)                                                                            \
+    do {                                                                                                                           \
+        RESERVE(sizeof(prefix) - 1 + value.len + 2 + add_size);                                                                    \
+        APPEND_STRLIT(prefix);                                                                                                     \
+        if (value.len != 0) {                                                                                                      \
+            APPEND(value.base, value.len);                                                                                         \
+            if (add_size != 0) {                                                                                                   \
+                buf.base[offset++] = ',';                                                                                          \
+                buf.base[offset++] = ' ';                                                                                          \
+            }                                                                                                                      \
+        }                                                                                                                          \
+    } while (0)
+
+    APPEND(req->method.base, req->method.len);
+    buf.base[offset++] = ' ';
+    APPEND(req->path.base, req->path.len);
+    APPEND_STRLIT(" HTTP/1.1\r\nconnection: ");
+    if (keepalive) {
+        APPEND_STRLIT("keep-alive\r\nhost: ");
+    } else {
+        APPEND_STRLIT("close\r\nhost: ");
+    }
+    APPEND(req->authority.base, req->authority.len);
+    buf.base[offset++] = '\r';
+    buf.base[offset++] = '\n';
+    assert(offset <= buf.len);
+    if (req->entity.base != NULL) {
+        RESERVE(sizeof("content-length: 18446744073709551615") - 1);
+        offset += sprintf(buf.base + offset, "content-length: %zu\r\n", req->entity.len);
+    }
+    {
+        const h2o_header_t *h, *h_end;
+        for (h = req->headers.entries, h_end = h + req->headers.size; h != h_end; ++h) {
+            if (h2o_iovec_is_token(h->name)) {
+                const h2o_token_t *token = (void *)h->name;
+                if (token->proxy_should_drop) {
+                    continue;
+                } else if (token == H2O_TOKEN_COOKIE) {
+                    /* merge the cookie headers; see HTTP/2 8.1.2.5 and HTTP/1 (RFC6265 5.4) */
+                    /* FIXME current algorithm is O(n^2) against the number of cookie headers */
+                    cookie_buf = build_request_merge_headers(&req->pool, cookie_buf, h->value, ';');
+                    continue;
+                } else if (token == H2O_TOKEN_VIA) {
+                    via_buf = build_request_merge_headers(&req->pool, via_buf, h->value, ',');
+                    continue;
+                }
+            }
+            if (h2o_lcstris(h->name->base, h->name->len, H2O_STRLIT("x-forwarded-proto")))
+                continue;
+            if (h2o_lcstris(h->name->base, h->name->len, H2O_STRLIT("x-forwarded-for"))) {
+                xff_buf = build_request_merge_headers(&req->pool, xff_buf, h->value, ',');
+                continue;
+            }
+            RESERVE(h->name->len + h->value.len + 2);
+            APPEND(h->name->base, h->name->len);
+            buf.base[offset++] = ':';
+            buf.base[offset++] = ' ';
+            APPEND(h->value.base, h->value.len);
+            buf.base[offset++] = '\r';
+            buf.base[offset++] = '\n';
+        }
+    }
+    if (cookie_buf.len != 0) {
+        FLATTEN_PREFIXED_VALUE("cookie: ", cookie_buf, 0);
+        buf.base[offset++] = '\r';
+        buf.base[offset++] = '\n';
+    }
+    FLATTEN_PREFIXED_VALUE("x-forwarded-proto: ", req->scheme->name, 0);
+    buf.base[offset++] = '\r';
+    buf.base[offset++] = '\n';
+    if (remote_addr_len != SIZE_MAX) {
+        FLATTEN_PREFIXED_VALUE("x-forwarded-for: ", xff_buf, remote_addr_len);
+        APPEND(remote_addr, remote_addr_len);
+    } else {
+        FLATTEN_PREFIXED_VALUE("x-forwarded-for: ", xff_buf, 0);
+    }
+    buf.base[offset++] = '\r';
+    buf.base[offset++] = '\n';
+    FLATTEN_PREFIXED_VALUE("via: ", via_buf, sizeof("1.1 ") - 1 + req->input.authority.len);
+    if (req->version < 0x200) {
+        buf.base[offset++] = '1';
+        buf.base[offset++] = '.';
+        buf.base[offset++] = '0' + (0x100 <= req->version && req->version <= 0x109 ? req->version - 0x100 : 0);
+    } else {
+        buf.base[offset++] = '2';
+    }
+    buf.base[offset++] = ' ';
+    APPEND(req->input.authority.base, req->input.authority.len);
+    APPEND_STRLIT("\r\n\r\n");
+
+#undef RESERVE
+#undef APPEND
+#undef APPEND_STRLIT
+#undef FLATTEN_PREFIXED_VALUE
+
+    /* set the length */
+    assert(offset <= buf.len);
+    buf.len = offset;
+
+    return buf;
+}
+
+static void do_close(h2o_generator_t *generator, h2o_req_t *req)
+{
+    struct rp_generator_t *self = (void *)generator;
+
+    if (self->client != NULL) {
+        h2o_http1client_cancel(self->client);
+        self->client = NULL;
+    }
+}
+
+static void swap_buffer(h2o_buffer_t **x, h2o_buffer_t **y)
+{
+    h2o_buffer_t *t = *x;
+    *x = *y;
+    *y = t;
+}
+
+static void do_send(struct rp_generator_t *self)
+{
+    assert(self->buf_sending->size == 0);
+
+    swap_buffer(&self->buf_sending, self->client != NULL ? &self->client->sock->input : &self->last_content_before_send);
+
+    if (self->buf_sending->size != 0) {
+        h2o_iovec_t buf = h2o_iovec_init(self->buf_sending->bytes, self->buf_sending->size);
+        h2o_send(self->src_req, &buf, 1, self->client == NULL);
+    } else if (self->client == NULL) {
+        h2o_send(self->src_req, NULL, 0, 1);
+    }
+}
+
+static void do_proceed(h2o_generator_t *generator, h2o_req_t *req)
+{
+    struct rp_generator_t *self = (void *)generator;
+
+    h2o_buffer_consume(&self->buf_sending, self->buf_sending->size);
+
+    do_send(self);
+}
+
+static int on_body(h2o_http1client_t *client, const char *errstr)
+{
+    struct rp_generator_t *self = client->data;
+
+    /* FIXME should there be a way to notify error downstream? */
+
+    if (errstr != NULL) {
+        /* detach the content */
+        self->last_content_before_send = self->client->sock->input;
+        h2o_buffer_init(&self->client->sock->input, &h2o_socket_buffer_prototype);
+        self->client = NULL;
+    }
+    if (self->buf_sending->size == 0)
+        do_send(self);
+
+    return 0;
+}
+
+static void on_link_header(h2o_req_t *req, const char *value, size_t value_len, h2o_url_t *base)
+{
+    h2o_iovec_t url;
+    h2o_url_t parsed, resolved;
+
+    if (req->version < 0x200)
+        return;
+
+    { /* extract URL value from: Link: </pushed.css>; rel=preload */
+        h2o_iovec_t iter = h2o_iovec_init(value, value_len), token_value;
+        const char *token;
+        size_t token_len;
+        /* first element should be <URL> */
+        if ((token = h2o_next_token(&iter, ';', &token_len, NULL)) == NULL)
+            return;
+        if (!(token_len >= 2 && token[0] == '<' && token[token_len - 1] == '>'))
+            return;
+        url = h2o_iovec_init(token + 1, token_len - 2);
+        /* find rel=preload */
+        while ((token = h2o_next_token(&iter, ';', &token_len, &token_value)) != NULL) {
+            if (h2o_lcstris(token, token_len, H2O_STRLIT("rel")) &&
+                h2o_lcstris(token_value.base, token_value.len, H2O_STRLIT("preload")))
+                break;
+        }
+        if (token == NULL)
+            return;
+    }
+
+    /* check the authority, and extract absolute path */
+    if (h2o_url_parse_relative(url.base, url.len, &parsed) != 0)
+        return;
+    h2o_url_resolve(&req->pool, base, &parsed, &resolved);
+    if (!(base->scheme == resolved.scheme &&
+          (parsed.authority.base == NULL ||
+           h2o_lcstris(base->authority.base, base->authority.len, resolved.authority.base, resolved.authority.len))))
+        return;
+
+    h2o_vector_reserve(&req->pool, (h2o_vector_t *)&req->http2_push_paths, sizeof(req->http2_push_paths.entries[0]),
+                       req->http2_push_paths.size + 1);
+    req->http2_push_paths.entries[req->http2_push_paths.size++] = resolved.path;
+}
+
+static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
+                                       h2o_iovec_t msg, struct phr_header *headers, size_t num_headers)
+{
+    struct rp_generator_t *self = client->data;
+    size_t i;
+    h2o_url_t url_parsed = {};
+
+    if (errstr != NULL && errstr != h2o_http1client_error_is_eos) {
+        self->client = NULL;
+        h2o_send_error(self->src_req, 502, "Gateway Error", errstr, 0);
+        return NULL;
+    }
+
+    /* copy the response (note: all the headers must be copied; http1client discards the input once we return from this callback) */
+    self->src_req->res.status = status;
+    self->src_req->res.reason = h2o_strdup(&self->src_req->pool, msg.base, msg.len).base;
+    for (i = 0; i != num_headers; ++i) {
+        const h2o_token_t *token = h2o_lookup_token(headers[i].name, headers[i].name_len);
+        h2o_iovec_t value;
+        if (token != NULL) {
+            if (token->proxy_should_drop) {
+                goto Skip;
+            }
+            if (token == H2O_TOKEN_CONTENT_LENGTH) {
+                if (self->src_req->res.content_length != SIZE_MAX ||
+                    (self->src_req->res.content_length = h2o_strtosize(headers[i].value, headers[i].value_len)) == SIZE_MAX) {
+                    self->client = NULL;
+                    h2o_send_error(self->src_req, 502, "Gateway Error", "invalid response from upstream", 0);
+                    return NULL;
+                }
+                goto Skip;
+            } else if (token == H2O_TOKEN_LOCATION) {
+                if (self->src_req->overrides != NULL || self->src_req->overrides->location_rewrite.match != NULL) {
+                    value =
+                        rewrite_location(&self->src_req->pool, headers[i].value, headers[i].value_len,
+                                         self->src_req->overrides->location_rewrite.match, self->src_req->scheme,
+                                         self->src_req->input.authority, self->src_req->overrides->location_rewrite.path_prefix);
+                    if (value.base != NULL)
+                        goto AddHeader;
+                }
+                goto AddHeaderDuped;
+            } else if (token == H2O_TOKEN_LINK) {
+                if (url_parsed.scheme == NULL) {
+                    if (h2o_url_parse_hostport(self->src_req->input.authority.base, self->src_req->input.authority.len,
+                                               &url_parsed.host, &url_parsed._port) != NULL) {
+                        url_parsed = (h2o_url_t){
+                            self->src_req->scheme,          /* scheme */
+                            self->src_req->input.authority, /* authority */
+                            {},                             /* host */
+                            self->src_req->path_normalized, /* path */
+                            65535                           /* port */
+                        };
+                    }
+                }
+                if (url_parsed.scheme != NULL)
+                    on_link_header(self->src_req, headers[i].value, headers[i].value_len, &url_parsed);
+            }
+        /* default behaviour, transfer the header downstream */
+        AddHeaderDuped:
+            value = h2o_strdup(&self->src_req->pool, headers[i].value, headers[i].value_len);
+        AddHeader:
+            h2o_add_header(&self->src_req->pool, &self->src_req->res.headers, token, value.base, value.len);
+        Skip:
+            ;
+        } else {
+            h2o_iovec_t name = h2o_strdup(&self->src_req->pool, headers[i].name, headers[i].name_len);
+            h2o_iovec_t value = h2o_strdup(&self->src_req->pool, headers[i].value, headers[i].value_len);
+            h2o_add_header_by_str(&self->src_req->pool, &self->src_req->res.headers, name.base, name.len, 0, value.base, value.len);
+        }
+    }
+
+    /* declare the start of the response */
+    h2o_start_response(self->src_req, &self->super);
+
+    if (errstr == h2o_http1client_error_is_eos) {
+        self->client = NULL;
+        h2o_send(self->src_req, NULL, 0, 1);
+        return NULL;
+    }
+
+    return on_body;
+}
+
+static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
+                                          int *method_is_head)
+{
+    struct rp_generator_t *self = client->data;
+
+    if (errstr != NULL) {
+        self->client = NULL;
+        h2o_send_error(self->src_req, 502, "Gateway Error", errstr, 0);
+        return NULL;
+    }
+
+    *reqbufs = self->up_req.bufs;
+    *reqbufcnt = self->up_req.bufs[1].base != NULL ? 2 : 1;
+    *method_is_head = self->up_req.is_head;
+    return on_head;
+}
+
+static void on_generator_dispose(void *_self)
+{
+    struct rp_generator_t *self = _self;
+
+    if (self->client != NULL) {
+        h2o_http1client_cancel(self->client);
+        self->client = NULL;
+    }
+    h2o_buffer_dispose(&self->last_content_before_send);
+    h2o_buffer_dispose(&self->buf_sending);
+}
+
+static struct rp_generator_t *proxy_send_prepare(h2o_req_t *req, int keepalive)
+{
+    struct rp_generator_t *self = h2o_mem_alloc_shared(&req->pool, sizeof(*self), on_generator_dispose);
+
+    self->super.proceed = do_proceed;
+    self->super.stop = do_close;
+    self->src_req = req;
+    self->up_req.bufs[0] = build_request(req, keepalive);
+    self->up_req.bufs[1] = req->entity;
+    self->up_req.is_head = h2o_memis(req->method.base, req->method.len, H2O_STRLIT("HEAD"));
+    h2o_buffer_init(&self->last_content_before_send, &h2o_socket_buffer_prototype);
+    h2o_buffer_init(&self->buf_sending, &h2o_socket_buffer_prototype);
+
+    return self;
+}
+
+void h2o__proxy_process_request(h2o_req_t *req)
+{
+    h2o_context_t *ctx = req->conn->ctx;
+    h2o_req_overrides_t *overrides = req->overrides;
+    struct rp_generator_t *self;
+
+    if (overrides != NULL && overrides->socketpool != NULL) {
+        self = proxy_send_prepare(req, 1);
+        self->client = h2o_http1client_connect_with_pool(&ctx->proxy.client_ctx, &req->pool, overrides->socketpool, on_connect);
+    } else {
+        self = proxy_send_prepare(req, 0);
+        if (overrides != NULL && overrides->hostport.host != NULL) {
+            self->client = h2o_http1client_connect(&ctx->proxy.client_ctx, &req->pool, req->overrides->hostport.host,
+                                                   req->overrides->hostport.port, on_connect);
+        } else {
+            h2o_iovec_t host;
+            uint16_t port;
+            if (h2o_url_parse_hostport(req->authority.base, req->authority.len, &host, &port) == NULL) {
+                assert(!"FIXME");
+            }
+            if (port == 65535)
+                port = 80;
+            self->client = h2o_http1client_connect(&ctx->proxy.client_ctx, &req->pool,
+                                                   h2o_strdup(&req->pool, host.base, host.len).base, port, on_connect);
+        }
+    }
+    self->client->data = self;
+}

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -321,6 +321,53 @@ None:
     return (h2o_iovec_t){};
 }
 
+static int handle_internal_redirect(h2o_req_t *req, int status, struct phr_header *headers, size_t num_headers, char **err)
+{
+    size_t loc_index;
+    h2o_url_t location;
+    int authority_changed;
+    h2o_iovec_t method;
+
+    *err = NULL;
+
+    /* find the location header, or return -1 */
+    for (loc_index = 0; loc_index != num_headers; ++loc_index) {
+        if (h2o_memis(headers[loc_index].name, headers[loc_index].name_len, H2O_STRLIT("location")))
+            goto Found;
+    }
+    return 0;
+
+Found:
+    /* parse the location URL */
+    if (h2o_url_parse_relative(headers[loc_index].value, headers[loc_index].value_len, &location) != 0) {
+        *err = h2o_concat(&req->pool, h2o_iovec_init(H2O_STRLIT("cannot handle location header: ")),
+                          h2o_iovec_init(headers[loc_index].value, headers[loc_index].value_len)).base;
+        return 1;
+    }
+    /* convert the location to absolute */
+    if (location.scheme == NULL)
+        location.scheme = req->scheme;
+    if (location.authority.base == NULL) {
+        location.authority = req->authority;
+        authority_changed = 0;
+    } else {
+        authority_changed = !h2o_lcstris(location.authority.base, location.authority.len, req->authority.base, req->authority.len);
+    }
+    h2o_iovec_t base_path = req->path;
+    h2o_url_resolve_path(&base_path, &location.path);
+    location.path = h2o_concat(&req->pool, base_path, location.path);
+
+    if (h2o_memis(req->method.base, req->method.len, H2O_STRLIT("POST")) && !(status == 307 || status == 308))
+        method = h2o_iovec_init(H2O_STRLIT("GET"));
+    else
+        method = req->method;
+
+    h2o_reprocess_request_deferred(req, method, location.scheme, location.authority, location.path,
+                                   authority_changed ? req->overrides : NULL, 1);
+
+    return 1;
+}
+
 static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
                                        h2o_iovec_t msg, struct phr_header *headers, size_t num_headers)
 {
@@ -333,6 +380,16 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
         self->client = NULL;
         h2o_send_error(req, 502, "Gateway Error", errstr, 0);
         return NULL;
+    }
+
+    if (req->res_is_delegated && (300 <= status && status <= 399) && status != 304) {
+        char *err;
+        if (handle_internal_redirect(req, status, headers, num_headers, &err)) {
+            self->client = NULL;
+            if (err != NULL)
+                send_error(req, err);
+            return NULL;
+        }
     }
 
     /* copy the response (note: all the headers must be copied; http1client discards the input once we return from this callback) */

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -355,7 +355,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                         goto AddHeader;
                 }
                 goto AddHeaderDuped;
-            } else if (token == H2O_TOKEN_LINK && req->version >= 0x200) {
+            } else if (token == H2O_TOKEN_LINK && req->version >= 0x200 && !req->res_is_delegated) {
                 if (url_parsed.scheme == NULL) {
                     if (h2o_url_parse_hostport(req->input.authority.base, req->input.authority.len, &url_parsed.host,
                                                &url_parsed._port) != NULL) {

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -346,7 +346,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                 }
                 goto Skip;
             } else if (token == H2O_TOKEN_LOCATION) {
-                if (self->src_req->overrides != NULL || self->src_req->overrides->location_rewrite.match != NULL) {
+                if (self->src_req->overrides != NULL && self->src_req->overrides->location_rewrite.match != NULL) {
                     value =
                         rewrite_location(&self->src_req->pool, headers[i].value, headers[i].value_len,
                                          self->src_req->overrides->location_rewrite.match, self->src_req->scheme,

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -39,6 +39,13 @@ struct rp_generator_t {
     h2o_buffer_t *buf_sending;
 };
 
+static void send_error(h2o_req_t *req, const char *internal_reason)
+{
+    fprintf(stderr, "[proxy] an error ocurred while handling internal redirect to %s://%.*s%.*s; %s\n", req->scheme->name.base,
+            (int)req->authority.len, req->authority.base, (int)req->path.len, req->path.base, internal_reason);
+    h2o_send_error(req, 502, "Gateway Error", "internal error", 0);
+}
+
 static h2o_iovec_t rewrite_location(h2o_mem_pool_t *pool, const char *location, size_t location_len, h2o_url_t *match,
                                     const h2o_url_scheme_t *req_scheme, h2o_iovec_t req_authority, h2o_iovec_t req_basepath)
 {
@@ -468,8 +475,13 @@ void h2o__proxy_process_request(h2o_req_t *req)
         } else {
             h2o_iovec_t host;
             uint16_t port;
+            if (req->scheme != &H2O_URL_SCHEME_HTTP) {
+                send_error(req, "only HTTP (not HTTPS) URLs are supported");
+                return;
+            }
             if (h2o_url_parse_hostport(req->authority.base, req->authority.len, &host, &port) == NULL) {
-                assert(!"FIXME");
+                send_error(req, "could not parse host and port of URL");
+                return;
             }
             if (port == 65535)
                 port = 80;

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -53,6 +53,7 @@ static h2o_hostconf_t *setup_before_processing(h2o_req_t *req)
         req->input.authority = hostconf->hostname;
     }
 
+    req->scheme = req->input.scheme;
     req->method = req->input.method;
     req->authority = req->input.authority;
     req->path = req->input.path;
@@ -143,7 +144,7 @@ void h2o_init_request(h2o_req_t *req, h2o_conn_t *conn, h2o_req_t *src)
         COPY(input.authority);
         COPY(input.method);
         COPY(input.path);
-        req->scheme = src->scheme;
+        req->input.scheme = src->input.scheme;
         req->version = src->version;
         h2o_vector_reserve(&req->pool, (h2o_vector_t *)&req->headers, sizeof(h2o_header_t), src->headers.size);
         memcpy(req->headers.entries, src->headers.entries, sizeof(req->headers.entries[0]) * src->headers.size);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -183,15 +183,22 @@ void h2o_process_request(h2o_req_t *req)
     process_hosted_request(req, hostconf);
 }
 
-void h2o_reprocess_request(h2o_req_t *req)
+void h2o_reprocess_request(h2o_req_t *req, h2o_iovec_t method, const h2o_url_scheme_t *scheme, h2o_iovec_t authority,
+                           h2o_iovec_t path, h2o_req_overrides_t *overrides, int is_delegated)
 {
     h2o_hostconf_t *hostconf;
 
     /* close generators and filters that are already running */
     close_generator_and_filters(req);
 
-    /* update path_normalized and query_at */
+    /* setup the request parameters */
+    req->method = method;
+    req->scheme = scheme;
+    req->authority = authority;
+    req->path = path;
     req->path_normalized = h2o_url_normalize_path(&req->pool, req->path.base, req->path.len, &req->query_at);
+    req->overrides = overrides;
+    req->res_is_delegated |= 1;
 
     /* reset the response */
     req->res = (h2o_res_t){0, NULL, SIZE_MAX, {}};

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -180,14 +180,15 @@ void h2o_process_request(h2o_req_t *req)
 void h2o_reprocess_request(h2o_req_t *req)
 {
     h2o_hostconf_t *hostconf;
-    memset(&req->res, 0, sizeof(req->res));
+    req->res = (h2o_res_t){0, NULL, SIZE_MAX, {}};
 
-    if ((hostconf = find_hostconf(req->conn->hosts, req->authority)) != NULL) {
+    if (req->overrides == NULL && (hostconf = find_hostconf(req->conn->hosts, req->authority)) != NULL) {
         process_hosted_request(req, hostconf);
         return;
     }
 
-    assert(!"FIXME use httpclient");
+    /* uses the current pathconf, in other words, proxy uses the previous pathconf for building filters */
+    h2o__proxy_process_request(req);
 }
 
 void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -209,7 +209,7 @@ void h2o_reprocess_request(h2o_req_t *req, h2o_iovec_t method, const h2o_url_sch
     req->path = path;
     req->path_normalized = h2o_url_normalize_path(&req->pool, req->path.base, req->path.len, &req->query_at);
     req->overrides = overrides;
-    req->res_is_delegated |= 1;
+    req->res_is_delegated |= is_delegated;
 
     /* reset the response */
     req->res = (h2o_res_t){0, NULL, SIZE_MAX, {}};

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -187,8 +187,13 @@ void h2o_reprocess_request(h2o_req_t *req)
 {
     h2o_hostconf_t *hostconf;
 
+    /* close generators and filters that are already running */
     close_generator_and_filters(req);
 
+    /* update path_normalized and query_at */
+    req->path_normalized = h2o_url_normalize_path(&req->pool, req->path.base, req->path.len, &req->query_at);
+
+    /* reset the response */
     req->res = (h2o_res_t){0, NULL, SIZE_MAX, {}};
     req->_ostr_init_index = 0;
 

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -325,8 +325,8 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
         case ELEMENT_TYPE_URL_PATH: /* %U */
         {
             size_t path_len = req->input.query_at == SIZE_MAX ? req->input.path.len : req->input.query_at;
-            RESERVE(req->scheme->name.len + (sizeof("://") - 1) + (req->input.authority.len + path_len) * 4);
-            pos = append_safe_string(pos, req->scheme->name.base, req->scheme->name.len);
+            RESERVE(req->input.scheme->name.len + (sizeof("://") - 1) + (req->input.authority.len + path_len) * 4);
+            pos = append_safe_string(pos, req->input.scheme->name.base, req->input.scheme->name.len);
             pos = append_safe_string(pos, H2O_STRLIT("://"));
             pos = append_unsafe_string(pos, req->input.authority.base, req->input.authority.len);
             pos = append_unsafe_string(pos, req->input.path.base, path_len);

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -294,21 +294,21 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
             }
             break;
         case ELEMENT_TYPE_METHOD: /* %m */
-            RESERVE(req->method.len * 4);
-            pos = append_unsafe_string(pos, req->method.base, req->method.len);
+            RESERVE(req->input.method.len * 4);
+            pos = append_unsafe_string(pos, req->input.method.base, req->input.method.len);
             break;
         case ELEMENT_TYPE_QUERY: /* %q */
-            if (req->query_at != SIZE_MAX) {
-                size_t len = req->path.len - req->query_at;
+            if (req->input.query_at != SIZE_MAX) {
+                size_t len = req->input.path.len - req->input.query_at;
                 RESERVE(len * 4);
-                pos = append_unsafe_string(pos, req->path.base + req->query_at, len);
+                pos = append_unsafe_string(pos, req->input.path.base + req->input.query_at, len);
             }
             break;
         case ELEMENT_TYPE_REQUEST_LINE: /* %r */
-            RESERVE((req->method.len + req->path.len) * 4 + sizeof("  HTTP/1.1") - 1);
-            pos = append_unsafe_string(pos, req->method.base, req->method.len);
+            RESERVE((req->input.method.len + req->input.path.len) * 4 + sizeof("  HTTP/1.1") - 1);
+            pos = append_unsafe_string(pos, req->input.method.base, req->input.method.len);
             *pos++ = ' ';
-            pos = append_unsafe_string(pos, req->path.base, req->path.len);
+            pos = append_unsafe_string(pos, req->input.path.base, req->input.path.len);
             *pos++ = ' ';
             pos = append_protocol(pos, req->version);
             break;
@@ -324,16 +324,16 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
             break;
         case ELEMENT_TYPE_URL_PATH: /* %U */
         {
-            size_t path_len = req->query_at == SIZE_MAX ? req->path.len : req->query_at;
-            RESERVE(req->scheme->name.len + (sizeof("://") - 1) + (req->authority.len + path_len) * 4);
+            size_t path_len = req->input.query_at == SIZE_MAX ? req->input.path.len : req->input.query_at;
+            RESERVE(req->scheme->name.len + (sizeof("://") - 1) + (req->input.authority.len + path_len) * 4);
             pos = append_safe_string(pos, req->scheme->name.base, req->scheme->name.len);
             pos = append_safe_string(pos, H2O_STRLIT("://"));
-            pos = append_unsafe_string(pos, req->authority.base, req->authority.len);
-            pos = append_unsafe_string(pos, req->path.base, path_len);
+            pos = append_unsafe_string(pos, req->input.authority.base, req->input.authority.len);
+            pos = append_unsafe_string(pos, req->input.path.base, path_len);
         } break;
         case ELEMENT_TYPE_AUTHORITY: /* %V */
-            RESERVE(req->authority.len * 4);
-            pos = append_unsafe_string(pos, req->authority.base, req->authority.len);
+            RESERVE(req->input.authority.len * 4);
+            pos = append_unsafe_string(pos, req->input.authority.base, req->input.authority.len);
             break;
         case ELEMENT_TYPE_HOSTCONF: /* %v */
             RESERVE(req->pathconf->host->hostname.len * 4);

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -70,7 +70,7 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
     /* RFC 2616 4.4 states that the following status codes (and response to a HEAD method) should not include message body */
     if ((100 <= req->res.status && req->res.status <= 199) || req->res.status == 204 || req->res.status == 304)
         goto Next;
-    else if (h2o_memis(req->method.base, req->method.len, H2O_STRLIT("HEAD")))
+    else if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
         goto Next;
     /* we cannot handle certain responses (like 101 switching protocols) */
     if (req->res.status != 200) {

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -68,9 +68,7 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
         goto ErrExit;
     }
     /* register */
-    h2o_proxy_register_reverse_proxy(ctx->pathconf, h2o_strdup(&pool, parsed.host.base, parsed.host.len).base,
-                                     h2o_url_get_port(&parsed), h2o_strdup(&pool, parsed.path.base, parsed.path.len).base,
-                                     self->vars);
+    h2o_proxy_register_reverse_proxy(ctx->pathconf, &parsed, self->vars);
 
     h2o_mem_clear_pool(&pool);
     return 0;
@@ -103,7 +101,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
 
     /* set default vars */
     c->vars = c->_vars_stack;
-    c->vars->io_timeout = 5000;
+    c->vars->io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
     c->vars->keepalive_timeout = 2000;
 
     /* setup handlers */
@@ -121,7 +119,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "proxy.timeout.io",
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
                                         H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
-                                    on_config_timeout_io, "sets upstream I/O timeout (in milliseconds, default: 5000)");
+                                    on_config_timeout_io, "sets upstream I/O timeout (in milliseconds, default: " H2O_TO_STR(H2O_DEFAULT_PROXY_IO_TIMEOUT) ")");
     h2o_configurator_define_command(
         &c->super, "proxy.timeout.keepalive", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST |
                                                   H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,

--- a/lib/handler/configurator/reproxy.c
+++ b/lib/handler/configurator/reproxy.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015 Daisuke Maki, DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <inttypes.h>
+#include "h2o.h"
+#include "h2o/configurator.h"
+
+struct config_t {
+    int enabled;
+};
+
+struct reproxy_configurator_t {
+    h2o_configurator_t super;
+    struct config_t *vars, _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
+};
+
+static int on_config_reproxy(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct reproxy_configurator_t *self = (void *)cmd->configurator;
+
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    self->vars->enabled = (int)ret;
+
+    return 0;
+}
+
+static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct reproxy_configurator_t *self = (void *)_self;
+
+    self->vars[1] = self->vars[0];
+    ++self->vars;
+    return 0;
+}
+
+static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct reproxy_configurator_t *self = (void *)_self;
+
+    if (ctx->pathconf != NULL && self->vars->enabled != 0)
+        h2o_reproxy_register(ctx->pathconf);
+
+    --self->vars;
+    return 0;
+}
+
+void h2o_reproxy_register_configurator(h2o_globalconf_t *conf)
+{
+    struct reproxy_configurator_t *c = (void *)h2o_configurator_create(conf, sizeof(*c));
+
+    /* set default vars */
+    c->vars = c->_vars_stack;
+
+    /* setup handlers */
+    c->super.enter = on_config_enter;
+    c->super.exit = on_config_exit;
+
+    /* reproxy: ON | OFF */
+    h2o_configurator_define_command(&c->super, "reproxy", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST |
+                                                              H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_reproxy, "boolean flag (ON/OFF) indicating whether or not to accept Reproxy-URL\n"
+                                                       "response headers from upstream (default: OFF)");
+}

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -213,7 +213,7 @@ static h2o_iovec_t build_request(h2o_req_t *req, h2o_proxy_location_t *upstream,
     }
     buf.base[offset++] = '\r';
     buf.base[offset++] = '\n';
-    FLATTEN_PREFIXED_VALUE("via: ", via_buf, sizeof("1.1 ") - 1 + req->authority.len);
+    FLATTEN_PREFIXED_VALUE("via: ", via_buf, sizeof("1.1 ") - 1 + req->input.authority.len);
     if (req->version < 0x200) {
         buf.base[offset++] = '1';
         buf.base[offset++] = '.';
@@ -222,7 +222,7 @@ static h2o_iovec_t build_request(h2o_req_t *req, h2o_proxy_location_t *upstream,
         buf.base[offset++] = '2';
     }
     buf.base[offset++] = ' ';
-    APPEND(req->authority.base, req->authority.len);
+    APPEND(req->input.authority.base, req->input.authority.len);
     APPEND_STRLIT("\r\n\r\n");
 
 #undef RESERVE
@@ -370,15 +370,15 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                 goto Skip;
             } else if (token == H2O_TOKEN_LOCATION) {
                 value = rewrite_location(&self->src_req->pool, headers[i].value, headers[i].value_len, self->upstream,
-                                         self->src_req->scheme, self->src_req->authority, self->src_req->pathconf->path);
+                                         self->src_req->scheme, self->src_req->input.authority, self->src_req->pathconf->path);
                 goto AddHeader;
             } else if (token == H2O_TOKEN_LINK) {
                 if (url_parsed.scheme == NULL) {
-                    if (h2o_url_parse_hostport(self->src_req->authority.base, self->src_req->authority.len, &url_parsed.host,
-                                               &url_parsed._port) != NULL) {
+                    if (h2o_url_parse_hostport(self->src_req->input.authority.base, self->src_req->input.authority.len,
+                                               &url_parsed.host, &url_parsed._port) != NULL) {
                         url_parsed = (h2o_url_t){
                             self->src_req->scheme,          /* scheme */
-                            self->src_req->authority,       /* authority */
+                            self->src_req->input.authority, /* authority */
                             {},                             /* host */
                             self->src_req->path_normalized, /* path */
                             65535                           /* port */

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -51,8 +51,10 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     }
 
     /* rewrite request */
-    if (!self->config.preserve_host)
+    if (!self->config.preserve_host) {
+        req->scheme = self->upstream.scheme;
         req->authority = self->upstream.authority;
+    }
     req->path = h2o_concat(&req->pool, self->upstream.path,
                            h2o_iovec_init(req->path.base + req->pathconf->path.len, req->path.len - req->pathconf->path.len));
 

--- a/lib/handler/reproxy.c
+++ b/lib/handler/reproxy.c
@@ -37,6 +37,7 @@ static void on_timeout(h2o_timeout_entry_t *entry)
     req->authority = args->authority;
     req->path = args->path;
     req->overrides = NULL;
+    req->res_is_delegated |= 1;
 
     h2o_reprocess_request(req);
 }

--- a/lib/handler/reproxy.c
+++ b/lib/handler/reproxy.c
@@ -32,16 +32,7 @@ struct st_reproxy_args_t {
 static void on_timeout(h2o_timeout_entry_t *entry)
 {
     struct st_reproxy_args_t *args = H2O_STRUCT_FROM_MEMBER(struct st_reproxy_args_t, timeout, entry);
-    h2o_req_t *req = args->req;
-
-    req->scheme = args->scheme;
-    req->method = h2o_iovec_init(H2O_STRLIT("GET"));
-    req->authority = args->authority;
-    req->path = args->path;
-    req->overrides = NULL;
-    req->res_is_delegated |= 1;
-
-    h2o_reprocess_request(req);
+    h2o_reprocess_request(args->req, h2o_iovec_init(H2O_STRLIT("GET")), args->scheme, args->authority, args->path, NULL, 1);
 }
 
 static void on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final)

--- a/lib/handler/reproxy.c
+++ b/lib/handler/reproxy.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2014,2015 DeNA Co., Ltd., Kazuho Oku, Daisuke Maki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "h2o.h"
+
+struct st_reproxy_args_t {
+    h2o_timeout_entry_t timeout;
+    h2o_req_t *req;
+    h2o_iovec_t authority;
+    h2o_iovec_t path;
+};
+
+static void on_timeout(h2o_timeout_entry_t *entry)
+{
+    struct st_reproxy_args_t *args = H2O_STRUCT_FROM_MEMBER(struct st_reproxy_args_t, timeout, entry);
+    h2o_req_t *req = args->req;
+
+    req->method = h2o_iovec_init(H2O_STRLIT("GET"));
+    req->authority = args->authority;
+    req->path = args->path;
+    req->overrides = NULL;
+
+    h2o_reprocess_request(req);
+}
+
+static void on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final)
+{
+    /* nothing to do */
+}
+
+static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t **slot)
+{
+    h2o_url_t xru_parsed;
+    size_t xru_index = h2o_find_header(&req->res.headers, H2O_TOKEN_X_REPROXY_URL, -1);
+
+    /* skip if not x-reproxy-url */
+    if (xru_index == -1)
+        goto Next;
+
+    /* see if we can parse x-reproxy-url */
+    if (h2o_url_parse(req->res.headers.entries[xru_index].value.base, req->res.headers.entries[xru_index].value.len, &xru_parsed) !=
+        0)
+        goto Next;
+
+    /* We got ourselves a X-Reproxy-URL header. make sure we have
+     * "http" scheme, cause that's all we handle
+     */
+    if (xru_parsed.scheme != &H2O_URL_SCHEME_HTTP)
+        goto Next;
+
+    /* schedule the reprocessing */
+    struct st_reproxy_args_t *args = h2o_mem_alloc_pool(&req->pool, sizeof(*args));
+    *args = (struct st_reproxy_args_t){
+        {0, on_timeout},      /* timeout */
+        req,                  /* req */
+        xru_parsed.authority, /* authority */
+        xru_parsed.path       /* path */
+    };
+    h2o_timeout_link(req->conn->ctx->loop, &req->conn->ctx->zero_timeout, &args->timeout);
+
+    /* setup filter (that swallows the response until the timeout gets fired) */
+    h2o_ostream_t *ostream = h2o_add_ostream(req, sizeof(*ostream), slot);
+    ostream->do_send = on_send;
+    return;
+
+Next: /* just bypass to the next filter */
+    h2o_setup_next_ostream(self, req, slot);
+}
+
+void h2o_reproxy_register(h2o_pathconf_t *pathconf)
+{
+    h2o_filter_t *self = h2o_create_filter(pathconf, sizeof(*self));
+    self->on_setup_ostream = on_setup_ostream;
+}

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -323,8 +323,8 @@ static ssize_t fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_header
     /* copy the values to pool, since the buffer pointed by the headers may get realloced */
     if (entity_header_index != -1) {
         size_t i;
-        conn->req.method = h2o_strdup(&conn->req.pool, conn->req.method.base, conn->req.method.len);
-        conn->req.path = h2o_strdup(&conn->req.pool, conn->req.path.base, conn->req.path.len);
+        conn->req.input.method = h2o_strdup(&conn->req.pool, conn->req.input.method.base, conn->req.input.method.len);
+        conn->req.input.path = h2o_strdup(&conn->req.pool, conn->req.input.path.base, conn->req.input.path.len);
         for (i = 0; i != conn->req.headers.size; ++i) {
             h2o_header_t *header = conn->req.headers.entries + i;
             if (!h2o_iovec_is_token(header->name)) {
@@ -340,7 +340,7 @@ static ssize_t fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_header
 
     /* move host header to req->authority */
     if (host.base != NULL)
-        conn->req.authority = host;
+        conn->req.input.authority = host;
 
     /* setup persistent flag (and upgrade info) */
     if (connection.base != NULL) {
@@ -384,9 +384,9 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
     ssize_t entity_body_header_index;
     h2o_iovec_t expect;
 
-    reqlen = phr_parse_request(conn->sock->input->bytes, inreqlen, (const char **)&conn->req.method.base, &conn->req.method.len,
-                               (const char **)&conn->req.path.base, &conn->req.path.len, &minor_version, headers, &num_headers,
-                               conn->_prevreqlen);
+    reqlen = phr_parse_request(conn->sock->input->bytes, inreqlen, (const char **)&conn->req.input.method.base,
+                               &conn->req.input.method.len, (const char **)&conn->req.input.path.base, &conn->req.input.path.len,
+                               &minor_version, headers, &num_headers, conn->_prevreqlen);
     conn->_prevreqlen = inreqlen;
 
     switch (reqlen) {

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -313,7 +313,7 @@ static ssize_t fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_header
     expect->base = NULL;
     expect->len = 0;
 
-    conn->req.scheme = conn->sock->ssl != NULL ? &H2O_URL_SCHEME_HTTPS : &H2O_URL_SCHEME_HTTP;
+    conn->req.input.scheme = conn->sock->ssl != NULL ? &H2O_URL_SCHEME_HTTPS : &H2O_URL_SCHEME_HTTP;
     conn->req.version = 0x100 | (minor_version != 0);
 
     /* init headers */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1026,10 +1026,11 @@ void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http
     h2o_http2_stream_prepare_for_request(conn, stream);
 
     /* setup request */
-    stream->req.method = (h2o_iovec_t){H2O_STRLIT("GET")};
+    stream->req.input.method = (h2o_iovec_t){H2O_STRLIT("GET")};
     stream->req.scheme = src_stream->req.scheme;
-    stream->req.authority = h2o_strdup(&stream->req.pool, src_stream->req.authority.base, src_stream->req.authority.len);
-    stream->req.path = h2o_strdup(&stream->req.pool, path.base, path.len);
+    stream->req.input.authority =
+        h2o_strdup(&stream->req.pool, src_stream->req.input.authority.base, src_stream->req.input.authority.len);
+    stream->req.input.path = h2o_strdup(&stream->req.pool, path.base, path.len);
     stream->req.version = 0x200;
 
     { /* copy headers that may affect the response (of a cacheable response) */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1027,7 +1027,7 @@ void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http
 
     /* setup request */
     stream->req.input.method = (h2o_iovec_t){H2O_STRLIT("GET")};
-    stream->req.scheme = src_stream->req.scheme;
+    stream->req.input.scheme = src_stream->req.input.scheme;
     stream->req.input.authority =
         h2o_strdup(&stream->req.pool, src_stream->req.input.authority.base, src_stream->req.input.authority.len);
     stream->req.input.path = h2o_strdup(&stream->req.pool, path.base, path.len);

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -402,19 +402,19 @@ int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_tab
                 /* FIXME validate the chars in the value (e.g. reject SP in path) */
                 if (r.name == &H2O_TOKEN_AUTHORITY->buf) {
                     /* FIXME should we perform this check? */
-                    if (req->authority.base != NULL)
+                    if (req->input.authority.base != NULL)
                         return H2O_HTTP2_ERROR_PROTOCOL;
-                    req->authority = *r.value;
+                    req->input.authority = *r.value;
                     *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS;
                 } else if (r.name == &H2O_TOKEN_METHOD->buf) {
-                    if (req->method.base != NULL)
+                    if (req->input.method.base != NULL)
                         return H2O_HTTP2_ERROR_PROTOCOL;
-                    req->method = *r.value;
+                    req->input.method = *r.value;
                     *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS;
                 } else if (r.name == &H2O_TOKEN_PATH->buf) {
-                    if (req->path.base != NULL)
+                    if (req->input.path.base != NULL)
                         return H2O_HTTP2_ERROR_PROTOCOL;
-                    req->path = *r.value;
+                    req->input.path = *r.value;
                     *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_PATH_EXISTS;
                 } else if (r.name == &H2O_TOKEN_SCHEME->buf) {
                     if (req->scheme != NULL)
@@ -675,10 +675,10 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
     size_t capacity = flatten_headers_calc_capacity(req->headers.entries, req->headers.size);
     capacity += H2O_HTTP2_FRAME_HEADER_SIZE /* first frame header */
                 + 4;                        /* promised stream id */
-    capacity += calc_capacity(H2O_TOKEN_METHOD->buf.len, req->method.len);
+    capacity += calc_capacity(H2O_TOKEN_METHOD->buf.len, req->input.method.len);
     capacity += calc_capacity(H2O_TOKEN_SCHEME->buf.len, req->scheme->name.len);
-    capacity += calc_capacity(H2O_TOKEN_AUTHORITY->buf.len, req->authority.len);
-    capacity += calc_capacity(H2O_TOKEN_PATH->buf.len, req->path.len);
+    capacity += calc_capacity(H2O_TOKEN_AUTHORITY->buf.len, req->input.authority.len);
+    capacity += calc_capacity(H2O_TOKEN_PATH->buf.len, req->input.path.len);
 
     size_t start_at = (*buf)->size;
     uint8_t *dst = (void *)h2o_buffer_reserve(buf, capacity).base + H2O_HTTP2_FRAME_HEADER_SIZE;
@@ -688,10 +688,10 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
     *dst++ = (uint8_t)(stream_id << 16);
     *dst++ = (uint8_t)(stream_id << 8);
     *dst++ = (uint8_t)stream_id;
-    dst = encode_header(header_table, dst, &H2O_TOKEN_METHOD->buf, &req->method);
+    dst = encode_header(header_table, dst, &H2O_TOKEN_METHOD->buf, &req->input.method);
     dst = encode_header(header_table, dst, &H2O_TOKEN_SCHEME->buf, &req->scheme->name);
-    dst = encode_header(header_table, dst, &H2O_TOKEN_AUTHORITY->buf, &req->authority);
-    dst = encode_header(header_table, dst, &H2O_TOKEN_PATH->buf, &req->path);
+    dst = encode_header(header_table, dst, &H2O_TOKEN_AUTHORITY->buf, &req->input.authority);
+    dst = encode_header(header_table, dst, &H2O_TOKEN_PATH->buf, &req->input.path);
     dst = flatten_headers(dst, header_table, req->headers.entries, req->headers.size);
     (*buf)->size = (char *)dst - (*buf)->bytes;
 

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -417,13 +417,13 @@ int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_tab
                     req->input.path = *r.value;
                     *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_PATH_EXISTS;
                 } else if (r.name == &H2O_TOKEN_SCHEME->buf) {
-                    if (req->scheme != NULL)
+                    if (req->input.scheme != NULL)
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     if (h2o_memis(r.value->base, r.value->len, H2O_STRLIT("https"))) {
-                        req->scheme = &H2O_URL_SCHEME_HTTPS;
+                        req->input.scheme = &H2O_URL_SCHEME_HTTPS;
                     } else {
                         /* draft-16 8.1.2.3 suggests quote: ":scheme is not restricted to http and https schemed URIs" */
-                        req->scheme = &H2O_URL_SCHEME_HTTP;
+                        req->input.scheme = &H2O_URL_SCHEME_HTTP;
                     }
                     *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS;
                 } else {
@@ -676,7 +676,7 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
     capacity += H2O_HTTP2_FRAME_HEADER_SIZE /* first frame header */
                 + 4;                        /* promised stream id */
     capacity += calc_capacity(H2O_TOKEN_METHOD->buf.len, req->input.method.len);
-    capacity += calc_capacity(H2O_TOKEN_SCHEME->buf.len, req->scheme->name.len);
+    capacity += calc_capacity(H2O_TOKEN_SCHEME->buf.len, req->input.scheme->name.len);
     capacity += calc_capacity(H2O_TOKEN_AUTHORITY->buf.len, req->input.authority.len);
     capacity += calc_capacity(H2O_TOKEN_PATH->buf.len, req->input.path.len);
 
@@ -689,7 +689,7 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
     *dst++ = (uint8_t)(stream_id << 8);
     *dst++ = (uint8_t)stream_id;
     dst = encode_header(header_table, dst, &H2O_TOKEN_METHOD->buf, &req->input.method);
-    dst = encode_header(header_table, dst, &H2O_TOKEN_SCHEME->buf, &req->scheme->name);
+    dst = encode_header(header_table, dst, &H2O_TOKEN_SCHEME->buf, &req->input.scheme->name);
     dst = encode_header(header_table, dst, &H2O_TOKEN_AUTHORITY->buf, &req->input.authority);
     dst = encode_header(header_table, dst, &H2O_TOKEN_PATH->buf, &req->input.path);
     dst = flatten_headers(dst, header_table, req->headers.entries, req->headers.size);

--- a/lib/websocket.c
+++ b/lib/websocket.c
@@ -166,7 +166,7 @@ int h2o_is_websocket_handshake(h2o_req_t *req, const char **ws_client_key)
     *ws_client_key = NULL;
 
     /* method */
-    if (h2o_memis(req->method.base, req->method.len, H2O_STRLIT("GET"))) {
+    if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("GET"))) {
         /* ok */
     } else {
         return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -1179,6 +1179,7 @@ static void setup_configurators(void)
     h2o_expires_register_configurator(&conf.globalconf);
     h2o_file_register_configurator(&conf.globalconf);
     h2o_proxy_register_configurator(&conf.globalconf);
+    h2o_reproxy_register_configurator(&conf.globalconf);
     h2o_redirect_register_configurator(&conf.globalconf);
 }
 

--- a/t/00unit/lib/core/proxy.c
+++ b/t/00unit/lib/core/proxy.c
@@ -20,22 +20,25 @@
  * IN THE SOFTWARE.
  */
 #include "../../test.h"
-#include "../../../../lib/handler/proxy.c"
+#include "../../../../lib/core/proxy.c"
 
 void test_lib__proxy_c()
 {
-    h2o_proxy_location_t conf = {{H2O_STRLIT("realhost")}, 81, {H2O_STRLIT("/real/")}};
+    h2o_url_t upstream;
     h2o_mem_pool_t pool;
     h2o_iovec_t ret;
 
+    h2o_url_parse(H2O_STRLIT("http://realhost:81/real/"), &upstream);
+
     h2o_mem_init_pool(&pool);
 
-    ret = rewrite_location(&pool, H2O_STRLIT("http://realhost:81/real/abc"), &conf, &H2O_URL_SCHEME_HTTPS,
+    ret = rewrite_location(&pool, H2O_STRLIT("http://realhost:81/real/abc"), &upstream, &H2O_URL_SCHEME_HTTPS,
                            h2o_iovec_init(H2O_STRLIT("vhost:8443")), h2o_iovec_init(H2O_STRLIT("/virtual/")));
     ok(h2o_memis(ret.base, ret.len, H2O_STRLIT("https://vhost:8443/virtual/abc")));
-    ret = rewrite_location(&pool, H2O_STRLIT("http://realhost:81/other/abc"), &conf, &H2O_URL_SCHEME_HTTPS,
+    ret = rewrite_location(&pool, H2O_STRLIT("http://realhost:81/other/abc"), &upstream, &H2O_URL_SCHEME_HTTPS,
                            h2o_iovec_init(H2O_STRLIT("vhost:8443")), h2o_iovec_init(H2O_STRLIT("/virtual/")));
-    ok(h2o_memis(ret.base, ret.len, H2O_STRLIT("http://realhost:81/other/abc")));
+    ok(ret.base == NULL);
+    ok(ret.len == 0);
 
     h2o_mem_clear_pool(&pool);
 }

--- a/t/00unit/lib/core/proxy.c
+++ b/t/00unit/lib/core/proxy.c
@@ -22,7 +22,7 @@
 #include "../../test.h"
 #include "../../../../lib/core/proxy.c"
 
-void test_lib__proxy_c()
+static void test_rewrite_location(void)
 {
     h2o_url_t upstream;
     h2o_mem_pool_t pool;
@@ -41,4 +41,46 @@ void test_lib__proxy_c()
     ok(ret.len == 0);
 
     h2o_mem_clear_pool(&pool);
+}
+
+static void test_extract_pushpath_from_link_header(void)
+{
+    h2o_mem_pool_t pool;
+    h2o_url_t base;
+    h2o_iovec_t path;
+
+    h2o_mem_init_pool(&pool);
+    h2o_url_parse(H2O_STRLIT("http://basehost/basepath/"), &base);
+
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("<http://basehost/otherpath>; rel=preload"), &base);
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/otherpath")));
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("</otherpath>; rel=preload"), &base);
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/otherpath")));
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("<otherpath>; rel=preload"), &base);
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/basepath/otherpath")));
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("<../otherpath>; rel=preload"), &base);
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/otherpath")));
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("<http:otherpath>; rel=preload"), &base);
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/basepath/otherpath")));
+
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("<../otherpath>; rel=author"), &base);
+    ok(path.base == NULL);
+    ok(path.len == 0);
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("<http://basehost:81/otherpath>; rel=preload"), &base);
+    ok(path.base == NULL);
+    ok(path.len == 0);
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("<https://basehost/otherpath>; rel=preload"), &base);
+    ok(path.base == NULL);
+    ok(path.len == 0);
+    path = extract_pushpath_from_link_header(&pool, H2O_STRLIT("<https:otherpath>; rel=preload"), &base);
+    ok(path.base == NULL);
+    ok(path.len == 0);
+
+    h2o_mem_clear_pool(&pool);
+}
+
+void test_lib__proxy_c()
+{
+    subtest("rewrite_location", test_rewrite_location);
+    subtest("extract_pushpath_from_link_header", test_extract_pushpath_from_link_header);
 }

--- a/t/00unit/lib/handler/file.c
+++ b/t/00unit/lib/handler/file.c
@@ -40,8 +40,8 @@ static void test_if_modified_since(void)
     { /* obtain last-modified */
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         ssize_t lm_index;
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         if ((lm_index = h2o_find_header(&conn->req.res.headers, H2O_TOKEN_LAST_MODIFIED, -1)) == -1) {
@@ -56,8 +56,8 @@ static void test_if_modified_since(void)
 
     { /* send if-modified-since using the obtained last-modified */
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
         h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE, lm_date, H2O_TIMESTR_RFC1123_LEN);
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 304);
@@ -67,8 +67,8 @@ static void test_if_modified_since(void)
 
     { /* send if-modified-since using an old date */
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
         h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE,
                        H2O_STRLIT("Sun, 06 Nov 1994 08:49:37 GMT"));
         h2o_loopback_run_loop(conn);
@@ -78,8 +78,8 @@ static void test_if_modified_since(void)
 
     { /* send if-modified-since using a date in the future */
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
         h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE,
                        H2O_STRLIT("Wed, 18 May 2033 12:33:20 GMT"));
         h2o_loopback_run_loop(conn);
@@ -96,8 +96,8 @@ static void test_if_match(void)
     { /* obtain etag */
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         ssize_t etag_index;
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         if ((etag_index = h2o_find_header(&conn->req.res.headers, H2O_TOKEN_ETAG, -1)) == -1) {
@@ -111,8 +111,8 @@ static void test_if_match(void)
 
     { /* send if-non-match using the obtained etag */
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
         h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_NONE_MATCH, etag.base, etag.len);
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 304);
@@ -138,8 +138,8 @@ void test_lib__file_c()
 
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/html"));
@@ -148,8 +148,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/html"));
@@ -158,8 +158,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/index.html"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index.html"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/html"));
@@ -168,8 +168,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/index.html"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index.html"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/html"));
@@ -178,8 +178,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -188,8 +188,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -199,8 +199,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/1000000.txt"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000000.txt"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -209,8 +209,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/1000000.txt"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000000.txt"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -220,8 +220,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/index_txt/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -230,8 +230,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/index_txt/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -240,8 +240,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/index_txt"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 301);
         ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "http://default/index_txt/"));
@@ -249,8 +249,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/index_txt"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 301);
         ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "http://default/index_txt/"));
@@ -258,8 +258,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/index_txt_as_dir/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("HEAD"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt_as_dir/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 301);
         ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "http://default/index_txt_as_dir/index.txt/"));
@@ -267,8 +267,8 @@ void test_lib__file_c()
     }
     {
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-        conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-        conn->req.path = h2o_iovec_init(H2O_STRLIT("/index_txt_as_dir/"));
+        conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+        conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt_as_dir/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 301);
         ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "http://default/index_txt_as_dir/index.txt/"));

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -40,12 +40,12 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len, &pseudo_headers_map, &content_length,
                                 &err_desc);
     ok(r == 0);
-    ok(req.authority.len == 15);
-    ok(memcmp(req.authority.base, H2O_STRLIT("www.example.com")) == 0);
-    ok(req.method.len == 3);
-    ok(memcmp(req.method.base, H2O_STRLIT("GET")) == 0);
-    ok(req.path.len == 1);
-    ok(memcmp(req.path.base, H2O_STRLIT("/")) == 0);
+    ok(req.input.authority.len == 15);
+    ok(memcmp(req.input.authority.base, H2O_STRLIT("www.example.com")) == 0);
+    ok(req.input.method.len == 3);
+    ok(memcmp(req.input.method.base, H2O_STRLIT("GET")) == 0);
+    ok(req.input.path.len == 1);
+    ok(memcmp(req.input.path.base, H2O_STRLIT("/")) == 0);
     ok(req.scheme == &H2O_URL_SCHEME_HTTP);
     ok(req.headers.size == 0);
 
@@ -57,12 +57,12 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len, &pseudo_headers_map, &content_length,
                                 &err_desc);
     ok(r == 0);
-    ok(req.authority.len == 15);
-    ok(memcmp(req.authority.base, H2O_STRLIT("www.example.com")) == 0);
-    ok(req.method.len == 3);
-    ok(memcmp(req.method.base, H2O_STRLIT("GET")) == 0);
-    ok(req.path.len == 1);
-    ok(memcmp(req.path.base, H2O_STRLIT("/")) == 0);
+    ok(req.input.authority.len == 15);
+    ok(memcmp(req.input.authority.base, H2O_STRLIT("www.example.com")) == 0);
+    ok(req.input.method.len == 3);
+    ok(memcmp(req.input.method.base, H2O_STRLIT("GET")) == 0);
+    ok(req.input.path.len == 1);
+    ok(memcmp(req.input.path.base, H2O_STRLIT("/")) == 0);
     ok(req.scheme == &H2O_URL_SCHEME_HTTP);
     ok(req.headers.size == 1);
     ok(h2o_memis(req.headers.entries[0].name->base, req.headers.entries[0].name->len, H2O_STRLIT("cache-control")));
@@ -76,12 +76,12 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     r = h2o_hpack_parse_headers(&req, &header_table, (const uint8_t *)in.base, in.len, &pseudo_headers_map, &content_length,
                                 &err_desc);
     ok(r == 0);
-    ok(req.authority.len == 15);
-    ok(memcmp(req.authority.base, H2O_STRLIT("www.example.com")) == 0);
-    ok(req.method.len == 3);
-    ok(memcmp(req.method.base, H2O_STRLIT("GET")) == 0);
-    ok(req.path.len == 11);
-    ok(memcmp(req.path.base, H2O_STRLIT("/index.html")) == 0);
+    ok(req.input.authority.len == 15);
+    ok(memcmp(req.input.authority.base, H2O_STRLIT("www.example.com")) == 0);
+    ok(req.input.method.len == 3);
+    ok(memcmp(req.input.method.base, H2O_STRLIT("GET")) == 0);
+    ok(req.input.path.len == 11);
+    ok(memcmp(req.input.path.base, H2O_STRLIT("/index.html")) == 0);
     ok(req.scheme == &H2O_URL_SCHEME_HTTPS);
     ok(req.headers.size == 1);
     ok(h2o_memis(req.headers.entries[0].name->base, req.headers.entries[0].name->len, H2O_STRLIT("custom-key")));
@@ -145,11 +145,11 @@ void test_lib__http2__hpack(void)
     {
         uint8_t buf[16];
         size_t len;
-#define TEST(encoded, value) \
-        memset(buf, 0, sizeof(buf)); \
-        len = encode_int(buf, value, 7) - buf; \
-        ok(len == sizeof(encoded) - 1); \
-        ok(memcmp(buf, encoded, sizeof(encoded) - 1) == 0);
+#define TEST(encoded, value)                                                                                                       \
+    memset(buf, 0, sizeof(buf));                                                                                                   \
+    len = encode_int(buf, value, 7) - buf;                                                                                         \
+    ok(len == sizeof(encoded) - 1);                                                                                                \
+    ok(memcmp(buf, encoded, sizeof(encoded) - 1) == 0);
         TEST("\x00", 0);
         TEST("\x03", 3);
         TEST("\x7e", 126);

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -46,7 +46,7 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     ok(memcmp(req.input.method.base, H2O_STRLIT("GET")) == 0);
     ok(req.input.path.len == 1);
     ok(memcmp(req.input.path.base, H2O_STRLIT("/")) == 0);
-    ok(req.scheme == &H2O_URL_SCHEME_HTTP);
+    ok(req.input.scheme == &H2O_URL_SCHEME_HTTP);
     ok(req.headers.size == 0);
 
     h2o_mem_clear_pool(&req.pool);
@@ -63,7 +63,7 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     ok(memcmp(req.input.method.base, H2O_STRLIT("GET")) == 0);
     ok(req.input.path.len == 1);
     ok(memcmp(req.input.path.base, H2O_STRLIT("/")) == 0);
-    ok(req.scheme == &H2O_URL_SCHEME_HTTP);
+    ok(req.input.scheme == &H2O_URL_SCHEME_HTTP);
     ok(req.headers.size == 1);
     ok(h2o_memis(req.headers.entries[0].name->base, req.headers.entries[0].name->len, H2O_STRLIT("cache-control")));
     ok(h2o_lcstris(req.headers.entries[0].value.base, req.headers.entries[0].value.len, H2O_STRLIT("no-cache")));
@@ -82,7 +82,7 @@ static void test_request(h2o_iovec_t first_req, h2o_iovec_t second_req, h2o_iove
     ok(memcmp(req.input.method.base, H2O_STRLIT("GET")) == 0);
     ok(req.input.path.len == 11);
     ok(memcmp(req.input.path.base, H2O_STRLIT("/index.html")) == 0);
-    ok(req.scheme == &H2O_URL_SCHEME_HTTPS);
+    ok(req.input.scheme == &H2O_URL_SCHEME_HTTPS);
     ok(req.headers.size == 1);
     ok(h2o_memis(req.headers.entries[0].name->base, req.headers.entries[0].name->len, H2O_STRLIT("custom-key")));
     ok(h2o_lcstris(req.headers.entries[0].value.base, req.headers.entries[0].value.len, H2O_STRLIT("custom-value")));

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -62,8 +62,8 @@ void h2o_loopback_destroy(h2o_loopback_conn_t *conn)
 
 void h2o_loopback_run_loop(h2o_loopback_conn_t *conn)
 {
-    if (conn->req.scheme == NULL)
-        conn->req.scheme = &H2O_URL_SCHEME_HTTP;
+    if (conn->req.input.scheme == NULL)
+        conn->req.input.scheme = &H2O_URL_SCHEME_HTTP;
     if (conn->req.version == 0)
         conn->req.version = 0x100; /* HTTP/1.0 */
 

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -111,8 +111,8 @@ static void test_loopback(void)
     h2o_context_init(&ctx, test_loop, &conf);
 
     conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
-    conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-    conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+    conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+    conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
     h2o_loopback_run_loop(conn);
 
     ok(conn->req.res.status == 404);

--- a/t/50reverse-proxy.t
+++ b/t/50reverse-proxy.t
@@ -91,7 +91,8 @@ sub run_tests_with_conf {
             is length($content), $huge_file_size, "$proto://127.0.0.1/echo (POST, chunked, mmap-backed, size)";
             is md5_hex($content), $huge_file_md5, "$proto://127.0.0.1/echo (POST, chunked, mmap-backed, md5)";
             subtest 'rewrite-redirect' => sub {
-                $content = `curl --silent --insecure --dump-header /dev/stdout --max-redirs 0 $proto://127.0.0.1:$port/redirect/http://127.0.0.1:$upstream_port/abc`;
+                $content = `curl --silent --insecure --dump-header /dev/stdout --max-redirs 0 "$proto://127.0.0.1:$port/?resp:status=302&resp:location=http://127.0.0.1:$upstream_port/abc"`;
+                like $content, qr{HTTP/1\.1 302 }m;
                 like $content, qr{^location: $proto://127.0.0.1:$port/abc\r$}m;
             };
             subtest "x-forwarded ($proto)" => sub {
@@ -132,7 +133,7 @@ sub run_tests_with_conf {
                 like $out, qr{^cookie: a=b; c=d$}m;
             };
             subtest 'issues/185' => sub {
-                my $out = `nghttp $opt -v "$proto://127.0.0.1:$port/set-headers?access-control-allow-origin=%2a"`;
+                my $out = `nghttp $opt -v "$proto://127.0.0.1:$port/?resp:access-control-allow-origin=%2a"`;
                 is $?, 0;
                 like $out, qr/ access-control-allow-origin: \*$/m;
             };
@@ -140,7 +141,7 @@ sub run_tests_with_conf {
                 my $cookie = '_yohoushi_session=ZU5tK2FhcllVQ1RGaTZmZE9MUXozZnAzdTdmR250ZjRFU1hNSnZ4Y2JxZm9pYzJJSEpISGFKNmtWcW1HcjBySmUxZzIwNngrdlVIOC9jdmg0R3I3TFR4eVYzaHlFSHdEL1M4dnh1SmRCbVl3ZE5FckZEU1NyRmZveWZwTmVjcVV5V1JhNUd5REIvWjAwQ3RiT1ZBNGVMUkhiN0tWR0c1RzZkSVhrVkdoeW1lWXRDeHJPUW52NUwxSytRTEQrWXdoZ1EvVG9kak9aeUxnUFRNTDB4Vis1RDNUYWVHZm12bDgwL1lTa09MTlJYcGpXN2VUWmdHQ2FuMnVEVDd4c3l1TTJPMXF1dGhYcGRHS2U2bW9UaG0yZGIwQ0ZWVzFsY1hNTkY5cVFvWjNqSWNrQ0pOY1gvMys4UmRHdXJLU1A0ZTZQc3pSK1dKcXlpTEF2djJHLzUwbytwSnVpS0xhdFp6NU9kTDhtcmgxamVXMkI0Nm9Nck1rMStLUmV0TEdUeGFSTjlKSzM0STc3NTlSZ05ZVjJhWUNibkdzY1I1NUg4bG96dWZSeGorYzF4M2tzMGhKSkxmeFBTNkpZS09HTFgrREN4SWd4a29kamRxT3FobDRQZ2xMVUE9PS0tQUxSWU5nWmVTVzRoN09sS3pmUVM3dz09--3a411c0cf59845f0b8ccf61f69b8eb87aa1727ac; path=/; HttpOnly';
                 my $cookie_encoded = $cookie;
                 $cookie_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
-                $out = `nghttp $opt -v $proto://127.0.0.1:$port/set-headers?set-cookie=$cookie_encoded`;
+                $out = `nghttp $opt -v $proto://127.0.0.1:$port/?resp:set-cookie=$cookie_encoded`;
                 is $?, 0;
                 like $out, qr/ set-cookie: $cookie$/m;
             };

--- a/t/50reverse-proxy.t
+++ b/t/50reverse-proxy.t
@@ -104,6 +104,8 @@ sub run_tests_with_conf {
                 }
                 my $content = `curl --silent --show-error --insecure "$proto://127.0.0.1:$port/streaming-body?resp:status=200&resp:x-reproxy-url=http://127.0.0.1:$upstream_port/index.txt"`;
                 is $content, "hello\n", "streaming-body";
+                $content = `curl --silent --dump-header /dev/stderr --insecure "$proto://127.0.0.1:$port/?resp:status=200&resp:x-reproxy-url=https://127.0.0.1:$upstream_port/index.txt" 2>&1 > /dev/null`;
+                like $content, qr{^HTTP/1\.1 502 }m;
             };
             subtest "x-forwarded ($proto)" => sub {
                 my $resp = `curl --silent --insecure $proto://127.0.0.1:$port/echo-headers`;
@@ -150,6 +152,8 @@ sub run_tests_with_conf {
                 }
                 my $content = `nghttp $opt "$proto://127.0.0.1:$port/streaming-body?resp:status=200&resp:x-reproxy-url=http://127.0.0.1:$upstream_port/index.txt"`;
                 is $content, "hello\n", "streaming-body";
+                $content = `nghttp -v $opt "$proto://127.0.0.1:$port/?resp:status=200&resp:x-reproxy-url=https://127.0.0.1:$upstream_port/index.txt"`;
+                like $content, qr/ :status: 502$/m;
             };
             subtest 'issues/185' => sub {
                 my $out = `nghttp $opt -v "$proto://127.0.0.1:$port/?resp:access-control-allow-origin=%2a"`;

--- a/t/80issues61.t
+++ b/t/80issues61.t
@@ -38,7 +38,7 @@ subtest 'http1' => sub {
         $extra .= ' --insecure'
             if $proto eq 'https';
         subtest $proto => sub {
-            my $resp = `curl --max-time 1 $extra $proto://127.0.0.1:$port/sleep 2>&1`;
+            my $resp = `curl --max-time 1 $extra $proto://127.0.0.1:$port/streaming-body 2>&1`;
             like $resp, qr/operation timed out/i, "operation should time out";
             sleep 1;
             $resp = `curl --silent --dump-header /dev/stderr $extra $proto://127.0.0.1:$port/ 2>&1 > /dev/null`;

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -37,13 +37,16 @@ builder {
             return sub {
                 my $env = shift;
                 my $res = $app->($env);
-                my @headers;
-                for (my $i = 0; $i != @{$res->[1]}; $i += 2) {
-                    push @headers, $res->[1][$i], $res->[1][$i + 1]
-                        if lc $res->[1][$i] ne 'content-length';
-                }
-                $res->[1] = \@headers;
-                return $res;
+                Plack::Util::response_cb($res, sub {
+                    my $res = shift;
+                    my @headers;
+                    for (my $i = 0; $i != @{$res->[1]}; $i += 2) {
+                        push @headers, $res->[1][$i], $res->[1][$i + 1]
+                            if lc $res->[1][$i] ne 'content-length';
+                    }
+                    $res->[1] = \@headers;
+                    return $res;
+                });
             };
         };
     }

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -84,4 +84,18 @@ builder {
             $writer->close;
         };
     };
+    mount "/sleep-and-respond" => sub {
+        my $env = shift;
+        my $query = Plack::Request->new($env)->parameters;
+        sleep($query->{sleep} || 0);
+        return [
+            200,
+            [
+                'content-type' => 'text/plain; charset=utf-8',
+            ],
+            [
+                'hello world',
+            ],
+        ];
+    };
 };

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -72,7 +72,7 @@ builder {
             [],
         ];
     };
-    mount "/sleep" => sub {
+    mount "/streaming-body" => sub {
         my $env = shift;
         return sub {
             my $responder = shift;

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -9,6 +9,25 @@ use t::Util;
 my $force_chunked = $ENV{FORCE_CHUNKED} || 0;
 
 builder {
+    enable sub {
+        my $app = shift;
+        return sub {
+            my $env = shift;
+            my $query = Plack::Request->new($env)->query_parameters;
+            my $res = $app->($env);
+            if ($query->{"resp:status"}) {
+                $res->[0] = $query->get("resp:status");
+                $query->remove("resp:status");
+            }
+            push @{$res->[1]}, map {
+                my $n = $_;
+                +(substr($n, length "resp:") => $query->get($n))
+            } grep {
+                $_ =~ /^resp:/
+            } $query->keys;
+            $res;
+        };
+    };
     if ($force_chunked) {
         enable sub {
             my $app = shift;
@@ -22,7 +41,7 @@ builder {
                 }
                 $res->[1] = \@headers;
                 return $res;
-            }
+            };
         };
     }
     mount "/" => Plack::App::File->new(root => DOC_ROOT)->to_app;
@@ -51,25 +70,6 @@ builder {
             [
                 join "\n", map { my $n = lc substr $_, 5; $n =~ tr/_/-/; "$n: $env->{$_}" } sort grep { /^HTTP_/ } keys %$env,
             ]
-        ];
-    };
-    mount "/set-headers" => sub {
-        my $env = shift;
-        my $query = Plack::Request->new($env)->parameters;
-        return [
-            200,
-            [ map { my $n = $_; map { $n => $_ } $query->get_all($n) } $query->keys ],
-            [ 'body' ],
-        ];
-    };
-    mount "/redirect" => sub {
-        my $env = shift;
-        return [
-            302,
-            [
-                location => substr($env->{PATH_INFO}, 1),
-            ],
-            [],
         ];
     };
     mount "/streaming-body" => sub {


### PR DESCRIPTION
This PR modifies the request handling procedure of H2O to support internal redirects, specifically by:
* create `h2o_req_t::input` for preserving the original request
* create function `h2o_reprocess_request` that internally re-issues a request with request attributes (e.g. method, authority, path) being altered
* move the proxy implementation into core, as it would be the _default_ handler for handling internally-redirected responses
* the reverse proxy handler merely _redirects_ the request (so that it would be handled by the now internalized proxy implementation)

The beauty of the new approach is that the proxy implementation can be shared with the reverse-proxy and the `x-reproxy-url` handler (see also #187), and that it is capable of handling `x-reproxy-url` header that points to a local resource (i.e. resources served by the file handler).