### PR TITLE
Emit warning (instead of fatal error) when failing to set TCP Fast Open

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -740,10 +740,8 @@ static int open_tcp_listener(h2o_configurator_command_t *cmd, yoml_t *node, cons
     /* set TCP_FASTOPEN; when tfo_queues is zero TFO is always disabled */
     if (conf.tfo_queues > 0) {
 #ifdef TCP_FASTOPEN
-        if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (const void *)&conf.tfo_queues, sizeof(conf.tfo_queues)) != 0) {
-            fprintf(stderr, "failed to set TCP_FASTOPEN:%s\n", strerror(errno));
-            goto Error;
-        }
+        if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (const void *)&conf.tfo_queues, sizeof(conf.tfo_queues)) != 0)
+            fprintf(stderr, "[warning] failed to set TCP_FASTOPEN:%s\n", strerror(errno));
 #else
         assert(!"conf.tfo_queues not zero on platform without TCP_FASTOPEN");
 #endif


### PR DESCRIPTION
In #356 we have added support for TCP Fast Open which is enabled by default (if `TCP_FASTOPEN` is defined in the header files).

However, people may use the server complied in an environment with `TCP_FASTOPEN` defined, and use the binary in an environment (i.e. kernel) that does not support the feature (see the comments on the pull-req).  In such situation, the server fails to boot up due to the fact that it exits with a fatal error if `setsockopt(TCP_FASTOPEN)` fails.

This PR changes how the error is being handled.  Instead of refusing to start, the server now just emits a warning and continues to operate if `setsockopt(TCP_FASTOPEN)` fails.