### PR TITLE
dump stacktrace in case of fatal error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ ELSE (LIBUV_FOUND)
   SET_TARGET_PROPERTIES(libh2o PROPERTIES EXCLUDE_FROM_ALL 1)
 ENDIF (LIBUV_FOUND)
 
-INSTALL(PROGRAMS share/h2o/fetch-ocsp-response share/h2o/start_server DESTINATION share/h2o)
+INSTALL(PROGRAMS share/h2o/annotate-backtrace-symbols share/h2o/fetch-ocsp-response share/h2o/start_server DESTINATION share/h2o)
 INSTALL(DIRECTORY doc/ DESTINATION share/doc/h2o PATTERN "Makefile" EXCLUDE PATTERN "README.md" EXCLUDE)
 
 # tests

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -363,6 +363,7 @@
 		1082150D1AB26F4700D27E66 /* FindLibYAML.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = FindLibYAML.cmake; sourceTree = "<group>"; };
 		1082150E1AB26F4700D27E66 /* FindLibUV.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = FindLibUV.cmake; sourceTree = "<group>"; };
 		108867741AD9069900987967 /* defaults.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = defaults.c.h; sourceTree = "<group>"; };
+		10A60DE91B0D87FE006E38EC /* annotate-backtrace-symbols */ = {isa = PBXFileReference; lastKnownFileType = text; path = "annotate-backtrace-symbols"; sourceTree = "<group>"; };
 		10AA2E931A80A592004322AC /* time_.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = time_.h; sourceTree = "<group>"; };
 		10AA2E951A80A612004322AC /* time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = time.c; sourceTree = "<group>"; };
 		10AA2E981A81F68A004322AC /* time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = time.c; sourceTree = "<group>"; };
@@ -489,6 +490,7 @@
 			isa = PBXGroup;
 			children = (
 				104B9A401A5CD69B009EEE64 /* fetch-ocsp-response */,
+				10A60DE91B0D87FE006E38EC /* annotate-backtrace-symbols */,
 			);
 			path = h2o;
 			sourceTree = "<group>";

--- a/include/h2o/serverutil.h
+++ b/include/h2o/serverutil.h
@@ -55,6 +55,16 @@ int h2o_setuidgid(struct passwd *passwd);
 size_t h2o_server_starter_get_fds(int **_fds);
 
 /**
+ * spawns a command with given arguments, while mapping the designated file descriptors.
+ * @param cmd file being executed
+ * @param argv argv passed to the executable
+ * @param mapped_fds if non-NULL, must point to an array contain containing a list of pair of file descriptors, terminated with -1.
+ *        Every pair of the mapping will be duplicated by calling `dup2` before execvp is being called.
+ * @return pid of the process being spawned if successful, or -1 if otherwise
+ */
+pid_t h2o_spawnp(const char *cmd, char **argv, const int *mapped_fds);
+
+/**
  * executes a command and returns its output
  * @param cmd
  * @param argv

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -20,6 +20,7 @@
  * IN THE SOFTWARE.
  */
 #include <errno.h>
+#include <fcntl.h>
 #include <grp.h>
 #include <pthread.h>
 #include <signal.h>
@@ -99,10 +100,85 @@ size_t h2o_server_starter_get_fds(int **_fds)
     return fds.size;
 }
 
