### PR TITLE
setuid the process spawned by `fastcgi.spawn`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,9 @@ INSTALL(TARGETS h2o
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib)
 
+ADD_EXECUTABLE(setuidgid src/setuidgid.c)
+INSTALL(TARGETS setuidgid RUNTIME DESTINATION share/h2o)
+
 INSTALL(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.h")
 INSTALL(TARGETS libh2o-evloop DESTINATION lib)
 # only install libh2o if libuv is found

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		107D4D501B58B342004A9B21 /* 40session-ticket.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40session-ticket.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		107D4D521B5B2412004A9B21 /* file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file.h; sourceTree = "<group>"; };
 		107D4D541B5B30EE004A9B21 /* file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = file.c; sourceTree = "<group>"; };
+		107D4D5D1B5F143B004A9B21 /* setuidgid.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = setuidgid.c; sourceTree = "<group>"; };
 		108214FE1AAD34DD00D27E66 /* 50reverse-proxy-0.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50reverse-proxy-0.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		108215071AAD41CE00D27E66 /* test.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; name = test.pl; path = "50reverse-proxy/test.pl"; sourceTree = "<group>"; };
 		108215081AB14B1100D27E66 /* 40server-push.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40server-push.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -1099,6 +1100,7 @@
 				10A3D40E1B584BEC00327CF9 /* standalone.h */,
 				10F417D519C190F800B6E31A /* main.c */,
 				107D4D4D1B58970D004A9B21 /* ssl.c */,
+				107D4D5D1B5F143B004A9B21 /* setuidgid.c */,
 			);
 			path = src;
 			sourceTree = "<group>";

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -229,6 +229,10 @@ struct st_h2o_globalconf_t {
      * maximum count for delegations
      */
     unsigned max_delegations;
+    /**
+     * setuid user (or NULL)
+     */
+    char *user;
 
     /**
      * SSL handshake timeout

--- a/include/h2o/serverutil.h
+++ b/include/h2o/serverutil.h
@@ -23,7 +23,6 @@
 #define h2o__server_starter_h
 
 #include <stddef.h>
-#include <pwd.h>
 
 /* taken from sysexits.h */
 #ifndef EX_SOFTWARE
@@ -47,7 +46,7 @@ void h2o_set_signal_handler(int signo, void (*cb)(int signo));
 /**
  * equiv. to setuidgid of djb
  */
-int h2o_setuidgid(struct passwd *passwd);
+int h2o_setuidgid(const char *user);
 
 /**
  * return a list of fds passed in from Server::Starter, or 0 if Server::Starter was not used.  -1 on error

--- a/include/h2o/serverutil.h
+++ b/include/h2o/serverutil.h
@@ -62,7 +62,7 @@ size_t h2o_server_starter_get_fds(int **_fds);
  *        pair is not -1.  If the second value is -1, then `close` is called with the first value as the argument.
  * @return pid of the process being spawned if successful, or -1 if otherwise
  */
-pid_t h2o_spawnp(const char *cmd, char **argv, const int *mapped_fds, int clocexec_mutex_is_locked);
+pid_t h2o_spawnp(const char *cmd, const char **argv, const int *mapped_fds, int clocexec_mutex_is_locked);
 
 /**
  * executes a command and returns its output

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -114,7 +114,7 @@ size_t h2o_server_starter_get_fds(int **_fds)
     return fds.size;
 }
 
-pid_t h2o_spawnp(const char *cmd, char **argv, const int *mapped_fds, int cloexec_mutex_is_locked)
+pid_t h2o_spawnp(const char *cmd, const char **argv, const int *mapped_fds, int cloexec_mutex_is_locked)
 {
 #if defined(__linux__)
 

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -23,6 +23,7 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <pthread.h>
+#include <pwd.h>
 #include <signal.h>
 #include <spawn.h>
 #include <stdint.h>
@@ -50,18 +51,30 @@ void h2o_set_signal_handler(int signo, void (*cb)(int signo))
     sigaction(signo, &action, NULL);
 }
 
-int h2o_setuidgid(struct passwd *passwd)
+int h2o_setuidgid(const char *user)
 {
-    if (setgid(passwd->pw_gid) != 0) {
-        fprintf(stderr, "setgid(%d) failed:%s\n", (int)passwd->pw_gid, strerror(errno));
+    struct passwd pwbuf, *pw;
+    char buf[65536]; /* should be large enough */
+
+    errno = 0;
+    if (getpwnam_r(user, &pwbuf, buf, sizeof(buf), &pw) != 0) {
+        perror("getpwnam_r");
         return -1;
     }
-    if (initgroups(passwd->pw_name, passwd->pw_gid) != 0) {
-        fprintf(stderr, "initgroups(%s, %d) failed:%s\n", passwd->pw_name, (int)passwd->pw_gid, strerror(errno));
+    if (pw == NULL) {
+        fprintf(stderr, "unknown user:%s\n", user);
         return -1;
     }
-    if (setuid(passwd->pw_uid) != 0) {
-        fprintf(stderr, "setuid(%d) failed:%s\n", (int)passwd->pw_uid, strerror(errno));
+    if (setgid(pw->pw_gid) != 0) {
+        fprintf(stderr, "setgid(%d) failed:%s\n", (int)pw->pw_gid, strerror(errno));
+        return -1;
+    }
+    if (initgroups(pw->pw_name, pw->pw_gid) != 0) {
+        fprintf(stderr, "initgroups(%s, %d) failed:%s\n", pw->pw_name, (int)pw->pw_gid, strerror(errno));
+        return -1;
+    }
+    if (setuid(pw->pw_uid) != 0) {
+        fprintf(stderr, "setuid(%d) failed:%s\n", (int)pw->pw_uid, strerror(errno));
         return -1;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -122,7 +122,6 @@ static struct {
     } server_starter;
     struct listener_config_t **listeners;
     size_t num_listeners;
-    struct passwd *running_user; /* NULL if not set */
     char *pid_file;
     char *error_log;
     int max_connections;
@@ -147,7 +146,6 @@ static struct {
     {},              /* server_starter */
     NULL,            /* listeners */
     0,               /* num_listeners */
-    NULL,            /* running_user */
     NULL,            /* pid_file */
     NULL,            /* error_log */
     1024,            /* max_connections */
@@ -927,36 +925,15 @@ static int on_config_listen_exit(h2o_configurator_t *_configurator, h2o_configur
     return 0;
 }
 
-static int setup_running_user(const char *login)
-{
-    struct passwd *passwdbuf = h2o_mem_alloc(sizeof(*passwdbuf));
-    char *buf;
-    size_t bufsz = 4096;
-
-Redo:
-    buf = h2o_mem_alloc(bufsz);
-    if (getpwnam_r(login, passwdbuf, buf, bufsz, &conf.running_user) != 0) {
-        if (errno == ERANGE
-#ifdef __APPLE__
-            || errno == EINVAL /* OS X 10.9.5 returns EINVAL if bufsz == 16 */
-#endif
-            ) {
-            free(buf);
-            bufsz *= 2;
-            goto Redo;
-        }
-        perror("getpwnam_r");
-    }
-    if (conf.running_user == NULL)
-        return -1;
-
-    return 0;
-}
-
 static int on_config_user(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
-    if (setup_running_user(node->data.scalar) != 0) {
-        h2o_configurator_errprintf(cmd, node, "user:%s does not exist", node->data.scalar);
+    errno = 0;
+    if (getpwnam(node->data.scalar) == NULL) {
+        if (errno == 0) {
+            h2o_configurator_errprintf(cmd, node, "user:%s does not exist", node->data.scalar);
+        } else {
+            perror("getpwnam");
+        }
         return -1;
     }
 
@@ -1344,6 +1321,10 @@ static void setup_configurators(void)
 {
     h2o_config_init(&conf.globalconf);
 
+    /* let the default setuid user be "nobody", if run as root */
+    if (getuid() == 0 && getpwnam("nobody") != NULL)
+        conf.globalconf.user = "nobody";
+
     {
         h2o_configurator_t *c = h2o_configurator_create(&conf.globalconf, sizeof(*c));
         c->enter = on_config_listen_enter;
@@ -1569,18 +1550,17 @@ int main(int argc, char **argv)
     }
 
     /* setuid */
-    if (conf.running_user == NULL && getuid() == 0) {
-        if (setup_running_user("nobody") == 0) {
-            fprintf(stderr, "cowardly switching to nobody; please use the `user` directive to set the running user\n");
-        } else {
-            fprintf(stderr, "refusing to run as root (and failed to switch to `nobody`); you can use the `user` directive to "
-                            "set the running user\n");
+    if (conf.globalconf.user != NULL) {
+        if (h2o_setuidgid(conf.globalconf.user) != 0) {
+            fprintf(stderr, "failed to change the running user (are you sure you are running as root?)\n");
+            return EX_OSERR;
+        }
+    } else {
+        if (getuid() == 0) {
+            fprintf(stderr, "refusing to run as root (and failed to switch to `nobody`); you can use the `user` directive to set "
+                            "the running user\n");
             return EX_CONFIG;
         }
-    }
-    if (conf.running_user != NULL && h2o_setuidgid(conf.running_user) != 0) {
-        fprintf(stderr, "failed to change the running user (are you sure you are running as root?)\n");
-        return EX_OSERR;
     }
 
     /* pid file must be written after setuid, since we need to remove it  */

--- a/src/setuidgid.c
+++ b/src/setuidgid.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <errno.h>
+#include <grp.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* taken from sysexits.h */
+#ifndef EX_OSERR
+#define EX_OSERR 71
+#endif
+#ifndef EX_CONFIG
+#define EX_CONFIG 78
+#endif
+
+int main(int argc, char **argv)
+{
+    struct passwd *user;
+
+    if (argc < 3) {
+        fprintf(stderr, "no command (usage: setuidgid user cmd args...)\n");
+        return EX_CONFIG;
+    }
+    --argc;
+    ++argv;
+
+    errno = 0;
+    if ((user = getpwnam(*argv)) == NULL) {
+        if (errno == 0) {
+            fprintf(stderr, "unknown user:%s\n", *argv);
+            return EX_CONFIG;
+        } else {
+            perror("getpwnam");
+            return EX_OSERR;
+        }
+    }
+    --argc;
+    ++argv;
+
+    if (setgid(user->pw_gid) != 0) {
+        perror("setgid failed");
+        return EX_OSERR;
+    }
+    if (initgroups(user->pw_name, user->pw_gid) != 0) {
+        perror("initgroups failed");
+        return EX_OSERR;
+    }
+    if (setuid(user->pw_uid) != 0) {
+        perror("setuid failed");
+        return EX_OSERR;
+    }
+
+    execvp(*argv, argv);
+    fprintf(stderr, "execvp failed to launch file:%s:%s\n", *argv, strerror(errno));
+    return EX_OSERR;
+}


### PR DESCRIPTION
The fastcgi process spawned by `fastcgi.spawn` is executed before H2O calls `setuid`.  So in case the server is spawned with root privileges (is a requirement if it needs to listen to port 80 or 443), the process gets spawned with root privileges.

As discussed in http://d.hatena.ne.jp/hirose31/20130808/1375965331, there are several ways to drop the privileges by using wrapper commands within the argument of the configuration directive.  But it is not easy for an ordinary user to install and use them correctly.

Therefore this PR does the following:
* by default, change the uid (and group privileges) of the spawned process to that specified using the global `user` directive (in other words, fastcgi processes will be run under the same privileges as the H2O server)
* optionally accept a mapping as the argument to `fastcgi.spawn`, and if it contains a `user` attribute, use spawn the fastcgi process under name of the given user