### PR TITLE
provide getsockname and getpeername wrappers (send `SERVER_(ADDR|PORT)` to fastcgi)

### DIFF
--- a/examples/libh2o/simple.c
+++ b/examples/libh2o/simple.c
@@ -107,7 +107,7 @@ static void on_accept(uv_stream_t *listener, int status)
         return;
     }
 
-    sock = h2o_uv_socket_create((uv_stream_t *)conn, NULL, 0, (uv_close_cb)free);
+    sock = h2o_uv_socket_create((uv_stream_t *)conn, (uv_close_cb)free);
     if (ssl_ctx != NULL)
         h2o_accept_ssl(&ctx, ctx.globalconf->hosts, sock, ssl_ctx);
     else

--- a/examples/libh2o/websocket.c
+++ b/examples/libh2o/websocket.c
@@ -71,7 +71,7 @@ static void on_connect(uv_stream_t *server, int status)
         return;
     }
 
-    sock = h2o_uv_socket_create((uv_stream_t *)conn, NULL, 0, (uv_close_cb)free);
+    sock = h2o_uv_socket_create((uv_stream_t *)conn, (uv_close_cb)free);
     if (ssl_ctx != NULL)
         h2o_accept_ssl(&ctx, ctx.globalconf->hosts, sock, ssl_ctx);
     else

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -458,12 +458,13 @@ struct st_h2o_conn_t {
      */
     h2o_hostconf_t **hosts;
     /**
-     * peername (peername.addr == NULL if not available)
+     * getsockname (return size of the obtained address, or 0 if failed)
      */
-    struct {
-        struct sockaddr *addr;
-        socklen_t len;
-    } peername;
+    socklen_t (*get_sockname)(h2o_conn_t *conn, struct sockaddr *sa);
+    /**
+     * getpeername (return size of the obtained address, or 0 if failed)
+     */
+    socklen_t (*get_peername)(h2o_conn_t *conn, struct sockaddr *sa);
 };
 
 typedef struct st_h2o_req_overrides_t {

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -84,13 +84,10 @@ struct st_h2o_socket_t {
         h2o_socket_cb read;
         h2o_socket_cb write;
     } _cb;
-    /* zero-filled in case of invalid address */
-    h2o_socket_peername_t peername;
 };
 
 typedef struct st_h2o_socket_export_t {
     int fd;
-    h2o_socket_peername_t peername;
     struct st_h2o_socket_ssl_t *ssl;
     h2o_buffer_t *input;
 } h2o_socket_export_t;
@@ -153,6 +150,14 @@ static int h2o_socket_is_writing(h2o_socket_t *sock);
  * returns a boolean value indicating whether if the socket is being polled for read
  */
 static int h2o_socket_is_reading(h2o_socket_t *sock);
+/**
+ * returns the length of the local address obtained (or 0 if failed)
+ */
+socklen_t h2o_socket_getsockname(h2o_socket_t *sock, struct sockaddr *sa);
+/**
+ * returns the length of the remote address obtained (or 0 if failed)
+ */
+socklen_t h2o_socket_getpeername(h2o_socket_t *sock, struct sockaddr *sa);
 /**
  * compares socket addresses
  */

--- a/include/h2o/socket/uv-binding.h
+++ b/include/h2o/socket/uv-binding.h
@@ -34,7 +34,7 @@ struct st_h2o_timeout_backend_properties_t {
     uv_timer_t timer;
 };
 
-h2o_socket_t *h2o_uv_socket_create(uv_stream_t *stream, struct sockaddr *addr, socklen_t addrlen, uv_close_cb close_cb);
+h2o_socket_t *h2o_uv_socket_create(uv_stream_t *stream, uv_close_cb close_cb);
 
 static inline uint64_t h2o_now(uv_loop_t *loop)
 {

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -87,11 +87,13 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive)
     h2o_iovec_t buf;
     size_t offset = 0, remote_addr_len = SIZE_MAX;
     char remote_addr[NI_MAXHOST];
+    struct sockaddr_storage ss;
+    socklen_t sslen;
     h2o_iovec_t cookie_buf = {}, xff_buf = {}, via_buf = {};
 
     /* for x-f-f */
-    if (req->conn->peername.addr != NULL)
-        remote_addr_len = h2o_socket_getnumerichost(req->conn->peername.addr, req->conn->peername.len, remote_addr);
+    if ((sslen = req->conn->get_peername(req->conn, (void *)&ss)) != 0)
+        remote_addr_len = h2o_socket_getnumerichost((void *)&ss, sslen, remote_addr);
 
     /* build response */
     buf.len = req->method.len + req->path.len + req->authority.len + 512;

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -186,6 +186,27 @@ static void *append_pair(h2o_mem_pool_t *pool, iovec_vector_t *blocks, const cha
     return name_buf;
 }
 
