### PR TITLE
[h2o_mruby] Add header method on on_req

### DIFF
--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -3,7 +3,17 @@
 #     file.dir: examples/doc_root
 #     mruby.handler_path: /path/to/hello.rb
 
+r = H2O::Request.new
+
 h = "hello"
 m =  "from h2o_mruby"
-H2O::Request.new.log_error h + m
-h + " " + m + "\n"
+
+ua = r.headers_in["User-Agent"].to_s
+host = r.headers_in["Accept"].to_s
+
+msg = h + " " + m + " from " + ua + ":" + host
+
+r.log_error msg
+
+msg + "\n"
+

--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -9,12 +9,13 @@ h = "hello"
 m =  "from h2o_mruby"
 
 ua = r.headers_in["User-Agent"].to_s
-host = r.headers_in["Accept"].to_s
+accept = r.headers_in["Accept"].to_s
+new_ua = r.headers_in["User-Agent"] = "new-#{ua}-h2o_mruby"
 
 r.headers_out["Hoge"] = "fuga"
 hoge = r.headers_out["Hoge"]
 
-msg = h + " " + m + " from " + ua + ":" + host + " " + hoge
+msg = h + " " + m + " from " + ua + ":" + new_ua + " " + accept + " " + hoge
 
 
 r.log_error msg

--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -11,7 +11,11 @@ m =  "from h2o_mruby"
 ua = r.headers_in["User-Agent"].to_s
 host = r.headers_in["Accept"].to_s
 
-msg = h + " " + m + " from " + ua + ":" + host
+r.headers_out["Hoge"] = "fuga"
+hoge = r.headers_out["Hoge"]
+
+msg = h + " " + m + " from " + ua + ":" + host + " " + hoge
+
 
 r.log_error msg
 

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -152,6 +152,10 @@ static int on_req(h2o_handler_t *_handler, h2o_req_t *req)
         fprintf(stderr, "%s: mruby raised: %s\n", H2O_MRUBY_MODULE_NAME, error->as.heap.ptr);
         mrb->exc = 0;
         h2o_send_error(req, 500, "Internal Server Error", "Internal Server Error", 0);
+    } else if (mrb_nil_p(result)) {
+        /* decline to send response for next handler when return value is nil */
+        mrb_gc_arena_restore(mrb, ai);
+        return -1;
     } else {
         h2o_send_error(req, 200, "OK", mrb_str_to_cstr(mrb, result), 0);
     }

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -31,7 +31,6 @@
 #include "mruby/class.h"
 #include <mruby/variable.h>
 
-
 static mrb_value h2o_mrb_req_init(mrb_state *mrb, mrb_value self)
 {
     return self;
@@ -50,17 +49,17 @@ static mrb_value h2o_mrb_req_log_error(mrb_state *mrb, mrb_value self)
 
 static mrb_value h2o_mrb_get_class_obj(mrb_state *mrb, mrb_value self, char *obj_id, char *class_name)
 {
-  mrb_value obj;
-  struct RClass *obj_class, *h2o_class;
+    mrb_value obj;
+    struct RClass *obj_class, *h2o_class;
 
-  obj = mrb_iv_get(mrb, self, mrb_intern_cstr(mrb, obj_id));
-  if (mrb_nil_p(obj)) {
-    h2o_class = mrb_class_get(mrb, "H2O");
-    obj_class = (struct RClass*)mrb_class_ptr(mrb_const_get(mrb, mrb_obj_value(h2o_class), mrb_intern_cstr(mrb, class_name)));
-    obj = mrb_obj_new(mrb, obj_class, 0, NULL);
-    mrb_iv_set(mrb, self, mrb_intern_cstr(mrb, obj_id), obj);
-  }
-  return obj;
+    obj = mrb_iv_get(mrb, self, mrb_intern_cstr(mrb, obj_id));
+    if (mrb_nil_p(obj)) {
+        h2o_class = mrb_class_get(mrb, "H2O");
+        obj_class = (struct RClass *)mrb_class_ptr(mrb_const_get(mrb, mrb_obj_value(h2o_class), mrb_intern_cstr(mrb, class_name)));
+        obj = mrb_obj_new(mrb, obj_class, 0, NULL);
+        mrb_iv_set(mrb, self, mrb_intern_cstr(mrb, obj_id), obj);
+    }
+    return obj;
 }
 
 static mrb_value h2o_mrb_headers_in_obj(mrb_state *mrb, mrb_value self)
@@ -73,68 +72,70 @@ static mrb_value h2o_mrb_headers_out_obj(mrb_state *mrb, mrb_value self)
     return h2o_mrb_get_class_obj(mrb, self, "headers_out_obj", "Headers_out");
 }
 
