### PR TITLE
avoid possible null pointer deref

### DIFF
--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -216,6 +216,9 @@ int h2o_url_parse_relative(const char *url, size_t url_len, h2o_url_t *parsed)
 {
     const char *url_end, *p;
 
+    if (url == NULL)
+        return -1;
+
     if (url_len == SIZE_MAX)
         url_len = strlen(url);
     url_end = url + url_len;


### PR DESCRIPTION
if `url == NULL` then later we would do `p = URL` then `p[0]`.  Oops.
