### PR TITLE
[h2o_mruby] Add some H2O::Request methods

### DIFF
--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -11,8 +11,9 @@ m =  "from h2o_mruby"
 ua = r.headers_in["User-Agent"].to_s
 new_ua = r.headers_in["User-Agent"] = "new-#{ua}-h2o_mruby"
 uri = r.uri
+host = r.hostname
 
-msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri}"
+msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri} host:#{host}"
 
 r.log_error msg
 

--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -9,16 +9,11 @@ h = "hello"
 m =  "from h2o_mruby"
 
 ua = r.headers_in["User-Agent"].to_s
-accept = r.headers_in["Accept"].to_s
 new_ua = r.headers_in["User-Agent"] = "new-#{ua}-h2o_mruby"
+uri = r.uri
 
-r.headers_out["Hoge"] = "fuga"
-hoge = r.headers_out["Hoge"]
-
-msg = h + " " + m + " from " + ua + ":" + new_ua + " " + accept + " " + hoge
-
+msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri}"
 
 r.log_error msg
 
-msg + "\n"
-
+H2O.return 200, "OK", msg + "\n"

--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -12,8 +12,9 @@ ua = r.headers_in["User-Agent"].to_s
 new_ua = r.headers_in["User-Agent"] = "new-#{ua}-h2o_mruby"
 uri = r.uri
 host = r.hostname
+method = r.method
 
-msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri} host:#{host}"
+msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri} host:#{host} method:#{method}"
 
 r.log_error msg
 

--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -13,8 +13,9 @@ new_ua = r.headers_in["User-Agent"] = "new-#{ua}-h2o_mruby"
 uri = r.uri
 host = r.hostname
 method = r.method
+query = r.query
 
-msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri} host:#{host} method:#{method}"
+msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri} host:#{host} method:#{method} query:#{query}"
 
 r.log_error msg
 

--- a/include/h2o/mruby.h
+++ b/include/h2o/mruby.h
@@ -34,4 +34,10 @@ h2o_mruby_handler_t *h2o_mruby_register(h2o_pathconf_t *pathconf, h2o_mruby_conf
 /* handler/configurator/mruby.c */
 void h2o_mruby_register_configurator(h2o_globalconf_t *conf);
 
+static mrb_value h2o_mrb_str_new(mrb_state *mrb, h2o_iovec_t *str);
+
+inline mrb_value h2o_mrb_str_new(mrb_state *mrb, h2o_iovec_t *str)
+{
+    return mrb_str_new(mrb, str->base, str->len);
+}
 #endif

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -47,6 +47,13 @@ static mrb_value h2o_mrb_req_log_error(mrb_state *mrb, mrb_value self)
     return log;
 }
 
+static mrb_value h2o_mrb_req_uri(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+
+    return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.path);
+}
+
 static mrb_value h2o_mrb_get_class_obj(mrb_state *mrb, mrb_value self, char *obj_id, char *class_name)
 {
     mrb_value obj;
@@ -148,6 +155,9 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
 
     mrb_define_method(mrb, class_request, "initialize", h2o_mrb_req_init, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "log_error", h2o_mrb_req_log_error, MRB_ARGS_REQ(1));
+    mrb_define_method(mrb, class_request, "uri", h2o_mrb_req_uri, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "path", h2o_mrb_req_uri, MRB_ARGS_NONE());
+
     mrb_define_method(mrb, class_request, "headers_in", h2o_mrb_headers_in_obj, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "headers_out", h2o_mrb_headers_out_obj, MRB_ARGS_NONE());
 

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -54,6 +54,18 @@ static mrb_value h2o_mrb_req_uri(mrb_state *mrb, mrb_value self)
     return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.path);
 }
 
+static mrb_value h2o_mrb_req_hostname(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+    h2o_iovec_t hostname;
+    uint16_t port;
+
+    if (h2o_url_parse_hostport(mruby_ctx->req->input.authority.base, mruby_ctx->req->input.authority.len, &hostname, &port) == NULL)
+        return mrb_nil_value();
+
+    return h2o_mrb_str_new(mrb, &hostname);
+}
+
 static mrb_value h2o_mrb_req_authority(mrb_state *mrb, mrb_value self)
 {
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
@@ -182,7 +194,7 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
     mrb_define_method(mrb, class_request, "log_error", h2o_mrb_req_log_error, MRB_ARGS_REQ(1));
     mrb_define_method(mrb, class_request, "uri", h2o_mrb_req_uri, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "path", h2o_mrb_req_uri, MRB_ARGS_NONE());
-    mrb_define_method(mrb, class_request, "hostname", h2o_mrb_req_authority, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "hostname", h2o_mrb_req_hostname, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "authority", h2o_mrb_req_authority, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "method", h2o_mrb_req_method, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "query", h2o_mrb_req_query, MRB_ARGS_NONE());

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -54,6 +54,13 @@ static mrb_value h2o_mrb_req_uri(mrb_state *mrb, mrb_value self)
     return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.path);
 }
 