-static mrb_value h2o_mrb_get_request_headers_in(mrb_state *mrb, mrb_value self) 
+static mrb_value h2o_mrb_get_request_headers_in(mrb_state *mrb, mrb_value self)
 {
-  h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
-  mrb_value key;
-  ssize_t index;
-  h2o_header_t *h;
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+    mrb_value key;
+    ssize_t index;
+    h2o_header_t *h;
 
-  mrb_get_args(mrb, "o", &key);
-  key = mrb_funcall(mrb, key, "downcase", 0);
+    mrb_get_args(mrb, "o", &key);
+    key = mrb_funcall(mrb, key, "downcase", 0);
 
-  index = h2o_find_header_by_str(&mruby_ctx->req->headers, RSTRING_PTR(key), RSTRING_LEN(key), -1);
-  if (index == -1)
-    return mrb_nil_value();
+    index = h2o_find_header_by_str(&mruby_ctx->req->headers, RSTRING_PTR(key), RSTRING_LEN(key), -1);
+    if (index == -1)
+        return mrb_nil_value();
 
-  h = mruby_ctx->req->headers.entries + index;
+    h = mruby_ctx->req->headers.entries + index;
 
-  return mrb_str_new(mrb, h->value.base, h->value.len);
+    return mrb_str_new(mrb, h->value.base, h->value.len);
 }
 
-static mrb_value h2o_mrb_set_request_headers_in(mrb_state *mrb, mrb_value self) 
+static mrb_value h2o_mrb_set_request_headers_in(mrb_state *mrb, mrb_value self)
 {
-  h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
-  mrb_value key, val;
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+    mrb_value key, val;
 
-  mrb_get_args(mrb, "oo", &key, &val);
-  key = mrb_funcall(mrb, key, "downcase", 0);
+    mrb_get_args(mrb, "oo", &key, &val);
+    key = mrb_funcall(mrb, key, "downcase", 0);
 
-  h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->headers, RSTRING_PTR(key), RSTRING_LEN(key), 0, RSTRING_PTR(val), RSTRING_LEN(val), 1);
+    h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->headers, RSTRING_PTR(key), RSTRING_LEN(key), 0, RSTRING_PTR(val),
+                          RSTRING_LEN(val), 1);
 
-  return key;
+    return key;
 }
 
-static mrb_value h2o_mrb_get_request_headers_out(mrb_state *mrb, mrb_value self) 
+static mrb_value h2o_mrb_get_request_headers_out(mrb_state *mrb, mrb_value self)
 {
-  h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
-  mrb_value key;
-  ssize_t index;
-  h2o_header_t *h;
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+    mrb_value key;
+    ssize_t index;
+    h2o_header_t *h;
 
-  mrb_get_args(mrb, "o", &key);
-  key = mrb_funcall(mrb, key, "downcase", 0);
+    mrb_get_args(mrb, "o", &key);
+    key = mrb_funcall(mrb, key, "downcase", 0);
 
-  index = h2o_find_header_by_str(&mruby_ctx->req->res.headers, RSTRING_PTR(key), RSTRING_LEN(key), -1);
-  if (index == -1)
-    return mrb_nil_value();
+    index = h2o_find_header_by_str(&mruby_ctx->req->res.headers, RSTRING_PTR(key), RSTRING_LEN(key), -1);
+    if (index == -1)
+        return mrb_nil_value();
 
-  h = mruby_ctx->req->res.headers.entries + index;
+    h = mruby_ctx->req->res.headers.entries + index;
 
-  return mrb_str_new(mrb, h->value.base, h->value.len);
+    return mrb_str_new(mrb, h->value.base, h->value.len);
 }
 
