### PR TITLE
Remove unused variable declarations

### DIFF
--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -181,7 +181,6 @@ int h2o_read_command(const char *cmd, char **argv, h2o_buffer_t **resp, int *chi
     int respfds[2] = {-1, -1};
     pid_t pid = -1;
     int ret = -1;
-    extern char **environ;
 
     h2o_buffer_init(resp, &h2o_socket_buffer_prototype);
 

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -412,7 +412,6 @@ int h2o_access_log_open_log(const char *path)
         int pipefds[2];
         pid_t pid;
         char* argv[4] = {"/bin/sh", "-c", (char *)(path + 1), NULL};
-        extern char **environ;
          /* create pipe */
         if (pipe(pipefds) != 0) {
             perror("pipe failed");


### PR DESCRIPTION
This causes compiler warnings and they are no longer necessary by #331 change.