### PR TITLE
limit max. number of delegations (i.e. `X-Reproxy-URL`)

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -59,6 +59,7 @@ extern "C" {
 #endif
 
 #define H2O_DEFAULT_MAX_REQUEST_ENTITY_SIZE (1024 * 1024 * 1024)
+#define H2O_DEFAULT_MAX_DELEGATIONS 5
 #define H2O_DEFAULT_HTTP1_REQ_TIMEOUT_IN_SECS 10
 #define H2O_DEFAULT_HTTP1_REQ_TIMEOUT (H2O_DEFAULT_HTTP1_REQ_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2 1
@@ -210,6 +211,10 @@ struct st_h2o_globalconf_t {
      * maximum size of the accepted request entity (e.g. POST data)
      */
     size_t max_request_entity_size;
+    /**
+     * maximum count for delegations
+     */
+    unsigned max_delegations;
 
     struct {
         /**
@@ -557,6 +562,10 @@ struct st_h2o_req_t {
      * number of bytes sent by the generator (excluding headers)
      */
     size_t bytes_sent;
+    /**
+     * counts the number of times the request has been delegated
+     */
+    unsigned num_delegated;
 
     /* flags */
 

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -85,6 +85,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     h2o_linklist_init_anchor(&config->configurators);
     config->server_name = h2o_iovec_init(H2O_STRLIT("h2o/" H2O_VERSION));
     config->max_request_entity_size = H2O_DEFAULT_MAX_REQUEST_ENTITY_SIZE;
+    config->max_delegations = H2O_DEFAULT_MAX_DELEGATIONS;
     config->http1.req_timeout = H2O_DEFAULT_HTTP1_REQ_TIMEOUT;
     config->http1.upgrade_to_http2 = H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2;
     config->http1.callbacks = H2O_HTTP1_CALLBACKS;

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -207,6 +207,11 @@ static int on_config_limit_request_body(h2o_configurator_command_t *cmd, h2o_con
     return h2o_configurator_scanf(cmd, node, "%zu", &ctx->globalconf->max_request_entity_size);
 }
 
+static int on_config_max_delegations(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    return h2o_configurator_scanf(cmd, node, "%u", &ctx->globalconf->max_delegations);
+}
+
 static int on_config_http1_request_timeout(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     unsigned timeout_in_secs;
@@ -266,6 +271,10 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
                                         on_config_limit_request_body,
                                         "maximum size of request body in bytes (e.g. content of POST)\n"
                                         "(default: unlimited)");
+        h2o_configurator_define_command(c, "max-delegations", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_max_delegations,
+                                        "limits the number of delegations (i.e. internal redirects using `X-Reproxy-URL`)\n"
+                                        "(default: " H2O_TO_STR(H2O_DEFAULT_MAX_DELEGATIONS) ")");
         h2o_configurator_define_command(
             c, "http1-request-timeout", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
             on_config_http1_request_timeout,

--- a/t/50reverse-proxy-config.t
+++ b/t/50reverse-proxy-config.t
@@ -74,4 +74,17 @@ EOT
     like $resp, qr{^HTTP/1\.1 502 }s, "respond after timeout";
 };
 
+subtest 'infinite-internal-redirect' => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+reproxy: ON
+EOT
+    my $resp = `curl --silent --dump-header /dev/stderr "http://127.0.0.1:$server->{port}/?resp:x-reproxy-url=http://127.0.0.1:$upstream_port/infinite-redirect" 2>&1 > /dev/null`;
+    like $resp, qr{^HTTP/1\.1 502 }s;
+};
+
 done_testing;

--- a/t/50reverse-proxy-config.t
+++ b/t/50reverse-proxy-config.t
@@ -87,4 +87,18 @@ EOT
     like $resp, qr{^HTTP/1\.1 502 }s;
 };
 
+subtest 'max-delegations' => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+reproxy: ON
+max-delegations: 0
+EOT
+    my $resp = `curl --silent --dump-header /dev/stderr "http://127.0.0.1:$server->{port}/?resp:x-reproxy-url=http://127.0.0.1:$upstream_port/index.txt" 2>&1 > /dev/null`;
+    like $resp, qr{^HTTP/1\.1 502 }s;
+};
+
 done_testing;

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -104,4 +104,14 @@ builder {
             ],
         ];
     };
+    mount "/infinite-redirect" => sub {
+        my $env = shift;
+        return [
+            302,
+            [
+                location => '/infinite-redirect',
+            ],
+            [],
+        ];
+    };
 };


### PR DESCRIPTION
add a counter (that can be configured by using the `max-delegations` directive; default is 5) that limits the maximum count of delegations (amends #197).