-static mrb_value h2o_mrb_set_request_headers_out(mrb_state *mrb, mrb_value self) 
+static mrb_value h2o_mrb_set_request_headers_out(mrb_state *mrb, mrb_value self)
 {
-  h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
-  mrb_value key, val;
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+    mrb_value key, val;
 
-  mrb_get_args(mrb, "oo", &key, &val);
-  key = mrb_funcall(mrb, key, "downcase", 0);
+    mrb_get_args(mrb, "oo", &key, &val);
+    key = mrb_funcall(mrb, key, "downcase", 0);
 
-  h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->res.headers, RSTRING_PTR(key), RSTRING_LEN(key), 0, RSTRING_PTR(val), RSTRING_LEN(val), 1);
+    h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->res.headers, RSTRING_PTR(key), RSTRING_LEN(key), 0,
+                          RSTRING_PTR(val), RSTRING_LEN(val), 1);
 
-  return key;
+    return key;
 }
 
 void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -92,6 +92,19 @@ static mrb_value h2o_mrb_get_request_headers_in(mrb_state *mrb, mrb_value self)
   return mrb_str_new(mrb, h->value.base, h->value.len);
 }
 
+static mrb_value h2o_mrb_set_request_headers_in(mrb_state *mrb, mrb_value self) 
+{
+  h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+  mrb_value key, val;
+
+  mrb_get_args(mrb, "oo", &key, &val);
+  key = mrb_funcall(mrb, key, "downcase", 0);
+
+  h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->headers, RSTRING_PTR(key), RSTRING_LEN(key), 0, RSTRING_PTR(val), RSTRING_LEN(val), 1);
+
+  return key;
+}
+
 static mrb_value h2o_mrb_get_request_headers_out(mrb_state *mrb, mrb_value self) 
 {
   h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
@@ -140,6 +153,7 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
     /* request haeder class */
     class_headers_in = mrb_define_class_under(mrb, class, "Headers_in", mrb->object_class);
     mrb_define_method(mrb, class_headers_in, "[]", h2o_mrb_get_request_headers_in, MRB_ARGS_REQ(1));
+    mrb_define_method(mrb, class_headers_in, "[]=", h2o_mrb_set_request_headers_in, MRB_ARGS_REQ(2));
 
     /* response haeder class */
     class_headers_out = mrb_define_class_under(mrb, class, "Headers_out", mrb->object_class);

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -68,6 +68,11 @@ static mrb_value h2o_mrb_headers_in_obj(mrb_state *mrb, mrb_value self)
     return h2o_mrb_get_class_obj(mrb, self, "headers_in_obj", "Headers_in");
 }
 
+static mrb_value h2o_mrb_headers_out_obj(mrb_state *mrb, mrb_value self)
+{
+    return h2o_mrb_get_class_obj(mrb, self, "headers_out_obj", "Headers_out");
+}
+
 static mrb_value h2o_mrb_get_request_headers_in(mrb_state *mrb, mrb_value self) 
 {
   h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
@@ -87,20 +92,59 @@ static mrb_value h2o_mrb_get_request_headers_in(mrb_state *mrb, mrb_value self)
   return mrb_str_new(mrb, h->value.base, h->value.len);
 }
 
