### PR TITLE
use h2o_malloc instead of malloc for allocation-error.

### DIFF
--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -103,7 +103,7 @@ static void init_async(h2o_multithread_queue_t *queue, h2o_loop_t *loop)
 
 h2o_multithread_queue_t *h2o_multithread_create_queue(h2o_loop_t *loop)
 {
-    h2o_multithread_queue_t *queue = malloc(sizeof(*queue));
+    h2o_multithread_queue_t *queue = h2o_mem_alloc(sizeof(*queue));
     *queue = (h2o_multithread_queue_t){};
 
 #if H2O_USE_LIBUV

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -220,7 +220,7 @@ void h2o_socketpool_connect(h2o_socketpool_connect_request_t **_req, h2o_socketp
     __sync_add_and_fetch(&pool->_shared.count, 1);
 
     /* prepare request object */
-    h2o_socketpool_connect_request_t *req = malloc(sizeof(*req));
+    h2o_socketpool_connect_request_t *req = h2o_mem_alloc(sizeof(*req));
     *req = (h2o_socketpool_connect_request_t){data, cb, pool, loop};
     if (_req != NULL)
         *_req = req;

--- a/lib/http2/scheduler.c
+++ b/lib/http2/scheduler.c
@@ -116,7 +116,7 @@ static void init_node(h2o_http2_scheduler_node_t *node, h2o_http2_scheduler_node
 static h2o_http2_scheduler_queue_t *get_queue(h2o_http2_scheduler_node_t *node)
 {
     if (node->_queue == NULL) {
-        node->_queue = malloc(sizeof(*node->_queue));
+        node->_queue = h2o_mem_alloc(sizeof(*node->_queue));
         queue_init(node->_queue);
     }
     return node->_queue;


### PR DESCRIPTION
As original code does not handling allocation-error, `h2o_mem_alloc()` is better.