### PR TITLE
avoid another possible pointer deref #107

### DIFF
--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -103,7 +103,7 @@ void h2o_mimemap_set_default_type(h2o_mimemap_t *mimemap, const char *type)
 void h2o_mimemap_set_type(h2o_mimemap_t *mimemap, const char *ext, const char *type)
 {
     khiter_t iter = kh_get(exttable, mimemap->table, ext);
-    if (iter != kh_end(mimemap->table)) {
+    if (iter != kh_end(mimemap->table) && mimemap->table->vals != NULL) {
         h2o_mem_release_shared(kh_val(mimemap->table, iter).base);
     } else {
         int ret;


### PR DESCRIPTION
the expression `kh_val(mimemap->table, iter)` expands to `mimemap->table->vals[iters]` which might be a null ptr deref if `vals` is `NULL`.