### PR TITLE
Add support for PROXY protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
   - $CXX --version
   # for speed, pre-install deps installed in `before_script` section as ubuntu packages
-  - sudo apt-get install -qq cpanminus libipc-signal-perl liblist-moreutils-perl libplack-perl libtest-tcp-perl libscope-guard-perl libwww-perl
+  - sudo apt-get install -qq cpanminus libipc-signal-perl liblist-moreutils-perl libplack-perl libtest-tcp-perl libscope-guard-perl libwww-perl libio-socket-ssl-perl
 
 before_script:
   # install libuv >= 1.0.0 (optionally required for building / testing libh2o)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/common/url.c
     t/00unit/lib/core/headers.c
     t/00unit/lib/core/proxy.c
+    t/00unit/lib/core/util.c
     t/00unit/lib/handler/fastcgi.c
     t/00unit/lib/handler/file.c
     t/00unit/lib/handler/headers.c
@@ -227,6 +228,7 @@ LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/common/url.c
     lib/core/headers.c
     lib/core/proxy.c
+    lib/core/util.c
     lib/handler/fastcgi.c
     lib/handler/file.c
     lib/handler/headers.c

--- a/examples/libh2o/websocket.c
+++ b/examples/libh2o/websocket.c
@@ -54,7 +54,7 @@ static int on_req(h2o_handler_t *self, h2o_req_t *req)
 
 static h2o_globalconf_t config;
 static h2o_context_t ctx;
-static SSL_CTX *ssl_ctx;
+static h2o_accept_ctx_t accept_ctx;
 
 static void on_connect(uv_stream_t *server, int status)
 {
@@ -72,10 +72,7 @@ static void on_connect(uv_stream_t *server, int status)
     }
 
     sock = h2o_uv_socket_create((uv_stream_t *)conn, (uv_close_cb)free);
-    if (ssl_ctx != NULL)
-        h2o_accept_ssl(&ctx, ctx.globalconf->hosts, sock, ssl_ctx);
-    else
-        h2o_http1_accept(&ctx, ctx.globalconf->hosts, sock);
+    h2o_accept(&accept_ctx, sock);
 }
 
 static int setup_ssl(const char *cert_file, const char *key_file)
@@ -84,15 +81,15 @@ static int setup_ssl(const char *cert_file, const char *key_file)
     SSL_library_init();
     OpenSSL_add_all_algorithms();
 
-    ssl_ctx = SSL_CTX_new(SSLv23_server_method());
-    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2);
+    accept_ctx.ssl_ctx = SSL_CTX_new(SSLv23_server_method());
+    SSL_CTX_set_options(accept_ctx.ssl_ctx, SSL_OP_NO_SSLv2);
 
     /* load certificate and private key */
-    if (SSL_CTX_use_certificate_file(ssl_ctx, cert_file, SSL_FILETYPE_PEM) != 1) {
+    if (SSL_CTX_use_certificate_file(accept_ctx.ssl_ctx, cert_file, SSL_FILETYPE_PEM) != 1) {
         fprintf(stderr, "an error occurred while trying to load server certificate file:%s\n", cert_file);
         return -1;
     }
-    if (SSL_CTX_use_PrivateKey_file(ssl_ctx, key_file, SSL_FILETYPE_PEM) != 1) {
+    if (SSL_CTX_use_PrivateKey_file(accept_ctx.ssl_ctx, key_file, SSL_FILETYPE_PEM) != 1) {
         fprintf(stderr, "an error occurred while trying to load private key file:%s\n", key_file);
         return -1;
     }
@@ -135,6 +132,9 @@ int main(int argc, char **argv)
     if (setup_ssl("server.crt", "server.key") != 0)
         goto Error;
     */
+
+    accept_ctx.ctx = &ctx;
+    accept_ctx.hosts = config.hosts;
 
     return uv_run(loop, UV_RUN_DEFAULT);
 

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		1065E70C19BF664300686E72 /* evloop.h in Headers */ = {isa = PBXBuildFile; fileRef = 1065E70419BF145700686E72 /* evloop.h */; };
 		1065E70D19BF6D4600686E72 /* uv-binding.h in Headers */ = {isa = PBXBuildFile; fileRef = 1065E70619BF14E500686E72 /* uv-binding.h */; };
 		1065E70E19BF6D9400686E72 /* uv-binding.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 1065E70719BF17FE00686E72 /* uv-binding.c.h */; };
+		1070E1631B4508B0001CCAFA /* util.c in Sources */ = {isa = PBXBuildFile; fileRef = 1070E1621B4508B0001CCAFA /* util.c */; };
 		10756E2A1AC126420009BF57 /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = 10756E261AC126420009BF57 /* api.c */; };
 		10756E2B1AC126420009BF57 /* dumper.c in Sources */ = {isa = PBXBuildFile; fileRef = 10756E271AC126420009BF57 /* dumper.c */; };
 		10756E2C1AC126420009BF57 /* emitter.c in Sources */ = {isa = PBXBuildFile; fileRef = 10756E281AC126420009BF57 /* emitter.c */; };
