### PR TITLE
fix potential use-after-free issue during hostname lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ SET(UNIT_TEST_SOURCE_FILES
     ${LIB_SOURCE_FILES}
     deps/picotest/picotest.c
     t/00unit/test.c
+    t/00unit/lib/common/hostinfo.c
     t/00unit/lib/common/multithread.c
     t/00unit/lib/common/serverutil.c
     t/00unit/lib/common/string.c
@@ -170,6 +171,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/http2/scheduler.c
     t/00unit/issues/293.c)
 LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
+    lib/common/hostinfo.c
     lib/common/multithread.c
     lib/common/serverutil.c
     lib/common/string.c

--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -70,9 +70,9 @@ static void start_request(h2o_http1client_ctx_t *ctx)
             h2o_socketpool_init(sockpool, url_parsed.host, h2o_url_get_port(&url_parsed), 10);
             h2o_socketpool_set_timeout(sockpool, ctx->loop, 5000 /* in msec */);
         }
-        h2o_http1client_connect_with_pool(NULL, req, ctx, &pool, sockpool, on_connect);
+        h2o_http1client_connect_with_pool(NULL, req, ctx, sockpool, on_connect);
     } else {
-        h2o_http1client_connect(NULL, req, ctx, &pool, url_parsed.host, h2o_url_get_port(&url_parsed), on_connect);
+        h2o_http1client_connect(NULL, req, ctx, url_parsed.host, h2o_url_get_port(&url_parsed), on_connect);
     }
 }
 

--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -73,8 +73,7 @@ static void start_request(h2o_http1client_ctx_t *ctx)
         }
         h2o_http1client_connect_with_pool(NULL, req, ctx, &pool, sockpool, on_connect);
     } else {
-        h2o_http1client_connect(NULL, req, ctx, &pool, h2o_strdup(&pool, url_parsed.host.base, url_parsed.host.len).base,
-                                h2o_url_get_port(&url_parsed), on_connect);
+        h2o_http1client_connect(NULL, req, ctx, &pool, url_parsed.host, h2o_url_get_port(&url_parsed), on_connect);
     }
 }
 