+static void append_address_info(h2o_req_t *req, iovec_vector_t *vecs, const char *addrlabel, size_t addrlabel_len,
+                                const char *portlabel, size_t portlabel_len, socklen_t (*cb)(h2o_conn_t *conn, struct sockaddr*))
+{
+    struct sockaddr_storage ss;
+    socklen_t sslen;
+    char buf[NI_MAXHOST];
+
+    if ((sslen = cb(req->conn, (void *)&ss)) == 0)
+        return;
+
+    size_t l = h2o_socket_getnumerichost((void *)&ss, sslen, buf);
+    if (l != SIZE_MAX)
+        append_pair(&req->pool, vecs, addrlabel, addrlabel_len, buf, l);
+    int32_t port = h2o_socket_getport((void *)&ss);
+    if (port != -1) {
+        char buf[6];
+        int l = sprintf(buf, "%" PRIu16, (uint16_t)port);
+        append_pair(&req->pool, vecs, portlabel, portlabel_len, buf, (size_t)l);
+    }
+}
+
 static void append_params(h2o_req_t *req, iovec_vector_t *vecs)
 {
     /* CONTENT_LENGTH */
@@ -204,34 +225,17 @@ static void append_params(h2o_req_t *req, iovec_vector_t *vecs)
         append_pair(&req->pool, vecs, H2O_STRLIT("PATH_INFO"), req->path.base, req->path.len);
         append_pair(&req->pool, vecs, H2O_STRLIT("QUERY_STRING"), NULL, 0);
     }
-    { /* REMOTE_ADDR & REMOTE_PORT */
-        struct sockaddr_storage ss;
-        socklen_t sslen;
-        char buf[NI_MAXHOST];
-        if ((sslen = req->conn->get_peername(req->conn, (void *)&ss)) != 0) {
-            size_t l = h2o_socket_getnumerichost((void *)&ss, sslen, buf);
-            if (l != SIZE_MAX)
-                append_pair(&req->pool, vecs, H2O_STRLIT("REMOTE_ADDR"), buf, l);
-            int32_t port = h2o_socket_getport((void *)&ss);
-            if (port != -1) {
-                char buf[6];
-                int l = sprintf(buf, "%" PRIu16, (uint16_t)port);
-                append_pair(&req->pool, vecs, H2O_STRLIT("REMOTE_PORT"), buf, (size_t)l);
-            }
-        }
-    }
+    /* REMOTE_ADDR & REMOTE_PORT */
+    append_address_info(req, vecs, H2O_STRLIT("REMOTE_ADDR"), H2O_STRLIT("REMOTE_PORT"), req->conn->get_peername);
     /* REQUEST_METHOD */
     append_pair(&req->pool, vecs, H2O_STRLIT("REQUEST_METHOD"), req->method.base, req->method.len);
     /* REQUEST_URI */
     append_pair(&req->pool, vecs, H2O_STRLIT("REQUEST_URI"), req->path.base, req->path.len);
+    /* SERVER_ADDR & SERVER_PORT */
+    append_address_info(req, vecs, H2O_STRLIT("SERVER_ADDR"), H2O_STRLIT("SERVER_PORT"), req->conn->get_sockname);
     /* SERVER_NAME */
     append_pair(&req->pool, vecs, H2O_STRLIT("SERVER_NAME"), req->pathconf->host->authority.host.base,
                 req->pathconf->host->authority.host.len);
-    { /* SERVER_PORT */
-        char buf[6];
-        int l = sprintf(buf, "%" PRIu16, req->pathconf->host->authority.port);
-        append_pair(&req->pool, vecs, H2O_STRLIT("SERVER_PORT"), buf, (size_t)l);
-    }
     { /* SERVER_PROTOCOL */
         char buf[sizeof("HTTP/1.1") - 1];
         size_t l = h2o_stringify_protocol_version(buf, req->version);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -676,6 +676,18 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
     }
 }
 