@@ -87,7 +88,6 @@
 		1079244C19A3266700C52AD6 /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 107923BA19A3217300C52AD6 /* memory.c */; };
 		1079244E19A3266700C52AD6 /* request.c in Sources */ = {isa = PBXBuildFile; fileRef = 107923BC19A3217300C52AD6 /* request.c */; };
 		1079245119A3266700C52AD6 /* token.c in Sources */ = {isa = PBXBuildFile; fileRef = 107923BF19A3217300C52AD6 /* token.c */; };
-		1079245219A3266700C52AD6 /* util.c in Sources */ = {isa = PBXBuildFile; fileRef = 107923C019A3217300C52AD6 /* util.c */; };
 		1079245419A32C0800C52AD6 /* token_table.h in Headers */ = {isa = PBXBuildFile; fileRef = 1079245319A32C0800C52AD6 /* token_table.h */; };
 		108867751AD9069900987967 /* defaults.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 108867741AD9069900987967 /* defaults.c.h */; };
 		10AA2E941A80A592004322AC /* time_.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AA2E931A80A592004322AC /* time_.h */; };
@@ -315,6 +315,8 @@
 		1065E70619BF14E500686E72 /* uv-binding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "uv-binding.h"; sourceTree = "<group>"; };
 		1065E70719BF17FE00686E72 /* uv-binding.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uv-binding.c.h"; sourceTree = "<group>"; };
 		1070E15C1B438E8F001CCAFA /* poll.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = poll.c.h; sourceTree = "<group>"; };
+		1070E1621B4508B0001CCAFA /* util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = util.c; sourceTree = "<group>"; };
+		1070E1641B451D43001CCAFA /* 40proxy-protocol.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40proxy-protocol.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10756E251AC126250009BF57 /* yaml.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yaml.h; sourceTree = "<group>"; };
 		10756E261AC126420009BF57 /* api.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = api.c; sourceTree = "<group>"; };
 		10756E271AC126420009BF57 /* dumper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dumper.c; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 			children = (
 				104B9A471A5F9472009EEE64 /* headers.c */,
 				105534C81A3BB41C00627ECB /* proxy.c */,
+				1070E1621B4508B0001CCAFA /* util.c */,
 			);
 			path = core;
 			sourceTree = "<group>";
@@ -990,6 +993,7 @@
 				104B9A301A58F55E009EEE64 /* 40max-connections.t */,
 				10F198EB1A7ED2CC00F4585E /* 40pathconf-redirect.t */,
 				105534F51A460EF600627ECB /* 40protocol.t */,
+				1070E1641B451D43001CCAFA /* 40proxy-protocol.t */,
 				104B9A311A59D7A2009EEE64 /* 40running-user.t */,
 				108215081AB14B1100D27E66 /* 40server-push.t */,
 				104B9A321A59E27A009EEE64 /* 40ssl-cipher-suite.t */,
@@ -1348,7 +1352,6 @@
 				10AA2EA31A88090B004322AC /* url.c in Sources */,
 				105534C91A3BB41C00627ECB /* proxy.c in Sources */,
 				1079245119A3266700C52AD6 /* token.c in Sources */,
-				1079245219A3266700C52AD6 /* util.c in Sources */,
 				1079244419A3265C00C52AD6 /* chunked.c in Sources */,
 				104B9A481A5F9472009EEE64 /* headers.c in Sources */,
 				10E2995A1A68D03100701AA6 /* scheduler.c in Sources */,
