### PR TITLE
[h2o_mruby] Add H2O class and simple method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,8 @@ SET(LIB_SOURCE_FILES
     lib/handler/redirect.c
     lib/handler/reproxy.c
     lib/handler/mruby.c
+    lib/handler/mruby/init.c
+    lib/handler/mruby/class/core.c
     lib/handler/configurator/access_log.c
     lib/handler/configurator/expires.c
     lib/handler/configurator/fastcgi.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/mruby.c
     lib/handler/mruby/init.c
     lib/handler/mruby/class/core.c
+    lib/handler/mruby/class/request.c
     lib/handler/configurator/access_log.c
     lib/handler/configurator/expires.c
     lib/handler/configurator/fastcgi.c

--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -5,4 +5,5 @@
 
 h = "hello"
 m =  "from h2o_mruby"
+H2O::Request.new.log_error h + m
 h + " " + m + "\n"

--- a/include/h2o/mruby.h
+++ b/include/h2o/mruby.h
@@ -4,6 +4,10 @@
 #include "h2o.h"
 #include <mruby.h>
 
+#define H2O_MRUBY_MODULE_NAME "h2o_mruby"
+#define H2O_MRUBY_MODULE_VERSION "0.0.1"
+#define H2O_MRUBY_MODULE_DESCRIPTION H2O_MRUBY_MODULE_NAME "/" H2O_MRUBY_MODULE_VERSION
+
 struct st_h2o_mruby_config_vars_t {
     h2o_iovec_t mruby_handler_path;
 };
@@ -16,6 +20,12 @@ struct st_h2o_mruby_handler_t {
 };
 
 typedef struct st_h2o_mruby_handler_t h2o_mruby_handler_t;
+
+struct st_h2o_mruby_internal_context_t {
+    h2o_req_t *req;
+};
+
+typedef struct st_h2o_mruby_internal_context_t h2o_mruby_internal_context_t;
 
 /* handler/mruby.c */
 h2o_mruby_handler_t *h2o_mruby_register(h2o_pathconf_t *pathconf, h2o_mruby_config_vars_t *vars);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -35,6 +35,8 @@
 #define MODULE_VERSION "0.0.1"
 #define MODULE_DESCRIPTION MODULE_NAME "/" MODULE_VERSION
 
+void h2o_mrb_class_init(mrb_state *mrb);
+
 enum code_type { H2O_MRUBY_STRING, H2O_MRUBY_FILE };
 
 struct st_h2o_mruby_code_t {
@@ -92,6 +94,7 @@ static void on_context_init(h2o_handler_t *_handler, h2o_context_t *ctx)
 
     /* ctx has a mrb_state per thread */
     handler_ctx->mrb = mrb_open();
+    h2o_mrb_class_init(handler_ctx->mrb);
     handler_ctx->h2o_mruby_handler_code = h2o_mem_alloc(sizeof(*handler_ctx->h2o_mruby_handler_code));
 
     if (handler_ctx->mrb) {

--- a/lib/handler/mruby/class/core.c
+++ b/lib/handler/mruby/class/core.c
@@ -29,12 +29,12 @@
 
 static mrb_value h2o_mrb_max_headers(mrb_state *mrb, mrb_value self)
 {
-  return mrb_fixnum_value(H2O_MAX_HEADERS);
+    return mrb_fixnum_value(H2O_MAX_HEADERS);
 }
 
 void h2o_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
 {
-  mrb_define_class_method(mrb, class, "max_headers", h2o_mrb_max_headers, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, class, "max_headers", h2o_mrb_max_headers, MRB_ARGS_NONE());
 }
 
 #endif /* H2O_USE_MRUBY */

--- a/lib/handler/mruby/class/core.c
+++ b/lib/handler/mruby/class/core.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014,2015 DeNA Co., Ltd., Kazuho Oku, Ryosuke Matsumoto
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifdef H2O_USE_MRUBY
+
+#include "h2o.h"
+
+#include "mruby.h"
+#include "mruby/string.h"
+
+static mrb_value h2o_mrb_max_headers(mrb_state *mrb, mrb_value self)
+{
+  return mrb_fixnum_value(H2O_MAX_HEADERS);
+}
+
+void h2o_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
+{
+  mrb_define_class_method(mrb, class, "max_headers", h2o_mrb_max_headers, MRB_ARGS_NONE());
+}
+
+#endif /* H2O_USE_MRUBY */

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -32,27 +32,27 @@
 
 static mrb_value h2o_mrb_req_init(mrb_state *mrb, mrb_value self)
 {
-  return self;
+    return self;
 }
 
 static mrb_value h2o_mrb_req_log_error(mrb_state *mrb, mrb_value self)
 {
-  h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
-  mrb_value log;
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+    mrb_value log;
 
-  mrb_get_args(mrb, "o", &log);
-  h2o_req_log_error(mruby_ctx->req, H2O_MRUBY_MODULE_NAME, "%.*s", RSTRING_LEN(log), RSTRING_PTR(log));
+    mrb_get_args(mrb, "o", &log);
+    h2o_req_log_error(mruby_ctx->req, H2O_MRUBY_MODULE_NAME, "%.*s", RSTRING_LEN(log), RSTRING_PTR(log));
 
-  return log;
+    return log;
 }
 
 void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
 {
-  struct RClass *class_request;
-  class_request = mrb_define_class_under(mrb, class, "Request", mrb->object_class);
+    struct RClass *class_request;
+    class_request = mrb_define_class_under(mrb, class, "Request", mrb->object_class);
 
-  mrb_define_method(mrb, class_request, "initialize", h2o_mrb_req_init, MRB_ARGS_NONE());
-  mrb_define_method(mrb, class_request, "log_error", h2o_mrb_req_log_error, MRB_ARGS_REQ(1));
+    mrb_define_method(mrb, class_request, "initialize", h2o_mrb_req_init, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "log_error", h2o_mrb_req_log_error, MRB_ARGS_REQ(1));
 }
 
 #endif /* H2O_USE_MRUBY */

--- a/lib/handler/mruby/init.c
+++ b/lib/handler/mruby/init.c
@@ -32,13 +32,14 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class);
 
 void h2o_mrb_class_init(mrb_state *mrb)
 {
-  struct RClass *class;
+    struct RClass *class;
 
-  class = mrb_define_class(mrb, "H2O", mrb->object_class);
+    class = mrb_define_class(mrb, "H2O", mrb->object_class);
 
-  h2o_mrb_core_class_init(mrb, class); GC_ARENA_RESTORE;
-  h2o_mrb_request_class_init(mrb, class); GC_ARENA_RESTORE;
-
+    h2o_mrb_core_class_init(mrb, class);
+    GC_ARENA_RESTORE;
+    h2o_mrb_request_class_init(mrb, class);
+    GC_ARENA_RESTORE;
 }
 
 #endif /* H2O_USE_MRUBY */

--- a/lib/handler/mruby/init.c
+++ b/lib/handler/mruby/init.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014,2015 DeNA Co., Ltd., Kazuho Oku, Ryosuke Matsumoto
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifdef H2O_USE_MRUBY
+
+#include <mruby.h>
+#include <mruby/compile.h>
+
+#define GC_ARENA_RESTORE mrb_gc_arena_restore(mrb, 0);
+
+void h2o_mrb_core_class_init(mrb_state *mrb, struct RClass *class);
+
+void h2o_mrb_class_init(mrb_state *mrb)
+{
+  struct RClass *class;
+
+  class = mrb_define_class(mrb, "H2O", mrb->object_class);
+
+  h2o_mrb_core_class_init(mrb, class); GC_ARENA_RESTORE;
+
+}
+
+#endif /* H2O_USE_MRUBY */

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -14,14 +14,20 @@ hosts:
     paths:
       /:
         file.dir: examples/doc_root
-        mruby.handler_path: examples/h2o_mruby/hello.rb
 $extra_conf
 EOT
     return `curl --silent /dev/stderr http://127.0.0.1:$server->{port}/ 2>&1`;
 }
 
 
-my $resp = fetch('');
+my $resp = fetch(<< 'EOT');
+        mruby.handler_path: examples/h2o_mruby/hello.rb
+EOT
 is $resp, "hello from h2o_mruby\n", "resoponse body from mruby";
+
+$resp = fetch(<< 'EOT');
+        mruby.handler_path: t/50mruby/max_header.rb
+EOT
+is $resp, "100", "H2O.max_headers method";
 
 done_testing();

--- a/t/50mruby/max_header.rb
+++ b/t/50mruby/max_header.rb
@@ -1,0 +1,1 @@
+H2O.max_headers.to_s


### PR DESCRIPTION
h2o_mruby support H2O class of mruby. For now, I implemented `H2O.max_headers` method.

```ruby
H2O.max_headers #=> 100
```