### PR TITLE
reprioritize blocking asset files (`.js`, `.css`) for Chrome

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -261,6 +261,10 @@ struct st_h2o_globalconf_t {
          */
         size_t max_streams_for_priority;
         /**
+         * a boolean value indicating whether or not to raise priority of blocking asset files
+         */
+        int reprioritize_blocking_assets;
+        /**
          * list of callbacks
          */
         h2o_protocol_callbacks_t callbacks;

--- a/include/h2o/http2_scheduler.h
+++ b/include/h2o/http2_scheduler.h
@@ -96,6 +96,10 @@ static int h2o_http2_scheduler_is_open(h2o_http2_scheduler_openref_t *ref);
  */
 static uint16_t h2o_http2_scheduler_get_weight(h2o_http2_scheduler_openref_t *ref);
 /**
+ * returns the parent
+ */
+static h2o_http2_scheduler_node_t *h2o_http2_scheduler_get_parent(h2o_http2_scheduler_openref_t *ref);
+/**
  * activates a reference so that it would be passed back as the argument to the callback of the h2o_http2_scheduler_run function
  * if any resource should be allocated
  */
@@ -116,6 +120,11 @@ inline int h2o_http2_scheduler_is_open(h2o_http2_scheduler_openref_t *ref)
 inline uint16_t h2o_http2_scheduler_get_weight(h2o_http2_scheduler_openref_t *ref)
 {
     return ref->weight;
+}
+
+inline h2o_http2_scheduler_node_t *h2o_http2_scheduler_get_parent(h2o_http2_scheduler_openref_t *ref)
+{
+    return ref->node._parent;
 }
 
 #endif

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -255,6 +255,16 @@ static int on_config_http2_max_concurrent_requests_per_connection(h2o_configurat
     return h2o_configurator_scanf(cmd, node, "%zu", &ctx->globalconf->http2.max_concurrent_requests_per_connection);
 }
 
+static int on_config_http2_reprioritize_blocking_assets(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx,
+                                                        yoml_t *node)
+{
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    ctx->globalconf->http2.reprioritize_blocking_assets = (int)ret;
+    return 0;
+}
+
 void h2o_configurator__init_core(h2o_globalconf_t *conf)
 {
     /* check if already initialized */
@@ -288,6 +298,9 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(c, "http2-max-concurrent-requests-per-connection",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_max_concurrent_requests_per_connection);
+        h2o_configurator_define_command(c, "http2-reprioritize-blocking-assets",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http2_reprioritize_blocking_assets);
     }
 }
 

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -345,7 +345,8 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     /* raise the priority of asset files that block rendering to highest if the user-agent is not using sophisticated prioritization
      * logic (e.g. that of Firefox)
      */
-    if (conn->num_streams.priority == 0 && h2o_http2_scheduler_get_parent(&stream->_refs.scheduler) == &conn->scheduler &&
+    if (conn->num_streams.priority == 0 && conn->super.ctx->globalconf->http2.reprioritize_blocking_assets &&
+        h2o_http2_scheduler_get_parent(&stream->_refs.scheduler) == &conn->scheduler &&
         h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("GET")) &&
         is_blocking_asset(stream->req.input.path.base, stream->req.input.path.len)) {
         h2o_http2_scheduler_rebind(&stream->_refs.scheduler, &conn->scheduler, 257, 0);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -307,6 +307,30 @@ static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta
     return 0;
 }
 
+static int is_blocking_asset(const char *path, size_t pathlen)
+{
+    size_t i;
+
+    /* move pathlen to '?' */
+    for (i = 0; i != pathlen; ++i) {
+        if (path[i] == '?') {
+            pathlen = i;
+            break;
+        }
+    }
+
+    /* check if end of path is either ".js" or ".css" */
+    if (pathlen < 3)
+        return 0;
+    if (memcmp(path + pathlen - 3, ".js", 3) == 0)
+        return 1;
+    if (pathlen < 4)
+        return 0;
+    if (memcmp(path + pathlen - 4, ".css", 4) == 0)
+        return 1;
+    return 0;
+}
+
 static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, const uint8_t *src, size_t len,
                                    const char **err_desc)
 {
@@ -317,6 +341,15 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     if ((ret = h2o_hpack_parse_headers(&stream->req, &conn->_input_header_table, src, len, &header_exists_map,
                                        &stream->_expected_content_length, err_desc)) != 0)
         return ret;
+
+    /* raise the priority of asset files that block rendering to highest if the user-agent is not using sophisticated prioritization
+     * logic (e.g. that of Firefox)
+     */
+    if (conn->num_streams.priority == 0 && h2o_http2_scheduler_get_parent(&stream->_refs.scheduler) == &conn->scheduler &&
+        h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("GET")) &&
+        is_blocking_asset(stream->req.input.path.base, stream->req.input.path.len)) {
+        h2o_http2_scheduler_rebind(&stream->_refs.scheduler, &conn->scheduler, 257, 0);
+    }
 
     conn->_read_expect = expect_default;
 

--- a/lib/http2/scheduler.c
+++ b/lib/http2/scheduler.c
@@ -252,7 +252,7 @@ void h2o_http2_scheduler_rebind(h2o_http2_scheduler_openref_t *ref, h2o_http2_sc
     assert(h2o_http2_scheduler_is_open(ref));
     assert(&ref->node != new_parent);
     assert(1 <= weight);
-    assert(weight <= 256);
+    assert(weight <= 257);
 
     /* do nothing if there'd be no change at all */
     if (ref->node._parent == new_parent && ref->weight == weight && !exclusive)


### PR DESCRIPTION
At the moment, Chrome falls behind Firefox in prioritizing the asset files, as discussed in http://blog.kazuhooku.com/2015/04/dependency-based-prioritization-makes.html.

This PR implements a workaround in the server-side by raising the priority to maximum of requests that are likely against asset files.  The reprioritization is not applied to HTTP2 connections that use priority trees (e.g. Firefox).