--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -67,8 +67,7 @@ static void start_request(h2o_http1client_ctx_t *ctx)
     if (1) {
         if (sockpool == NULL) {
             sockpool = h2o_mem_alloc(sizeof(*sockpool));
-            h2o_socketpool_init(sockpool, h2o_strdup(&pool, url_parsed.host.base, url_parsed.host.len).base,
-                                h2o_url_get_port(&url_parsed), 10);
+            h2o_socketpool_init(sockpool, url_parsed.host, h2o_url_get_port(&url_parsed), 10);
             h2o_socketpool_set_timeout(sockpool, ctx->loop, 5000 /* in msec */);
         }
         h2o_http1client_connect_with_pool(NULL, req, ctx, &pool, sockpool, on_connect);

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		10F4180119C2D31600B6E31A /* yoml.h in Headers */ = {isa = PBXBuildFile; fileRef = 10F4180019C2D31600B6E31A /* yoml.h */; };
 		10F4180519CA75C500B6E31A /* configurator.c in Sources */ = {isa = PBXBuildFile; fileRef = 10F4180419CA75C500B6E31A /* configurator.c */; };
 		10F9F2651AF4795D0056F26B /* redirect.c in Sources */ = {isa = PBXBuildFile; fileRef = 10F9F2641AF4795D0056F26B /* redirect.c */; };
+		10F9F2671AFC5F550056F26B /* hostinfo.c in Sources */ = {isa = PBXBuildFile; fileRef = 10F9F2661AFC5F550056F26B /* hostinfo.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -414,6 +415,7 @@
 		10F4180219C2D32100B6E31A /* yoml-parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "yoml-parser.h"; path = "yoml/yoml-parser.h"; sourceTree = "<group>"; };
 		10F4180419CA75C500B6E31A /* configurator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = configurator.c; sourceTree = "<group>"; };
 		10F9F2641AF4795D0056F26B /* redirect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = redirect.c; sourceTree = "<group>"; };
+		10F9F2661AFC5F550056F26B /* hostinfo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hostinfo.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -548,6 +550,7 @@
 		104B9A4D1A5FAA7B009EEE64 /* common */ = {
 			isa = PBXGroup;
 			children = (
+				10F9F2661AFC5F550056F26B /* hostinfo.c */,
 				10AA2EAD1A8E22DA004322AC /* multithread.c */,
 				104B9A271A4A5139009EEE64 /* serverutil.c */,
 				105534C61A3BB29100627ECB /* string.c */,
@@ -1320,6 +1323,7 @@
 				10E2995A1A68D03100701AA6 /* scheduler.c in Sources */,
 				10583C001AEF368A004A3AD6 /* 293.c in Sources */,
 				105534BE1A3B8F7700627ECB /* file.c in Sources */,
+				10F9F2671AFC5F550056F26B /* hostinfo.c in Sources */,
 				1079244719A3265C00C52AD6 /* http1.c in Sources */,
 				10F9F2651AF4795D0056F26B /* redirect.c in Sources */,
 				1079244819A3265C00C52AD6 /* connection.c in Sources */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -472,10 +472,10 @@ typedef struct st_h2o_req_overrides_t {
      */
     h2o_socketpool_t *socketpool;
     /**
-     * upstream host:port to connect to (or host == NULL)
+     * upstream host:port to connect to (or host.base == NULL)
      */
     struct {
-        char *host;
+        h2o_iovec_t host;
         uint16_t port;
     } hostport;
     /**

--- a/include/h2o/hostinfo.h
+++ b/include/h2o/hostinfo.h
@@ -38,7 +38,7 @@ extern size_t h2o_hostinfo_max_threads;
 /**
  * dispatches a (possibly) asynchronous hostname lookup
  */
-h2o_hostinfo_getaddr_req_t *h2o_hostinfo_getaddr(h2o_multithread_receiver_t *receiver, const char *name, const char *serv,
+h2o_hostinfo_getaddr_req_t *h2o_hostinfo_getaddr(h2o_multithread_receiver_t *receiver, h2o_iovec_t name, h2o_iovec_t serv,
                                                  int family, int socktype, int protocol, int flags, h2o_hostinfo_getaddr_cb cb,
                                                  void *cbdata);
 /**

--- a/include/h2o/hostinfo.h
+++ b/include/h2o/hostinfo.h
@@ -60,6 +60,11 @@ void h2o_hostinfo_getaddr_receiver(h2o_multithread_receiver_t *receiver, h2o_lin
  */
 static struct addrinfo *h2o_hostinfo_select_one(struct addrinfo *res);
 
+/**
+ * equiv. to inet_pton(AF_INET4)
+ */
+int h2o_hostinfo_aton(h2o_iovec_t host, struct in_addr *addr);
+
 /* inline defs */
 
 inline struct addrinfo *h2o_hostinfo_select_one(struct addrinfo *res)

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -49,7 +49,6 @@ typedef struct st_h2o_http1client_ctx_t {
 
 struct st_h2o_http1client_t {
     h2o_http1client_ctx_t *ctx;
-    h2o_mem_pool_t *pool;
     struct {
         h2o_socketpool_t *pool;
         h2o_socketpool_connect_request_t *connect_req;
@@ -60,9 +59,9 @@ struct st_h2o_http1client_t {
 
 extern const char *const h2o_http1client_error_is_eos;
 
-void h2o_http1client_connect(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
-                             h2o_iovec_t host, uint16_t port, h2o_http1client_connect_cb cb);
-void h2o_http1client_connect_with_pool(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
+void h2o_http1client_connect(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_iovec_t host, uint16_t port,
+                             h2o_http1client_connect_cb cb);
+void h2o_http1client_connect_with_pool(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx,
                                        h2o_socketpool_t *sockpool, h2o_http1client_connect_cb cb);
 void h2o_http1client_cancel(h2o_http1client_t *client);
 

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -61,7 +61,7 @@ struct st_h2o_http1client_t {
 extern const char *const h2o_http1client_error_is_eos;
 
 void h2o_http1client_connect(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
-                             const char *host, uint16_t port, h2o_http1client_connect_cb cb);
+                             h2o_iovec_t host, uint16_t port, h2o_http1client_connect_cb cb);
 void h2o_http1client_connect_with_pool(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
                                        h2o_socketpool_t *sockpool, h2o_http1client_connect_cb cb);
 void h2o_http1client_cancel(h2o_http1client_t *client);

--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -67,7 +67,7 @@ typedef void (*h2o_socketpool_connect_cb)(h2o_socket_t *sock, const char *errstr
 /**
  * initializes a socket loop
  */
-void h2o_socketpool_init(h2o_socketpool_t *pool, const char *host, uint16_t port, size_t capacity);
+void h2o_socketpool_init(h2o_socketpool_t *pool, h2o_iovec_t host, uint16_t port, size_t capacity);
 /**
  * disposes of a socket loop
  */

--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -40,7 +40,7 @@ typedef struct st_h2o_socketpool_t {
         union {
             struct {
                 h2o_iovec_t host;
-                char port[sizeof("65535")];
+                h2o_iovec_t port;
             } named;
             struct sockaddr_in sin;
         };

--- a/lib/common/hostinfo.c
+++ b/lib/common/hostinfo.c
@@ -110,20 +110,21 @@ static void create_lookup_thread(void)
     ++queue.num_threads_idle;
 }
 
-h2o_hostinfo_getaddr_req_t *h2o_hostinfo_getaddr(h2o_multithread_receiver_t *receiver, const char *name, const char *serv,
+h2o_hostinfo_getaddr_req_t *h2o_hostinfo_getaddr(h2o_multithread_receiver_t *receiver, h2o_iovec_t name, h2o_iovec_t serv,
                                                  int family, int socktype, int protocol, int flags, h2o_hostinfo_getaddr_cb cb,
                                                  void *cbdata)
 {
-    size_t name_len = strlen(name), serv_len = strlen(serv);
-    h2o_hostinfo_getaddr_req_t *req = h2o_mem_alloc(sizeof(*req) + name_len + 1 + serv_len + 1);
+    h2o_hostinfo_getaddr_req_t *req = h2o_mem_alloc(sizeof(*req) + name.len + 1 + serv.len + 1);
     req->_receiver = receiver;
     req->_cb = cb;
     req->cbdata = cbdata;
     req->_pending = (h2o_linklist_t){};
     req->_in.name = (char *)req + sizeof(*req);
-    memcpy(req->_in.name, name, name_len + 1);
-    req->_in.serv = req->_in.name + name_len + 1;
-    memcpy(req->_in.serv, serv, serv_len + 1);
+    memcpy(req->_in.name, name.base, name.len);
+    req->_in.name[name.len] = '\0';
+    req->_in.serv = req->_in.name + name.len + 1;
+    memcpy(req->_in.serv, serv.base, serv.len);
+    req->_in.serv[serv.len] = '\0';
     memset(&req->_in.hints, 0, sizeof(req->_in.hints));
     req->_in.hints.ai_family = family;
     req->_in.hints.ai_socktype = socktype;

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -408,11 +408,11 @@ static void on_getaddr(h2o_hostinfo_getaddr_req_t *getaddr_req, const char *errs
 }
 
 static struct st_h2o_http1client_private_t *create_client(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx,
-                                                          h2o_mem_pool_t *pool, h2o_http1client_connect_cb cb)
+                                                          h2o_http1client_connect_cb cb)
 {
     struct st_h2o_http1client_private_t *client = h2o_mem_alloc(sizeof(*client));
 
-    *client = (struct st_h2o_http1client_private_t){{ctx, pool}};
+    *client = (struct st_h2o_http1client_private_t){{ctx}};
     if (_client != NULL)
         *_client = &client->super;
     client->super.data = data;
@@ -424,14 +424,14 @@ static struct st_h2o_http1client_private_t *create_client(h2o_http1client_t **_c
 
 const char *const h2o_http1client_error_is_eos = "end of stream";
 
-void h2o_http1client_connect(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
-                             h2o_iovec_t host, uint16_t port, h2o_http1client_connect_cb cb)
+void h2o_http1client_connect(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx, h2o_iovec_t host, uint16_t port,
+                             h2o_http1client_connect_cb cb)
 {
     struct st_h2o_http1client_private_t *client;
     char serv[sizeof("65536")];
 
     /* setup */
-    client = create_client(_client, data, ctx, pool, cb);
+    client = create_client(_client, data, ctx, cb);
     client->_timeout.cb = on_connect_timeout;
     h2o_timeout_link(ctx->loop, ctx->io_timeout, &client->_timeout);
 
@@ -449,10 +449,10 @@ void h2o_http1client_connect(h2o_http1client_t **_client, void *data, h2o_http1c
                              SOCK_STREAM, IPPROTO_TCP, AI_ADDRCONFIG | AI_NUMERICSERV, on_getaddr, client);
 }
 
-void h2o_http1client_connect_with_pool(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,
+void h2o_http1client_connect_with_pool(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx,
                                        h2o_socketpool_t *sockpool, h2o_http1client_connect_cb cb)
 {
-    struct st_h2o_http1client_private_t *client = create_client(_client, data, ctx, pool, cb);
+    struct st_h2o_http1client_private_t *client = create_client(_client, data, ctx, cb);
     client->super.sockpool.pool = sockpool;
     client->_timeout.cb = on_connect_timeout;
     h2o_timeout_link(ctx->loop, ctx->io_timeout, &client->_timeout);

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -444,8 +444,9 @@ void h2o_http1client_connect(h2o_http1client_t **_client, void *data, h2o_http1c
         return;
     }
     /* resolve destination and then connect */
-    client->_getaddr_req = h2o_hostinfo_getaddr(ctx->getaddr_receiver, host, h2o_iovec_init(serv, sprintf(serv, "%u", (unsigned)port)), AF_UNSPEC,
-                                                SOCK_STREAM, IPPROTO_TCP, AI_ADDRCONFIG | AI_NUMERICSERV, on_getaddr, client);
+    client->_getaddr_req =
+        h2o_hostinfo_getaddr(ctx->getaddr_receiver, host, h2o_iovec_init(serv, sprintf(serv, "%u", (unsigned)port)), AF_UNSPEC,
+                             SOCK_STREAM, IPPROTO_TCP, AI_ADDRCONFIG | AI_NUMERICSERV, on_getaddr, client);
 }
 
 void h2o_http1client_connect_with_pool(h2o_http1client_t **_client, void *data, h2o_http1client_ctx_t *ctx, h2o_mem_pool_t *pool,

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -81,15 +81,15 @@ static void on_timeout(h2o_timeout_entry_t *timeout_entry)
     h2o_timeout_link(pool->_interval_cb.loop, &pool->_interval_cb.timeout, &pool->_interval_cb.entry);
 }
 
-void h2o_socketpool_init(h2o_socketpool_t *pool, const char *host, uint16_t port, size_t capacity)
+void h2o_socketpool_init(h2o_socketpool_t *pool, h2o_iovec_t host, uint16_t port, size_t capacity)
 {
     memset(pool, 0, sizeof(*pool));
 
-    if (inet_pton(AF_INET, host, &pool->peer.sin.sin_addr) == 1) {
+    if (h2o_hostinfo_aton(host, &pool->peer.sin.sin_addr) == 0) {
         pool->peer.sin.sin_family = AF_INET;
         pool->peer.sin.sin_port = htons(port);
     } else {
-        pool->peer.named.host = h2o_strdup(NULL, host, SIZE_MAX);
+        pool->peer.named.host = h2o_strdup(NULL, host.base, host.len);
         pool->peer.named.port.base = h2o_mem_alloc(sizeof("65535"));
         pool->peer.named.port.len = sprintf(pool->peer.named.port.base, "%u", (unsigned)port);
         pool->peer.is_named = 1;

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -471,12 +471,12 @@ void h2o__proxy_process_request(h2o_req_t *req)
     if (overrides != NULL) {
         if (overrides->socketpool != NULL) {
             self = proxy_send_prepare(req, 1);
-            h2o_http1client_connect_with_pool(&self->client, self, client_ctx, &req->pool, overrides->socketpool, on_connect);
+            h2o_http1client_connect_with_pool(&self->client, self, client_ctx, overrides->socketpool, on_connect);
             return;
         } else if (overrides->hostport.host.base != NULL) {
             self = proxy_send_prepare(req, 0);
-            h2o_http1client_connect(&self->client, self, client_ctx, &req->pool, req->overrides->hostport.host,
-                                    req->overrides->hostport.port, on_connect);
+            h2o_http1client_connect(&self->client, self, client_ctx, req->overrides->hostport.host, req->overrides->hostport.port,
+                                    on_connect);
             return;
         }
     }
@@ -494,7 +494,7 @@ void h2o__proxy_process_request(h2o_req_t *req)
         if (port == 65535)
             port = 80;
         self = proxy_send_prepare(req, 0);
-        h2o_http1client_connect(&self->client, self, client_ctx, &req->pool, host, port, on_connect);
+        h2o_http1client_connect(&self->client, self, client_ctx, host, port, on_connect);
         return;
     }
 }

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -473,7 +473,7 @@ void h2o__proxy_process_request(h2o_req_t *req)
             self = proxy_send_prepare(req, 1);
             h2o_http1client_connect_with_pool(&self->client, self, client_ctx, &req->pool, overrides->socketpool, on_connect);
             return;
-        } else if (overrides->hostport.host != NULL) {
+        } else if (overrides->hostport.host.base != NULL) {
             self = proxy_send_prepare(req, 0);
             h2o_http1client_connect(&self->client, self, client_ctx, &req->pool, req->overrides->hostport.host,
                                     req->overrides->hostport.port, on_connect);
@@ -494,8 +494,7 @@ void h2o__proxy_process_request(h2o_req_t *req)
         if (port == 65535)
             port = 80;
         self = proxy_send_prepare(req, 0);
-        h2o_http1client_connect(&self->client, self, client_ctx, &req->pool, h2o_strdup(&req->pool, host.base, host.len).base, port,
-                                on_connect);
+        h2o_http1client_connect(&self->client, self, client_ctx, &req->pool, host, port, on_connect);
         return;
     }
 }

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -121,7 +121,7 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
     h2o_url_copy(NULL, &self->upstream, upstream);
     if (config->keepalive_timeout != 0) {
         self->sockpool = h2o_mem_alloc(sizeof(*self->sockpool));
-        h2o_socketpool_init(self->sockpool, self->upstream.host.base, h2o_url_get_port(&self->upstream), SIZE_MAX /* FIXME */);
+        h2o_socketpool_init(self->sockpool, self->upstream.host, h2o_url_get_port(&self->upstream), SIZE_MAX /* FIXME */);
     }
     self->config = *config;
 }

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -41,7 +41,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     if (self->sockpool != NULL) {
         overrides->socketpool = self->sockpool;
     } else if (self->config.preserve_host) {
-        overrides->hostport.host = self->upstream.host.base;
+        overrides->hostport.host = self->upstream.host;
         overrides->hostport.port = h2o_url_get_port(&self->upstream);
     }
     overrides->location_rewrite.match = &self->upstream;

--- a/t/00unit/lib/common/hostinfo.c
+++ b/t/00unit/lib/common/hostinfo.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014 DeNA Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <arpa/inet.h>
+#include "../../test.h"
+#include "../../../../lib/common/hostinfo.c"
+
+static void test_aton(void)
+{
+    struct in_addr addr;
+
+    memset(&addr, 0x55, sizeof(addr));
+    ok(h2o_hostinfo_aton((h2o_iovec_t){H2O_STRLIT("127.0.0.1")}, &addr) == 0);
+    ok(ntohl(addr.s_addr) == 0x7f000001);
+
+    memset(&addr, 0x55, sizeof(addr));
+    ok(h2o_hostinfo_aton((h2o_iovec_t){"127.0.0.12", sizeof("127.0.0.1") - 1}, &addr) == 0);
+    ok(ntohl(addr.s_addr) == 0x7f000001);
+
+    memset(&addr, 0x55, sizeof(addr));
+    ok(h2o_hostinfo_aton((h2o_iovec_t){H2O_STRLIT("255.001.002.128")}, &addr) == 0);
+    ok(ntohl(addr.s_addr) == 0xff010280);
+
+    ok(h2o_hostinfo_aton((h2o_iovec_t){H2O_STRLIT("127.0.0.z")}, &addr) != 0);
+    ok(h2o_hostinfo_aton((h2o_iovec_t){H2O_STRLIT("256.0.0.0")}, &addr) != 0);
+    ok(h2o_hostinfo_aton((h2o_iovec_t){H2O_STRLIT("0001.0.0.0")}, &addr) != 0);
+    ok(h2o_hostinfo_aton((h2o_iovec_t){H2O_STRLIT("0.0..1")}, &addr) != 0);
+    ok(h2o_hostinfo_aton((h2o_iovec_t){H2O_STRLIT("1.0.0.0.")}, &addr) != 0);
+}
+
+void test_lib__common__hostinfo_c(void)
+{
+    /* TODO add tests for h2o_hostinfo_getaddr and related */
+    subtest("aton", test_aton);
+}

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -125,6 +125,7 @@ int main(int argc, char **argv)
 {
     { /* library tests */
         subtest("lib/common/multithread.c", test_lib__common__multithread_c);
+        subtest("lib/common/hostinfo.c", test_lib__common__hostinfo_c);
         subtest("lib/common/serverutil.c", test_lib__common__serverutil_c);
         subtest("lib/common/string.c", test_lib__common__string_c);
         subtest("lib/common/url.c", test_lib__common__url_c);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -48,6 +48,7 @@ extern h2o_loop_t *test_loop;
 
 char *sha1sum(const void *src, size_t len);
 
+void test_lib__common__hostinfo_c(void);
 void test_lib__common__multithread_c(void);
 void test_lib__common__serverutil_c(void);
 void test_lib__common__string_c(void);


### PR DESCRIPTION
This PR fixes a potential use-after free issue in hostname lookup, by copying the `name` and `serv` passed into `h2o_hostinfo_getaddr`.

It also refactors the API of the related functions, removes an unused property: `h2o_http1client_t::pool`.

relates to #306