### PR TITLE
Refactor how SSL_write is called

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -51,6 +51,7 @@ extern "C" {
 #endif
 
 #define H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE 4096
+#define H2O_SSL_MAX_PAYLOAD_SIZE 1400
 
 typedef struct st_h2o_socket_t h2o_socket_t;
 

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -129,7 +129,7 @@ h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, sockle
  * @param bufcnt length of the buffer array
  * @param cb callback to be called when write is complete
  */
-void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb);
+void h2o_socket_write(h2o_socket_t *sock, const h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb);
 /**
  * starts polling on the socket (for read) and calls given callback when data arrives
  * @param sock the socket

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -51,7 +51,7 @@ extern "C" {
 #endif
 
 #define H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE 4096
-#define H2O_SSL_MAX_PAYLOAD_SIZE 1400
+#define H2O_SSL_MAX_PAYLOAD_SIZE 1376
 
 typedef struct st_h2o_socket_t h2o_socket_t;
 

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -61,7 +61,7 @@ struct st_h2o_ssl_context_t {
 
 /* backend functions */
 static void do_dispose_socket(h2o_socket_t *sock);
-static void do_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb);
+static void do_write(h2o_socket_t *sock, const h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb);
 static void do_read_start(h2o_socket_t *sock);
 static void do_read_stop(h2o_socket_t *sock);
 static int do_export(h2o_socket_t *_sock, h2o_socket_export_t *info);
@@ -316,7 +316,7 @@ void h2o_socket_close(h2o_socket_t *sock)
     }
 }
 
-void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb)
+void h2o_socket_write(h2o_socket_t *sock, const h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb)
 {
 #if H2O_SOCKET_DUMP_WRITE
     {

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -111,7 +111,7 @@ void do_read_stop(h2o_socket_t *_sock)
     uv_read_stop(sock->uv.stream);
 }
 
-void do_write(h2o_socket_t *_sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb)
+void do_write(h2o_socket_t *_sock, const h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb)
 {
     struct st_h2o_uv_socket_t *sock = (struct st_h2o_uv_socket_t *)_sock;
 


### PR DESCRIPTION
This PR makes couple of changes to how SSL_write is being called:
* concatenates small iovecs to before calling SSL_write
 * results in faster operation and lesser overhead in bandwidth (since the number of TLS records gets reduced)
 * HTTP/1 w. push generators will benefit from this change (see how the chunked encoder builds the iovecs)
* does not emit log if SSL_write returns an error (final fix for #297)
 * see comment on 3666bbd for the reasons behind this change; the protocol implementation that is doing this is the HTTP/2 impl.
* changes the max. payload size of a TLS record from 1400 to 1376
 * 1376 has been chosen since it is the largest value multiple of 32 below 1400
 * AVX registers are 256-bits (32-bytes) long and we would expect memcpy / TLS encryption operations to use aligned access to the data
 * raising the value to 1408 (smallest multiple of 32 above 1408) since in such case the TLS record size might become somewhere above 1440 depending on the cipher-suite being used; it would become too near to the MSS