### PR TITLE
Simplify the build rules of the mruby handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ IF (WITH_MRUBY)
         lib/handler/mruby/class/core.c
         lib/handler/mruby/class/request.c
         lib/handler/configurator/mruby.c)
-    LIST(INSERT EXTRA_LIBRARIES 0 ${MRUBY_LIBRARIES})
+    LIST(INSERT EXTRA_LIBRARIES 0 ${MRUBY_LIBRARIES} "m")
 ENDIF (WITH_MRUBY)
 
 ADD_LIBRARY(libh2o ${LIB_SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,9 +126,11 @@ IF (NOT MRUBY_FOUND)
         INCLUDE_DIRECTORIES(${MRUBY_INCLUDE_DIR})
     ENDIF (MRUBY_FOUND)
 ENDIF (NOT MRUBY_FOUND)
-IF (NOT MRUBY_FOUND)
-    SET(MRUBY_LIBRARIES -lmruby)
-ENDIF (NOT MRUBY_FOUND)
+IF (WITH_MRUBY)
+    IF (NOT MRUBY_FOUND)
+        MESSAGE(FATAL "-DWITH_MRUBY=ON was set, but could not find libmruby")
+    ENDIF (NOT MRUBY_FOUND)
+ENDIF (WITH_MRUBY)
 
 SET(CMAKE_C_FLAGS "-O2 -g -Wall -Wno-unused-function ${CMAKE_C_FLAGS} -DH2O_ROOT=\"\\\"${CMAKE_INSTALL_PREFIX}\\\"\"")
 
@@ -196,10 +198,6 @@ SET(LIB_SOURCE_FILES
     lib/handler/proxy.c
     lib/handler/redirect.c
     lib/handler/reproxy.c
-    lib/handler/mruby.c
-    lib/handler/mruby/init.c
-    lib/handler/mruby/class/core.c
-    lib/handler/mruby/class/request.c
     lib/handler/configurator/access_log.c
     lib/handler/configurator/expires.c
     lib/handler/configurator/fastcgi.c
@@ -208,7 +206,6 @@ SET(LIB_SOURCE_FILES
     lib/handler/configurator/proxy.c
     lib/handler/configurator/redirect.c
     lib/handler/configurator/reproxy.c
-    lib/handler/configurator/mruby.c
 
     lib/http1.c
 
@@ -262,6 +259,17 @@ LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/http2/scheduler.c)
 
 SET(EXTRA_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+
+IF (WITH_MRUBY)
+    ADD_DEFINITIONS("-DH2O_USE_MRUBY=1")
+    LIST(APPEND LIB_SOURCE_FILES
+        lib/handler/mruby.c
+        lib/handler/mruby/init.c
+        lib/handler/mruby/class/core.c
+        lib/handler/mruby/class/request.c
+        lib/handler/configurator/mruby.c)
+    LIST(INSERT EXTRA_LIBRARIES 0 ${MRUBY_LIBRARIES})
+ENDIF (WITH_MRUBY)
 
 ADD_LIBRARY(libh2o ${LIB_SOURCE_FILES})
 ADD_LIBRARY(libh2o-evloop ${LIB_SOURCE_FILES})
@@ -333,14 +341,6 @@ ELSE (WITH_BUNDLED_SSL)
         TARGET_LINK_LIBRARIES(h2o ${OPENSSL_LIBRARIES})
     ENDIF (OPENSSL_FOUND)
 ENDIF (WITH_BUNDLED_SSL)
-IF (WITH_MRUBY)
-    ADD_DEFINITIONS("-DH2O_USE_MRUBY=1")
-    IF (APPLE)
-        SET(EXTRA_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} ${MRUBY_LIBRARIES} "m")
-    ELSE (APPLE)
-        SET(EXTRA_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} ${MRUBY_LIBRARIES} "m" "rt")
-    ENDIF (APPLE)
-ENDIF (WITH_MRUBY)
 TARGET_LINK_LIBRARIES(h2o ${EXTRA_LIBRARIES})
 
 INSTALL(TARGETS h2o

--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
-#ifdef H2O_USE_MRUBY
-
 #include <inttypes.h>
 #include "h2o.h"
 #include "h2o/configurator.h"
@@ -75,5 +72,3 @@ void h2o_mruby_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "mruby.handler_path",
                                     H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_mruby_handler_path);
 }
-
-#endif /* H2O_USE_MRUBY */

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -19,17 +19,13 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
-#ifdef H2O_USE_MRUBY
-
-#include "h2o.h"
-#include "h2o/mruby.h"
+#include <errno.h>
 #include <mruby.h>
 #include <mruby/proc.h>
 #include <mruby/compile.h>
 #include <mruby/string.h>
-
-#include <errno.h>
+#include "h2o.h"
+#include "h2o/mruby.h"
 
 void h2o_mrb_class_init(mrb_state *mrb);
 
@@ -198,5 +194,3 @@ h2o_mruby_handler_t *h2o_mruby_register(h2o_pathconf_t *pathconf, h2o_mruby_conf
 
     return handler;
 }
-
-#endif /* H2O_USE_MRUBY */

--- a/lib/handler/mruby/class/core.c
+++ b/lib/handler/mruby/class/core.c
@@ -19,14 +19,10 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
-#ifdef H2O_USE_MRUBY
-
+#include <mruby.h>
+#include <mruby/string.h>
 #include "h2o.h"
 #include "h2o/mruby.h"
-
-#include "mruby.h"
-#include "mruby/string.h"
 
 static mrb_value h2o_mrb_max_headers(mrb_state *mrb, mrb_value self)
 {
@@ -62,5 +58,3 @@ void h2o_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
     mrb_define_class_method(mrb, class, "max_headers", h2o_mrb_max_headers, MRB_ARGS_NONE());
     mrb_define_class_method(mrb, class, "return", h2o_mrb_return, MRB_ARGS_REQ(3));
 }
-
-#endif /* H2O_USE_MRUBY */

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -82,7 +82,7 @@ static mrb_value h2o_mrb_req_query(mrb_state *mrb, mrb_value self)
     h2o_iovec_t *path = &mruby_ctx->req->input.path;
     size_t offset = mruby_ctx->req->input.query_at;
     if (offset == SIZE_MAX)
-      return mrb_nil_value();
+        return mrb_nil_value();
 
     return mrb_str_new(mrb, path->base + offset, path->len - offset);
 }

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -19,17 +19,13 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
-#ifdef H2O_USE_MRUBY
-
+#include <mruby.h>
+#include <mruby/string.h>
+#include <mruby/data.h>
+#include <mruby/class.h>
+#include <mruby/variable.h>
 #include "h2o.h"
 #include "h2o/mruby.h"