@@ -1360,6 +1363,7 @@
 				10F9F2651AF4795D0056F26B /* redirect.c in Sources */,
 				1079244819A3265C00C52AD6 /* connection.c in Sources */,
 				1079244119A3264300C52AD6 /* picohttpparser.c in Sources */,
+				1070E1631B4508B0001CCAFA /* util.c in Sources */,
 				1058C87D1AA41789008D6180 /* headers.c in Sources */,
 				10AA2EAE1A8E22DA004322AC /* multithread.c in Sources */,
 			);

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -648,6 +648,12 @@ struct st_h2o_req_t {
     h2o_mem_pool_t pool;
 };
 
+typedef struct st_h2o_accept_ctx_t {
+    h2o_context_t *ctx;
+    h2o_hostconf_t **hosts;
+    SSL_CTX *ssl_ctx;
+} h2o_accept_ctx_t;
+
 /* token */
 
 extern h2o_token_t h2o__tokens[H2O_MAX_TOKENS];
@@ -713,9 +719,9 @@ ssize_t h2o_delete_header(h2o_headers_t *headers, ssize_t cursor);
 /* util */
 
 /**
- * accepts a SSL connection
+ * accepts a connection
  */
-void h2o_accept_ssl(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock, SSL_CTX *ssl_ctx);
+void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
 /**
  * returns the protocol version (e.g. "HTTP/1.1", "HTTP/2")
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -652,6 +652,7 @@ typedef struct st_h2o_accept_ctx_t {
     h2o_context_t *ctx;
     h2o_hostconf_t **hosts;
     SSL_CTX *ssl_ctx;
+    int expect_proxy_line;
 } h2o_accept_ctx_t;
 
 /* token */

--- a/include/h2o/http1.h
+++ b/include/h2o/http1.h
@@ -30,7 +30,7 @@ typedef void (*h2o_http1_upgrade_cb)(void *user_data, h2o_socket_t *sock, size_t
 
 extern const h2o_protocol_callbacks_t H2O_HTTP1_CALLBACKS;
 
-void h2o_http1_accept(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock);
+void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
 void h2o_http1_upgrade(h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_http1_upgrade_cb on_complete, void *user_data);
 
 #ifdef __cplusplus

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -57,7 +57,7 @@ typedef struct st_h2o_http2_priority_t {
 
 extern const h2o_http2_priority_t h2o_http2_default_priority;
 
-void h2o_http2_accept(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock);
+void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
 int h2o_http2_handle_upgrade(h2o_req_t *req);
 
 #ifdef __cplusplus

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -72,7 +72,6 @@ typedef struct st_h2o_socket_peername_t {
  */
 struct st_h2o_socket_t {
     void *data;
-    void *data2;
     struct st_h2o_socket_ssl_t *ssl;
     h2o_buffer_t *input;
     size_t bytes_read;

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -159,6 +159,10 @@ socklen_t h2o_socket_getsockname(h2o_socket_t *sock, struct sockaddr *sa);
  */
 socklen_t h2o_socket_getpeername(h2o_socket_t *sock, struct sockaddr *sa);
 /**
+ * sets the remote address (used for overriding the value)
+ */
+void h2o_socket_setpeername(h2o_socket_t *sock, struct sockaddr *sa, socklen_t len);
+/**
  * compares socket addresses
  */
 int h2o_socket_compare_address(struct sockaddr *x, struct sockaddr *y);

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -62,10 +62,10 @@ typedef void (*h2o_socket_cb)(h2o_socket_t *sock, int err);
 #include "socket/evloop.h"
 #endif
 
-typedef struct st_h2o_socket_peername_t {
-    struct sockaddr_storage addr;
+struct st_h2o_socket_peername_t {
     socklen_t len;
-} h2o_socket_peername_t;
+    struct sockaddr addr;
+};
 
 /**
  * abstraction layer for sockets (SSL vs. TCP)
@@ -83,6 +83,7 @@ struct st_h2o_socket_t {
         h2o_socket_cb read;
         h2o_socket_cb write;
     } _cb;
+    struct st_h2o_socket_peername_t *_peername;
 };
 
 typedef struct st_h2o_socket_export_t {

--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -49,7 +49,7 @@ struct st_h2o_timeout_backend_properties_t {
     char _dummy; /* sizeof(empty_struct) differs bet. C (GCC extension) and C++ */
 };
 
-h2o_socket_t *h2o_evloop_socket_create(h2o_evloop_t *loop, int fd, struct sockaddr *addr, socklen_t addrlen, int flags);
+h2o_socket_t *h2o_evloop_socket_create(h2o_evloop_t *loop, int fd, int flags);
 h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *listener);
 
 h2o_evloop_t *h2o_evloop_create(void);

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -93,7 +93,7 @@ static void init_async(h2o_multithread_queue_t *queue, h2o_loop_t *loop)
     }
     fcntl(fds[1], F_SETFL, O_NONBLOCK);
     queue->async.write = fds[1];
-    queue->async.read = h2o_evloop_socket_create(loop, fds[0], NULL, 0, 0);
+    queue->async.read = h2o_evloop_socket_create(loop, fds[0], 0);
     queue->async.read->data = queue;
     h2o_socket_read_start(queue->async.read, on_read);
 }

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -66,6 +66,7 @@ static void do_read_start(h2o_socket_t *sock);
 static void do_read_stop(h2o_socket_t *sock);
 static int do_export(h2o_socket_t *_sock, h2o_socket_export_t *info);
 static h2o_socket_t *do_import(h2o_loop_t *loop, h2o_socket_export_t *info);
