### PR TITLE
do not use `zero_timeout` in http1client

### DIFF
--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -42,7 +42,6 @@ static void start_request(h2o_http1client_ctx_t *ctx)
 {
     h2o_url_t url_parsed;
     h2o_iovec_t *req;
-    h2o_http1client_t *client;
 
     /* clear memory pool */
     h2o_mem_clear_pool(&pool);
@@ -72,13 +71,11 @@ static void start_request(h2o_http1client_ctx_t *ctx)
                                 h2o_url_get_port(&url_parsed), 10);
             h2o_socketpool_set_timeout(sockpool, ctx->loop, 5000 /* in msec */);
         }
-        client = h2o_http1client_connect_with_pool(ctx, &pool, sockpool, on_connect);
+        h2o_http1client_connect_with_pool(NULL, req, ctx, &pool, sockpool, on_connect);
     } else {
-        client = h2o_http1client_connect(ctx, &pool, h2o_strdup(&pool, url_parsed.host.base, url_parsed.host.len).base,
-                                         h2o_url_get_port(&url_parsed), on_connect);
+        h2o_http1client_connect(NULL, req, ctx, &pool, h2o_strdup(&pool, url_parsed.host.base, url_parsed.host.len).base,
+                                h2o_url_get_port(&url_parsed), on_connect);
     }
-    assert(client != NULL);
-    client->data = req;
 }
 
 static int on_body(h2o_http1client_t *client, const char *errstr)

