### PR TITLE
empty struct should not be used in C code

### DIFF
--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -46,6 +46,7 @@ typedef struct st_h2o_evloop_t {
 typedef h2o_evloop_t h2o_loop_t;
 
 struct st_h2o_timeout_backend_properties_t {
+    char _dummy; /* sizeof(empty_struct) differs bet. C (GCC extension) and C++ */
 };
 
 h2o_socket_t *h2o_evloop_socket_create(h2o_evloop_t *loop, int fd, struct sockaddr *addr, socklen_t addrlen, int flags);


### PR DESCRIPTION
fixes #225