+static socklen_t get_peername_uncached(h2o_socket_t *sock, struct sockaddr *sa);
 
 /* internal functions called from the backend */
 static int decode_ssl_input(h2o_socket_t *sock);
@@ -228,6 +229,10 @@ static void dispose_socket(h2o_socket_t *sock, int status)
         sock->ssl = NULL;
     }
     h2o_buffer_dispose(&sock->input);
+    if (sock->_peername != NULL) {
+        free(sock->_peername);
+        sock->_peername = NULL;
+    }
 
     close_cb = sock->on_close.cb;
     close_cb_data = sock->on_close.data;
@@ -394,6 +399,22 @@ void h2o_socket_read_stop(h2o_socket_t *sock)
 {
     sock->_cb.read = NULL;
     do_read_stop(sock);
+}
+
+socklen_t h2o_socket_getpeername(h2o_socket_t *sock, struct sockaddr *sa)
+{
+    /* return cached, if exists */
+    if (sock->_peername != NULL) {
+        memcpy(sa, &sock->_peername->addr, sock->_peername->len);
+        return sock->_peername->len;
+    }
+
+    /* call, copy to cache, and return */
+    socklen_t len = get_peername_uncached(sock, sa);
+    sock->_peername = h2o_mem_alloc(offsetof(struct st_h2o_socket_peername_t, addr) + len);
+    sock->_peername->len = len;
+    memcpy(&sock->_peername->addr, sa, len);
+    return len;
 }
 
 int h2o_socket_compare_address(struct sockaddr *x, struct sockaddr *y)

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -401,6 +401,15 @@ void h2o_socket_read_stop(h2o_socket_t *sock)
     do_read_stop(sock);
 }
 
+void h2o_socket_setpeername(h2o_socket_t *sock, struct sockaddr *sa, socklen_t len)
+{
+    if (sock->_peername != NULL)
+        free(sock->_peername);
+    sock->_peername = h2o_mem_alloc(offsetof(struct st_h2o_socket_peername_t, addr) + len);
+    sock->_peername->len = len;
+    memcpy(&sock->_peername->addr, sa, len);
+}
+
 socklen_t h2o_socket_getpeername(h2o_socket_t *sock, struct sockaddr *sa)
 {
     /* return cached, if exists */
@@ -408,12 +417,9 @@ socklen_t h2o_socket_getpeername(h2o_socket_t *sock, struct sockaddr *sa)
         memcpy(sa, &sock->_peername->addr, sock->_peername->len);
         return sock->_peername->len;
     }
-
     /* call, copy to cache, and return */
     socklen_t len = get_peername_uncached(sock, sa);
-    sock->_peername = h2o_mem_alloc(offsetof(struct st_h2o_socket_peername_t, addr) + len);
-    sock->_peername->len = len;
-    memcpy(&sock->_peername->addr, sa, len);
+    h2o_socket_setpeername(sock, sa, len);
     return len;
 }
 
