### PR TITLE
fix HTTP/2 compliance issue found by h2spec v0.08

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -462,8 +462,8 @@ static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, c
 
     /* save the input in the request body buffer, or send error (and close the stream) */
     if (stream == NULL) {
-        send_stream_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
-        stream = NULL;
+        *err_desc = "invalid DATA frame";
+        return H2O_HTTP2_ERROR_PROTOCOL;
     } else if (stream->state != H2O_HTTP2_STREAM_STATE_RECV_BODY) {
         send_stream_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
         h2o_http2_stream_reset(conn, stream);


### PR DESCRIPTION
Endpoint should close the connection with PROTOCOL_ERROR when receiving a DATA frame on an idle/closed stream.