### PR TITLE
fetch-ocsp-response: Support LibreSSL

### DIFF
--- a/share/h2o/fetch-ocsp-response
+++ b/share/h2o/fetch-ocsp-response
@@ -73,7 +73,7 @@ my $ocsp_uri = run_openssl("x509 -in $cert_fn -noout -ocsp_uri");
 chomp $ocsp_uri;
 die "failed to extract ocsp URI from $cert_fn\n"
     if $ocsp_uri !~ m{^https?://};
-my($ocsp_host) = $ocsp_uri =~ m{^https?://([^/:]+)};
+my($ocsp_host) = $ocsp_uri =~ m{^https?://([^/]+)};
 
 # save issuer certificate
 if (! defined $issuer_fn) {
@@ -88,7 +88,7 @@ if (! defined $issuer_fn) {
 print STDERR "sending OCSP request to $ocsp_uri\n";
 my $resp = run_openssl(
     "ocsp -issuer $issuer_fn -cert $cert_fn -url $ocsp_uri"
-    . ($openssl_version =~ /^OpenSSL 1\./is ? " -header Host $ocsp_host" : "")
+    . ($openssl_version =~ /^(OpenSSL 1\.|LibreSSL )/is ? " -header Host $ocsp_host" : "")
     . " -noverify -respout $tempdir/resp.der " . join(' ', @ARGV),
     1,
 );


### PR DESCRIPTION
Previously, we only used -header when openssl_version starts with
"OpenSSL 1.".  This is because the availability of -header is limited
to that series.  But it turns out that LibreSSL also has this option,
but its version line starts with "LibreSSL ", which does not match our
regexp, and some ocsp responder fails because of lack of Host header
field.  This commit fixes this problem, by allowing sending -header if
version string starts with "LibreSSL ".  LibreSSL's first release tag
is 2.0.0, which is based on OpenSSL 1.0.1h, so it should have -header
option.  Also this commit include fixes to include port part to
ocsp_host.  Technically, Host header field should include port number
(it can omit it if it is a default port for the scheme).