### PR TITLE
Include '<netinet/in.h>' for using 'struct sockaddr_in'

### DIFF
--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -26,6 +26,7 @@
 extern "C" {
 #endif
 
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <pthread.h>
 #include "h2o/linklist.h"


### PR DESCRIPTION
This is related to #211.