### PR TITLE
fix laggy response if upstream sends a response known not to contain body

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -271,7 +271,7 @@ static void on_head(h2o_socket_t *sock, int status)
         client->_can_keepalive = 0;
 
     /* RFC 2616 4.4 */
-    if (client->_method_is_head || ((100 <= status && status <= 199) || status == 204 || status == 304)) {
+    if (client->_method_is_head || ((100 <= http_status && http_status <= 199) || http_status == 204 || http_status == 304)) {
         is_eos = 1;
     } else {
         is_eos = 0;

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -266,15 +266,15 @@ static void on_head(h2o_socket_t *sock, int status)
                 reader = on_body_content_length;
         }
     }
-    /* close the connection if impossible to determine the end of the response (RFC 7230 3.3.3) */
-    if (reader == on_body_until_close)
-        client->_can_keepalive = 0;
 
     /* RFC 2616 4.4 */
     if (client->_method_is_head || ((100 <= http_status && http_status <= 199) || http_status == 204 || http_status == 304)) {
         is_eos = 1;
     } else {
         is_eos = 0;
+        /* close the connection if impossible to determine the end of the response (RFC 7230 3.3.3) */
+        if (reader == on_body_until_close)
+            client->_can_keepalive = 0;
     }
 
     /* call the callback */


### PR DESCRIPTION
The proxy fails to determine by using status code that response is expected to contain body (the code is referring to a wrong value).  Therefore, if the upstream server sends either 204 or 304 response and if the connection is persistent, H2O errorneously waits for content from upstream until `proxy.timeout.io` expires or until upstream closes the connection.

This PR fixes the issue; also adjusts the code to preserve connection if possible in case the response is not known to contain body.

fixes #274