+static mrb_value h2o_mrb_get_request_headers_out(mrb_state *mrb, mrb_value self) 
+{
+  h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+  mrb_value key;
+  ssize_t index;
+  h2o_header_t *h;
+
+  mrb_get_args(mrb, "o", &key);
+  key = mrb_funcall(mrb, key, "downcase", 0);
+
+  index = h2o_find_header_by_str(&mruby_ctx->req->res.headers, RSTRING_PTR(key), RSTRING_LEN(key), -1);
+  if (index == -1)
+    return mrb_nil_value();
+
+  h = mruby_ctx->req->res.headers.entries + index;
+
+  return mrb_str_new(mrb, h->value.base, h->value.len);
+}
+
+static mrb_value h2o_mrb_set_request_headers_out(mrb_state *mrb, mrb_value self) 
+{
+  h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+  mrb_value key, val;
+
+  mrb_get_args(mrb, "oo", &key, &val);
+  key = mrb_funcall(mrb, key, "downcase", 0);
+
+  h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->res.headers, RSTRING_PTR(key), RSTRING_LEN(key), 0, RSTRING_PTR(val), RSTRING_LEN(val), 1);
+
+  return key;
+}
+
 void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
 {
     struct RClass *class_request;
     struct RClass *class_headers_in;
+    struct RClass *class_headers_out;
 
     class_request = mrb_define_class_under(mrb, class, "Request", mrb->object_class);
 
     mrb_define_method(mrb, class_request, "initialize", h2o_mrb_req_init, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "log_error", h2o_mrb_req_log_error, MRB_ARGS_REQ(1));
     mrb_define_method(mrb, class_request, "headers_in", h2o_mrb_headers_in_obj, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "headers_out", h2o_mrb_headers_out_obj, MRB_ARGS_NONE());
 
     /* request haeder class */
     class_headers_in = mrb_define_class_under(mrb, class, "Headers_in", mrb->object_class);
     mrb_define_method(mrb, class_headers_in, "[]", h2o_mrb_get_request_headers_in, MRB_ARGS_REQ(1));
+
+    /* response haeder class */
+    class_headers_out = mrb_define_class_under(mrb, class, "Headers_out", mrb->object_class);
+    mrb_define_method(mrb, class_headers_out, "[]", h2o_mrb_get_request_headers_out, MRB_ARGS_REQ(1));
+    mrb_define_method(mrb, class_headers_out, "[]=", h2o_mrb_set_request_headers_out, MRB_ARGS_REQ(2));
 }
 
 #endif /* H2O_USE_MRUBY */

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -22,6 +22,18 @@ EOT
     return `curl --silent /dev/stderr -H User-Agent:h2o_mruby_test http://127.0.0.1:$server->{port}/ 2>&1`;
 }
 
+sub fetch_header {
+    my $extra_conf = shift;
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: examples/doc_root
+$extra_conf
+EOT
+    return `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/ 2>&1`;
+}
 
 my $resp = fetch(<< 'EOT');
         mruby.handler_path: t/50mruby/hello.rb
@@ -37,5 +49,10 @@ $resp = fetch(<< 'EOT');
         mruby.handler_path: t/50mruby/headers_in.rb
 EOT
 is $resp, "new-h2o_mruby_test", "H2O::Request#headers_in test";
+
+$resp = fetch_header(<< 'EOT');
+        mruby.handler_path: t/50mruby/headers_out.rb
+EOT
+like $resp, qr/^new-header:.*\Wh2o-mruby\W/im, "H2O::Response#headers_out test";
 
 done_testing();

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -19,7 +19,7 @@ hosts:
         file.dir: examples/doc_root
 $extra_conf
 EOT
-    return `curl --silent /dev/stderr http://127.0.0.1:$server->{port}/ 2>&1`;
+    return `curl --silent /dev/stderr -H User-Agent:h2o_mruby_test http://127.0.0.1:$server->{port}/ 2>&1`;
 }
 
 
