### PR TITLE
Fix memory corruption when proxying large cookie headers

### DIFF
--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -99,8 +99,11 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive)
 
 #define RESERVE(sz)                                                                                                                \
     do {                                                                                                                           \
-        if (offset + sz + 4 /* for "\r\n\r\n" */ > buf.len) {                                                                      \
-            buf.len *= 2;                                                                                                          \
+        size_t required = offset + sz + 4 /* for "\r\n\r\n" */;                                                                    \
+        if (required > buf.len) {                                                                                                  \
+            do {                                                                                                                   \
+                buf.len *= 2;                                                                                                      \
+            } while (required > buf.len);                                                                                          \
             char *newp = h2o_mem_alloc_pool(&req->pool, buf.len);                                                                  \
             memcpy(newp, buf.base, offset);                                                                                        \
             buf.base = newp;                                                                                                       \

--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -129,6 +129,10 @@ sub run_tests_with_conf {
                 like $resp, qr/^x-forwarded-for: 127\.0\.0\.2, 127\.0\.0\.1$/mi, "x-forwarded-for (append)";
                 like $resp, qr/^via: 2 example.com, 1\.1 127\.0\.0\.1:$port$/mi, "via (append)";
             };
+            subtest 'issues/266' => sub {
+                my $resp = `curl --dump-header /dev/stderr --silent --insecure -H 'cookie: a=@{['x' x 4000]}' $proto://127.0.0.1:$port/index.txt 2>&1 > /dev/null`;
+                like $resp, qr{^HTTP/1\.1 200 }m;
+            };
         };
         $doit->('http', $port);
         $doit->('https', $tls_port);


### PR DESCRIPTION
fixes #266 (while maintaining the exponential back-off algorithm for calculating the next allocation size).

note: should better use `__builtin_clz` for rounding up the number by power of two.