### PR TITLE
avoid 3 unitialized argument value bugs #107

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1170,6 +1170,11 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
                                       on_server_notification);
     conf.threads[thread_index].tid = pthread_self();
 
+    if (conf.num_listeners < 1) {
+      perror("not enought listeners to start listening");
+      abort();
+    }
+
     /* setup listeners */
     for (i = 0; i != conf.num_listeners; ++i) {
         struct listener_config_t *listener_config = conf.listeners[i];


### PR DESCRIPTION
Hey Kazuho,
This silences 3 errors caught by clang's static analysis tool scan-build, all related to `listeners[i].sock` possibly being unitialized, if `conf.num_listeners` is `0`.