--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -143,7 +143,7 @@ h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr
 
 int main(int argc, char **argv)
 {
-    h2o_http1client_ctx_t ctx = {NULL, &zero_timeout, &io_timeout};
+    h2o_http1client_ctx_t ctx = {NULL, &io_timeout};
 
     if (argc != 2) {
         fprintf(stderr, "Usage: %s <url>\n", argv[0]);

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -43,7 +43,6 @@ typedef h2o_http1client_head_cb (*h2o_http1client_connect_cb)(h2o_http1client_t 
 
 typedef struct st_h2o_http1client_ctx_t {
     h2o_loop_t *loop;
-    h2o_timeout_t *zero_timeout;
     h2o_timeout_t *io_timeout;
 } h2o_http1client_ctx_t;
 

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -60,10 +60,10 @@ struct st_h2o_http1client_t {
 
 extern const char *const h2o_http1client_error_is_eos;
 
-h2o_http1client_t *h2o_http1client_connect(h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool, const char *host, uint16_t port,
-                                           h2o_http1client_connect_cb cb);
-h2o_http1client_t *h2o_http1client_connect_with_pool(h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool, h2o_socketpool_t *sockpool,
-                                                     h2o_http1client_connect_cb cb);
+void h2o_http1client_connect(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
+                             const char *host, uint16_t port, h2o_http1client_connect_cb cb);
+void h2o_http1client_connect_with_pool(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
+                                       h2o_socketpool_t *sockpool, h2o_http1client_connect_cb cb);
 void h2o_http1client_cancel(h2o_http1client_t *client);
 
 #ifdef __cplusplus

--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -71,8 +71,8 @@ void h2o_socketpool_set_timeout(h2o_socketpool_t *pool, h2o_loop_t *loop, uint64
 /**
  * connects to the peer (or returns a pooled connection)
  */
-h2o_socketpool_connect_request_t *h2o_socketpool_connect(h2o_socketpool_t *pool, h2o_loop_t *loop, h2o_timeout_t *zero_timeout,
-                                                         h2o_socketpool_connect_cb cb, void *data);
+void h2o_socketpool_connect(h2o_socketpool_connect_request_t **req, h2o_socketpool_t *pool, h2o_loop_t *loop,
+                            h2o_socketpool_connect_cb cb, void *data);
 /**
  * cancels a connect request
  */

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -34,7 +34,6 @@ struct st_h2o_http1client_private_t {
         h2o_http1client_head_cb on_head;
         h2o_http1client_body_cb on_body;
     } _cb;
-    const char *_errstr;
     h2o_timeout_entry_t _timeout;
     int _method_is_head;
     int _can_keepalive;
@@ -372,15 +371,18 @@ static void on_pool_connect(h2o_socket_t *sock, const char *errstr, void *data)
 static void on_connect_timeout(h2o_timeout_entry_t *entry)
 {
     struct st_h2o_http1client_private_t *client = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1client_private_t, _timeout, entry);
-    on_connect_error(client, client->_errstr != NULL ? client->_errstr : "connection timeout");
+    on_connect_error(client, "connection timeout");
 }
 
-static struct st_h2o_http1client_private_t *create_client(h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
-                                                          h2o_http1client_connect_cb cb)
+static struct st_h2o_http1client_private_t *create_client(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx,
+                                                          h2o_mem_pool_t *pool, h2o_http1client_connect_cb cb)
 {
     struct st_h2o_http1client_private_t *client = h2o_mem_alloc(sizeof(*client));
 
     *client = (struct st_h2o_http1client_private_t){{ctx, pool}};
+    if (_client != NULL)
+        *_client = &client->super;
+    client->super.data = data;
     client->_cb.on_connect = cb;
     /* caller needs to setup _cb, timeout.cb, sock, and sock->data */
 
@@ -389,8 +391,8 @@ static struct st_h2o_http1client_private_t *create_client(h2o_http1client_ctx_t 
 
 const char *const h2o_http1client_error_is_eos = "end of stream";
 
-h2o_http1client_t *h2o_http1client_connect(h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool, const char *host, uint16_t port,
-                                           h2o_http1client_connect_cb cb)
+void h2o_http1client_connect(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
+                             const char *host, uint16_t port, h2o_http1client_connect_cb cb)
 {
     struct st_h2o_http1client_private_t *client;
     struct addrinfo hints, *res;
@@ -398,7 +400,7 @@ h2o_http1client_t *h2o_http1client_connect(h2o_http1client_ctx_t *ctx, h2o_mem_p
     int err;
 
     /* setup */
-    client = create_client(ctx, pool, cb);
+    client = create_client(_client, data, ctx, pool, cb);
     client->_timeout.cb = on_connect_timeout;
     /* resolve destination (FIXME use the function supplied by the loop) */
     sprintf(serv, "%u", (unsigned)port);
@@ -407,34 +409,28 @@ h2o_http1client_t *h2o_http1client_connect(h2o_http1client_ctx_t *ctx, h2o_mem_p
     hints.ai_protocol = IPPROTO_TCP;
     hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICSERV;
     if ((err = getaddrinfo(host, serv, &hints, &res)) != 0) {
-        client->_errstr = "name resulution failure";
-        goto Error;
+        on_connect_error(client, "name resolution failure");
+        return;
     }
     /* start connecting */
     client->super.sock = h2o_socket_connect(ctx->loop, res->ai_addr, res->ai_addrlen, on_connect);
     freeaddrinfo(res);
     if (client->super.sock == NULL) {
-        client->_errstr = "socket create error";
-        goto Error;
+        on_connect_error(client, "socket create error");
+        return;
     }
     client->super.sock->data = client;
     h2o_timeout_link(ctx->loop, ctx->io_timeout, &client->_timeout);
-
-    return &client->super;
-Error:
-    h2o_timeout_link(ctx->loop, ctx->zero_timeout, &client->_timeout);
-    return &client->super;
 }
 
-h2o_http1client_t *h2o_http1client_connect_with_pool(h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool, h2o_socketpool_t *sockpool,
-                                                     h2o_http1client_connect_cb cb)
+void h2o_http1client_connect_with_pool(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
+                                       h2o_socketpool_t *sockpool, h2o_http1client_connect_cb cb)
 {
-    struct st_h2o_http1client_private_t *client = create_client(ctx, pool, cb);
+    struct st_h2o_http1client_private_t *client = create_client(_client, data, ctx, pool, cb);
     client->super.sockpool.pool = sockpool;
     client->super.sockpool.connect_req = h2o_socketpool_connect(sockpool, ctx->loop, ctx->zero_timeout, on_pool_connect, client);
     client->_timeout.cb = on_connect_timeout;
     h2o_timeout_link(ctx->loop, ctx->io_timeout, &client->_timeout);
-    return &client->super;
 }
 
 void h2o_http1client_cancel(h2o_http1client_t *_client)

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -428,9 +428,9 @@ void h2o_http1client_connect_with_pool(h2o_http1client_t **_client, void *data, 
 {
     struct st_h2o_http1client_private_t *client = create_client(_client, data, ctx, pool, cb);
     client->super.sockpool.pool = sockpool;
-    client->super.sockpool.connect_req = h2o_socketpool_connect(sockpool, ctx->loop, ctx->zero_timeout, on_pool_connect, client);
     client->_timeout.cb = on_connect_timeout;
     h2o_timeout_link(ctx->loop, ctx->io_timeout, &client->_timeout);
+    h2o_socketpool_connect(&client->super.sockpool.connect_req, sockpool, ctx->loop, on_pool_connect, client);
 }
 
 void h2o_http1client_cancel(h2o_http1client_t *_client)

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -81,7 +81,6 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     ctx->proxy.client_ctx.loop = loop;
     h2o_timeout_init(ctx->loop, &ctx->proxy.io_timeout, config->proxy.io_timeout);
     ctx->proxy.client_ctx.io_timeout = &ctx->proxy.io_timeout;
-    ctx->proxy.client_ctx.zero_timeout = &ctx->zero_timeout;
 
     ctx->_module_configs = h2o_mem_alloc(sizeof(*ctx->_module_configs) * config->_num_config_slots);
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -468,13 +468,13 @@ void h2o__proxy_process_request(h2o_req_t *req)
     if (overrides != NULL) {
         if (overrides->socketpool != NULL) {
             self = proxy_send_prepare(req, 1);
-            self->client = h2o_http1client_connect_with_pool(client_ctx, &req->pool, overrides->socketpool, on_connect);
-            goto Connecting;
+            h2o_http1client_connect_with_pool(&self->client, self, client_ctx, &req->pool, overrides->socketpool, on_connect);
+            return;
         } else if (overrides->hostport.host != NULL) {
             self = proxy_send_prepare(req, 0);
-            self->client = h2o_http1client_connect(client_ctx, &req->pool, req->overrides->hostport.host,
-                                                   req->overrides->hostport.port, on_connect);
-            goto Connecting;
+            h2o_http1client_connect(&self->client, self, client_ctx, &req->pool, req->overrides->hostport.host,
+                                    req->overrides->hostport.port, on_connect);
+            return;
         }
     }
     { /* default logic */
@@ -490,10 +490,8 @@ void h2o__proxy_process_request(h2o_req_t *req)
         if (port == 65535)
             port = 80;
         self = proxy_send_prepare(req, 0);
-        self->client =
-            h2o_http1client_connect(client_ctx, &req->pool, h2o_strdup(&req->pool, host.base, host.len).base, port, on_connect);
+        h2o_http1client_connect(&self->client, self, client_ctx, &req->pool, h2o_strdup(&req->pool, host.base, host.len).base, port,
+                                on_connect);
+        return;
     }
-
-Connecting:
-    self->client->data = self;
 }

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -79,7 +79,6 @@ static void *on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
         return NULL;
     h2o_http1client_ctx_t *client_ctx = h2o_mem_alloc(sizeof(*ctx) + sizeof(*client_ctx->io_timeout));
     client_ctx->loop = ctx->loop;
-    client_ctx->zero_timeout = &ctx->zero_timeout;
     client_ctx->io_timeout = (void *)(client_ctx + 1);
     h2o_timeout_init(client_ctx->loop, client_ctx->io_timeout, self->config.io_timeout);
     return client_ctx;


### PR DESCRIPTION
This is a performance improvement (& simplification).

The PR converts `h2o_http1client_connect`, `h2o_http1client_connect_with_pool`, `h2o_socketpool_connect` to tail calls, and let them call the supplied callback synchronously when possible.