### PR TITLE
refactor virtual-host lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,8 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/handler/headers.c
     t/00unit/lib/handler/mimemap.c
     t/00unit/lib/http2/hpack.c
-    t/00unit/lib/http2/scheduler.c)
+    t/00unit/lib/http2/scheduler.c
+    t/00unit/issues/293.c)
 LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/common/multithread.c
     lib/common/serverutil.c

--- a/examples/libh2o/simple.c
+++ b/examples/libh2o/simple.c
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
     signal(SIGPIPE, SIG_IGN);
 
     h2o_config_init(&config);
-    hostconf = h2o_config_register_host(&config, "default");
+    hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT("default")), 65535);
     register_handler(hostconf, "/post-test", post_test);
     register_handler(hostconf, "/chunked-test", chunked_test);
     h2o_reproxy_register(register_handler(hostconf, "/reproxy-test", reproxy_test));

--- a/examples/libh2o/websocket.c
+++ b/examples/libh2o/websocket.c
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
     }
 
     h2o_config_init(&config);
-    hostconf = h2o_config_register_host(&config, "default");
+    hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT("default")), 65535);
     pathconf = h2o_config_register_path(hostconf, "/");
     h2o_create_handler(pathconf, sizeof(h2o_handler_t))->on_req = on_req;
 

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		105534EF1A440FC800627ECB /* config.c in Sources */ = {isa = PBXBuildFile; fileRef = 105534EE1A440FC800627ECB /* config.c */; };
 		10583BF11AE5A37B004A3AD6 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = 10583BED1AE5A37B004A3AD6 /* Makefile */; };
 		10583BF21AE5A37B004A3AD6 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = 10583BEE1AE5A37B004A3AD6 /* README.md */; };
+		10583C001AEF368A004A3AD6 /* 293.c in Sources */ = {isa = PBXBuildFile; fileRef = 10583BFF1AEF368A004A3AD6 /* 293.c */; };
 		1058C87D1AA41789008D6180 /* headers.c in Sources */ = {isa = PBXBuildFile; fileRef = 1058C87C1AA41789008D6180 /* headers.c */; };
 		1058C87E1AA41A1F008D6180 /* headers.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EBD1AA019D8004322AC /* headers.c */; };
 		1058C8881AA6DE4B008D6180 /* hostinfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 1058C8871AA6DE4B008D6180 /* hostinfo.h */; };