@@ -532,7 +538,15 @@ void h2o_socket_ssl_server_handshake(h2o_socket_t *sock, SSL_CTX *ssl_ctx, h2o_s
 
     sock->ssl = h2o_mem_alloc(sizeof(*sock->ssl));
     memset(sock->ssl, 0, offsetof(struct st_h2o_socket_ssl_t, output.pool));
+
+    /* setup the buffers; sock->input should be empty, sock->ssl->input.encrypted should contain the initial input, if any */
     h2o_buffer_init(&sock->ssl->input.encrypted, &h2o_socket_buffer_prototype);
+    if (sock->input->size != 0) {
+        h2o_buffer_t *tmp = sock->input;
+        sock->input = sock->ssl->input.encrypted;
+        sock->ssl->input.encrypted = tmp;
+    }
+
     h2o_mem_init_pool(&sock->ssl->output.pool);
     bio = BIO_new(&bio_methods);
     bio->ptr = sock;

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -212,7 +212,7 @@ socklen_t h2o_socket_getsockname(h2o_socket_t *_sock, struct sockaddr *sa)
     return (socklen_t)len;
 }
 
-socklen_t h2o_socket_getpeername(h2o_socket_t *_sock, struct sockaddr *sa)
+socklen_t get_peername_uncached(h2o_socket_t *_sock, struct sockaddr *sa)
 {
     struct st_h2o_uv_socket_t *sock = (void *)_sock;
     int len = sizeof(struct sockaddr_storage);

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -32,10 +32,8 @@
 static void on_ssl_handshake_complete(h2o_socket_t *sock, int status)
 {
     const h2o_iovec_t *ident;
-    h2o_context_t *ctx = sock->data;
-    h2o_hostconf_t **hosts = sock->data2;
+    h2o_accept_ctx_t *ctx = sock->data;
     sock->data = NULL;
-    sock->data2 = NULL;
 
     h2o_iovec_t proto;
     if (status != 0) {
@@ -50,19 +48,22 @@ static void on_ssl_handshake_complete(h2o_socket_t *sock, int status)
         }
     }
     /* connect as http1 */
-    h2o_http1_accept(ctx, hosts, sock);
+    h2o_http1_accept(ctx, sock);
     return;
 
 Is_Http2:
     /* connect as http2 */
-    h2o_http2_accept(ctx, hosts, sock);
+    h2o_http2_accept(ctx, sock);
 }
 
-void h2o_accept_ssl(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock, SSL_CTX *ssl_ctx)
+void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
 {
-    sock->data = ctx;
-    sock->data2 = hosts;
-    h2o_socket_ssl_server_handshake(sock, ssl_ctx, on_ssl_handshake_complete);
+    if (ctx->ssl_ctx != NULL) {
+        sock->data = ctx;
+        h2o_socket_ssl_server_handshake(sock, ctx->ssl_ctx, on_ssl_handshake_complete);
+    } else {
+        h2o_http1_accept(ctx, sock);
+    }
 }
 
 size_t h2o_stringify_protocol_version(char *dst, int version)

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1100,9 +1100,9 @@ void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http
     execute_or_enqueue_request(conn, stream);
 }
 
