### PR TITLE
[h2o_mruby] Add the method which return status code or declined behavior to h2o

### DIFF
--- a/include/h2o/mruby.h
+++ b/include/h2o/mruby.h
@@ -23,6 +23,7 @@ typedef struct st_h2o_mruby_handler_t h2o_mruby_handler_t;
 
 struct st_h2o_mruby_internal_context_t {
     h2o_req_t *req;
+    int is_last;
 };
 
 typedef struct st_h2o_mruby_internal_context_t h2o_mruby_internal_context_t;

--- a/lib/handler/mruby/class/core.c
+++ b/lib/handler/mruby/class/core.c
@@ -57,6 +57,8 @@ static mrb_value h2o_mrb_return(mrb_state *mrb, mrb_value self)
 
 void h2o_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
 {
+    mrb_define_const(mrb, class, "DECLINED", mrb_fixnum_value(-1));
+
     mrb_define_class_method(mrb, class, "max_headers", h2o_mrb_max_headers, MRB_ARGS_NONE());
     mrb_define_class_method(mrb, class, "return", h2o_mrb_return, MRB_ARGS_REQ(3));
 }

--- a/lib/handler/mruby/class/core.c
+++ b/lib/handler/mruby/class/core.c
@@ -23,6 +23,7 @@
 #ifdef H2O_USE_MRUBY
 
 #include "h2o.h"
+#include "h2o/mruby.h"
 
 #include "mruby.h"
 #include "mruby/string.h"
@@ -32,9 +33,32 @@ static mrb_value h2o_mrb_max_headers(mrb_state *mrb, mrb_value self)
     return mrb_fixnum_value(H2O_MAX_HEADERS);
 }
 
+static mrb_value h2o_mrb_return(mrb_state *mrb, mrb_value self)
+{
+    mrb_int status;
+    const char *reason, *body;
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+
+    reason = body = NULL;
+    mrb_get_args(mrb, "i|zz", &status, &reason, &body);
+    if (status == -1) {
+        /* pass to next handler */
+        mruby_ctx->is_last = 0;
+    } else {
+        if (reason == NULL || body == NULL)
+            mrb_raise(mrb, E_ARGUMENT_ERROR, "need both reason and body with status code");
+        /* send response using h2o_send_error */
+        h2o_send_error(mruby_ctx->req, status, reason, body, 0);
+        mruby_ctx->is_last = 1;
+    }
+
+    return mrb_fixnum_value(status);
+}
+
 void h2o_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
 {
     mrb_define_class_method(mrb, class, "max_headers", h2o_mrb_max_headers, MRB_ARGS_NONE());
+    mrb_define_class_method(mrb, class, "return", h2o_mrb_return, MRB_ARGS_REQ(3));
 }
 
 #endif /* H2O_USE_MRUBY */

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -16,7 +16,6 @@ hosts:
   default:
     paths:
       /:
-        file.dir: examples/doc_root
 $extra_conf
 EOT
     return `curl --silent /dev/stderr -H User-Agent:h2o_mruby_test http://127.0.0.1:$server->{port}/ 2>&1`;
@@ -29,30 +28,45 @@ hosts:
   default:
     paths:
       /:
-        file.dir: examples/doc_root
 $extra_conf
 EOT
     return `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/ 2>&1`;
 }
 
 my $resp = fetch(<< 'EOT');
+        file.dir: examples/doc_root
         mruby.handler_path: t/50mruby/hello.rb
 EOT
 is $resp, "hello from h2o_mruby\n", "resoponse body from mruby";
 
 $resp = fetch(<< 'EOT');
+        file.dir: examples/doc_root
         mruby.handler_path: t/50mruby/max_header.rb
 EOT
 is $resp, "100", "H2O.max_headers method";
 
 $resp = fetch(<< 'EOT');
+        file.dir: examples/doc_root
         mruby.handler_path: t/50mruby/headers_in.rb
 EOT
 is $resp, "new-h2o_mruby_test", "H2O::Request#headers_in test";
 
 $resp = fetch_header(<< 'EOT');
+        file.dir: examples/doc_root
         mruby.handler_path: t/50mruby/headers_out.rb
 EOT
 like $resp, qr/^new-header:.*\Wh2o-mruby\W/im, "H2O::Response#headers_out test";
+
+$resp = fetch(<< 'EOT');
+        file.dir: examples/doc_root
+        mruby.handler_path: t/50mruby/return_status.rb
+EOT
+is $resp, "not found", "H2O.return with status code test";
+
+$resp = fetch(<< 'EOT');
+        file.dir: t/50mruby/
+        mruby.handler_path: t/50mruby/return_declined.rb
+EOT
+is $resp, "I'm index.html\n", "H2O.return with declined code test";
 
 done_testing();

--- a/t/50mruby/index.html
+++ b/t/50mruby/index.html
@@ -1,0 +1,1 @@
+I'm index.html

--- a/t/50mruby/return_declined.rb
+++ b/t/50mruby/return_declined.rb
@@ -1,0 +1,1 @@
+H2O.return -1

--- a/t/50mruby/return_declined.rb
+++ b/t/50mruby/return_declined.rb
@@ -1,1 +1,1 @@
-H2O.return -1
+H2O.return H2O::DECLINED

--- a/t/50mruby/return_status.rb
+++ b/t/50mruby/return_status.rb
@@ -1,0 +1,1 @@
+H2O.return 404, "not found", "not found"


### PR DESCRIPTION
`H2O.return` method send http status code to clients, or decline to send response for next handler. It's useful in practice. If using this method, you can write access control which is the selective restriction of access to a place or other resource. But, I don't implement the method of request parameters yet like `H2O::Request#uri` or `H2O::Request#filename`. So I'll implement these method as soon!

- return http status code
```ruby
H2O.return 404, "not found", "not found"
```

- decline to send response for next handler
```ruby
H2O.return H2O::DECLINED
```