### PR TITLE
Implement features to sufficient to support WordPress URL rewrites

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1134,10 +1134,11 @@ typedef struct st_h2o_redirect_handler_t h2o_redirect_handler_t;
 /**
  * registers the redirect handler to the context
  * @param pathconf
+ * @param internal whether if the redirect is internal or external
  * @param status status code to be sent (e.g. 301, 303, 308, ...)
  * @param prefix prefix of the destitation URL
  */
-h2o_redirect_handler_t *h2o_redirect_register(h2o_pathconf_t *pathconf, int status, const char *prefix);
+h2o_redirect_handler_t *h2o_redirect_register(h2o_pathconf_t *pathconf, int internal, int status, const char *prefix);
 /**
  * registers the configurator
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1023,6 +1023,7 @@ typedef struct st_h2o_fastcgi_config_vars_t {
     uint64_t io_timeout;
     uint64_t keepalive_timeout; /* 0 to disable */
     h2o_iovec_t document_root;  /* .base=NULL if not set */
+    int send_delegated_uri;     /* whether to send the rewritten HTTP_HOST & REQUEST_URI by delegation, or the original */
     struct {
         void (*dispose)(h2o_fastcgi_handler_t *handler, void *data);
         void *data;

--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -53,6 +53,15 @@ static uint16_t h2o_url_get_port(const h2o_url_t *url);
  */
 h2o_iovec_t h2o_url_normalize_path(h2o_mem_pool_t *pool, const char *path, size_t len, size_t *query_at);
 /**
+ * initializes URL object given scheme, authority, and path
+ * @param the output
+ * @param scheme scheme
+ * @param authority
+ * @param path
+ * @return 0 if successful
+ */
+static int h2o_url_init(h2o_url_t *url, const h2o_url_scheme_t *scheme, h2o_iovec_t authority, h2o_iovec_t path);
+/**
  * parses absolute URL (either http or https)
  */
 int h2o_url_parse(const char *url, size_t url_len, h2o_url_t *result);
@@ -83,6 +92,16 @@ static h2o_iovec_t h2o_url_stringify(h2o_mem_pool_t *pool, const h2o_url_t *url)
 void h2o_url_copy(h2o_mem_pool_t *pool, h2o_url_t *dest, const h2o_url_t *src);
 
 /* inline definitions */
+
+inline int h2o_url_init(h2o_url_t *url, const h2o_url_scheme_t *scheme, h2o_iovec_t authority, h2o_iovec_t path)
+{
+    if (h2o_url_parse_hostport(authority.base, authority.len, &url->host, &url->_port) != authority.base + authority.len)
+        return -1;
+    url->scheme = scheme;
+    url->authority = authority;
+    url->path = path;
+    return 0;
+}
 
 inline uint16_t h2o_url_get_port(const h2o_url_t *url)
 {

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -67,6 +67,17 @@ static int on_config_document_root(h2o_configurator_command_t *cmd, h2o_configur
     return 0;
 }
 
+static int on_config_send_delegated_uri(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct fastcgi_configurator_t *self = (void *)cmd->configurator;
+    ssize_t v;
+
+    if ((v = h2o_configurator_get_one_of(cmd, node, "OFF,ON")) == -1)
+        return -1;
+    self->vars->send_delegated_uri = (int)v;
+    return 0;
+}
+
 static int on_config_connect(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct fastcgi_configurator_t *self = (void *)cmd->configurator;
@@ -274,4 +285,7 @@ void h2o_fastcgi_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "fastcgi.document_root",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_document_root);
+    h2o_configurator_define_command(&c->super, "fastcgi.send-delegated-uri",
+                                    H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_send_delegated_uri);
 }

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -619,7 +619,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
         if (h2o_mimemap_has_dynamic_type(self->mimemap) && try_dynamic_request(self, req, rpath, rpath_len) == 0)
             return 0;
         if (errno == ENOENT) {
-            h2o_send_error(req, 404, "File Not Found", "file not found", 0);
+            return -1;
         } else {
             h2o_send_error(req, 403, "Access Forbidden", "access forbidden", 0);
         }

--- a/t/00unit/lib/handler/fastcgi.c
+++ b/t/00unit/lib/handler/fastcgi.c
@@ -76,10 +76,10 @@ static void test_build_request(void)
     iovec_vector_t vecs;
     size_t vec_index;
 
-    conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
-    conn->req.scheme = &H2O_URL_SCHEME_HTTP;
-    conn->req.authority = h2o_iovec_init(H2O_STRLIT("localhost"));
-    conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
+    conn->req.input.method = conn->req.method = h2o_iovec_init(H2O_STRLIT("GET"));
+    conn->req.input.scheme = conn->req.scheme = &H2O_URL_SCHEME_HTTP;
+    conn->req.input.authority = conn->req.authority = h2o_iovec_init(H2O_STRLIT("localhost"));
+    conn->req.input.path = conn->req.path = h2o_iovec_init(H2O_STRLIT("/"));
     conn->req.path_normalized = conn->req.path;
     conn->req.query_at = SIZE_MAX;
     conn->req.version = 0x101;
@@ -101,13 +101,13 @@ static void test_build_request(void)
                                "\x0b\x09REMOTE_ADDR127.0.0.1"                                                           /* */
                                "\x0b\x05REMOTE_PORT55555"                                                               /* */
                                "\x0e\x03REQUEST_METHODGET"                                                              /* */
+                               "\x09\x09HTTP_HOSTlocalhost"                                                             /* */
                                "\x0b\x01REQUEST_URI/"                                                                   /* */
                                "\x0b\x09SERVER_ADDR127.0.0.1"                                                           /* */
                                "\x0b\x02SERVER_PORT80"                                                                  /* */
                                "\x0b\x07SERVER_NAMEdefault"                                                             /* */
                                "\x0f\x08SERVER_PROTOCOLHTTP/1.1"                                                        /* */
                                "\x0f\x10SERVER_SOFTWAREh2o/1.2.1-alpha1"                                                /* */
-                               "\x09\x09HTTP_HOSTlocalhost"                                                             /* */
                                "\x0f\x3fHTTP_USER_AGENTMozilla/5.0 (X11; Linux) KHTML/4.9.1 (like Gecko) Konqueror/4.9" /* */
                                "\x0b\x07HTTP_COOKIEfoo=bar"                                                             /* */
                                )));