-
-#include "mruby.h"
-#include "mruby/string.h"
-#include "mruby/data.h"
-#include "mruby/class.h"
-#include <mruby/variable.h>
 
 static mrb_value h2o_mrb_req_init(mrb_state *mrb, mrb_value self)
 {
@@ -212,5 +208,3 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
     mrb_define_method(mrb, class_headers_out, "[]", h2o_mrb_get_request_headers_out, MRB_ARGS_REQ(1));
     mrb_define_method(mrb, class_headers_out, "[]=", h2o_mrb_set_request_headers_out, MRB_ARGS_REQ(2));
 }
-
-#endif /* H2O_USE_MRUBY */

--- a/lib/handler/mruby/init.c
+++ b/lib/handler/mruby/init.c
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
-#ifdef H2O_USE_MRUBY
-
 #include <mruby.h>
 #include <mruby/compile.h>
 
@@ -41,5 +38,3 @@ void h2o_mrb_class_init(mrb_state *mrb)
     h2o_mrb_request_class_init(mrb, class);
     GC_ARENA_RESTORE;
 }
-
-#endif /* H2O_USE_MRUBY */


### PR DESCRIPTION
This PR simplifies the build rules of the mruby handler as follows:

* only compile and link the mruby handler if `-DWITH_MRUBY=ON` is specified
* remove `#if H2O_USE_MRUBY` from source files
* abort CMake configuration if `-DWITH_MRUBY=ON` is used and if libmruby was not found