### PR TITLE
unnecessary atomic decrement already contained by mutex

### DIFF
--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -106,7 +106,7 @@ void h2o_socketpool_dispose(h2o_socketpool_t *pool)
     while (!h2o_linklist_is_empty(&pool->_shared.sockets)) {
         struct pool_entry_t *entry = H2O_STRUCT_FROM_MEMBER(struct pool_entry_t, link, pool->_shared.sockets.next);
         destroy_attached(entry);
-        __sync_sub_and_fetch(&pool->_shared.count, 1);
+        --pool->_shared.count;
     }
     pthread_mutex_unlock(&pool->_shared.mutex);
     pthread_mutex_destroy(&pool->_shared.mutex);


### PR DESCRIPTION
[Here](https://github.com/h2o/h2o/blob/132f7b226de47b48a27fda1c0e5368d726c8c87e/lib/common/socketpool.c#L105-L109) we can see an atomic operation already protected by a mutex.  Either it doesn't need to be atomic, the mutex protects too much, or we can leave it (might be nice for someone who might change the code in the future to recognize they should operate on the socketpool count atomically).