+pid_t h2o_spawnp(const char *cmd, char **argv, const int *mapped_fds)
+{
+#if defined(__linux__)
+
+    /* posix_spawnp of Linux does not return error if the executable does not exist, see
+     * https://gist.github.com/kazuho/0c233e6f86d27d6e4f09
+     */
+    int pipefds[2] = {-1, -1}, errnum;
+    pid_t pid;
+
+    /* create pipe, used for sending error codes */
+    if (pipe2(pipefds, O_CLOEXEC) != 0)
+        goto Error;
+
+    /* fork */
+    if ((pid = fork()) == -1)
+        goto Error;
+
+    if (pid == 0) {
+        /* in child process, map the file descriptors and execute; return the errnum through pipe if exec failed */
+        if (mapped_fds != NULL) {
+            for (; *mapped_fds != -1; mapped_fds += 2)
+                dup2(mapped_fds[0], mapped_fds[1]);
+        }
+        execvp(cmd, argv);
+        errnum = errno;
+        write(pipefds[1], &errnum, sizeof(errnum));
+        _exit(EX_SOFTWARE);
+    }
+
+    /* parent process */
+    close(pipefds[1]);
+    pipefds[1] = -1;
+    ssize_t rret;
+    errnum = 0;
+    while ((rret = read(pipefds[0], &errnum, sizeof(errnum))) == -1 && errno == EINTR)
+        ;
+    if (rret != 0) {
+        /* spawn failed */
+        while (waitpid(pid, NULL, 0) != pid)
+            ;
+        pid = -1;
+        errno = errnum;
+        goto Error;
+    }
+
+    /* spawn succeeded */
+    close(pipefds[0]);
+    return pid;
+
+Error:
+    errnum = errno;
+    if (pipefds[0] != -1)
+        close(pipefds[0]);
+    if (pipefds[1] != -1)
+        close(pipefds[1]);
+    errno = errnum;
+    return -1;
+
+#else
+
+    posix_spawn_file_actions_t file_actions;
+    pid_t pid;
+    extern char** environ;
+    posix_spawn_file_actions_init(&file_actions);
+    if (mapped_fds != NULL) {
+        for (; *mapped_fds != -1; mapped_fds += 2)
+            posix_spawn_file_actions_adddup2(&file_actions, mapped_fds[0], mapped_fds[1]);
+    }
+    if ((errno = posix_spawnp(&pid, cmd, &file_actions, NULL, argv, environ)) != 0)
+        return -1;
+    return pid;
+
+#endif
+}
+
 int h2o_read_command(const char *cmd, char **argv, h2o_buffer_t **resp, int *child_status)
 {
     int respfds[2] = {-1, -1};
-    posix_spawn_file_actions_t file_actions;
     pid_t pid = -1;
     int ret = -1;
     extern char **environ;
@@ -114,12 +190,12 @@ int h2o_read_command(const char *cmd, char **argv, h2o_buffer_t **resp, int *chi
         goto Exit;
 
     /* spawn */
-    posix_spawn_file_actions_init(&file_actions);
-    posix_spawn_file_actions_adddup2(&file_actions, respfds[1], 1);
-    if ((errno = posix_spawnp(&pid, cmd, &file_actions, NULL, argv, environ)) != 0) {
-        pid = -1;
+    int mapped_fds[] = {
+        respfds[1], 1, /* stdout of the child process is read from the pipe */
+        -1
+    };
+    if ((pid = h2o_spawnp(cmd, argv, mapped_fds)) == -1)
         goto Exit;
-    }
     close(respfds[1]);
     respfds[1] = -1;
 

--- a/share/h2o/annotate-backtrace-symbols
+++ b/share/h2o/annotate-backtrace-symbols
@@ -1,0 +1,26 @@
+#! /bin/sh
+exec perl -x $0 "$@"
+#! perl
+
+use strict;
+use warnings;
+
+while (my $line = <STDIN>) {
+    chomp $line;
+    if ($line =~ m{^([^\(\[]+)(.*?)\[(0x[0-9A-Fa-f]+)\]}) {
+        my ($exe, $info, $addr) = ($1, $2, $3);
+        my $resolved = addr2line($exe, $addr);
+        $line = "$exe${info}[$addr] $resolved"
+            if $resolved;
+    }
+    print "$line\n";
+}
+
+sub addr2line {
+    my ($exe, $addr) = @_;
+    open my $fh, "-|", qw(addr2line -pif -e), $exe, $addr
+        or return;
+    my $resolved = <$fh>;
+    chomp $resolved;
+    $resolved;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1066,7 +1066,7 @@ static int popen_annotate_backtrace_symbols(void)
         perror("pipe failed");
         return -1;
     }
-    if (fcntl(pipefds[1], FD_CLOEXEC, 1) == -1) {
+    if (fcntl(pipefds[1], F_SETFD, FD_CLOEXEC) == -1) {
         perror("failed to set FD_CLOEXEC on pipefds[1]");
         return -1;
     }


### PR DESCRIPTION
The PR sets a signal handler for fatal signals that emits the stacktrace to standard error (or the error log file).
It uses an external wrapper (that calls addr2line) to look-up the corresponding source lines.