@@ -32,5 +32,10 @@ $resp = fetch(<< 'EOT');
         mruby.handler_path: t/50mruby/max_header.rb
 EOT
 is $resp, "100", "H2O.max_headers method";
+
+$resp = fetch(<< 'EOT');
+        mruby.handler_path: t/50mruby/headers_in.rb
+EOT
+is $resp, "new-h2o_mruby_test", "H2O::Request#headers_in test";
 
 done_testing();

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -24,7 +24,7 @@ EOT
 
 
 my $resp = fetch(<< 'EOT');
-        mruby.handler_path: examples/h2o_mruby/hello.rb
+        mruby.handler_path: t/50mruby/hello.rb
 EOT
 is $resp, "hello from h2o_mruby\n", "resoponse body from mruby";
 

--- a/t/50mruby/headers_in.rb
+++ b/t/50mruby/headers_in.rb
@@ -1,0 +1,8 @@
+r = H2O::Request.new
+
+ua = r.headers_in["User-Agent"]
+
+r.headers_in["User-Agent"] = "new-#{ua}"
+
+
+r.headers_in["User-Agent"]

--- a/t/50mruby/headers_out.rb
+++ b/t/50mruby/headers_out.rb
@@ -1,0 +1,6 @@
+r = H2O::Request.new
+
+r.headers_out["new-header"] = "h2o-mruby"
+
+# pass to next handler
+nil

--- a/t/50mruby/hello.rb
+++ b/t/50mruby/hello.rb
@@ -1,0 +1,8 @@
+# paths:
+#   /:
+#     file.dir: examples/doc_root
+#     mruby.handler_path: /path/to/hello.rb
+
+h = "hello"
+m =  "from h2o_mruby"
+h + " " + m + "\n"


### PR DESCRIPTION
Hello @kazuho !!

I implemented some method which control both request and response headers. 

- hello.rb
```ruby
$ cat examples/h2o_mruby/hello.rb 
# paths:
#   /:
#     file.dir: examples/doc_root
#     mruby.handler_path: /path/to/hello.rb

r = H2O::Request.new

h = "hello"
m =  "from h2o_mruby"

ua = r.headers_in["User-Agent"].to_s
accept = r.headers_in["Accept"].to_s
new_ua = r.headers_in["User-Agent"] = "new-#{ua}-h2o_mruby"

r.headers_out["Hoge"] = "fuga"
hoge = r.headers_out["Hoge"]

msg = h + " " + m + " from " + ua + ":" + new_ua + " " + accept + " " + hoge

r.log_error msg

# pass to next handler when return value is nil
nil                                                                   
```

- curl
```
$ curl 127.0.0.1:8080/ -v -H User-Agent:h2o_mruby_test
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8080
> Accept: */*
> User-Agent:h2o_mruby_test
> 
< HTTP/1.1 200 OK
< Date: Sat, 18 Jul 2015 14:41:53 GMT
* Server h2o/1.3.2-alpha1 is not blacklisted
< Server: h2o/1.3.2-alpha1
< Connection: keep-alive
< Content-Length: 177
< hoge: fuga
< content-type: text/html
< last-modified: Mon, 22 Jun 2015 03:33:14 GMT
< etag: "558781fa-b1"
< accept-ranges: bytes
< 
<!DOCTYPE html>
<html>
  <head>
    <title>Welcome to H2O</title>
  </head>
  <body>
    <p>Welcome to H2O - an optimized HTTP server</p>
    <p>It works!</p>
  </body>
</html>
* Connection #0 to host 127.0.0.1 left intact
```

- logs

```
[h2o_mruby] in request:/:hello from h2o_mruby from h2o_mruby_test:new-h2o_mruby_test-h2o_mruby */* fuga
127.0.0.1 - - [18/Jul/2015:23:41:53 +0900] "GET / HTTP/1.1" 200 177 "-" "new-h2o_mruby_test-h2o_mruby"
```