### PR TITLE
Add H2O::Connection class and remote_ip method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,7 @@ IF (WITH_MRUBY)
         lib/handler/mruby/init.c
         lib/handler/mruby/class/core.c
         lib/handler/mruby/class/request.c
+        lib/handler/mruby/class/connection.c
         lib/handler/configurator/mruby.c)
     LIST(INSERT EXTRA_LIBRARIES 0 ${MRUBY_LIBRARIES} "m")
 ENDIF (WITH_MRUBY)

--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -15,7 +15,7 @@ host = r.hostname
 method = r.method
 query = r.query
 
-msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri} host:#{host} method:#{method} query:#{query}"
+msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{uri} host:#{host} method:#{method} query:#{query} remote_ip:#{H2O::Connection.new.remote_ip}"
 
 r.log_error msg
 

--- a/lib/handler/mruby/class/connection.c
+++ b/lib/handler/mruby/class/connection.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014,2015 DeNA Co., Ltd., Kazuho Oku, Ryosuke Matsumoto
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <mruby.h>
+#include <mruby/string.h>
+#include <mruby/data.h>
+#include <mruby/class.h>
+#include <mruby/variable.h>
+#include "h2o.h"
+#include "h2o/mruby.h"
+
+static mrb_value h2o_mrb_conn_init(mrb_state *mrb, mrb_value self)
+{
+    return self;
+}
+
+static mrb_value h2o_mrb_conn_remote_ip(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+    size_t remote_addr_len = SIZE_MAX;
+    char remote_addr[NI_MAXHOST];
+    struct sockaddr_storage ss;
+    socklen_t sslen;
+
+    if ((sslen = mruby_ctx->req->conn->get_peername(mruby_ctx->req->conn, (void *)&ss)) != 0) {
+        remote_addr_len = h2o_socket_getnumerichost((void *)&ss, sslen, remote_addr);
+    } else {
+        return mrb_nil_value();
+    }
+
+    return mrb_str_new(mrb, remote_addr, remote_addr_len);
+}
+
+void h2o_mrb_conn_class_init(mrb_state *mrb, struct RClass *class)
+{
+    struct RClass *class_conn;
+
+    class_conn = mrb_define_class_under(mrb, class, "Connection", mrb->object_class);
+
+    mrb_define_method(mrb, class_conn, "initialize", h2o_mrb_conn_init, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_conn, "remote_ip", h2o_mrb_conn_remote_ip, MRB_ARGS_NONE());
+}

--- a/lib/handler/mruby/init.c
+++ b/lib/handler/mruby/init.c
@@ -26,6 +26,7 @@
 
 void h2o_mrb_core_class_init(mrb_state *mrb, struct RClass *class);
 void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class);
+void h2o_mrb_conn_class_init(mrb_state *mrb, struct RClass *class);
 
 void h2o_mrb_class_init(mrb_state *mrb)
 {
@@ -36,5 +37,7 @@ void h2o_mrb_class_init(mrb_state *mrb)
     h2o_mrb_core_class_init(mrb, class);
     GC_ARENA_RESTORE;
     h2o_mrb_request_class_init(mrb, class);
+    GC_ARENA_RESTORE;
+    h2o_mrb_conn_class_init(mrb, class);
     GC_ARENA_RESTORE;
 }

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -111,4 +111,10 @@ is $resp, "127.0.0.1:$port", "H2O::Request#authority test";
 EOT
 is $resp, "127.0.0.1", "H2O::Request#hostname test";
 
+($resp, $port) = fetch(<< 'EOT');
+        file.dir: t/50mruby/
+        mruby.handler_path: t/50mruby/remote_ip.rb
+EOT
+is $resp, "127.0.0.1", "H2O::Connection#remote_ip test";
+
 done_testing();

--- a/t/50mruby/remote_ip.rb
+++ b/t/50mruby/remote_ip.rb
@@ -1,0 +1,1 @@
+H2O::Connection.new.remote_ip


### PR DESCRIPTION
Hello @kazuho !!

I added H2O::Connection#remote_ip for ipaddress based access controls.

For example,

```ruby
deny_list = %w{
  192.168.0.11
}

if deny_list.include? H2O::Connection.new.remote_ip
  H2O.return 403, "Forbidden", "Forbidden"
end
```