### PR TITLE
use abspath (not absurl) for redirecting to directory

### DIFF
--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -88,10 +88,8 @@ static void process_hosted_request(h2o_req_t *req, h2o_hostconf_t *hostconf)
         if (req->path_normalized.len >= confpath_wo_slash &&
             memcmp(req->path_normalized.base, pathconf->path.base, confpath_wo_slash) == 0) {
             if (req->path_normalized.len == confpath_wo_slash) {
-                h2o_iovec_t dest = h2o_concat(&req->pool, req->scheme->name, h2o_iovec_init(H2O_STRLIT("://")),
-                                              req->input.authority, pathconf->path);
                 req->pathconf = pathconf;
-                h2o_send_redirect(req, 301, "Moved Permanently", dest.base, dest.len);
+                h2o_send_redirect(req, 301, "Moved Permanently", pathconf->path.base, pathconf->path.len);
                 return;
             }
             if (req->path_normalized.base[confpath_wo_slash] == '/') {

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -322,8 +322,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
             }
             if (is_dir) {
                 /* note: apache redirects "path/" to "path/index.txt/" if index.txt is a dir */
-                h2o_iovec_t dest = h2o_concat(&req->pool, req->scheme->name, h2o_iovec_init(H2O_STRLIT("://")), req->authority,
-                                              req->path_normalized, *index_file, h2o_iovec_init(H2O_STRLIT("/")));
+                h2o_iovec_t dest = h2o_concat(&req->pool, req->path_normalized, *index_file, h2o_iovec_init(H2O_STRLIT("/")));
                 h2o_send_redirect(req, 301, "Moved Permantently", dest.base, dest.len);
                 return 0;
             }
@@ -340,8 +339,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
         if ((generator = create_generator(req, rpath, rpath_len, &is_dir, self->flags)) != NULL)
             goto Opened;
         if (is_dir) {
-            h2o_iovec_t dest = h2o_concat(&req->pool, req->scheme->name, h2o_iovec_init(H2O_STRLIT("://")), req->authority,
-                                          req->path_normalized, h2o_iovec_init(H2O_STRLIT("/")));
+            h2o_iovec_t dest = h2o_concat(&req->pool, req->path_normalized, h2o_iovec_init(H2O_STRLIT("/")));
             h2o_send_redirect(req, 301, "Moved Permanently", dest.base, dest.len);
             return 0;
         }

--- a/t/00unit/lib/handler/file.c
+++ b/t/00unit/lib/handler/file.c
@@ -244,7 +244,7 @@ void test_lib__handler__file_c()
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 301);
-        ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "http://default/index_txt/"));
+        ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "/index_txt/"));
         h2o_loopback_destroy(conn);
     }
     {
@@ -253,7 +253,7 @@ void test_lib__handler__file_c()
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 301);
-        ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "http://default/index_txt/"));
+        ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "/index_txt/"));
         h2o_loopback_destroy(conn);
     }
     {
@@ -262,7 +262,7 @@ void test_lib__handler__file_c()
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt_as_dir/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 301);
-        ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "http://default/index_txt_as_dir/index.txt/"));
+        ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "/index_txt_as_dir/index.txt/"));
         h2o_loopback_destroy(conn);
     }
     {
@@ -271,7 +271,7 @@ void test_lib__handler__file_c()
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/index_txt_as_dir/"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 301);
-        ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "http://default/index_txt_as_dir/index.txt/"));
+        ok(check_header(&conn->req.res, H2O_TOKEN_LOCATION, "/index_txt_as_dir/index.txt/"));
         h2o_loopback_destroy(conn);
     }
 

--- a/t/40pathconf-redirect.t
+++ b/t/40pathconf-redirect.t
@@ -17,7 +17,7 @@ sub doit {
     my ($proto, $port) = @_;
     my ($stderr, $stdout) = run_prog("curl --silent --show-error --insecure --max-redirs 0 --dump-header /dev/stderr $proto://127.0.0.1:$port/abc");
     like $stderr, qr{^HTTP/1\.1 301 .*}s, "is 301";
-    like $stderr, qr{^location: $proto://127.0.0.1:$port/abc/\r$}im, "location header";
+    like $stderr, qr{^location: /abc/\r$}im, "location header";
 }
 
 subtest 'http' => sub { doit('http', $server->{port}); };

--- a/t/50reverse-proxy.t
+++ b/t/50reverse-proxy.t
@@ -119,8 +119,9 @@ sub run_tests_with_conf {
                 is md5_hex($content), $files{"index.txt"}->{md5}, "reproxy & internal redirect to file (md5)";
                 $content = `curl --silent --dump-header /dev/stderr --insecure "$proto://127.0.0.1:$port/?resp:status=200&resp:x-reproxy-url=http://127.0.0.1:$upstream_port/?resp:status=302%26resp:location=https://127.0.0.1:$upstream_port/index.txt" 2>&1 > /dev/null`;
                 like $content, qr{^HTTP/1\.1 502 }m, "cannot handle internal redirect via location: to https";
-                $content = `curl --silent --dump-header /dev/stderr --insecure "$proto://127.0.0.1:$port/?resp:status=200&resp:x-reproxy-url=http://default/files" 2>&1 > /dev/null`;
-                unlike $content, qr{^HTTP/1\.1 3}m, "once delegated, redirects of the file handler should be handled internally";
+                $content = `curl --silent --insecure "$proto://127.0.0.1:$port/?resp:status=200&resp:x-reproxy-url=http://default/files"`;
+                is length($content), $files{"index.txt"}->{size}, "redirect handled internally after delegation (size)";
+                is md5_hex($content), $files{"index.txt"}->{md5}, "redirect handled internally after delegation (md5)";
             };
             subtest "x-forwarded ($proto)" => sub {
                 my $resp = `curl --silent --insecure $proto://127.0.0.1:$port/echo-headers`;


### PR DESCRIPTION
Since using absurl may cause issues with hostname rewrites.

Also fixes the `[lib/core/proxy.c] in request:/files/:I/O error (head)` error in t/50reverse-proxy.t introduced in #202; the error was due to the use of `req->input.authority` in [lib/core/request.c line 92](https://github.com/h2o/h2o/blob/283459211df8e2a9c1561728fa831cc23269bb10/lib/core/request.c#L92).  The line was causing the proxy to connect to H2O's TLS port.