### PR TITLE
Fix typo

### DIFF
--- a/doc/configure/base_directives.html
+++ b/doc/configure/base_directives.html
@@ -191,7 +191,7 @@ The feature is useful for setting up a HTTPS virtual host using <a href="https:/
       port: 443
       ssl:
         key-file: /path/to/www_example_com.key
-        certifilate-file: /path/to/www_example_com.crt
+        certificate-file: /path/to/www_example_com.crt
     paths:
       &quot;/&quot;:
         file.dir: /path/to/doc-root_of_www_example_com
@@ -200,7 +200,7 @@ The feature is useful for setting up a HTTPS virtual host using <a href="https:/
       port: 443
       ssl:
         key-file: /path/to/www_example_jp.key
-        certifilate-file: /path/to/www_example_jp.crt
+        certificate-file: /path/to/www_example_jp.crt
     paths:
       &quot;/&quot;:
         file.dir: /path/to/doc-root_of_www_example_jp

--- a/srcdoc/configure/base_directives.mt
+++ b/srcdoc/configure/base_directives.mt
@@ -115,7 +115,7 @@ hosts:
       port: 443
       ssl:
         key-file: /path/to/www_example_com.key
-        certifilate-file: /path/to/www_example_com.crt
+        certificate-file: /path/to/www_example_com.crt
     paths:
       "/":
         file.dir: /path/to/doc-root_of_www_example_com
@@ -124,7 +124,7 @@ hosts:
       port: 443
       ssl:
         key-file: /path/to/www_example_jp.key
-        certifilate-file: /path/to/www_example_jp.crt
+        certificate-file: /path/to/www_example_jp.crt
     paths:
       "/":
         file.dir: /path/to/doc-root_of_www_example_jp


### PR DESCRIPTION
SSL certificate directive is called `certificate-file`, not `certifilate-file`