### PR TITLE
Add fail handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 CMakeCache.txt
 CMakeFiles/
 Makefile
+*.gch
 build/
 cmake_install.cmake
 xcuserdata

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/access_log.c
     lib/handler/chunked.c
     lib/handler/expires.c
+    lib/handler/fail.c
     lib/handler/fastcgi.c
     lib/handler/file.c
     lib/handler/headers.c
@@ -200,6 +201,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/reproxy.c
     lib/handler/configurator/access_log.c
     lib/handler/configurator/expires.c
+    lib/handler/configurator/fail.c
     lib/handler/configurator/fastcgi.c
     lib/handler/configurator/file.c
     lib/handler/configurator/headers.c

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,6 +11,7 @@ OUTPUT=\
     configure/http2_directives.html \
     configure/access_log_directives.html \
     configure/expires_directives.html \
+	configure/fail_directives.html \
     configure/fastcgi_directives.html \
     configure/file_directives.html \
     configure/headers_directives.html \

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1046,6 +1046,20 @@ void h2o_expires_register(h2o_pathconf_t *pathconf, h2o_expires_args_t *args);
  */
 void h2o_expires_register_configurator(h2o_globalconf_t *conf);
 
+/* lib/fail.c */
+
+typedef struct st_h2o_fail_handler_t h2o_fail_handler_t;
+
+/**
+ * registers the fail handler to the context
+ * @param status status code to be sent (e.g. 403, 404, 500, ...)
+ */
+h2o_fail_handler_t *h2o_fail_register(h2o_pathconf_t *pathconf, int status);
+/**
+ * registers the configurator
+ */
+void h2o_fail_register_configurator(h2o_globalconf_t *conf);
+
 /* lib/fastcgi.c */
 
 typedef struct st_h2o_fastcgi_handler_t h2o_fastcgi_handler_t;

--- a/lib/handler/configurator/fail.c
+++ b/lib/handler/configurator/fail.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "h2o.h"
+#include "h2o/configurator.h"
+
+static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    int status;
+
+    if (h2o_configurator_scanf(cmd, node, "%d", &status) != 0)
+        return -1;
+    if (status != 426 && !(400 <= status && status <= 417) && !(500 <= status && status <= 505)) {
+        h2o_configurator_errprintf(cmd, node, "fail status should be within 400 to 417, 426, or 500 to 505");
+        return -1;
+    }
+
+    h2o_fail_register(ctx->pathconf, status);
+
+    return 0;
+}
+
+void h2o_fail_register_configurator(h2o_globalconf_t *conf)
+{
+    h2o_configurator_t *c = h2o_configurator_create(conf, sizeof(*c));
+
+    h2o_configurator_define_command(c, "fail", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config);
+}

--- a/lib/handler/fail.c
+++ b/lib/handler/fail.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <stdlib.h>
+#include "h2o.h"
+
+struct st_h2o_fail_handler_t {
+    h2o_handler_t super;
+    int status;
+    const char *reason;
+};
+
+static int on_req(h2o_handler_t *_self, h2o_req_t *req)
+{
+    h2o_fail_handler_t *self = (void *) _self;
+    h2o_send_error(req, self->status, self->reason, self->reason, 0);
+    return 0;
+}
+
+static const char *reasons[] = {
+    /* 40x */
+    "Bad Request",
+    "Unauthorized",
+    "Payment Required",
+    "Forbidden",
+    "Not Found",
+    "Method Not Allowed",
+    "Not Acceptable",
+    "Proxy Authentication Required",
+    "Request Timeout",
+    "Conflict",
+    "Gone",
+    "Length Required",
+    "Precondition Failed",
+    "Payload Too Large",
+    "URI Too Long",
+    "Unsupported Media Type",
+    "Range Not Satisfiable",
+    "Expectation Failed",
+    /* 50x */
+    "Internal Server Error",
+    "Not Implemented",
+    "Bad Gateway",
+    "Service Unavailable",
+    "Gateway Timeout",
+    "HTTP Version not supported"
+};
+
+h2o_fail_handler_t *h2o_fail_register(h2o_pathconf_t *pathconf, int status)
+{
+    h2o_fail_handler_t *self = (void *)h2o_create_handler(pathconf, sizeof(*self));
+    self->super.on_req = on_req;
+    self->status = status;
+
+    if (400 <= status && status <= 417)
+        self->reason = reasons[status - 400];
+    else if (status == 426)
+        self->reason = "Upgrade Required";
+    else if (500 <= status && status <= 505)
+        self->reason = reasons[status - 500 + 18];
+    else
+        self->reason = "";
+
+    return self;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1352,6 +1352,7 @@ static void setup_configurators(void)
 
     h2o_access_log_register_configurator(&conf.globalconf);
     h2o_expires_register_configurator(&conf.globalconf);
+    h2o_fail_register_configurator(&conf.globalconf);
     h2o_fastcgi_register_configurator(&conf.globalconf);
     h2o_file_register_configurator(&conf.globalconf);
     h2o_headers_register_configurator(&conf.globalconf);

--- a/srcdoc/configure.mt
+++ b/srcdoc/configure.mt
@@ -15,6 +15,7 @@
 <li><a href="configure/http2_directives.html">HTTP/2</a>
 <li><a href="configure/access_log_directives.html">Access Log</a>
 <li><a href="configure/expires_directives.html">Expires</a>
+<li><a href="configure/fail_directives.html">Fail</a>
 <li><a href="configure/fastcgi_directives.html">FastCGI</a>
 <li><a href="configure/file_directives.html">File</a>
 <li><a href="configure/headers_directives.html">Headers</a>

--- a/srcdoc/configure/fail_directives.mt
+++ b/srcdoc/configure/fail_directives.mt
@@ -1,0 +1,35 @@
+? my $ctx = $main::context;
+? $_mt->wrapper_file("wrapper.mt", "Configure", "Fail Directives")->(sub {
+
+<p>
+This document describes the configuration directives of the fail handler.
+</p>
+
+<?
+$ctx->{directive}->(
+    name      => "fail",
+     levels    => [ qw(path) ],
+     desc      => q{Aborts the requests with the given status},
+)->(sub {
+?>
+<p>
+The directive aborts request processing and sends an error response with the given status.
+</p>
+<p>
+The argument should be a valid HTTP error code (400 to 417, 426, 500 to 505).
+</p>
+<?= $ctx->{example}->('Reject requests on unknown hosts', <<'EOT');
+hosts:
+    default:
+      /:
+        fail: 403
+    "example.com:80":
+        paths:
+            "/":
+                file.dir: /path/to/doc-root
+EOT
+?>
+
+? })
+
+? })

--- a/t/50fail.t
+++ b/t/50fail.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        fail: 403
+      /abc:
+        fail: 500
+EOT
+
+sub doit {
+    my ($url, $expected_status, $expected_reason) = @_;
+    my ($stderr, $stdout) = run_prog("curl --silent --show-error --insecure --max-redirs 0 --dump-header /dev/stderr $url");
+    like $stderr, qr{^HTTP/1\.1 $expected_status $expected_reason}s, "Status is $expected_status $expected_reason";
+}
+
+doit("http://127.0.0.1:$server->{port}/foo", 403, "Forbidden");
+doit("http://127.0.0.1:$server->{port}/abc/foo", 500, "Internal Server Error");
+
+done_testing;


### PR DESCRIPTION
Fail handler sends an error response with the specified status. This is useful to prevent clients from accessing non-existent hosts or protected paths.