### PR TITLE
Fixes file-descriptor leaks being found

### DIFF
--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -417,7 +417,7 @@ int h2o_access_log_open_log(const char *path)
             perror("pipe failed");
             return -1;
         }
-        if (fcntl(pipefds[1], FD_CLOEXEC, 1) == -1) {
+        if (fcntl(pipefds[1], F_SETFD, FD_CLOEXEC) == -1) {
             perror("failed to set FD_CLOEXEC on pipefds[1]");
             return -1;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -1036,6 +1036,8 @@ yoml_t *load_config(const char *fn)
 
     yaml_parser_delete(&parser);
 
+    fclose(fp);
+
     return yoml;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1475,8 +1475,12 @@ int main(int argc, char **argv)
     /* setup conf.server_starter */
     if ((conf.server_starter.num_fds = h2o_server_starter_get_fds(&conf.server_starter.fds)) == SIZE_MAX)
         exit(EX_CONFIG);
-    if (conf.server_starter.fds != 0)
+    if (conf.server_starter.fds != 0) {
+        size_t i;
+        for (i = 0; i != conf.server_starter.num_fds; ++i)
+            set_cloexec(conf.server_starter.fds[i]);
         conf.server_starter.bound_fd_map = alloca(conf.server_starter.num_fds);
+    }
 
     { /* configure */
         yoml_t *yoml;


### PR DESCRIPTION
Fix three file descriptor leaks found.

The combination of 47b5c51 and d978e0d was leading to restart failures when logs are emitted via pipes.  Due to the bug fixed in d978e0d the logging process was not exitting when the server dies, and since the listening port (passed in from `start_server`) was not marked as `FD_CLOEXEC` and thus was passed to the logging process, it was unable to spawn the server once again.