+static mrb_value h2o_mrb_req_authority(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+
+    return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.authority);
+}
+
 static mrb_value h2o_mrb_get_class_obj(mrb_state *mrb, mrb_value self, char *obj_id, char *class_name)
 {
     mrb_value obj;
@@ -157,6 +164,8 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
     mrb_define_method(mrb, class_request, "log_error", h2o_mrb_req_log_error, MRB_ARGS_REQ(1));
     mrb_define_method(mrb, class_request, "uri", h2o_mrb_req_uri, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "path", h2o_mrb_req_uri, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "hostname", h2o_mrb_req_authority, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "authority", h2o_mrb_req_authority, MRB_ARGS_NONE());
 
     mrb_define_method(mrb, class_request, "headers_in", h2o_mrb_headers_in_obj, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "headers_out", h2o_mrb_headers_out_obj, MRB_ARGS_NONE());

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -61,6 +61,13 @@ static mrb_value h2o_mrb_req_authority(mrb_state *mrb, mrb_value self)
     return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.authority);
 }
 
+static mrb_value h2o_mrb_req_method(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+
+    return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.method);
+}
+
 static mrb_value h2o_mrb_get_class_obj(mrb_state *mrb, mrb_value self, char *obj_id, char *class_name)
 {
     mrb_value obj;
@@ -166,6 +173,7 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
     mrb_define_method(mrb, class_request, "path", h2o_mrb_req_uri, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "hostname", h2o_mrb_req_authority, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "authority", h2o_mrb_req_authority, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "method", h2o_mrb_req_method, MRB_ARGS_NONE());
 
     mrb_define_method(mrb, class_request, "headers_in", h2o_mrb_headers_in_obj, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "headers_out", h2o_mrb_headers_out_obj, MRB_ARGS_NONE());

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -68,6 +68,17 @@ static mrb_value h2o_mrb_req_method(mrb_state *mrb, mrb_value self)
     return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.method);
 }
 
+static mrb_value h2o_mrb_req_query(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+    h2o_iovec_t *path = &mruby_ctx->req->input.path;
+    size_t offset = mruby_ctx->req->input.query_at;
+    if (offset == SIZE_MAX)
+      return mrb_nil_value();
+
+    return mrb_str_new(mrb, path->base + offset, path->len - offset);
+}
+
 static mrb_value h2o_mrb_get_class_obj(mrb_state *mrb, mrb_value self, char *obj_id, char *class_name)
 {
     mrb_value obj;
@@ -174,6 +185,7 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
     mrb_define_method(mrb, class_request, "hostname", h2o_mrb_req_authority, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "authority", h2o_mrb_req_authority, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "method", h2o_mrb_req_method, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "query", h2o_mrb_req_query, MRB_ARGS_NONE());
 
     mrb_define_method(mrb, class_request, "headers_in", h2o_mrb_headers_in_obj, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "headers_out", h2o_mrb_headers_out_obj, MRB_ARGS_NONE());

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -18,7 +18,7 @@ hosts:
       /:
 $extra_conf
 EOT
-    return `curl --silent /dev/stderr -H User-Agent:h2o_mruby_test http://127.0.0.1:$server->{port}/ 2>&1`;
+    return (`curl --silent /dev/stderr -H User-Agent:h2o_mruby_test http://127.0.0.1:$server->{port}/ 2>&1`, $server->{port});
 }
 
 sub fetch_header {
@@ -33,19 +33,31 @@ EOT
     return `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/ 2>&1`;
 }
 
-my $resp = fetch(<< 'EOT');
+sub fetch_uri {
+    my ($extra_conf, $uri) = @_;
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+$extra_conf
+EOT
+    return `curl --silent /dev/stderr http://127.0.0.1:$server->{port}/$uri 2>&1`;
+}
+
+my ($resp, $port) = fetch(<< 'EOT');
         file.dir: examples/doc_root
         mruby.handler_path: t/50mruby/hello.rb
 EOT
 is $resp, "hello from h2o_mruby\n", "resoponse body from mruby";
 