@@ -279,6 +280,7 @@
 		10583BF91AE783BE004A3AD6 /* searchstyle.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = searchstyle.css; path = assets/searchstyle.css; sourceTree = "<group>"; };
 		10583BFA1AE783BE004A3AD6 /* style.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = style.css; path = assets/style.css; sourceTree = "<group>"; };
 		10583BFB1AE78DCC004A3AD6 /* syntax_and_structure.mt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = syntax_and_structure.mt; sourceTree = "<group>"; };
+		10583BFF1AEF368A004A3AD6 /* 293.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = 293.c; sourceTree = "<group>"; };
 		1058C87C1AA41789008D6180 /* headers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = headers.c; sourceTree = "<group>"; };
 		1058C87F1AA42568008D6180 /* 50headers.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 50headers.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		1058C8871AA6DE4B008D6180 /* hostinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hostinfo.h; sourceTree = "<group>"; };
@@ -573,6 +575,7 @@
 		105534C41A3BB1C300627ECB /* 00unit */ = {
 			isa = PBXGroup;
 			children = (
+				10583BFE1AEF3652004A3AD6 /* issues */,
 				105534C51A3BB1E700627ECB /* lib */,
 				10D0906F19F494CC0043D458 /* test.h */,
 				10D0906E19F494CC0043D458 /* test.c */,
@@ -663,6 +666,14 @@
 				10583BFA1AE783BE004A3AD6 /* style.css */,
 			);
 			name = assets;
+			sourceTree = "<group>";
+		};
+		10583BFE1AEF3652004A3AD6 /* issues */ = {
+			isa = PBXGroup;
+			children = (
+				10583BFF1AEF368A004A3AD6 /* 293.c */,
+			);
+			path = issues;
 			sourceTree = "<group>";
 		};
 		1065E6F319B9969000686E72 /* evloop */ = {
@@ -1282,6 +1293,7 @@
 				1079244419A3265C00C52AD6 /* chunked.c in Sources */,
 				104B9A481A5F9472009EEE64 /* headers.c in Sources */,
 				10E2995A1A68D03100701AA6 /* scheduler.c in Sources */,
+				10583C001AEF368A004A3AD6 /* 293.c in Sources */,
 				105534BE1A3B8F7700627ECB /* file.c in Sources */,
 				1079244719A3265C00C52AD6 /* http1.c in Sources */,
 				1079244819A3265C00C52AD6 /* connection.c in Sources */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -178,9 +178,22 @@ struct st_h2o_hostconf_t {
      */
     h2o_globalconf_t *global;
     /**
-     * hostname in lower-case (base is NUL terminated)
+     * host and port
      */
-    h2o_iovec_t hostname;
+    struct {
+        /**
+         * host and port (in lower-case; base is NULL-terminated)
+         */
+        h2o_iovec_t hostport;
+        /**
+         *  in lower-case; base is NULL-terminated
+         */
+        h2o_iovec_t host;
+        /**
+         * port number (or 65535 if default)
+         */
+        uint16_t port;
+    } authority;
     /**
      * list of path configurations
      */
@@ -758,7 +771,7 @@ void h2o_config_init(h2o_globalconf_t *config);
 /**
  * registers a host context
  */
-h2o_hostconf_t *h2o_config_register_host(h2o_globalconf_t *config, const char *hostname);
+h2o_hostconf_t *h2o_config_register_host(h2o_globalconf_t *config, h2o_iovec_t host, uint16_t port);
 /**
  * registers a path context
  */

--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -62,6 +62,7 @@ int h2o_url_parse(const char *url, size_t url_len, h2o_url_t *result);
 int h2o_url_parse_relative(const char *url, size_t url_len, h2o_url_t *result);
 /**
  * parses the authority and returns the next position (i.e. start of path)
+ * @return pointer to the end of hostport if successful, or NULL if failed.  *port becomes the specified port number or 65535 if not
  */
 const char *h2o_url_parse_hostport(const char *s, size_t len, h2o_iovec_t *host, uint16_t *port);
 /**

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -108,7 +108,7 @@ void h2o_context_dispose(h2o_context_t *ctx)
     for (i = 0; config->hosts[i] != NULL; ++i) {
         h2o_hostconf_t *hostconf = config->hosts[i];
         for (j = 0; j != hostconf->paths.size; ++j) {
-            h2o_pathconf_t *pathconf = hostconf->paths.entries + i;
+            h2o_pathconf_t *pathconf = hostconf->paths.entries + j;
             on_context_dispose(ctx, pathconf);
         }
     }

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -336,8 +336,9 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
             pos = append_unsafe_string(pos, req->input.authority.base, req->input.authority.len);
             break;
         case ELEMENT_TYPE_HOSTCONF: /* %v */
-            RESERVE(req->pathconf->host->hostname.len * 4);
-            pos = append_unsafe_string(pos, req->pathconf->host->hostname.base, req->pathconf->host->hostname.len);
+            RESERVE(req->pathconf->host->authority.hostport.len * 4);
+            pos = append_unsafe_string(pos, req->pathconf->host->authority.hostport.base,
+                                       req->pathconf->host->authority.hostport.len);
             break;
 
         case ELEMENT_TYPE_LOGNAME:     /* %l */

--- a/src/main.c
+++ b/src/main.c
@@ -503,7 +503,7 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
         for (i = 0; i != listener->ssl.size; ++i) {
             struct listener_ssl_config_t *ssl_config = listener->ssl.entries + i;
             if (strcmp(ssl_config->certificate_file, certificate_file->data.scalar) == 0) {
-                listener_setup_ssl_add_host(ssl_config, ctx->hostconf->hostname);
+                listener_setup_ssl_add_host(ssl_config, ctx->hostconf->authority.hostport);
                 return 0;
             }
         }
@@ -573,7 +573,7 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
         ssl_config = listener->ssl.entries + listener->ssl.size++;
         memset(ssl_config, 0, sizeof(*ssl_config));
         if (ctx->hostconf != NULL) {
-            listener_setup_ssl_add_host(ssl_config, ctx->hostconf->hostname);
+            listener_setup_ssl_add_host(ssl_config, ctx->hostconf->authority.hostport);
         }
         ssl_config->ctx = ssl_ctx;
         ssl_config->certificate_file = h2o_strdup(NULL, certificate_file->data.scalar, SIZE_MAX).base;
@@ -584,8 +584,8 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
         SSL_CTX_set_tlsext_status_cb(ssl_ctx, on_ocsp_stapling_callback);
         SSL_CTX_set_tlsext_status_arg(ssl_ctx, ssl_config);
         pthread_mutex_init(&ssl_config->ocsp_stapling.response.mutex, NULL);
-        ssl_config->ocsp_stapling.cmd =
-            ocsp_update_cmd != NULL ? h2o_strdup(NULL, ocsp_update_cmd->data.scalar, SIZE_MAX).base : "share/h2o/fetch-ocsp-response";
+        ssl_config->ocsp_stapling.cmd = ocsp_update_cmd != NULL ? h2o_strdup(NULL, ocsp_update_cmd->data.scalar, SIZE_MAX).base
+                                                                : "share/h2o/fetch-ocsp-response";
         if (ocsp_update_interval != 0) {
             switch (conf.run_mode) {
             case RUN_MODE_WORKER:

--- a/t/00unit/issues/293.c
+++ b/t/00unit/issues/293.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2014 DeNA Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <inttypes.h>
+#include <stdio.h>
+#include "../test.h"
+
+static h2o_context_t ctx;
+
+static void register_authority(h2o_globalconf_t *globalconf, h2o_iovec_t host, uint16_t port)
+{
+    static h2o_iovec_t x_authority = {H2O_STRLIT("x-authority")};
+
+    h2o_hostconf_t *hostconf = h2o_config_register_host(globalconf, host, port);
+    h2o_pathconf_t *pathconf = h2o_config_register_path(hostconf, "/");
+    h2o_file_register(pathconf, "t/00unit/assets", NULL, NULL, 0);
+
+    char *authority = h2o_mem_alloc(host.len + sizeof(":65535"));
+    sprintf(authority, "%.*s:%" PRIu16, (int)host.len, host.base, port);
+    h2o_headers_command_t *cmds = h2o_mem_alloc(sizeof(*cmds) * 2);
+    cmds[0] = (h2o_headers_command_t){H2O_HEADERS_CMD_ADD, &x_authority, {authority, strlen(authority)}};
+    cmds[1] = (h2o_headers_command_t){H2O_HEADERS_CMD_NULL};
+    h2o_headers_register(pathconf, cmds);
+}
+
+static void check(const h2o_url_scheme_t *scheme, const char *host, const char *expected)
+{
+    h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
+
+    conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
+    conn->req.input.scheme = scheme;
+    conn->req.input.authority = h2o_iovec_init(host, strlen(host));
+    conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
+    h2o_loopback_run_loop(conn);
+    ok(conn->req.res.status == 200);
+
+    size_t index = h2o_find_header_by_str(&conn->req.res.headers, H2O_STRLIT("x-authority"), SIZE_MAX);
+    ok(index != SIZE_MAX);
+
+    if (index != SIZE_MAX) {
+        ok(h2o_memis(conn->req.res.headers.entries[index].value.base, conn->req.res.headers.entries[index].value.len, expected, strlen(expected)));
+    }
+
+    h2o_loopback_destroy(conn);
+}
+
+void test_issues293()
+{
+    h2o_globalconf_t globalconf;
+
+    h2o_config_init(&globalconf);
+
+    /* register two hosts, using 80 and 443 */
+    register_authority(&globalconf, h2o_iovec_init(H2O_STRLIT("default")), 65535);
+    register_authority(&globalconf, h2o_iovec_init(H2O_STRLIT("host1")), 80);
+    register_authority(&globalconf, h2o_iovec_init(H2O_STRLIT("host1")), 443);
+    register_authority(&globalconf, h2o_iovec_init(H2O_STRLIT("host2")), 80);
+    register_authority(&globalconf, h2o_iovec_init(H2O_STRLIT("host2")), 443);
+    register_authority(&globalconf, h2o_iovec_init(H2O_STRLIT("host3")), 65535);
+
+    h2o_context_init(&ctx, test_loop, &globalconf);
+
+    /* run the tests */
+    check(&H2O_URL_SCHEME_HTTP, "host1", "host1:80");
+    check(&H2O_URL_SCHEME_HTTPS, "host1", "host1:443");
+    check(&H2O_URL_SCHEME_HTTP, "host2", "host2:80");
+    check(&H2O_URL_SCHEME_HTTPS, "host2", "host2:443");
+
+    /* supplied port number in the Host header must be preferred */
+    check(&H2O_URL_SCHEME_HTTP, "host1:80", "host1:80");
+    check(&H2O_URL_SCHEME_HTTP, "host1:443", "host1:443");
+    check(&H2O_URL_SCHEME_HTTPS, "host1:80", "host1:80");
+    check(&H2O_URL_SCHEME_HTTPS, "host1:443", "host1:443");
+    check(&H2O_URL_SCHEME_HTTP, "host2:80", "host2:80");
+    check(&H2O_URL_SCHEME_HTTP, "host2:443", "host2:443");
+    check(&H2O_URL_SCHEME_HTTPS, "host2:80", "host2:80");
+    check(&H2O_URL_SCHEME_HTTPS, "host2:443", "host2:443");
+
+    /* host-level conf without default port */
+    check(&H2O_URL_SCHEME_HTTP, "host3", "host3:65535");
+    check(&H2O_URL_SCHEME_HTTPS, "host3", "host3:65535");
+    check(&H2O_URL_SCHEME_HTTP, "host3", "host3:65535");
+    check(&H2O_URL_SCHEME_HTTPS, "host3", "host3:65535");
+    check(&H2O_URL_SCHEME_HTTP, "host3:80", "host3:65535");
+    check(&H2O_URL_SCHEME_HTTPS, "host3:80", "default:65535");
+    check(&H2O_URL_SCHEME_HTTP, "host3:443", "default:65535");
+    check(&H2O_URL_SCHEME_HTTPS, "host3:443", "host3:65535");
+
+    /* upper-case */
+    check(&H2O_URL_SCHEME_HTTP, "HoST1", "host1:80");
+    check(&H2O_URL_SCHEME_HTTP, "HoST1:80", "host1:80");
+    check(&H2O_URL_SCHEME_HTTPS, "HoST1", "host1:443");
+    check(&H2O_URL_SCHEME_HTTPS, "HoST1:443", "host1:443");
+
+    h2o_context_dispose(&ctx);
+    h2o_config_dispose(&globalconf);
+}

--- a/t/00unit/lib/handler/file.c
+++ b/t/00unit/lib/handler/file.c
@@ -130,7 +130,7 @@ void test_lib__handler__file_c()
     h2o_pathconf_t *pathconf;
 
     h2o_config_init(&globalconf);
-    hostconf = h2o_config_register_host(&globalconf, "default");
+    hostconf = h2o_config_register_host(&globalconf, h2o_iovec_init(H2O_STRLIT("default")), 65535);
     pathconf = h2o_config_register_path(hostconf, "/");
     h2o_file_register(pathconf, "t/00unit/assets", NULL, NULL, 0);
 

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -107,7 +107,7 @@ static void test_loopback(void)
     h2o_loopback_conn_t *conn;
 
     h2o_config_init(&conf);
-    h2o_config_register_host(&conf, "default");
+    h2o_config_register_host(&conf, h2o_iovec_init(H2O_STRLIT("default")), 65535);
     h2o_context_init(&ctx, test_loop, &conf);
 
     conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -147,6 +147,7 @@ int main(int argc, char **argv)
 
         subtest("lib/t/test.c/loopback", test_loopback);
         subtest("lib/file.c", test_lib__handler__file_c);
+        subtest("issues/293.c", test_issues293);
 
 #if H2O_USE_LIBUV
         uv_loop_close(test_loop);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -60,5 +60,6 @@ void test_lib__handler__headers_c(void);
 void test_lib__handler__mimemap_c(void);
 void test_lib__http2__hpack(void);
 void test_lib__http2__scheduler(void);
+void test_issues293(void);
 
 #endif


### PR DESCRIPTION
reimplements the lookup logic of host-level conf to be as follows:

* compares hostnames case-less
* host-level configuration _wo. port number_ matches the requests coming in to the default ports (i.e. http coming into port 80 __and__ https coming into port 443)
* host-level configuration _with port number_ matches the requests with host headers wo. port number

The original logic was simply using memcmp for comparing hostport.

fixes #293