### PR TITLE
add directives to tweak the headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/chunked.c
     lib/handler/expires.c
     lib/handler/file.c
+    lib/handler/headers.c
     lib/handler/mimemap.c
     lib/handler/proxy.c
     lib/handler/redirect.c
@@ -69,6 +70,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/configurator/access_log.c
     lib/handler/configurator/expires.c
     lib/handler/configurator/file.c
+    lib/handler/configurator/headers.c
     lib/handler/configurator/proxy.c
     lib/handler/configurator/redirect.c
     lib/handler/configurator/reproxy.c
@@ -93,6 +95,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/core/headers.c
     t/00unit/lib/core/proxy.c
     t/00unit/lib/handler/file.c
+    t/00unit/lib/handler/headers.c
     t/00unit/lib/handler/mimemap.c
     t/00unit/lib/http2/hpack.c
     t/00unit/lib/http2/scheduler.c)
@@ -105,6 +108,7 @@ LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/core/headers.c
     lib/core/proxy.c
     lib/handler/file.c
+    lib/handler/headers.c
     lib/handler/mimemap.c
     lib/http2/hpack.c
     lib/http2/scheduler.c)

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		105534EB1A42A87E00627ECB /* _templates.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 105534EA1A42A87E00627ECB /* _templates.c.h */; };
 		105534ED1A42AD5E00627ECB /* templates.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 105534EC1A42AD5E00627ECB /* templates.c.h */; };
 		105534EF1A440FC800627ECB /* config.c in Sources */ = {isa = PBXBuildFile; fileRef = 105534EE1A440FC800627ECB /* config.c */; };
+		1058C87D1AA41789008D6180 /* headers.c in Sources */ = {isa = PBXBuildFile; fileRef = 1058C87C1AA41789008D6180 /* headers.c */; };
+		1058C87E1AA41A1F008D6180 /* headers.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EBD1AA019D8004322AC /* headers.c */; };
 		1065E6ED19B7B9CB00686E72 /* websocket.c in Sources */ = {isa = PBXBuildFile; fileRef = 107923C119A3217300C52AD6 /* websocket.c */; };
 		1065E6EE19B7BA5A00686E72 /* websocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 107923A319A3215F00C52AD6 /* websocket.h */; };
 		1065E6F919BEBAC600686E72 /* timeout.c in Sources */ = {isa = PBXBuildFile; fileRef = 1065E6F819BEBAC600686E72 /* timeout.c */; };
@@ -87,6 +89,7 @@
 		10AA2EB71A970EFC004322AC /* http2_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AA2EB61A970EFC004322AC /* http2_internal.h */; };
 		10AA2EB91A971280004322AC /* http2_scheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AA2EB81A971280004322AC /* http2_scheduler.h */; };
 		10AA2EBC1A9EEDF8004322AC /* proxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EBB1A9EEDF8004322AC /* proxy.c */; };
+		10AA2EC01AA019FC004322AC /* headers.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EBF1AA019FC004322AC /* headers.c */; };
 		10AA2EC21AA0402E004322AC /* reproxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EC11AA0402E004322AC /* reproxy.c */; };
 		10AA2EC41AA0403A004322AC /* reproxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EC31AA0403A004322AC /* reproxy.c */; };
 		10BA72AA19AAD6300059392A /* stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 10BA72A919AAD6300059392A /* stream.c */; };