@@ -136,13 +136,13 @@ static void test_build_request(void)
                                "\x0b\x09REMOTE_ADDR127.0.0.1"                                                           /* */
                                "\x0b\x05REMOTE_PORT55555"                                                               /* */
                                "\x0e\x03REQUEST_METHODGET"                                                              /* */
+                               "\x09\x09HTTP_HOSTlocalhost"                                                             /* */
                                "\x0b\x01REQUEST_URI/"                                                                   /* */
                                "\x0b\x09SERVER_ADDR127.0.0.1"                                                           /* */
                                "\x0b\x02SERVER_PORT80"                                                                  /* */
                                "\x0b\x07SERVER_NAMEdefault"                                                             /* */
                                "\x0f\x08SERVER_PROTOCOLHTTP/1.1"                                                        /* */
                                "\x0f\x10SERVER_SOFTWAREh2o/1.2.1-alpha1"                                                /* */
-                               "\x09\x09HTTP_HOSTlocalhost"                                                             /* */
                                "\x0f\x3fHTTP_USER_AGENTMozilla/5.0 (X11; Linux) KHTML/4.9.1 (like Gecko) Konqueror/4.9" /* */
                                "\x0b\x11HTTP_COOKIEfoo=bar;hoge=fuga"                                                   /* */
                                )));

--- a/t/00unit/lib/handler/redirect.c
+++ b/t/00unit/lib/handler/redirect.c
@@ -42,7 +42,7 @@ void test_lib__handler__redirect_c()
     h2o_config_init(&globalconf);
     hostconf = h2o_config_register_host(&globalconf, h2o_iovec_init(H2O_STRLIT("default")), 65535);
     pathconf = h2o_config_register_path(hostconf, "/");
-    h2o_redirect_register(pathconf, 301, "https://example.com/bar/");
+    h2o_redirect_register(pathconf, 0, 301, "https://example.com/bar/");
 
     h2o_context_init(&ctx, test_loop, &globalconf);
 


### PR DESCRIPTION
This PR implements features that are sufficient to support WordPress-style URL rewrites without stepping into the mod_rewrite-hell.

For example, with the PR it becomes possible to map `/2015/06/15/blogpost/` internally to `/index.php/2015/06/15/blogpost/` in case no file was found.

The approach is a combination of:
* the file handler passes the request through to the next handler if it failed to find the file
* adds `internal` attribute to `redirect` handler, so that it could be used for declaring internal redirections

With these features, it is possible to support WordPress-like URL rewrites by setting the configuration directive like:

```
file.custom-handler:
  extension: .php
  fastcgi.spawn: "PHP_FCGI_CHILDREN=10 exec php-cgi"
hosts:
  "hostname":
    paths:
      /:
        file.dir: /www/root/dir   # serve the files, should they exist
        redirect:                 # if file was not found, retry with /index.php/<path>
          url: /index.php/
          internal: YES
          status: 307
```