### PR TITLE
suppressed compiler warnings for ignoring return value of ‘write’.

### DIFF
--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -130,7 +130,8 @@ pid_t h2o_spawnp(const char *cmd, char **argv, const int *mapped_fds)
         }
         execvp(cmd, argv);
         errnum = errno;
-        write(pipefds[1], &errnum, sizeof(errnum));
+        if (write(pipefds[1], &errnum, sizeof(errnum)) == -1)
+            perror("write failed");
         _exit(EX_SOFTWARE);
     }
 

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -376,7 +376,8 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
         pos = append_safe_string(pos, element->suffix.base, element->suffix.len);
     }
 
-    write(fh->fd, line, pos - line);
+    if (write(fh->fd, line, pos - line) == -1)
+        perror("write failed");
 
     if (line_end - line != LOG_ALLOCA_SIZE)
         free(line);


### PR DESCRIPTION
## warning messages

```
/home/bokko/workspace/h2o/lib/common/serverutil.c: In function ‘h2o_spawnp’:
/home/bokko/workspace/h2o/lib/common/serverutil.c:133:14: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
         write(pipefds[1], &errnum, sizeof(errnum));
                                                      ・
                                                      ・
                                                      ・
/home/bokko/workspace/h2o/lib/handler/access_log.c: In function ‘log_access’:
/home/bokko/workspace/h2o/lib/handler/access_log.c:379:10: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
     write(fh->fd, line, pos - line);
```
