### PR TITLE
Disable TLS compression

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -481,6 +481,11 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
             }
         }
     }
+    
+    /* disable tls compression to avoid "CRIME" attacks (see http://en.wikipedia.org/wiki/CRIME) */
+    #ifdef SSL_OP_NO_COMPRESSION
+    ssl_options |= SSL_OP_NO_COMPRESSION;
+    #endif
 
     /* setup */
     init_openssl();


### PR DESCRIPTION
When compiling against openssl with compression support, h2o is using it, becoming vulnerable to CRIME attacks.