### PR TITLE
pass `HTTPS: on` to fcgi app. if the connection is HTTPS

### DIFF
--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -269,6 +269,9 @@ static void append_params(h2o_req_t *req, iovec_vector_t *vecs, h2o_fastcgi_conf
     /* SERVER_SOFTWARE */
     append_pair(&req->pool, vecs, H2O_STRLIT("SERVER_SOFTWARE"), req->conn->ctx->globalconf->server_name.base,
                 req->conn->ctx->globalconf->server_name.len);
+    /* set HTTPS: on if necessary */
+    if (req->scheme == &H2O_URL_SCHEME_HTTPS)
+        append_pair(&req->pool, vecs, H2O_STRLIT("HTTPS"), H2O_STRLIT("on"));
     { /* headers */
         const h2o_header_t *h = req->headers.entries, *h_end = h + req->headers.size;
         size_t cookie_length = 0;

--- a/t/50fastcgi.t
+++ b/t/50fastcgi.t
@@ -66,10 +66,18 @@ EOT
             # send header that exceeds the max. length fcgi record (the size of the response also exceeds the record size, and uses chunked encoding)
             my $doit = sub {
                 my ($proto, $port) = @_;
-                my $content = `curl --silent --show-error --insecure -H foo:@{["0123456789"x7000]} $proto://127.0.0.1:$port/echo-headers`;
-                like $content, qr/^foo: (0123456789){7000,7000}$/mi;
+                subtest $proto => sub {
+                    my $content = `curl --silent --show-error --insecure -H foo:@{["0123456789"x7000]} $proto://127.0.0.1:$port/echo-headers`;
+                    like $content, qr/^foo: (0123456789){7000,7000}$/mi;
+                    if ($proto eq 'https') {
+                        like $content, qr/^https: on$/m;
+                    } else {
+                        unlike $content, qr/^https: on$/m;
+                    }
+                };
             };
             $doit->('http', $server->{port});
+            $doit->('https', $server->{tls_port});
         };
         subtest 'cookie-merge' => sub {
             plan skip_all => "curl does not support HTTP/2"

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -78,7 +78,7 @@ builder {
                 'content-type' => 'text/plain',
             ],
             [
-                join "\n", map { my $n = lc substr $_, 5; $n =~ tr/_/-/; "$n: $env->{$_}" } sort grep { /^HTTP_/ } keys %$env,
+                join "\n", map { my $n = lc $_; $n=~ s/^http_//; $n =~ tr/_/-/; "$n: $env->{$_}" } sort grep { /^(HTTP_|HTTPS$)/ } keys %$env,
             ]
         ];
     };


### PR DESCRIPTION
As suggested in #397 some FastCGI-based web applications use `HTTPS` variable of the input to determine the protocol.

This PR changes the fastcgi handler of H2O to automatically set the variable.

FWIW a complete list of variables that could possibly be set by the Apache HTTP server can be found [here](http://httpd.apache.org/docs/2.4/mod/mod_ssl.html).