-$resp = fetch(<< 'EOT');
+($resp, $port) = fetch(<< 'EOT');
         file.dir: examples/doc_root
         mruby.handler_path: t/50mruby/max_header.rb
 EOT
 is $resp, "100", "H2O.max_headers method";
 
-$resp = fetch(<< 'EOT');
+($resp, $port) = fetch(<< 'EOT');
         file.dir: examples/doc_root
         mruby.handler_path: t/50mruby/headers_in.rb
 EOT
@@ -57,16 +69,40 @@ $resp = fetch_header(<< 'EOT');
 EOT
 like $resp, qr/^new-header:.*\Wh2o-mruby\W/im, "H2O::Response#headers_out test";
 
-$resp = fetch(<< 'EOT');
+($resp, $port) = fetch(<< 'EOT');
         file.dir: examples/doc_root
         mruby.handler_path: t/50mruby/return_status.rb
 EOT
 is $resp, "not found", "H2O.return with status code test";
 
-$resp = fetch(<< 'EOT');
+($resp, $port)= fetch(<< 'EOT');
         file.dir: t/50mruby/
         mruby.handler_path: t/50mruby/return_declined.rb
 EOT
 is $resp, "I'm index.html\n", "H2O.return with declined code test";
+
+($resp, $port) = fetch(<< 'EOT');
+        file.dir: t/50mruby/
+        mruby.handler_path: t/50mruby/method.rb
+EOT
+is $resp, "GET", "H2O::Request#method test";
+
+$resp = fetch_uri(<< 'EOT', 'index.html?a=1');
+        file.dir: t/50mruby/
+        mruby.handler_path: t/50mruby/query.rb
+EOT
+is $resp, "?a=1", "H2O::Request#query test";
+
+$resp = fetch_uri(<< 'EOT', 'index.html?a=1');
+        file.dir: t/50mruby/
+        mruby.handler_path: t/50mruby/uri.rb
+EOT
+is $resp, "/index.html?a=1", "H2O::Request#uri test";
+
+($resp, $port) = fetch(<< 'EOT');
+        file.dir: t/50mruby/
+        mruby.handler_path: t/50mruby/hostname.rb
+EOT
+is $resp, "127.0.0.1:$port", "H2O::Request#hostname test";
 
 done_testing();

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -101,8 +101,14 @@ is $resp, "/index.html?a=1", "H2O::Request#uri test";
 
 ($resp, $port) = fetch(<< 'EOT');
         file.dir: t/50mruby/
+        mruby.handler_path: t/50mruby/authority.rb
+EOT
+is $resp, "127.0.0.1:$port", "H2O::Request#authority test";
+
+($resp, $port) = fetch(<< 'EOT');
+        file.dir: t/50mruby/
         mruby.handler_path: t/50mruby/hostname.rb
 EOT
-is $resp, "127.0.0.1:$port", "H2O::Request#hostname test";
+is $resp, "127.0.0.1", "H2O::Request#hostname test";
 
 done_testing();

--- a/t/50mruby/authority.rb
+++ b/t/50mruby/authority.rb
@@ -1,0 +1,1 @@
+H2O::Request.new.authority

--- a/t/50mruby/hostname.rb
+++ b/t/50mruby/hostname.rb
@@ -1,0 +1,1 @@
+H2O::Request.new.hostname

--- a/t/50mruby/method.rb
+++ b/t/50mruby/method.rb
@@ -1,0 +1,1 @@
+H2O::Request.new.method

--- a/t/50mruby/query.rb
+++ b/t/50mruby/query.rb
@@ -1,0 +1,1 @@
+H2O::Request.new.query

--- a/t/50mruby/uri.rb
+++ b/t/50mruby/uri.rb
@@ -1,0 +1,1 @@
+H2O::Request.new.uri


### PR DESCRIPTION
Hello @kazuho !!

I implemented some H2O::Request methods. For example, executed `curl 127.0.0.1:8080/index.html?a=1`: 

 ```ruby
r = H2O::Request.new

r.hostname    #=> "127.0.0.1:8080"
r.authority   #=> "127.0.0.1:8080"
r.uri         #=> "/index.html?a=1"
r.path        #=> "/index.html?a=1"
r.method      #=> "GET"
r.qeury       #=> "?a=1"
# If not found query, r.query return nil
```