+static socklen_t get_sockname(h2o_conn_t *_conn, struct sockaddr *sa)
+{
+    struct st_h2o_http1_conn_t *conn = (void *)_conn;
+    return h2o_socket_getsockname(conn->sock, sa);
+}
+
+static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
+{
+    struct st_h2o_http1_conn_t *conn = (void *)_conn;
+    return h2o_socket_getpeername(conn->sock, sa);
+}
+
 void h2o_http1_accept(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock)
 {
     struct st_h2o_http1_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
@@ -686,10 +698,8 @@ void h2o_http1_accept(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *
     /* init properties that need to be non-zero */
     conn->super.ctx = ctx;
     conn->super.hosts = hosts;
-    if (sock->peername.len != 0) {
-        conn->super.peername.addr = (void *)&sock->peername.addr;
-        conn->super.peername.len = sock->peername.len;
-    }
+    conn->super.get_sockname = get_sockname;
+    conn->super.get_peername = get_peername;
     conn->sock = sock;
     sock->data = conn;
 

--- a/t/00unit/lib/handler/fastcgi.c
+++ b/t/00unit/lib/handler/fastcgi.c
@@ -94,6 +94,8 @@ static void test_build_request(void)
     ok(check_params(vecs.entries, &vec_index, 0x1234,
                     H2O_STRLIT("\x09\x01PATH_INFO/"                      /* */
                                "\x0c\x00QUERY_STRING"                    /* */
+                               "\xb\x09REMOTE_ADDR127.0.0.1"             /* */
+                               "\xb\x05REMOTE_PORT55555"                 /* */
                                "\x0e\x03REQUEST_METHODGET"               /* */
                                "\x0b\x01REQUEST_URI/"                    /* */
                                "\x0b\x07SERVER_NAMEdefault"              /* */
@@ -119,6 +121,8 @@ static void test_build_request(void)
                                "CONTENT_LENGTH126"                       /* */
                                "\x09\x01PATH_INFO/"                      /* */
                                "\x0c\x00QUERY_STRING"                    /* */
+                               "\xb\x09REMOTE_ADDR127.0.0.1"             /* */
+                               "\xb\x05REMOTE_PORT55555"                 /* */
                                "\x0e\x03REQUEST_METHODGET"               /* */
                                "\x0b\x01REQUEST_URI/"                    /* */
                                "\x0b\x07SERVER_NAMEdefault"              /* */

--- a/t/00unit/lib/handler/fastcgi.c
+++ b/t/00unit/lib/handler/fastcgi.c
@@ -94,12 +94,13 @@ static void test_build_request(void)
     ok(check_params(vecs.entries, &vec_index, 0x1234,
                     H2O_STRLIT("\x09\x01PATH_INFO/"                      /* */
                                "\x0c\x00QUERY_STRING"                    /* */
-                               "\xb\x09REMOTE_ADDR127.0.0.1"             /* */
-                               "\xb\x05REMOTE_PORT55555"                 /* */
+                               "\x0b\x09REMOTE_ADDR127.0.0.1"            /* */
+                               "\x0b\x05REMOTE_PORT55555"                /* */
                                "\x0e\x03REQUEST_METHODGET"               /* */
                                "\x0b\x01REQUEST_URI/"                    /* */
+                               "\x0b\x09SERVER_ADDR127.0.0.1"            /* */
+                               "\x0b\x02SERVER_PORT80"                   /* */
                                "\x0b\x07SERVER_NAMEdefault"              /* */
-                               "\x0b\x05SERVER_PORT65535"                /* */
                                "\x0f\x08SERVER_PROTOCOLHTTP/1.1"         /* */
                                "\x0f\x10SERVER_SOFTWAREh2o/1.2.1-alpha1" /* */
                                "\x0b\x00SCRIPT_NAME"                     /* */
@@ -121,12 +122,13 @@ static void test_build_request(void)
                                "CONTENT_LENGTH126"                       /* */
                                "\x09\x01PATH_INFO/"                      /* */
                                "\x0c\x00QUERY_STRING"                    /* */
-                               "\xb\x09REMOTE_ADDR127.0.0.1"             /* */
-                               "\xb\x05REMOTE_PORT55555"                 /* */
+                               "\x0b\x09REMOTE_ADDR127.0.0.1"            /* */
+                               "\x0b\x05REMOTE_PORT55555"                /* */
                                "\x0e\x03REQUEST_METHODGET"               /* */
                                "\x0b\x01REQUEST_URI/"                    /* */
+                               "\x0b\x09SERVER_ADDR127.0.0.1"            /* */
+                               "\x0b\x02SERVER_PORT80"                   /* */
                                "\x0b\x07SERVER_NAMEdefault"              /* */
-                               "\x0b\x05SERVER_PORT65535"                /* */
                                "\x0f\x08SERVER_PROTOCOLHTTP/1.1"         /* */
                                "\x0f\x10SERVER_SOFTWAREh2o/1.2.1-alpha1" /* */
                                "\x0b\x00SCRIPT_NAME"                     /* */


### PR DESCRIPTION
This PR adds three things,
* refactors the socket and `h2o_conn_t`, adding `get_peername` callback to obtain the peer address (instead of providing a pointer to `struct sockaddr`)
* adds `get_sockname` callback to obtain the local address
* the fastcgi handler uses `get_sockname` callback to build `SERVER_ADDR` and `SERVER_PORT` properties of `FCGI_PARAMS`

amends #346 