### PR TITLE
Configurable timeout for TLS handshake and the PROXY protocol

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -61,6 +61,8 @@ extern "C" {
 
 #define H2O_DEFAULT_MAX_REQUEST_ENTITY_SIZE (1024 * 1024 * 1024)
 #define H2O_DEFAULT_MAX_DELEGATIONS 5
+#define H2O_DEFAULT_HANDSHAKE_TIMEOUT_IN_SECS 10
+#define H2O_DEFAULT_HANDSHAKE_TIMEOUT (H2O_DEFAULT_HANDSHAKE_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_HTTP1_REQ_TIMEOUT_IN_SECS 10
 #define H2O_DEFAULT_HTTP1_REQ_TIMEOUT (H2O_DEFAULT_HTTP1_REQ_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2 1
@@ -227,6 +229,11 @@ struct st_h2o_globalconf_t {
      */
     unsigned max_delegations;
 
+    /**
+     * SSL handshake timeout
+     */
+    uint64_t handshake_timeout;
+
     struct {
         /**
          * request timeout (in milliseconds)
@@ -321,6 +328,11 @@ struct st_h2o_context_t {
      * flag indicating if shutdown has been requested
      */
     int shutdown_requested;
+
+    /**
+     * SSL handshake timeout
+     */
+    h2o_timeout_t handshake_timeout;
 
     struct {
         /**

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -91,6 +91,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->server_name = h2o_iovec_init(H2O_STRLIT("h2o/" H2O_VERSION));
     config->max_request_entity_size = H2O_DEFAULT_MAX_REQUEST_ENTITY_SIZE;
     config->max_delegations = H2O_DEFAULT_MAX_DELEGATIONS;
+    config->handshake_timeout = H2O_DEFAULT_HANDSHAKE_TIMEOUT;
     config->http1.req_timeout = H2O_DEFAULT_HTTP1_REQ_TIMEOUT;
     config->http1.upgrade_to_http2 = H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2;
     config->http1.callbacks = H2O_HTTP1_CALLBACKS;

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -94,6 +94,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     ctx->queue = h2o_multithread_create_queue(loop);
     h2o_multithread_register_receiver(ctx->queue, &ctx->receivers.hostinfo_getaddr, h2o_hostinfo_getaddr_receiver);
 
+    h2o_timeout_init(ctx->loop, &ctx->handshake_timeout, config->handshake_timeout);
     h2o_timeout_init(ctx->loop, &ctx->http1.req_timeout, config->http1.req_timeout);
     h2o_timeout_init(ctx->loop, &ctx->http2.idle_timeout, config->http2.idle_timeout);
     h2o_linklist_init_anchor(&ctx->http2._conns);
@@ -135,6 +136,7 @@ void h2o_context_dispose(h2o_context_t *ctx)
     free(ctx->_module_configs);
     h2o_timeout_dispose(ctx->loop, &ctx->zero_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->one_sec_timeout);
+    h2o_timeout_dispose(ctx->loop, &ctx->handshake_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http1.req_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http2.idle_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->proxy.io_timeout);

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -29,19 +29,57 @@
 #include "h2o/http1.h"
 #include "h2o/http2.h"
 
+struct st_h2o_accept_data_t {
+    h2o_accept_ctx_t *ctx;
+    h2o_socket_t *sock;
+    h2o_timeout_entry_t timeout;
+};
+
+static void on_accept_timeout(h2o_timeout_entry_t *entry);
+
+static struct st_h2o_accept_data_t *create_accept_data(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
+{
+    struct st_h2o_accept_data_t *data = h2o_mem_alloc(sizeof(*data));
+
+    data->ctx = ctx;
+    data->sock = sock;
+    data->timeout = (h2o_timeout_entry_t){};
+    data->timeout.cb = on_accept_timeout;
+    h2o_timeout_link(ctx->ctx->loop, &ctx->ctx->handshake_timeout, &data->timeout);
+
+    sock->data = data;
+    return data;
+}
+
+static h2o_accept_ctx_t *free_accept_data(struct st_h2o_accept_data_t *data)
+{
+    h2o_accept_ctx_t *ctx = data->ctx;
+    h2o_timeout_unlink(&data->timeout);
+    free(data);
+    return ctx;
+}
+
+void on_accept_timeout(h2o_timeout_entry_t *entry)
+{
+    /* TODO log */
+    struct st_h2o_accept_data_t *data = H2O_STRUCT_FROM_MEMBER(struct st_h2o_accept_data_t, timeout, entry);
+    h2o_socket_t *sock = data->sock;
+    free_accept_data(data);
+    h2o_socket_close(sock);
+}
+
 static void on_ssl_handshake_complete(h2o_socket_t *sock, int status)
 {
-    const h2o_iovec_t *ident;
-    h2o_accept_ctx_t *ctx = sock->data;
+    h2o_accept_ctx_t *ctx = free_accept_data(sock->data);
     sock->data = NULL;
 
-    h2o_iovec_t proto;
     if (status != 0) {
         h2o_socket_close(sock);
         return;
     }
 
-    proto = h2o_socket_ssl_get_selected_protocol(sock);
+    h2o_iovec_t proto = h2o_socket_ssl_get_selected_protocol(sock);
+    const h2o_iovec_t *ident;
     for (ident = h2o_http2_alpn_protocols; ident->len != 0; ++ident) {
         if (proto.len == ident->len && memcmp(proto.base, ident->base, proto.len) == 0) {
             goto Is_Http2;
@@ -54,14 +92,6 @@ static void on_ssl_handshake_complete(h2o_socket_t *sock, int status)
 Is_Http2:
     /* connect as http2 */
     h2o_http2_accept(ctx, sock);
-}
-
-static void accept_ssl_or_http1(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
-{
-    if (ctx->ssl_ctx != NULL)
-        h2o_socket_ssl_server_handshake(sock, ctx->ssl_ctx, on_ssl_handshake_complete);
-    else
-        h2o_http1_accept(ctx, sock);
 }
 
 static ssize_t parse_proxy_line(char *src, size_t len, struct sockaddr *sa, socklen_t *salen)
@@ -162,7 +192,10 @@ SkipToEOL:
 
 static void on_read_proxy_line(h2o_socket_t *sock, int status)
 {
+    struct st_h2o_accept_data_t *data = sock->data;
+
     if (status != 0) {
+        free_accept_data(data);
         h2o_socket_close(sock);
         return;
     }
@@ -182,16 +215,27 @@ static void on_read_proxy_line(h2o_socket_t *sock, int status)
         break;
     }
 
-    accept_ssl_or_http1(sock->data, sock);
+    if (data->ctx->ssl_ctx != NULL) {
+        h2o_socket_ssl_server_handshake(sock, data->ctx->ssl_ctx, on_ssl_handshake_complete);
+    } else {
+        h2o_accept_ctx_t *ctx = free_accept_data(data);
+        sock->data = NULL;
+        h2o_http1_accept(ctx, sock);
+    }
 }
 
 void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
 {
-    sock->data = ctx;
-    if (ctx->expect_proxy_line)
-        h2o_socket_read_start(sock, on_read_proxy_line);
-    else
-        accept_ssl_or_http1(ctx, sock);
+    if (ctx->expect_proxy_line || ctx->ssl_ctx != NULL) {
+        create_accept_data(ctx, sock);
+        if (ctx->expect_proxy_line) {
+            h2o_socket_read_start(sock, on_read_proxy_line);
+        } else {
+            h2o_socket_ssl_server_handshake(sock, ctx->ssl_ctx, on_ssl_handshake_complete);
+        }
+    } else {
+        h2o_http1_accept(ctx, sock);
+    }
 }
 
 size_t h2o_stringify_protocol_version(char *dst, int version)


### PR DESCRIPTION
H2O lacks timeout configuration for TLS handshake and the PROXY protocol recently added in #386.

This PR implements the timeout with the configuration variable named `handshake-timeout`.