@@ -245,6 +248,8 @@
 		105534FA1A460F4200627ECB /* 50sni.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = 50sni.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		105534FB1A460F4200627ECB /* Util.pm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.perl; path = Util.pm; sourceTree = "<group>"; };
 		105534FE1A46134A00627ECB /* 80issues61.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = 80issues61.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		1058C87C1AA41789008D6180 /* headers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = headers.c; sourceTree = "<group>"; };
+		1058C87F1AA42568008D6180 /* 50headers.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 50headers.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		1065E6EF19B8C64200686E72 /* evloop.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = evloop.c.h; sourceTree = "<group>"; };
 		1065E6F419B996B400686E72 /* select.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = select.c.h; sourceTree = "<group>"; };
 		1065E6F619B99E6D00686E72 /* kqueue.c.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = kqueue.c.h; sourceTree = "<group>"; };
@@ -303,6 +308,8 @@
 		10AA2EB61A970EFC004322AC /* http2_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http2_internal.h; sourceTree = "<group>"; };
 		10AA2EB81A971280004322AC /* http2_scheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http2_scheduler.h; sourceTree = "<group>"; };
 		10AA2EBB1A9EEDF8004322AC /* proxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = proxy.c; sourceTree = "<group>"; };
+		10AA2EBD1AA019D8004322AC /* headers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = headers.c; sourceTree = "<group>"; };
+		10AA2EBF1AA019FC004322AC /* headers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = headers.c; sourceTree = "<group>"; };
 		10AA2EC11AA0402E004322AC /* reproxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = reproxy.c; sourceTree = "<group>"; };
 		10AA2EC31AA0403A004322AC /* reproxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = reproxy.c; sourceTree = "<group>"; };
 		10AA2EC61AA05598004322AC /* upstream.psgi */ = {isa = PBXFileReference; lastKnownFileType = text; path = upstream.psgi; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -438,6 +445,7 @@
 				104B9A501A5FB096009EEE64 /* expires.c */,
 				107923AF19A3217300C52AD6 /* file.c */,
 				105534E91A42A83700627ECB /* file */,
+				10AA2EBD1AA019D8004322AC /* headers.c */,
 				107923BB19A3217300C52AD6 /* mimemap.c */,
 				10D0907219F633B00043D458 /* proxy.c */,
 				10AA2EA41A8D9999004322AC /* redirect.c */,
@@ -488,6 +496,7 @@
 			children = (
 				105534BD1A3B8F7700627ECB /* file.c */,
 				105534C21A3B917000627ECB /* mimemap.c */,
+				1058C87C1AA41789008D6180 /* headers.c */,
 			);
 			path = handler;
 			sourceTree = "<group>";
@@ -528,6 +537,7 @@
 				105534DA1A3C7A5400627ECB /* access_log.c */,
 				104B9A521A5FC7C4009EEE64 /* expires.c */,
 				105534DC1A3C7AA900627ECB /* file.c */,
+				10AA2EBF1AA019FC004322AC /* headers.c */,
 				105534DE1A3C7B9800627ECB /* proxy.c */,
 				10AA2EA61A8DA93C004322AC /* redirect.c */,
 				10AA2EC11AA0402E004322AC /* reproxy.c */,
@@ -746,6 +756,7 @@
 				10AA2EB11A931409004322AC /* 50access-log.t */,
 				104B9A541A60773E009EEE64 /* 50expires.t */,
 				105534F61A460EF600627ECB /* 50file-config.t */,
+				1058C87F1AA42568008D6180 /* 50headers.t */,
 				105534F71A460F2E00627ECB /* 50mimemap.t */,
 				105534F81A460F2E00627ECB /* 50post-size-limit.t */,
 				10AA2EA81A8DAFD4004322AC /* 50redirect.t */,
@@ -997,10 +1008,12 @@
 				10D0905519F102C70043D458 /* http1client.c in Sources */,
 				107923D219A3217300C52AD6 /* token.c in Sources */,
 				10AA2EBC1A9EEDF8004322AC /* proxy.c in Sources */,
+				10AA2EC01AA019FC004322AC /* headers.c in Sources */,
 				104B9A511A5FB096009EEE64 /* expires.c in Sources */,
 				105534DB1A3C7A5400627ECB /* access_log.c in Sources */,
 				107923CE19A3217300C52AD6 /* mimemap.c in Sources */,
 				107923C619A3217300C52AD6 /* connection.c in Sources */,
+				1058C87E1AA41A1F008D6180 /* headers.c in Sources */,
 				10AA2E961A80A612004322AC /* time.c in Sources */,
 				107923C319A3217300C52AD6 /* file.c in Sources */,
 				107923CD19A3217300C52AD6 /* memory.c in Sources */,
@@ -1077,6 +1090,7 @@
 				1079244719A3265C00C52AD6 /* http1.c in Sources */,
 				1079244819A3265C00C52AD6 /* connection.c in Sources */,
 				1079244119A3264300C52AD6 /* picohttpparser.c in Sources */,
+				1058C87D1AA41789008D6180 /* headers.c in Sources */,
 				10AA2EAE1A8E22DA004322AC /* multithread.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -839,8 +839,7 @@ void h2o_send_redirect_internal(h2o_req_t *req, int status, const char *url_str,
 /**
  * logs an error
  */
-void h2o_req_log_error(h2o_req_t *req, const char *module, const char *fmt, ...)
-    __attribute__((format(printf, 3, 4)));
+void h2o_req_log_error(h2o_req_t *req, const char *module, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 
 /* proxy */
 
@@ -948,6 +947,33 @@ h2o_mimemap_t *h2o_file_get_mimemap(h2o_file_handler_t *handler);
  * registers the configurator
  */
 void h2o_file_register_configurator(h2o_globalconf_t *conf);
+
+/* lib/headers.c */
+
+enum {
+    H2O_HEADERS_CMD_NULL,
+    H2O_HEADERS_CMD_ADD,        /* adds a new header line */
+    H2O_HEADERS_CMD_APPEND,     /* adds a new header line or contenates to the existing header */
+    H2O_HEADERS_CMD_MERGE,      /* merges the value into a comma-listed values of the named header */
+    H2O_HEADERS_CMD_SET,        /* sets a header line, overwriting the existing one (if any) */
+    H2O_HEADERS_CMD_SETIFEMPTY, /* sets a header line if empty */
+    H2O_HEADERS_CMD_UNSET       /* removes the named header(s) */
+};
+
+typedef struct st_h2o_headers_command_t {
+    int cmd;
+    h2o_iovec_t *name; /* maybe a token */
+    h2o_iovec_t value;
+} h2o_headers_command_t;
+
+/**
+ * registers a list of commands terminated by cmd==H2O_HEADERS_CMD_NULL
+ */
+void h2o_headers_register(h2o_pathconf_t *pathconf, h2o_headers_command_t *cmds);
+/**
+ * registers the configurator
+ */
+void h2o_headers_register_configurator(h2o_globalconf_t *conf);
 
 /* lib/proxy.c */
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -971,6 +971,10 @@ typedef struct st_h2o_headers_command_t {
  */
 void h2o_headers_register(h2o_pathconf_t *pathconf, h2o_headers_command_t *cmds);
 /**
+ * returns whether if the given name can be registered to the filter
+ */
+int h2o_headers_is_prohibited_name(const h2o_token_t *token);
+/**
  * registers the configurator
  */
 void h2o_headers_register_configurator(h2o_globalconf_t *conf);

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -77,6 +77,10 @@ void h2o_base64_encode(char *dst, const void *src, size_t len, int url_encoded);
  */
 const char *h2o_get_filext(const char *path, size_t len);
 /**
+ * returns a vector with surrounding WS stripped
+ */
+h2o_iovec_t h2o_str_stripws(const char *s, size_t len);
+/**
  * returns the offset of given substring or SIZE_MAX if not found
  */
 size_t h2o_strstr(const char *haysack, size_t haysack_len, const char *needle, size_t needle_len);

--- a/lib/common/string.c
+++ b/lib/common/string.c
@@ -238,6 +238,28 @@ const char *h2o_get_filext(const char *path, size_t len)
     return NULL;
 }
 
+static int is_ws(int ch)
+{
+    return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n';
+}
+
+h2o_iovec_t h2o_str_stripws(const char *s, size_t len)
+{
+    const char *end = s + len;
+
+    while (s != end) {
+        if (!is_ws(*s))
+            break;
+        ++s;
+    }
+    while (s != end) {
+        if (!is_ws(end[-1]))
+            break;
+        --end;
+    }
+    return h2o_iovec_init(s, end - s);
+}
+
 size_t h2o_strstr(const char *haysack, size_t haysack_len, const char *needle, size_t needle_len)
 {
     /* TODO optimize */

--- a/lib/handler/configurator/headers.c
+++ b/lib/handler/configurator/headers.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <string.h>
+#include "h2o.h"
+#include "h2o/configurator.h"
+
+struct headers_configurator_t {
+    h2o_configurator_t super;
+    H2O_VECTOR(h2o_headers_command_t) * cmds, _cmd_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
+};
+
+static int extract_name(const char *src, size_t len, h2o_iovec_t **_name)
+{
+    h2o_iovec_t name;
+    const h2o_token_t *name_token;
+
+    name = h2o_str_stripws(src, len);
+    if (name.len == 0)
+        return -1;
+
+    name = h2o_strdup(NULL, name.base, name.len);
+    h2o_strtolower(name.base, name.len);
+
+    if ((name_token = h2o_lookup_token(name.base, name.len)) != NULL) {
+        *_name = (h2o_iovec_t *)&name_token->buf;
+        free(name.base);
+    } else {
+        *_name = h2o_mem_alloc(sizeof(**_name));
+        **_name = name;
+    }
+
+    return 0;
+}
+
+static int extract_name_value(const char *src, h2o_iovec_t **name, h2o_iovec_t *value)
+{
+    const char *colon = strchr(src, ':');
+
+    if (colon == NULL)
+        return -1;
+
+    if (extract_name(src, colon - src, name) != 0)
+        return -1;
+    *value = h2o_str_stripws(colon + 1, strlen(colon + 1));
+    *value = h2o_strdup(NULL, value->base, value->len);
+
+    return 0;
+}
+
+static void add_cmd(struct headers_configurator_t *self, int cmd_id, h2o_iovec_t *name, h2o_iovec_t value)
+{
+    h2o_vector_reserve(NULL, (h2o_vector_t *)self->cmds, sizeof(self->cmds->entries[0]), self->cmds->size + 1);
+    self->cmds->entries[self->cmds->size++] = (h2o_headers_command_t){cmd_id, name, value};
+}
+
+static int on_config_header_2arg(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, int cmd_id, yoml_t *node)
+{
+    struct headers_configurator_t *self = (void *)cmd->configurator;
+    h2o_iovec_t *name, value;
+
+    if (extract_name_value(node->data.scalar, &name, &value) != 0) {
+        h2o_configurator_errprintf(cmd, node, "failed to parse the value; should be in form of `name: value`");
+        return -1;
+    }
+    add_cmd(self, cmd_id, name, value);
+    return 0;
+}
+
+#define DEFINE_2ARG(fn, cmd_id)                                                                                                    \
+    static int fn(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)                                  \
+    {                                                                                                                              \
+        return on_config_header_2arg(cmd, ctx, cmd_id, node);                                                                      \
+    }
+
+DEFINE_2ARG(on_config_header_add, H2O_HEADERS_CMD_ADD)
+DEFINE_2ARG(on_config_header_append, H2O_HEADERS_CMD_APPEND)
+DEFINE_2ARG(on_config_header_merge, H2O_HEADERS_CMD_MERGE)
+DEFINE_2ARG(on_config_header_set, H2O_HEADERS_CMD_SET)
+DEFINE_2ARG(on_config_header_setifempty, H2O_HEADERS_CMD_SETIFEMPTY)
+
+#undef DEFINE_2ARG
+
+static int on_config_header_unset(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct headers_configurator_t *self = (void *)cmd->configurator;
+    h2o_iovec_t *name;
+
+    if (extract_name(node->data.scalar, strlen(node->data.scalar), &name) != 0) {
+        h2o_configurator_errprintf(cmd, node, "invalid header name");
+        return -1;
+    }
+    add_cmd(self, H2O_HEADERS_CMD_UNSET, name, (h2o_iovec_t){});
+    return 0;
+}
+
+static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct headers_configurator_t *self = (void *)_self;
+
+    h2o_vector_reserve(NULL, (h2o_vector_t *)&self->cmds[1], sizeof(self->cmds[0].entries[0]), self->cmds[0].size);
+    memcpy(self->cmds[1].entries, self->cmds[0].entries, sizeof(self->cmds->entries[0]) * self->cmds->size);
+    self->cmds[1].size = self->cmds[0].size;
+    ++self->cmds;
+    return 0;
+}
+
+static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct headers_configurator_t *self = (void *)_self;
+
+    if (ctx->pathconf != NULL && self->cmds->size != 0) {
+        h2o_vector_reserve(NULL, (h2o_vector_t *)self->cmds, sizeof(self->cmds->entries[0]), sizeof(self->cmds->size));
+        self->cmds->entries[self->cmds->size] = (h2o_headers_command_t){H2O_HEADERS_CMD_NULL};
+        h2o_headers_register(ctx->pathconf, self->cmds->entries);
+    } else {
+        free(self->cmds->entries);
+        memset(self->cmds, 0, sizeof(*self->cmds));
+    }
+
+    --self->cmds;
+    return 0;
+}
+
+void h2o_headers_register_configurator(h2o_globalconf_t *conf)
+{
+    struct headers_configurator_t *c = (void *)h2o_configurator_create(conf, sizeof(*c));
+
+    c->super.enter = on_config_enter;
+    c->super.exit = on_config_exit;
+#define DEFINE_CMD(name, cb, desc)                                                                                                 \
+    h2o_configurator_define_command(&c->super, name, H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST |                   \
+                                                         H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,         \
+                                    cb, desc)
+    DEFINE_CMD("header.add", on_config_header_add, "adds a new header line to the response headers");
+    DEFINE_CMD("header.append", on_config_header_append,
+               "adds a new header line, or appends the value to the existing header with the same name (separated by `,`)");
+    DEFINE_CMD("header.merge", on_config_header_merge,
+               "adds a new header line, or merges the value to the existing header of comma-separated values");
+    DEFINE_CMD("header.set", on_config_header_set, "sets a header line, removing headers with the same name (if exist)");
+    DEFINE_CMD("header.setifempty", on_config_header_setifempty,
+               "sets a header line, only when a header with the same name does not exist");
+    DEFINE_CMD("header.unset", on_config_header_unset, "removes headers with the specified name");
+#undef DEFINE_CMD
+
+    c->cmds = c->_cmd_stack;
+}

--- a/lib/handler/headers.c
+++ b/lib/handler/headers.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "h2o.h"
+
+struct st_headers_filter_t {
+    h2o_filter_t super;
+    h2o_headers_command_t *cmds;
+};
+
+static h2o_header_t *find_header(h2o_headers_t *headers, h2o_headers_command_t *cmd)
+{
+    size_t index;
+
+    if (h2o_iovec_is_token(cmd->name)) {
+        index = h2o_find_header(headers, (void *)cmd->name, SIZE_MAX);
+    } else {
+        index = h2o_find_header_by_str(headers, cmd->name->base, cmd->name->len, SIZE_MAX);
+    }
+    if (index == SIZE_MAX)
+        return NULL;
+    return headers->entries + index;
+}
+
+static void remove_header(h2o_headers_t *headers, h2o_headers_command_t *cmd)
+{
+    size_t src, dst = 0;
+
+    for (src = 0; src != headers->size; ++src) {
+        if (h2o_iovec_is_token(cmd->name)) {
+            if (headers->entries[src].name == cmd->name)
+                continue;
+        } else {
+            if (h2o_memis(headers->entries[src].name->base, headers->entries[src].name->len, cmd->name->base, cmd->name->len))
+                continue;
+        }
+        /* not matched */
+        if (dst != src)
+            headers->entries[dst] = headers->entries[src];
+        ++dst;
+    }
+    headers->size = dst;
+}
+
+static void rewrite_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2o_headers_command_t *cmd)
+{
+    h2o_header_t *target;
+
+    switch (cmd->cmd) {
+    case H2O_HEADERS_CMD_ADD:
+        goto AddHeader;
+    case H2O_HEADERS_CMD_APPEND:
+        if ((target = find_header(headers, cmd)) == NULL)
+            goto AddHeader;
+        goto AppendToken;
+    case H2O_HEADERS_CMD_MERGE:
+        if ((target = find_header(headers, cmd)) == NULL)
+            goto AddHeader;
+        if (h2o_contains_token(target->value.base, target->value.len, cmd->value.base, cmd->value.len, ','))
+            return;
+        goto AppendToken;
+    case H2O_HEADERS_CMD_SET:
+        remove_header(headers, cmd);
+        goto AddHeader;
+    case H2O_HEADERS_CMD_SETIFEMPTY:
+        if (find_header(headers, cmd) != NULL)
+            return;
+        goto AddHeader;
+    case H2O_HEADERS_CMD_UNSET:
+        remove_header(headers, cmd);
+        return;
+    }
+
+    assert(!"FIXME");
+    return;
+
+AddHeader:
+    if (h2o_iovec_is_token(cmd->name)) {
+        h2o_add_header(pool, headers, (void *)cmd->name, cmd->value.base, cmd->value.len);
+    } else {
+        h2o_add_header_by_str(pool, headers, cmd->name->base, cmd->name->len, 0, cmd->value.base, cmd->value.len);
+    }
+    return;
+
+AppendToken:
+    if (target->value.len != 0) {
+        h2o_iovec_t v;
+        v.len = target->value.len + 2 + cmd->value.len;
+        v.base = h2o_mem_alloc_pool(pool, v.len);
+        memcpy(v.base, target->value.base, target->value.len);
+        v.base[target->value.len] = ',';
+        v.base[target->value.len + 1] = ' ';
+        memcpy(v.base + target->value.len + 2, cmd->value.base, cmd->value.len);
+        target->value = v;
+    } else {
+        target->value = cmd->value;
+    }
+    return;
+}
+
+static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t **slot)
+{
+    struct st_headers_filter_t *self = (void *)_self;
+    h2o_headers_command_t *cmd;
+
+    for (cmd = self->cmds; cmd->cmd != H2O_HEADERS_CMD_NULL; ++cmd)
+        rewrite_headers(&req->pool, &req->res.headers, cmd);
+
+    h2o_setup_next_ostream(&self->super, req, slot);
+}
+
+void h2o_headers_register(h2o_pathconf_t *pathconf, h2o_headers_command_t *cmds)
+{
+    struct st_headers_filter_t *self = (void *)h2o_create_filter(pathconf, sizeof(*self));
+
+    self->super.on_setup_ostream = on_setup_ostream;
+    self->cmds = cmds;
+}

