### PR TITLE
introduce `poll`-based backend for i/o multiplexing, replacing `select`

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -308,13 +308,13 @@
 		1058C8871AA6DE4B008D6180 /* hostinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hostinfo.h; sourceTree = "<group>"; };
 		1058C8891AA6E5E3008D6180 /* hostinfo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hostinfo.c; sourceTree = "<group>"; };
 		1065E6EF19B8C64200686E72 /* evloop.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = evloop.c.h; sourceTree = "<group>"; };
-		1065E6F419B996B400686E72 /* select.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = select.c.h; sourceTree = "<group>"; };
 		1065E6F619B99E6D00686E72 /* kqueue.c.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = kqueue.c.h; sourceTree = "<group>"; };
 		1065E6F719B9B1AC00686E72 /* epoll.c.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = epoll.c.h; sourceTree = "<group>"; };
 		1065E6F819BEBAC600686E72 /* timeout.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = timeout.c; sourceTree = "<group>"; };
 		1065E70419BF145700686E72 /* evloop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = evloop.h; sourceTree = "<group>"; };
 		1065E70619BF14E500686E72 /* uv-binding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "uv-binding.h"; sourceTree = "<group>"; };
 		1065E70719BF17FE00686E72 /* uv-binding.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uv-binding.c.h"; sourceTree = "<group>"; };
+		1070E15C1B438E8F001CCAFA /* poll.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = poll.c.h; sourceTree = "<group>"; };
 		10756E251AC126250009BF57 /* yaml.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yaml.h; sourceTree = "<group>"; };
 		10756E261AC126420009BF57 /* api.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = api.c; sourceTree = "<group>"; };
 		10756E271AC126420009BF57 /* dumper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dumper.c; sourceTree = "<group>"; };
@@ -726,7 +726,7 @@
 		1065E6F319B9969000686E72 /* evloop */ = {
 			isa = PBXGroup;
 			children = (
-				1065E6F419B996B400686E72 /* select.c.h */,
+				1070E15C1B438E8F001CCAFA /* poll.c.h */,
 				1065E6F619B99E6D00686E72 /* kqueue.c.h */,
 				1065E6F719B9B1AC00686E72 /* epoll.c.h */,
 			);

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -64,7 +64,7 @@ static void evloop_do_on_socket_create(struct st_h2o_evloop_socket_t *sock);
 static void evloop_do_on_socket_close(struct st_h2o_evloop_socket_t *sock);
 static void evloop_do_on_socket_export(struct st_h2o_evloop_socket_t *sock);
 
-#if H2O_USE_SELECT || H2O_USE_EPOLL || H2O_USE_KQUEUE
+#if H2O_USE_POLL || H2O_USE_EPOLL || H2O_USE_KQUEUE
 /* explicitly specified */
 #else
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
@@ -72,12 +72,12 @@ static void evloop_do_on_socket_export(struct st_h2o_evloop_socket_t *sock);
 #elif defined(__linux)
 #define H2O_USE_EPOLL 1
 #else
-#define H2O_USE_SELECT 1
+#define H2O_USE_POLL 1
 #endif
 #endif
 
-#if H2O_USE_SELECT
-#include "evloop/select.c.h"
+#if H2O_USE_POLL
+#include "evloop/poll.c.h"
 #elif H2O_USE_EPOLL
 #include "evloop/epoll.c.h"
 #elif H2O_USE_KQUEUE

--- a/lib/common/socket/evloop/poll.c.h
+++ b/lib/common/socket/evloop/poll.c.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 DeNA Co., Ltd.
+ * Copyright (c) 2014,2015 DeNA Co., Ltd., Kazuho Oku
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -20,7 +20,7 @@
  * IN THE SOFTWARE.
  */
 #include <stdio.h>
-#include <sys/select.h>
+#include <poll.h>
 
 #if 0
 #define DEBUG_LOG(...) fprintf(stderr, __VA_ARGS__)
@@ -28,15 +28,14 @@
 #define DEBUG_LOG(...)
 #endif
 
-struct st_h2o_evloop_select_t {
+struct st_h2o_evloop_poll_t {
     h2o_evloop_t super;
-    fd_set readfds, writefds;
-    int max_fd;
-    struct st_h2o_evloop_socket_t *socks[FD_SETSIZE];
+    H2O_VECTOR(struct st_h2o_evloop_socket_t *) socks;
 };
 
-static void update_fdset(struct st_h2o_evloop_select_t *loop)
+static void update_socks(struct st_h2o_evloop_poll_t *loop)
 {
+    /* update loop->socks */
     while (loop->super._statechanged.head != NULL) {
         /* detach the top */
         struct st_h2o_evloop_socket_t *sock = loop->super._statechanged.head;
@@ -44,34 +43,28 @@ static void update_fdset(struct st_h2o_evloop_select_t *loop)
         sock->_next_statechanged = sock;
         /* update the state */
         if ((sock->_flags & H2O_SOCKET_FLAG_IS_DISPOSED) != 0) {
-            if (sock->fd != -1) {
-                assert(loop->socks[sock->fd] == sock);
-                loop->socks[sock->fd] = NULL;
-            }
+            assert(sock->fd == -1);
             free(sock);
         } else {
-            if (loop->socks[sock->fd] == NULL) {
-                loop->socks[sock->fd] = sock;
+            assert(sock->fd < loop->socks.size);
+            if (loop->socks.entries[sock->fd] == NULL) {
+                loop->socks.entries[sock->fd] = sock;
             } else {
-                assert(loop->socks[sock->fd] == sock);
+                assert(loop->socks.entries[sock->fd] == sock);
             }
             if (h2o_socket_is_reading(&sock->super)) {
                 DEBUG_LOG("setting READ for fd: %d\n", sock->fd);
-                FD_SET(sock->fd, &loop->readfds);
                 sock->_flags |= H2O_SOCKET_FLAG_IS_POLLED_FOR_READ;
             } else {
                 DEBUG_LOG("clearing READ for fd: %d\n", sock->fd);
-                FD_CLR(sock->fd, &loop->readfds);
                 sock->_flags &= ~H2O_SOCKET_FLAG_IS_POLLED_FOR_READ;
             }
             if (h2o_socket_is_writing(&sock->super) &&
                 (sock->_wreq.cnt != 0 || (sock->_flags & H2O_SOCKET_FLAG_IS_CONNECTING) != 0)) {
                 DEBUG_LOG("setting WRITE for fd: %d\n", sock->fd);
-                FD_SET(sock->fd, &loop->writefds);
                 sock->_flags |= H2O_SOCKET_FLAG_IS_POLLED_FOR_WRITE;
             } else {
                 DEBUG_LOG("clearing WRITE for fd: %d\n", sock->fd);
-                FD_CLR(sock->fd, &loop->writefds);
                 sock->_flags &= ~H2O_SOCKET_FLAG_IS_POLLED_FOR_WRITE;
             }
         }
@@ -81,49 +74,62 @@ static void update_fdset(struct st_h2o_evloop_select_t *loop)
 
 int evloop_do_proceed(h2o_evloop_t *_loop)
 {
-    struct st_h2o_evloop_select_t *loop = (struct st_h2o_evloop_select_t *)_loop;
-    fd_set rfds, wfds;
-    int32_t max_wait;
-    struct timeval timeout;
+    struct st_h2o_evloop_poll_t *loop = (struct st_h2o_evloop_poll_t *)_loop;
+    H2O_VECTOR(struct pollfd) pollfds = {};
     int fd, ret;
 
     /* update status */
-    update_fdset(loop);
+    update_socks(loop);
 
-    /* calc timeout */
-    max_wait = get_max_wait(&loop->super);
-    timeout.tv_sec = max_wait / 1000;
-    timeout.tv_usec = max_wait % 1000 * 1000;
-    /* set fds */
-    memcpy(&rfds, &loop->readfds, sizeof(rfds));
-    memcpy(&wfds, &loop->writefds, sizeof(wfds));
+    /* build list of fds to be polled */
+    for (fd = 0; fd != loop->socks.size; ++fd) {
+        struct st_h2o_evloop_socket_t *sock = loop->socks.entries[fd];
+        if (sock == NULL)
+            continue;
+        assert(fd == sock->fd);
+        if ((sock->_flags & (H2O_SOCKET_FLAG_IS_POLLED_FOR_READ | H2O_SOCKET_FLAG_IS_POLLED_FOR_WRITE)) != 0) {
+            h2o_vector_reserve(NULL, (void *)&pollfds, sizeof(pollfds.entries[0]), pollfds.size + 1);
+            struct pollfd *slot = pollfds.entries + pollfds.size++;
+            slot->fd = fd;
+            slot->events = 0;
+            slot->revents = 0;
+            if ((sock->_flags & H2O_SOCKET_FLAG_IS_POLLED_FOR_READ) != 0)
+                slot->events |= POLLIN;
+            if ((sock->_flags & H2O_SOCKET_FLAG_IS_POLLED_FOR_WRITE) != 0)
+                slot->events |= POLLOUT;
+        }
+    }
+
     /* call */
-    ret = select(loop->max_fd + 1, &rfds, &wfds, NULL, &timeout);
+    ret = poll(pollfds.entries, (nfds_t)pollfds.size, get_max_wait(&loop->super));
     update_now(&loop->super);
     if (ret == -1)
         return -1;
-    DEBUG_LOG("select returned: %d\n", ret);
+    DEBUG_LOG("poll returned: %d\n", ret);
 
     /* update readable flags, perform writes */
     if (ret > 0) {
-        for (fd = 0; fd <= loop->max_fd; ++fd) {
+        size_t i;
+        for (i = 0; i != pollfds.size; ++i) {
             /* set read_ready flag before calling the write cb, since app. code invoked by the latter may close the socket, clearing
              * the former flag */
-            if (FD_ISSET(fd, &rfds)) {
-                struct st_h2o_evloop_socket_t *sock = loop->socks[fd];
+            if ((pollfds.entries[i].revents & POLLIN) != 0) {
+                struct st_h2o_evloop_socket_t *sock = loop->socks.entries[pollfds.entries[i].fd];
                 assert(sock != NULL);
+                assert(sock->fd == pollfds.entries[i].fd);
                 if (sock->_flags != H2O_SOCKET_FLAG_IS_DISPOSED) {
                     sock->_flags |= H2O_SOCKET_FLAG_IS_READ_READY;
                     link_to_pending(sock);
-                    DEBUG_LOG("added fd %d as read_ready\n", fd);
+                    DEBUG_LOG("added fd %d as read_ready\n", sock->fd);
                 }
             }
-            if (FD_ISSET(fd, &wfds)) {
-                struct st_h2o_evloop_socket_t *sock = loop->socks[fd];
+            if ((pollfds.entries[i].revents & POLLOUT) != 0) {
+                struct st_h2o_evloop_socket_t *sock = loop->socks.entries[pollfds.entries[i].fd];
                 assert(sock != NULL);
+                assert(sock->fd == pollfds.entries[i].fd);
                 if (sock->_flags != H2O_SOCKET_FLAG_IS_DISPOSED) {
                     DEBUG_LOG("handling pending writes on fd %d\n", fd);
-                    write_pending(loop->socks[fd]);
+                    write_pending(sock);
                 }
             }
         }
@@ -134,39 +140,36 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
 
 static void evloop_do_on_socket_create(struct st_h2o_evloop_socket_t *sock)
 {
-    struct st_h2o_evloop_select_t *loop = (struct st_h2o_evloop_select_t *)sock->loop;
+    struct st_h2o_evloop_poll_t *loop = (struct st_h2o_evloop_poll_t *)sock->loop;
 
-    if (loop->max_fd < sock->fd)
-        loop->max_fd = sock->fd;
-
-    if (loop->socks[sock->fd] != NULL) {
-        assert(loop->socks[sock->fd]->_flags == H2O_SOCKET_FLAG_IS_DISPOSED);
+    if (sock->fd >= loop->socks.size) {
+        h2o_vector_reserve(NULL, (void *)&loop->socks, sizeof(loop->socks.entries[0]), sock->fd + 1);
+        memset(loop->socks.entries + loop->socks.size, 0,
+               (sock->fd + 1 - loop->socks.size) * sizeof(loop->socks.entries[0]));
+        loop->socks.size = sock->fd + 1;
     }
-    assert(!FD_ISSET(sock->fd, &loop->readfds));
-    assert(!FD_ISSET(sock->fd, &loop->writefds));
+
+    if (loop->socks.entries[sock->fd] != NULL)
+        assert(loop->socks.entries[sock->fd]->_flags == H2O_SOCKET_FLAG_IS_DISPOSED);
 }
 
 static void evloop_do_on_socket_close(struct st_h2o_evloop_socket_t *sock)
 {
-    struct st_h2o_evloop_select_t *loop = (struct st_h2o_evloop_select_t *)sock->loop;
-    if (sock->fd == -1)
-        return;
-    if (loop->socks[sock->fd] == NULL)
-        return;
-    DEBUG_LOG("clearing READ/WRITE for fd: %d\n", sock->fd);
-    FD_CLR(sock->fd, &loop->readfds);
-    FD_CLR(sock->fd, &loop->writefds);
+    struct st_h2o_evloop_poll_t *loop = (struct st_h2o_evloop_poll_t *)sock->loop;
+
+    if (sock->fd != -1)
+        loop->socks.entries[sock->fd] = NULL;
 }
 
 static void evloop_do_on_socket_export(struct st_h2o_evloop_socket_t *sock)
 {
-    struct st_h2o_evloop_select_t *loop = (struct st_h2o_evloop_select_t *)sock->loop;
+    struct st_h2o_evloop_poll_t *loop = (struct st_h2o_evloop_poll_t *)sock->loop;
     evloop_do_on_socket_close(sock);
-    loop->socks[sock->fd] = NULL;
+    loop->socks.entries[sock->fd] = NULL;
 }
 
 h2o_evloop_t *h2o_evloop_create(void)
 {
-    struct st_h2o_evloop_select_t *loop = (struct st_h2o_evloop_select_t *)create_evloop(sizeof(*loop));
+    struct st_h2o_evloop_poll_t *loop = (struct st_h2o_evloop_poll_t *)create_evloop(sizeof(*loop));
     return &loop->super;
 }


### PR DESCRIPTION
`select` has been the backend for OSes that do not support `epoll` nor `kqueue`.

However, the backend has had issues when handling large number of sockets, as discussed in #287.

This PR fixes the issue by replacing the default (i.e. fallback) backend from using `select` to `poll`.