-void h2o_http2_accept(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock)
+void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
 {
-    h2o_http2_conn_t *conn = create_conn(ctx, hosts, sock);
+    h2o_http2_conn_t *conn = create_conn(ctx->ctx, ctx->hosts, sock);
     sock->data = conn;
     h2o_socket_read_start(conn->sock, on_read);
     update_idle_timeout(conn);

--- a/src/main.c
+++ b/src/main.c
@@ -1231,9 +1231,7 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
         listeners[i].accept_ctx.ctx = &conf.threads[thread_index].ctx;
         listeners[i].accept_ctx.hosts = listener_config->hosts;
         listeners[i].accept_ctx.ssl_ctx = listener_config->ssl.size != 0 ? listener_config->ssl.entries[0]->ctx : NULL;
-        listeners[i].sock =
-            h2o_evloop_socket_create(conf.threads[thread_index].ctx.loop, fd, (struct sockaddr *)&listener_config->addr,
-                                     listener_config->addrlen, H2O_SOCKET_FLAG_DONT_READ);
+        listeners[i].sock = h2o_evloop_socket_create(conf.threads[thread_index].ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
         listeners[i].sock->data = listeners + i;
     }
     /* and start listening */

--- a/t/00unit/lib/core/util.c
+++ b/t/00unit/lib/core/util.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <string.h>
+#include "../../test.h"
+#include "../../../../lib/core/util.c"
+
+static void test_parse_proxy_line(void)
+{
+    char in[256];
+    struct sockaddr_storage sa;
+    ssize_t ret;
+
+    strcpy(in, "");
+    ret = parse_proxy_line(in, strlen(in), (void *)&sa);
+    ok(ret == -2);
+
+    strcpy(in, "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\nabc");
+    ret = parse_proxy_line(in, strlen(in), (void *)&sa);
+    ok(ret == strlen(in) - 3);
+    ok(sa.ss_family == AF_INET);
+    ok(((struct sockaddr_in *)&sa)->sin_addr.s_addr == htonl(0xc0a80001));
+    ok(((struct sockaddr_in *)&sa)->sin_port == htons(56324));
+
+    strcpy(in, "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r");
+    ret = parse_proxy_line(in, strlen(in), (void *)&sa);
+    ok(ret == -2);
+
+    strcpy(in, "PROXY TCP5");
+    ret = parse_proxy_line(in, strlen(in), (void *)&sa);
+    ok(ret == -1);
+
+    strcpy(in, "PROXY UNKNOWN");
+    ret = parse_proxy_line(in, strlen(in), (void *)&sa);
+    ok(ret == -2);
+
+    strcpy(in, "PROXY UNKNOWN\r\nabc");
+    ret = parse_proxy_line(in, strlen(in), (void *)&sa);
+    ok(ret == strlen(in) - 3);
+    ok(sa.ss_len == 0);
+
+    strcpy(in, "PROXY TCP6 ::1 ::1 56324 443\r\n");
+    ret = parse_proxy_line(in, strlen(in), (void *)&sa);
+    ok(ret == strlen(in));
+    ok(sa.ss_family == AF_INET6);
+    ok(memcmp(&((struct sockaddr_in6 *)&sa)->sin6_addr, H2O_STRLIT("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1")) == 0);
+    ok(((struct sockaddr_in6 *)&sa)->sin6_port == htons(56324));
+}
+
+void test_lib__core__util_c()
+{
+    subtest("parse_proxy_line", test_parse_proxy_line);
+}

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -153,6 +153,7 @@ int main(int argc, char **argv)
         subtest("lib/common/time.c", test_lib__common__time_c);
         subtest("lib/core/headers.c", test_lib__core__headers_c);
         subtest("lib/core/proxy.c", test_lib__core__proxy_c);
+        subtest("lib/core/util.c", test_lib__core__util_c);
         subtest("lib/handler/headers.c", test_lib__handler__headers_c);
         subtest("lib/handler/mimemap.c", test_lib__handler__mimemap_c);
         subtest("lib/http2/hpack.c", test_lib__http2__hpack);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -57,6 +57,7 @@ void test_lib__common__time_c(void);
 void test_lib__common__url_c(void);
 void test_lib__core__headers_c(void);
 void test_lib__core__proxy_c(void);
+void test_lib__core__util_c(void);
 void test_lib__handler__fastcgi_c(void);
 void test_lib__handler__file_c(void);
 void test_lib__handler__headers_c(void);

--- a/t/40proxy-protocol.t
+++ b/t/40proxy-protocol.t
@@ -66,7 +66,7 @@ sub fetch_ssl {
         SSL_startHandshake => 0,
     ) or die "failed to connect to host:$!";
     $conn->write($pre);
-    IO::Socket::SSL->start_SSL($conn)
+    IO::Socket::SSL->start_SSL($conn, SSL_verify_mode => 0)
         or die $SSL_ERROR;
     $conn->write($req);
     $conn->read(my $buf, 1048576);

--- a/t/40proxy-protocol.t
+++ b/t/40proxy-protocol.t
@@ -1,0 +1,127 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use IO::Socket::INET;
+use IO::Socket::SSL;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+my $tempdir = tempdir(CLEANUP => 1);
+my $port = empty_port();
+
+sub spawn_h2o {
+    my ($proxy_protocol, $ssl) = @_;
+
+    open my $fh, ">", "$tempdir/h2o.conf"
+        or die "failed to create file:$tempdir/h2o.conf:$!";
+    print $fh <<"EOT";
+hosts:
+  default:
+    access-log:
+      format: "%h"
+      path: $tempdir/access_log
+    paths:
+      /:
+        file.dir: @{[ DOC_ROOT ]}
+    listen:
+      host: 127.0.0.1
+      port: $port
+      proxy-protocol: @{[$proxy_protocol ?  "ON" : "OFF"]}
+EOT
+    if ($ssl) {
+        print $fh <<"EOT";
+      ssl:
+        key-file: examples/h2o/server.key
+        certificate-file: examples/h2o/server.crt
+EOT
+    }
+    close $fh;
+
+    spawn_server(
+        argv     => [ bindir() . "/h2o", "-c", "$tempdir/h2o.conf" ],
+        is_ready => sub {
+            check_port($port);
+        },
+    );
+}
+
+sub fetch {
+    my $req = shift;
+    my $conn = IO::Socket::INET->new(
+        PeerHost => q(127.0.0.1),
+        PeerPort => $port,
+        Proto    => q(tcp),
+    ) or die "failed to connect to host:$!";
+    $conn->write($req);
+    $conn->read(my $buf, 1048576);
+    $buf;
+}
+
+sub fetch_ssl {
+    my ($pre, $req) = @_;
+    my $conn = IO::Socket::INET->new(
+        PeerHost           => q(127.0.0.1),
+        PeerPort           => $port,
+        SSL_startHandshake => 0,
+    ) or die "failed to connect to host:$!";
+    $conn->write($pre);
+    IO::Socket::SSL->start_SSL($conn)
+        or die $SSL_ERROR;
+    $conn->write($req);
+    $conn->read(my $buf, 1048576);
+    $buf;
+}
+
+sub last_log {
+    open my $fh, "<", "$tempdir/access_log"
+        or die "failed to open file:$tempdir/access_log:$!";
+    my $last;
+    while (<$fh>) {
+        $last = $_;
+    }
+    chomp $last;
+    $last;
+}
+
+subtest "http" => sub {
+    my $guard = spawn_h2o(1, 0);
+    subtest "with proxy" => sub {
+        my $resp = fetch("PROXY TCP4 1.2.3.4 5.6.7.8 1234 9999\r\nGET / HTTP/1.0\r\n\r\n");
+        like $resp, qr{^HTTP/1.1 200 OK\r\n}s;
+        is last_log(), "1.2.3.4";
+    };
+    subtest "without proxy" => sub {
+        my $resp = fetch("GET / HTTP/1.0\r\n\r\n");
+        like $resp, qr{^HTTP/1.1 200 OK\r\n}s;
+        is last_log(), "127.0.0.1";
+    };
+};
+
+subtest "https" => sub {
+    my $guard = spawn_h2o(1, 1);
+    subtest "with proxy" => sub {
+        my $resp = fetch_ssl("PROXY TCP4 1.2.3.4 5.6.7.8 1234 9999\r\n", "GET / HTTP/1.0\r\n\r\n");
+        like $resp, qr{^HTTP/1.1 200 OK\r\n}s;
+        is last_log(), "1.2.3.4";
+    };
+    subtest "without proxy" => sub {
+        my $resp = fetch_ssl("", "GET / HTTP/1.0\r\n\r\n");
+        like $resp, qr{^HTTP/1.1 200 OK\r\n}s;
+        is last_log(), "127.0.0.1";
+    };
+};
+
+subtest "off" => sub {
+    my $guard = spawn_h2o(0, 0);
+    subtest "with proxy" => sub {
+        my $resp = fetch("PROXY TCP4 1.2.3.4 5.6.7.8 1234 9999\r\nGET / HTTP/1.0\r\n\r\n");
+        unlike $resp, qr{^HTTP/1.1 200 OK\r\n}s;
+    };
+    subtest "without proxy" => sub {
+        my $resp = fetch("GET / HTTP/1.0\r\n\r\n");
+        like $resp, qr{^HTTP/1.1 200 OK\r\n}s;
+    };
+};
+
+done_testing;


### PR DESCRIPTION
The PROXY protocol is a simple protocol defined in http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt.  As discussed in #350, it is useful for running a TCP-based server behind L4-level load balancers such as HAProxy or Amazon AWS ELB.

This PR implements version 1 of the protocol.

The server can be configured to accept the protocol by adding `proxy-protocol: ON` to the `listen` directive, e.g.:

```
listen:
    port: 443
    proxy-protocol: ON
    ssl:
        ...
```