--- a/lib/handler/headers.c
+++ b/lib/handler/headers.c
@@ -134,3 +134,10 @@ void h2o_headers_register(h2o_pathconf_t *pathconf, h2o_headers_command_t *cmds)
     self->super.on_setup_ostream = on_setup_ostream;
     self->cmds = cmds;
 }
+
+int h2o_headers_is_prohibited_name(const h2o_token_t *token)
+{
+    if (token == H2O_TOKEN_CONNECTION || token == H2O_TOKEN_CONTENT_LENGTH || token == H2O_TOKEN_TRANSFER_ENCODING)
+        return 1;
+    return 0;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1178,6 +1178,7 @@ static void setup_configurators(void)
     h2o_access_log_register_configurator(&conf.globalconf);
     h2o_expires_register_configurator(&conf.globalconf);
     h2o_file_register_configurator(&conf.globalconf);
+    h2o_headers_register_configurator(&conf.globalconf);
     h2o_proxy_register_configurator(&conf.globalconf);
     h2o_reproxy_register_configurator(&conf.globalconf);
     h2o_redirect_register_configurator(&conf.globalconf);

--- a/t/00unit/lib/common/string.c
+++ b/t/00unit/lib/common/string.c
@@ -22,6 +22,24 @@
 #include "../../test.h"
 #include "../../../../lib/common/string.c"
 
+static void test_stripws(void)
+{
+    h2o_iovec_t t;
+
+    t = h2o_str_stripws(H2O_STRLIT(""));
+    ok(h2o_memis(t.base, t.len, H2O_STRLIT("")));
+    t = h2o_str_stripws(H2O_STRLIT("hello world"));
+    ok(h2o_memis(t.base, t.len, H2O_STRLIT("hello world")));
+    t = h2o_str_stripws(H2O_STRLIT("   hello world"));
+    ok(h2o_memis(t.base, t.len, H2O_STRLIT("hello world")));
+    t = h2o_str_stripws(H2O_STRLIT("hello world   "));
+    ok(h2o_memis(t.base, t.len, H2O_STRLIT("hello world")));
+    t = h2o_str_stripws(H2O_STRLIT("   hello world   "));
+    ok(h2o_memis(t.base, t.len, H2O_STRLIT("hello world")));
+    t = h2o_str_stripws(H2O_STRLIT("     "));
+    ok(h2o_memis(t.base, t.len, H2O_STRLIT("")));
+}
+
 static void test_next_token(void)
 {
     h2o_iovec_t iter;
@@ -151,6 +169,7 @@ static void test_htmlescape(void)
 
 void test_lib__string_c(void)
 {
+    subtest("stripws", test_stripws);
     subtest("next_token", test_next_token);
     subtest("next_token2", test_next_token2);
     subtest("decode_base64", test_decode_base64);

--- a/t/00unit/lib/handler/headers.c
+++ b/t/00unit/lib/handler/headers.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "../../test.h"
+#include "../../../../lib/handler/headers.c"
+
+static int headers_are(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *s, size_t len)
+{
+    size_t i;
+    h2o_iovec_t flattened = {};
+
+    for (i = 0; i != headers->size; ++i) {
+        flattened = h2o_concat(pool, flattened, *headers->entries[i].name, h2o_iovec_init(H2O_STRLIT(": ")),
+                               headers->entries[i].value, h2o_iovec_init(H2O_STRLIT("\n")));
+    }
+
+    return h2o_memis(flattened.base, flattened.len, s, len);
+}
+
+static void setup_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers)
+{
+    *headers = (h2o_headers_t){};
+    h2o_add_header(pool, headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain"));
+    h2o_add_header(pool, headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("public, max-age=86400"));
+    h2o_add_header(pool, headers, H2O_TOKEN_SET_COOKIE, H2O_STRLIT("a=b"));
+    h2o_add_header_by_str(pool, headers, H2O_STRLIT("x-foo"), 0, H2O_STRLIT("bar"));
+}
+
+void test_lib__handler__headers_c(void)
+{
+    h2o_mem_pool_t pool;
+    h2o_headers_t headers;
+    h2o_headers_command_t cmd;
+    h2o_iovec_t header_str;
+
+    h2o_mem_init_pool(&pool);
+
+    /* tests using token headers */
+    setup_headers(&pool, &headers);
+    ok(headers_are(&pool, &headers,
+                   H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: bar\n")));
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_ADD, &H2O_TOKEN_SET_COOKIE->buf, {H2O_STRLIT("c=d")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: bar\nset-cookie: c=d\n")));
+
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_APPEND, &H2O_TOKEN_CACHE_CONTROL->buf, {H2O_STRLIT("public")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400, public\nset-cookie: a=b\nx-foo: bar\n")));
+
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_MERGE, &H2O_TOKEN_CACHE_CONTROL->buf, {H2O_STRLIT("public")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: bar\n")));
+
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_SET, &H2O_TOKEN_CACHE_CONTROL->buf, {H2O_STRLIT("no-cache")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\nset-cookie: a=b\nx-foo: bar\ncache-control: no-cache\n")));
+
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_SETIFEMPTY, &H2O_TOKEN_CACHE_CONTROL->buf, {H2O_STRLIT("no-cache")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: bar\n")));
+
+    /* tests using non-token headers */
+    header_str = h2o_iovec_init(H2O_STRLIT("x-foo"));
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_ADD, &header_str, {H2O_STRLIT("baz")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: bar\nx-foo: baz\n")));
+
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_APPEND, &header_str, {H2O_STRLIT("bar")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: bar, bar\n")));
+
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_MERGE, &header_str, {H2O_STRLIT("bar")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: bar\n")));
+
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_SET, &header_str, {H2O_STRLIT("baz")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: baz\n")));
+
+    setup_headers(&pool, &headers);
+    cmd = (h2o_headers_command_t){H2O_HEADERS_CMD_SETIFEMPTY, &header_str, {H2O_STRLIT("baz")}};
+    rewrite_headers(&pool, &headers, &cmd);
+    ok(headers_are(
+        &pool, &headers,
+        H2O_STRLIT("content-type: text/plain\ncache-control: public, max-age=86400\nset-cookie: a=b\nx-foo: bar\n")));
+
+    h2o_mem_clear_pool(&pool);
+}

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -131,6 +131,7 @@ int main(int argc, char **argv)
         subtest("lib/common/time.c", test_lib__common__time_c);
         subtest("lib/core/headers.c", test_lib__core__headers_c);
         subtest("lib/core/proxy.c", test_lib__core__proxy_c);
+        subtest("lib/handler/headers.c", test_lib__handler__headers_c);
         subtest("lib/handler/mimemap.c", test_lib__handler__mimemap_c);
         subtest("lib/http2/hpack.c", test_lib__http2__hpack);
         subtest("lib/http2/scheduler.c", test_lib__http2__scheduler);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -56,6 +56,7 @@ void test_lib__common__url_c(void);
 void test_lib__core__headers_c(void);
 void test_lib__core__proxy_c(void);
 void test_lib__handler__file_c(void);
+void test_lib__handler__headers_c(void);
 void test_lib__handler__mimemap_c(void);
 void test_lib__http2__hpack(void);
 void test_lib__http2__scheduler(void);

--- a/t/50headers.t
+++ b/t/50headers.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[ DOC_ROOT ]}
+header.add: "strict-transport-security: max-age=31536000; includeSubDomains; preload "
+header.unset: last-modified
+EOT
+
+my $resp = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/index.txt 2>&1 > /dev/null`;
+like $resp, qr{^HTTP/1\.1 200 }s, "200 response";
+like $resp, qr{^strict-transport-security: max-age=31536000; includeSubDomains; preload\r$}im, "hsts added";
+unlike $resp, qr{^last-modified: }, "last-modified unset";
+
+done_testing();


### PR DESCRIPTION
This PR implements directives to tweak the response headers; model after [`Headers` directive of Apache](http://httpd.apache.org/docs/2.4/en/mod/mod_headers.html#header).

It provides following directives: `header.add`, `header.append`, `header.merge`, `header.set`, `header.setifempty`, `header.unset`.

see #196