### PR TITLE
process pending callbacks ASAP (for every timeout callback)

### DIFF
--- a/include/h2o/timeout.h
+++ b/include/h2o/timeout.h
@@ -78,12 +78,12 @@ void h2o_timeout_unlink(h2o_timeout_entry_t *entry);
  */
 static int h2o_timeout_is_linked(h2o_timeout_entry_t *entry);
 
-size_t h2o_timeout_run(h2o_timeout_t *timeout, uint64_t now);
-size_t h2o_timeout_run_all(h2o_linklist_t *timeouts, uint64_t now);
+void h2o_timeout_run(h2o_loop_t *loop, h2o_timeout_t *timeout, uint64_t now);
 uint64_t h2o_timeout_get_wake_at(h2o_linklist_t *timeouts);
 void h2o_timeout__do_init(h2o_loop_t *loop, h2o_timeout_t *timeout);
 void h2o_timeout__do_dispose(h2o_loop_t *loop, h2o_timeout_t *timeout);
 void h2o_timeout__do_link(h2o_loop_t *loop, h2o_timeout_t *timeout, h2o_timeout_entry_t *entry);
+void h2o_timeout__do_post_callback(h2o_loop_t *loop);
 
 /* inline defs */
 

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -220,7 +220,7 @@ static void on_timeout(uv_timer_t *timer)
 {
     h2o_timeout_t *timeout = H2O_STRUCT_FROM_MEMBER(h2o_timeout_t, _backend.timer, timer);
 
-    h2o_timeout_run(timeout, h2o_now(timer->loop));
+    h2o_timeout_run(timer->loop, timeout, h2o_now(timer->loop));
     if (!h2o_linklist_is_empty(&timeout->_entries))
         schedule_timer(timeout);
 }
@@ -247,4 +247,9 @@ void h2o_timeout__do_link(h2o_loop_t *loop, h2o_timeout_t *timeout, h2o_timeout_
     /* register the timer if the entry just being added is the only entry */
     if (timeout->_entries.next == &entry->_link)
         schedule_timer(timeout);
+}
+
+void h2o_timeout__do_post_callback(h2o_loop_t *loop)
+{
+    /* nothing to do */
 }


### PR DESCRIPTION
As discussed in http://blog.kazuhooku.com/2014/09/the-reasons-why-i-stopped-using-libuv.html the embedded event loop is designed to call i/o completion callbacks ASAP, so that memory can be freed before handling the next connection.

However the timeout callbacks were not called in such a manner, and therefore the HTTP/2 connection layer was using more memory than it should (the protocol handler was not reusing a single ~80KB block for many connections which is feasible for HTTP/2 64KB connection window).

This PR fixes the issue.