### PR TITLE
cache-aware server push (cookie-based)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ SET(LIB_SOURCE_FILES
 
     lib/http1.c
 
+    lib/http2/casper.c
     lib/http2/connection.c
     lib/http2/frame.c
     lib/http2/hpack.c
@@ -236,6 +237,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/handler/headers.c
     t/00unit/lib/handler/mimemap.c
     t/00unit/lib/handler/redirect.c
+    t/00unit/lib/http2/casper.c
     t/00unit/lib/http2/hpack.c
     t/00unit/lib/http2/scheduler.c
     t/00unit/src/ssl.c
@@ -256,6 +258,7 @@ LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/handler/headers.c
     lib/handler/mimemap.c
     lib/handler/redirect.c
+    lib/http2/casper.c
     lib/http2/hpack.c
     lib/http2/scheduler.c)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ SET(CMAKE_C_FLAGS "-O2 -g -Wall -Wno-unused-function ${CMAKE_C_FLAGS} -DH2O_ROOT
 INCLUDE_DIRECTORIES(
     include
     deps/cloexec
+    deps/golombset
     deps/libyrmcds
     deps/klib
     deps/picohttpparser

--- a/deps/golombset/README.md
+++ b/deps/golombset/README.md
@@ -1,0 +1,26 @@
+golombset
+===
+
+Golombset is a pure-C, header-file-only implementation of Golomb coded set, which is an compressed form of [Bloom filter](https://en.wikipedia.org/Bloom_filter).
+
+It is compresses every zero-range of Bloom filter (e.g. `0000...1`) using [Golomb coding](https://en.wikipedia.org/wiki/Golomb_coding).
+Please refer to [Golomb-coded sets: smaller than Bloom filters](http://giovanni.bajo.it/post/47119962313/golomb-coded-sets-smaller-than-bloom-filters) for more information about the algorithm.
+
+API
+---
+
+__`int golombset_encode(unsigned fixed_bits, const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize);`__
+
+The function encodes an pre-sorted array of keys into given buffer.
+
+The function returns zero if successful, or -1 if otherwise (e.g. the size of the buffer is not sufficient).
+`bufsize` is an input-output parameter.
+Upon calling the function the value of the pointer must specify the size of the buffer being supplied.
+When the function returns successfully, the value is updated the length of the bytes actually used to store the encoded data.
+
+__`int golombset_decode(unsigned fixed_bits, const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys);`__
+
+The function decodes the compressed data into an array of keys.
+
+The function returns zero if successful, or -1 if the size of the `keys` buffer is too small (specified by `*num_keys` when the function is being called).
+Upon successful return, the number of keys decoded will be stored in `*num_keys`.

--- a/deps/golombset/golombset.h
+++ b/deps/golombset/golombset.h
@@ -39,9 +39,9 @@ struct st_golombset_decode_t {
 static int golombset_encode_bit(struct st_golombset_encode_t *ctx, int bit)
 {
     if (ctx->dst_shift == 0) {
-        if (ctx->dst == ctx->dst_max)
+        if (++ctx->dst == ctx->dst_max)
             return -1;
-        *++ctx->dst = 0xff;
+        *ctx->dst = 0xff;
         ctx->dst_shift = 8;
     }
     --ctx->dst_shift;

--- a/deps/golombset/golombset.h
+++ b/deps/golombset/golombset.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2015 Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef GOLOMBSET_H
+#define GOLOMBSET_H
+
+struct st_golombset_encode_t {
+    const unsigned fixed_bits;
+    unsigned char *dst;
+    unsigned char *dst_max;
+    unsigned dst_shift;
+};
+
+struct st_golombset_decode_t {
+    const unsigned fixed_bits;
+    const unsigned char *src;
+    const unsigned char *src_max;
+    unsigned src_shift;
+};
+
+static int golombset_encode_bit(struct st_golombset_encode_t *ctx, int bit)
+{
+    if (ctx->dst_shift == 0) {
+        if (ctx->dst == ctx->dst_max)
+            return -1;
+        *++ctx->dst = 0xff;
+        ctx->dst_shift = 8;
+    }
+    --ctx->dst_shift;
+    if (!bit)
+        *ctx->dst &= ~(1 << ctx->dst_shift);
+    return 0;
+}
+
+static int golombset_decode_bit(struct st_golombset_decode_t *ctx)
+{
+    if (ctx->src_shift == 0) {
+        if (++ctx->src == ctx->src_max)
+            return -1;
+        ctx->src_shift = 8;
+    }
+    return (*ctx->src >> --ctx->src_shift) & 1;
+}
+
+static int golombset_encode_value(struct st_golombset_encode_t *ctx, unsigned value)
+{
+    /* emit the unary bits */
+    unsigned unary_bits = value >> ctx->fixed_bits;
+    for (; unary_bits != 0; --unary_bits)
+        if (golombset_encode_bit(ctx, 1) != 0)
+            return -1;
+    if (golombset_encode_bit(ctx, 0) != 0)
+        return -1;
+    /* emit the rest */
+    unsigned shift = ctx->fixed_bits;
+    do {
+        if (golombset_encode_bit(ctx, (value >> --shift) & 1) != 0)
+            return -1;
+    } while (shift != 0);
+
+    return 0;
+}
+
+static int golombset_decode_value(struct st_golombset_decode_t *ctx, unsigned *value)
+{
+    int bit;
+    *value = 0;
+
+    /* decode the unary bits */
+    while (1) {
+        if ((bit = golombset_decode_bit(ctx)) == -1)
+            return -1;
+        if (bit == 0)
+            break;
+        *value += 1 << ctx->fixed_bits;
+    }
+    /* decode the rest */
+    unsigned shift = ctx->fixed_bits;
+    do {
+        if ((bit = golombset_decode_bit(ctx)) == -1)
+            return -1;
+        *value |= bit << --shift;
+    } while (shift != 0);
+
+    return 0;
+}
+
+static int golombset_encode(unsigned fixed_bits, const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize)
+{
+    struct st_golombset_encode_t ctx = {fixed_bits, buf, buf + *bufsize, 8};
+    size_t i;
+    unsigned next_min = 0;
+
+    *(unsigned char *)buf = 0xff;
+    for (i = 0; i != num_keys; ++i) {
+        if (golombset_encode_value(&ctx, keys[i] - next_min) != 0)
+            return -1;
+        next_min = keys[i] + 1;
+    }
+
+    if (ctx.dst_shift == 8)
+        --ctx.dst;
+    *bufsize = ctx.dst + 1 - (unsigned char *)buf;
+
+    return 0;
+}
+
+static int golombset_decode(unsigned fixed_bits, const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys)
+{
+    struct st_golombset_decode_t ctx = {fixed_bits, buf, buf + bufsize, 8};
+    size_t index = 0;
+    unsigned next_min = 0;
+
+    while (1) {
+        unsigned value;
+        if (golombset_decode_value(&ctx, &value) != 0)
+            break;
+        if (index == *num_keys) {
+            /* not enough space */
+            return -1;
+        }
+        value += next_min;
+        keys[index++] = value;
+        next_min = value + 1;
+    }
+    *num_keys = index;
+    return 0;
+}
+
+#endif

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		10F417FF19C2D2F800B6E31A /* picotest.c in Sources */ = {isa = PBXBuildFile; fileRef = 10F417FD19C2D2F800B6E31A /* picotest.c */; };
 		10F4180119C2D31600B6E31A /* yoml.h in Headers */ = {isa = PBXBuildFile; fileRef = 10F4180019C2D31600B6E31A /* yoml.h */; };
 		10F4180519CA75C500B6E31A /* configurator.c in Sources */ = {isa = PBXBuildFile; fileRef = 10F4180419CA75C500B6E31A /* configurator.c */; };
+		10F419801B64E70D00BEAEAC /* golombset.h in Headers */ = {isa = PBXBuildFile; fileRef = 10F4197F1B64E70D00BEAEAC /* golombset.h */; };
 		10F9F2651AF4795D0056F26B /* redirect.c in Sources */ = {isa = PBXBuildFile; fileRef = 10F9F2641AF4795D0056F26B /* redirect.c */; };
 		10F9F2671AFC5F550056F26B /* hostinfo.c in Sources */ = {isa = PBXBuildFile; fileRef = 10F9F2661AFC5F550056F26B /* hostinfo.c */; };
 		10FCC13E1B2E4A4500F13674 /* cloexec.c in Sources */ = {isa = PBXBuildFile; fileRef = 10FCC13C1B2E4A4500F13674 /* cloexec.c */; };
@@ -462,6 +463,7 @@
 		10F4180019C2D31600B6E31A /* yoml.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = yoml.h; path = yoml/yoml.h; sourceTree = "<group>"; };
 		10F4180219C2D32100B6E31A /* yoml-parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "yoml-parser.h"; path = "yoml/yoml-parser.h"; sourceTree = "<group>"; };
 		10F4180419CA75C500B6E31A /* configurator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = configurator.c; sourceTree = "<group>"; };
+		10F4197F1B64E70D00BEAEAC /* golombset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = golombset.h; sourceTree = "<group>"; };
 		10F9F2641AF4795D0056F26B /* redirect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = redirect.c; sourceTree = "<group>"; };
 		10F9F2661AFC5F550056F26B /* hostinfo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hostinfo.c; sourceTree = "<group>"; };
 		10FCC13C1B2E4A4500F13674 /* cloexec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cloexec.c; sourceTree = "<group>"; };
@@ -858,6 +860,7 @@
 			isa = PBXGroup;
 			children = (
 				10FCC13B1B2E4A2C00F13674 /* cloexec */,
+				10F4197E1B64E6C300BEAEAC /* golombset */,
 				1079231F19A3210D00C52AD6 /* klib */,
 				10A3D3DC1B4FAA5900327CF9 /* libyrmcds */,
 				1079235619A3210D00C52AD6 /* picohttpparser */,
@@ -1123,6 +1126,14 @@
 			name = yoml;
 			sourceTree = "<group>";
 		};
+		10F4197E1B64E6C300BEAEAC /* golombset */ = {
+			isa = PBXGroup;
+			children = (
+				10F4197F1B64E70D00BEAEAC /* golombset.h */,
+			);
+			path = golombset;
+			sourceTree = "<group>";
+		};
 		10FCC13B1B2E4A2C00F13674 /* cloexec */ = {
 			isa = PBXGroup;
 			children = (
@@ -1162,6 +1173,7 @@
 				10D0905919F22FA10043D458 /* string_.h in Headers */,
 				10D0904119F0B9CD0043D458 /* timeout.h in Headers */,
 				10AA2EB71A970EFC004322AC /* http2_internal.h in Headers */,
+				10F419801B64E70D00BEAEAC /* golombset.h in Headers */,
 				104B9A261A4A5041009EEE64 /* serverutil.h in Headers */,
 				1079239719A3210E00C52AD6 /* picohttpparser.h in Headers */,
 				1065E70C19BF664300686E72 /* evloop.h in Headers */,

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		1065E70C19BF664300686E72 /* evloop.h in Headers */ = {isa = PBXBuildFile; fileRef = 1065E70419BF145700686E72 /* evloop.h */; };
 		1065E70D19BF6D4600686E72 /* uv-binding.h in Headers */ = {isa = PBXBuildFile; fileRef = 1065E70619BF14E500686E72 /* uv-binding.h */; };
 		1065E70E19BF6D9400686E72 /* uv-binding.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 1065E70719BF17FE00686E72 /* uv-binding.c.h */; };
+		1070866A1B70A00F002B8F18 /* casper.c in Sources */ = {isa = PBXBuildFile; fileRef = 107086691B70A00F002B8F18 /* casper.c */; };
 		1070E1631B4508B0001CCAFA /* util.c in Sources */ = {isa = PBXBuildFile; fileRef = 1070E1621B4508B0001CCAFA /* util.c */; };
 		10756E2A1AC126420009BF57 /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = 10756E261AC126420009BF57 /* api.c */; };
 		10756E2B1AC126420009BF57 /* dumper.c in Sources */ = {isa = PBXBuildFile; fileRef = 10756E271AC126420009BF57 /* dumper.c */; };
@@ -127,6 +128,8 @@
 		10AA2EC01AA019FC004322AC /* headers.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EBF1AA019FC004322AC /* headers.c */; };
 		10AA2EC21AA0402E004322AC /* reproxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EC11AA0402E004322AC /* reproxy.c */; };
 		10AA2EC41AA0403A004322AC /* reproxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EC31AA0403A004322AC /* reproxy.c */; };
+		10AAAC631B6C7A7D004487C3 /* http2_casper.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AAAC621B6C7A7D004487C3 /* http2_casper.h */; };
+		10AAAC651B6C9275004487C3 /* casper.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AAAC641B6C9275004487C3 /* casper.c */; };
 		10BA72AA19AAD6300059392A /* stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 10BA72A919AAD6300059392A /* stream.c */; };
 		10BCF2FD1B168CAE0076939D /* fastcgi.c in Sources */ = {isa = PBXBuildFile; fileRef = 10BCF2FC1B168CAE0076939D /* fastcgi.c */; };
 		10BCF2FF1B1A892F0076939D /* fastcgi.c in Sources */ = {isa = PBXBuildFile; fileRef = 10BCF2FE1B1A892F0076939D /* fastcgi.c */; };
@@ -335,6 +338,7 @@
 		1065E70419BF145700686E72 /* evloop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = evloop.h; sourceTree = "<group>"; };
 		1065E70619BF14E500686E72 /* uv-binding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "uv-binding.h"; sourceTree = "<group>"; };
 		1065E70719BF17FE00686E72 /* uv-binding.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uv-binding.c.h"; sourceTree = "<group>"; };
+		107086691B70A00F002B8F18 /* casper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = casper.c; sourceTree = "<group>"; };
 		1070E15C1B438E8F001CCAFA /* poll.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = poll.c.h; sourceTree = "<group>"; };
 		1070E1621B4508B0001CCAFA /* util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = util.c; sourceTree = "<group>"; };
 		1070E1641B451D43001CCAFA /* 40proxy-protocol.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40proxy-protocol.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -431,6 +435,8 @@
 		10AA2EC11AA0402E004322AC /* reproxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = reproxy.c; sourceTree = "<group>"; };
 		10AA2EC31AA0403A004322AC /* reproxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = reproxy.c; sourceTree = "<group>"; };
 		10AA2EC61AA05598004322AC /* upstream.psgi */ = {isa = PBXFileReference; lastKnownFileType = text; path = upstream.psgi; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		10AAAC621B6C7A7D004487C3 /* http2_casper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http2_casper.h; sourceTree = "<group>"; };
+		10AAAC641B6C9275004487C3 /* casper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = casper.c; sourceTree = "<group>"; };
 		10BA72A919AAD6300059392A /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
 		10BCF2FC1B168CAE0076939D /* fastcgi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fastcgi.c; sourceTree = "<group>"; };
 		10BCF2FE1B1A892F0076939D /* fastcgi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fastcgi.c; sourceTree = "<group>"; };
@@ -648,6 +654,7 @@
 			children = (
 				105534C01A3B911300627ECB /* hpack.c */,
 				10E299591A68D03100701AA6 /* scheduler.c */,
+				107086691B70A00F002B8F18 /* casper.c */,
 			);
 			path = http2;
 			sourceTree = "<group>";
@@ -906,6 +913,7 @@
 				107923A019A3215F00C52AD6 /* http1.h */,
 				10D0905619F102DA0043D458 /* http1client.h */,
 				107923A119A3215F00C52AD6 /* http2.h */,
+				10AAAC621B6C7A7D004487C3 /* http2_casper.h */,
 				10AA2EB61A970EFC004322AC /* http2_internal.h */,
 				10AA2EB81A971280004322AC /* http2_scheduler.h */,
 				10A3D3D01B4CDBC700327CF9 /* memcached.h */,
@@ -959,6 +967,7 @@
 			children = (
 				107923B519A3217300C52AD6 /* hpack_huffman_table.h */,
 				107923B619A3217300C52AD6 /* hpack_static_table.h */,
+				10AAAC641B6C9275004487C3 /* casper.c */,
 				107923B319A3217300C52AD6 /* connection.c */,
 				107923B819A3217300C52AD6 /* frame.c */,
 				107923B419A3217300C52AD6 /* hpack.c */,
@@ -1151,6 +1160,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				107923C919A3217300C52AD6 /* hpack_static_table.h in Headers */,
+				10AAAC631B6C7A7D004487C3 /* http2_casper.h in Headers */,
 				10D0904319F0BA780043D458 /* linklist.h in Headers */,
 				10EC2A361A0B4D370083514F /* socketpool.h in Headers */,
 				105534EB1A42A87E00627ECB /* _templates.c.h in Headers */,
@@ -1378,6 +1388,7 @@
 				10AA2EA11A88082E004322AC /* url.c in Sources */,
 				10EC2A381A0B4DC70083514F /* socketpool.c in Sources */,
 				1079239619A3210E00C52AD6 /* picohttpparser.c in Sources */,
+				10AAAC651B6C9275004487C3 /* casper.c in Sources */,
 				10AA2EC41AA0403A004322AC /* reproxy.c in Sources */,
 				10AA2EAC1A8DE0AE004322AC /* multithread.c in Sources */,
 				1065E6F919BEBAC600686E72 /* timeout.c in Sources */,
@@ -1455,6 +1466,7 @@
 				107D4D451B5880BC004A9B21 /* api.c in Sources */,
 				1079245119A3266700C52AD6 /* token.c in Sources */,
 				1079244419A3265C00C52AD6 /* chunked.c in Sources */,
+				1070866A1B70A00F002B8F18 /* casper.c in Sources */,
 				107D4D491B5880BC004A9B21 /* parser.c in Sources */,
 				104B9A481A5F9472009EEE64 /* headers.c in Sources */,
 				107D4D4C1B5880BC004A9B21 /* writer.c in Sources */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -210,6 +210,15 @@ struct st_h2o_hostconf_t {
      * mimemap
      */
     h2o_mimemap_t *mimemap;
+    /**
+     * http2
+     */
+    struct {
+        /**
+         * size of the casper capacity (0 if disabled)
+         */
+        unsigned casper_capacity_bits;
+    } http2;
 };
 
 typedef struct st_h2o_protocol_callbacks_t {

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -215,6 +215,11 @@ struct st_h2o_hostconf_t {
      */
     struct {
         /**
+         * whether if blocking assets being pulled should be given highest priority in case of clients that do not implement
+         * dependency-based prioritization
+         */
+        int reprioritize_blocking_assets;
+        /**
          * size of the casper capacity (0 if disabled)
          */
         unsigned casper_capacity_bits;
@@ -286,10 +291,6 @@ struct st_h2o_globalconf_t {
          * maximum nuber of streams (per connection) to be allowed in IDLE / CLOSED state (used for tracking dependencies).
          */
         size_t max_streams_for_priority;
-        /**
-         * a boolean value indicating whether or not to raise priority of blocking asset files
-         */
-        int reprioritize_blocking_assets;
         /**
          * list of callbacks
          */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -149,6 +149,17 @@ typedef struct st_h2o_timestamp_t {
     h2o_timestamp_string_t *str;
 } h2o_timestamp_t;
 
+typedef struct st_h2o_casper_conf_t {
+    /**
+     * capacity bits (0 to disable casper)
+     */
+    unsigned capacity_bits;
+    /**
+     * whether if all type of files should be tracked (or only the blocking assets)
+     */
+    int track_all_types;
+} h2o_casper_conf_t;
+
 typedef struct st_h2o_pathconf_t {
     /**
      * globalconf to which the pathconf belongs
@@ -220,9 +231,9 @@ struct st_h2o_hostconf_t {
          */
         int reprioritize_blocking_assets;
         /**
-         * size of the casper capacity (0 if disabled)
+         * casper settings
          */
-        unsigned casper_capacity_bits;
+        h2o_casper_conf_t casper;
     } http2;
 };
 

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -59,6 +59,7 @@ extern const h2o_http2_priority_t h2o_http2_default_priority;
 
 void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
 int h2o_http2_handle_upgrade(h2o_req_t *req);
+int h2o_http2_is_blocking_asset(h2o_context_t *ctx, const char *path, size_t pathlen);
 
 #ifdef __cplusplus
 }

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -59,7 +59,6 @@ extern const h2o_http2_priority_t h2o_http2_default_priority;
 
 void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
 int h2o_http2_handle_upgrade(h2o_req_t *req);
-int h2o_http2_is_blocking_asset(h2o_context_t *ctx, const char *path, size_t pathlen);
 
 #ifdef __cplusplus
 }

--- a/include/h2o/http2_casper.h
+++ b/include/h2o/http2_casper.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef h2o__http2__casper_h
+#define h2o__http2__casper_h
+
+#include <stddef.h>
+#include <stdlib.h>
+#include "h2o/memory.h"
+
+typedef struct st_h2o_http2_casper_t {
+    H2O_VECTOR(unsigned) keys;
+    unsigned capacity_bits;
+    unsigned remainder_bits;
+} h2o_http2_casper_t;
+
+/**
+ * initializes the structure with provided parameters
+ */
+static void h2o_http2_casper_init(h2o_http2_casper_t *casper, unsigned capacity_bits, unsigned remainder_bits);
+/**
+ * disposes of the structure and resources associated to it
+ */
+static void h2o_http2_casper_dispose(h2o_http2_casper_t *casper);
+/**
+ * checks if a key is (was) marked as cached at the moment the fuction is invoked
+ */
+int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len, int set);
+/**
+ * consumes the `Cookie` headers in requests and updates the structure
+ */
+void h2o_http2_casper_consume_cookie(h2o_http2_casper_t *casper, const char *cookie, size_t cookie_len);
+/**
+ * emits a `Set-Cookie` header that should be sent to the client
+ */
+h2o_iovec_t h2o_http2_casper_build_cookie(h2o_http2_casper_t *casper, h2o_mem_pool_t *pool);
+
+/* inline definitions */
+
+inline void h2o_http2_casper_init(h2o_http2_casper_t *casper, unsigned capacity_bits, unsigned remainder_bits)
+{
+    memset(&casper->keys, 0, sizeof(casper->keys));
+    casper->capacity_bits = capacity_bits;
+    casper->remainder_bits = remainder_bits;
+}
+
+inline void h2o_http2_casper_dispose(h2o_http2_casper_t *casper)
+{
+    free(casper->keys.entries);
+}
+
+#endif

--- a/include/h2o/http2_casper.h
+++ b/include/h2o/http2_casper.h
@@ -37,9 +37,14 @@ h2o_http2_casper_t *h2o_http2_casper_create(unsigned capacity_bits, unsigned rem
  */
 void h2o_http2_casper_destroy(h2o_http2_casper_t *casper);
 /**
+ * returns the number of keys stored
+ */
+size_t h2o_http2_casper_num_entries(h2o_http2_casper_t *casper);
+/**
  * checks if a key is (was) marked as cached at the moment the fuction is invoked
  */
-int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len, int set);
+int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len,
+                            int set);
 /**
  * consumes the `Cookie` headers in requests and updates the structure
  */

--- a/include/h2o/http2_casper.h
+++ b/include/h2o/http2_casper.h
@@ -26,20 +26,16 @@
 #include <stdlib.h>
 #include "h2o/memory.h"
 
-typedef struct st_h2o_http2_casper_t {
-    H2O_VECTOR(unsigned) keys;
-    unsigned capacity_bits;
-    unsigned remainder_bits;
-} h2o_http2_casper_t;
+typedef struct st_h2o_http2_casper_t h2o_http2_casper_t;
 
 /**
- * initializes the structure with provided parameters
+ * creates an object with provided parameters
  */
-static void h2o_http2_casper_init(h2o_http2_casper_t *casper, unsigned capacity_bits, unsigned remainder_bits);
+h2o_http2_casper_t *h2o_http2_casper_create(unsigned capacity_bits, unsigned remainder_bits);
 /**
- * disposes of the structure and resources associated to it
+ * destroys the object and resources associated to it
  */
-static void h2o_http2_casper_dispose(h2o_http2_casper_t *casper);
+void h2o_http2_casper_destroy(h2o_http2_casper_t *casper);
 /**
  * checks if a key is (was) marked as cached at the moment the fuction is invoked
  */
@@ -52,19 +48,5 @@ void h2o_http2_casper_consume_cookie(h2o_http2_casper_t *casper, const char *coo
  * emits a `Set-Cookie` header that should be sent to the client
  */
 h2o_iovec_t h2o_http2_casper_build_cookie(h2o_http2_casper_t *casper, h2o_mem_pool_t *pool);
-
-/* inline definitions */
-
-inline void h2o_http2_casper_init(h2o_http2_casper_t *casper, unsigned capacity_bits, unsigned remainder_bits)
-{
-    memset(&casper->keys, 0, sizeof(casper->keys));
-    casper->capacity_bits = capacity_bits;
-    casper->remainder_bits = remainder_bits;
-}
-
-inline void h2o_http2_casper_dispose(h2o_http2_casper_t *casper)
-{
-    free(casper->keys.entries);
-}
 
 #endif

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -25,6 +25,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include "khash.h"
+#include "h2o/http2_casper.h"
 #include "h2o/http2_scheduler.h"
 
 typedef struct st_h2o_http2_conn_t h2o_http2_conn_t;
@@ -213,7 +214,6 @@ struct st_h2o_http2_conn_t {
     h2o_http2_window_t _input_window;
     h2o_hpack_header_table_t _output_header_table;
     h2o_linklist_t _pending_reqs; /* list of h2o_http2_stream_t that contain pending requests */
-    int _is_dispatching_pending_reqs;
     h2o_timeout_entry_t _timeout_entry;
     struct {
         h2o_buffer_t *buf;
@@ -222,6 +222,7 @@ struct st_h2o_http2_conn_t {
         h2o_timeout_entry_t timeout_entry;
         h2o_http2_window_t window;
     } _write;
+    h2o_http2_casper_t *casper;
 };
 
 int h2o_http2_update_peer_settings(h2o_http2_settings_t *settings, const uint8_t *src, size_t len, const char **err_desc);
@@ -252,6 +253,7 @@ void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http
 void h2o_http2_conn_request_write(h2o_http2_conn_t *conn);
 void h2o_http2_conn_register_for_proceed_callback(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 static ssize_t h2o_http2_conn_get_buffer_window(h2o_http2_conn_t *conn);
+static void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn);
 
 /* stream */
 static int h2o_http2_stream_is_push(uint32_t stream_id);
@@ -329,6 +331,12 @@ inline ssize_t h2o_http2_conn_get_buffer_window(h2o_http2_conn_t *conn)
     if (winsz < ret)
         ret = winsz;
     return ret;
+}
+
+inline void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn)
+{
+    assert(conn->casper == NULL);
+    conn->casper = h2o_http2_casper_create(13, 6);
 }
 
 inline void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, uint32_t *slot)

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -254,7 +254,7 @@ void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http
 void h2o_http2_conn_request_write(h2o_http2_conn_t *conn);
 void h2o_http2_conn_register_for_proceed_callback(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 static ssize_t h2o_http2_conn_get_buffer_window(h2o_http2_conn_t *conn);
-static void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn);
+static void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn, unsigned capacity_bits);
 
 /* stream */
 static int h2o_http2_stream_is_push(uint32_t stream_id);
@@ -335,10 +335,10 @@ inline ssize_t h2o_http2_conn_get_buffer_window(h2o_http2_conn_t *conn)
     return ret;
 }
 
-inline void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn)
+inline void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn, unsigned capacity_bits)
 {
     assert(conn->casper == NULL);
-    conn->casper = h2o_http2_casper_create(13, 6);
+    conn->casper = h2o_http2_casper_create(capacity_bits, 6);
 }
 
 inline void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, uint32_t *slot)

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -25,6 +25,39 @@
 #include "h2o.h"
 #include "h2o/configurator.h"
 
+struct st_core_config_vars_t {
+    struct {
+        unsigned casper_capacity_bits;
+    } http2;
+};
+
+struct st_core_configurator_t {
+    h2o_configurator_t super;
+    struct st_core_config_vars_t *vars, _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
+};
+
+static int on_core_enter(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct st_core_configurator_t *self = (void *)_self;
+
+    ++self->vars;
+    self->vars[0] = self->vars[-1];
+    return 0;
+}
+
+static int on_core_exit(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct st_core_configurator_t *self = (void *)_self;
+
+    if (ctx->hostconf != NULL && ctx->pathconf == NULL) {
+        /* exitting from host-level configuration */
+        ctx->hostconf->http2.casper_capacity_bits = self->vars->http2.casper_capacity_bits;
+    }
+
+    --self->vars;
+    return 0;
+}
+
 static void destroy_configurator(h2o_configurator_t *configurator)
 {
     if (configurator->dispose != NULL)
@@ -294,6 +327,38 @@ static int on_config_http2_reprioritize_blocking_assets(h2o_configurator_command
     return 0;
 }
 
+static int on_config_http2_casper(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct st_core_configurator_t *self = (void *)cmd->configurator;
+
+    switch (node->type) {
+    case YOML_TYPE_SCALAR:
+        if (strcasecmp(node->data.scalar, "OFF") == 0) {
+            self->vars->http2.casper_capacity_bits = 0;
+        } else if (strcasecmp(node->data.scalar, "ON") == 0) {
+            self->vars->http2.casper_capacity_bits = 13; /* default (2^13 ~= 100 assets * 1/0.01 collision probability) */
+        }
+        break;
+    case YOML_TYPE_MAPPING: {
+        yoml_t *t;
+        if ((t = yoml_get(node, "capacity-bits")) == NULL) {
+            h2o_configurator_errprintf(cmd, node, "mandatory attribute `capacity-bits` is not defined");
+            return -1;
+        }
+        if (!(t->type == YOML_TYPE_SCALAR && sscanf(t->data.scalar, "%u", &self->vars->http2.casper_capacity_bits) == 0 &&
+              self->vars->http2.casper_capacity_bits < 16)) {
+            h2o_configurator_errprintf(cmd, t, "value of `capacity-bits` must be an integer between 0 to 15");
+            return -1;
+        }
+    } break;
+    default:
+        h2o_configurator_errprintf(cmd, node, "value must be `OFF`,`ON` or a mapping containing `capacity-bits`");
+        return -1;
+    }
+
+    return 0;
+}
+
 static int assert_is_mimetype(h2o_configurator_command_t *cmd, yoml_t *node)
 {
     if (node->type != YOML_TYPE_SCALAR) {
@@ -495,44 +560,53 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
     };
 
     { /* setup global configurators */
-        h2o_configurator_t *c = h2o_configurator_create(conf, sizeof(*c));
-        h2o_configurator_define_command(c, "limit-request-body", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+        struct st_core_configurator_t *c = (void *)h2o_configurator_create(conf, sizeof(*c));
+        c->super.enter = on_core_enter;
+        c->super.exit = on_core_exit;
+        c->vars = c->_vars_stack;
+        h2o_configurator_define_command(&c->super, "limit-request-body",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_limit_request_body);
-        h2o_configurator_define_command(c, "max-delegations", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+        h2o_configurator_define_command(&c->super, "max-delegations",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_max_delegations);
-        h2o_configurator_define_command(c, "handshake-timeout", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+        h2o_configurator_define_command(&c->super, "handshake-timeout",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_handshake_timeout);
-        h2o_configurator_define_command(c, "http1-request-timeout",
+        h2o_configurator_define_command(&c->super, "http1-request-timeout",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http1_request_timeout);
-        h2o_configurator_define_command(c, "http1-upgrade-to-http2",
+        h2o_configurator_define_command(&c->super, "http1-upgrade-to-http2",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http1_upgrade_to_http2);
-        h2o_configurator_define_command(c, "http2-idle-timeout", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+        h2o_configurator_define_command(&c->super, "http2-idle-timeout",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_idle_timeout);
-        h2o_configurator_define_command(c, "http2-max-concurrent-requests-per-connection",
+        h2o_configurator_define_command(&c->super, "http2-max-concurrent-requests-per-connection",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_max_concurrent_requests_per_connection);
-        h2o_configurator_define_command(c, "http2-reprioritize-blocking-assets",
+        h2o_configurator_define_command(&c->super, "http2-reprioritize-blocking-assets",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_reprioritize_blocking_assets);
-        h2o_configurator_define_command(c, "file.mime.settypes",
+        h2o_configurator_define_command(&c->super, "http2-casper", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST,
+                                        on_config_http2_casper);
+        h2o_configurator_define_command(&c->super, "file.mime.settypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,
                                         on_config_mime_settypes);
-        h2o_configurator_define_command(c, "file.mime.addtypes",
+        h2o_configurator_define_command(&c->super, "file.mime.addtypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,
                                         on_config_mime_addtypes);
-        h2o_configurator_define_command(c, "file.mime.removetypes",
+        h2o_configurator_define_command(&c->super, "file.mime.removetypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE,
                                         on_config_mime_removetypes);
-        h2o_configurator_define_command(c, "file.mime.setdefaulttype",
+        h2o_configurator_define_command(&c->super, "file.mime.setdefaulttype",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_mime_setdefaulttype);
-        h2o_configurator_define_command(c, "file.custom-handler",
+        h2o_configurator_define_command(&c->super, "file.custom-handler",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_SEMI_DEFERRED,
                                         on_config_custom_handler);

--- a/lib/http2/casper.c
+++ b/lib/http2/casper.c
@@ -88,7 +88,7 @@ int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t
 
     /* we need to set a new value */
     h2o_vector_reserve(NULL, (void *)&casper->keys, sizeof(casper->keys.entries[0]), casper->keys.size + 1);
-    memmove(casper->keys.entries + i + 1, casper->keys.entries + i, casper->keys.size - i);
+    memmove(casper->keys.entries + i + 1, casper->keys.entries + i, (casper->keys.size - i) * sizeof(casper->keys.entries[0]));
     ++casper->keys.size;
     casper->keys.entries[i] = key;
     return 0;

--- a/lib/http2/casper.c
+++ b/lib/http2/casper.c
@@ -27,6 +27,12 @@
 #define COOKIE_NAME "h2o_casper"
 #define COOKIE_ATTRIBUTES "; Path=/; Expires=Tue, 01 Jan 2030 00:00:00 GMT"
 
+struct st_h2o_http2_casper_t {
+    H2O_VECTOR(unsigned) keys;
+    unsigned capacity_bits;
+    unsigned remainder_bits;
+};
+
 static unsigned calc_key(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len)
 {
     SHA_CTX ctx;
@@ -42,6 +48,24 @@ static unsigned calc_key(h2o_http2_casper_t *casper, const char *path, size_t pa
 
     return md.key & ((1 << casper->capacity_bits) - 1);
 }
+
+h2o_http2_casper_t *h2o_http2_casper_create(unsigned capacity_bits, unsigned remainder_bits)
+{
+    h2o_http2_casper_t *casper = h2o_mem_alloc(sizeof(*casper));
+
+    memset(&casper->keys, 0, sizeof(casper->keys));
+    casper->capacity_bits = capacity_bits;
+    casper->remainder_bits = remainder_bits;
+
+    return casper;
+}
+
+void h2o_http2_casper_destroy(h2o_http2_casper_t *casper)
+{
+    free(casper->keys.entries);
+    free(casper);
+}
+
 
 int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len,
                             int set)

--- a/lib/http2/casper.c
+++ b/lib/http2/casper.c
@@ -66,6 +66,10 @@ void h2o_http2_casper_destroy(h2o_http2_casper_t *casper)
     free(casper);
 }
 
+size_t h2o_http2_casper_num_entries(h2o_http2_casper_t *casper)
+{
+    return casper->keys.size;
+}
 
 int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len,
                             int set)

--- a/lib/http2/casper.c
+++ b/lib/http2/casper.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <openssl/sha.h>
+#include "golombset.h"
+#include "h2o/string_.h"
+#include "h2o/http2_casper.h"
+
+#define COOKIE_NAME "h2o_casper"
+#define COOKIE_ATTRIBUTES "; Path=/; Expires=Tue, 01 Jan 2030 00:00:00 GMT"
+
+static unsigned calc_key(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len)
+{
+    SHA_CTX ctx;
+    SHA1_Init(&ctx);
+    SHA1_Update(&ctx, path, path_len);
+    SHA1_Update(&ctx, etag, etag_len);
+
+    union {
+        unsigned key;
+        unsigned char bytes[SHA_DIGEST_LENGTH];
+    } md;
+    SHA1_Final(md.bytes, &ctx);
+
+    return md.key & ((1 << casper->capacity_bits) - 1);
+}
+
+int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len,
+                            int set)
+{
+    unsigned key = calc_key(casper, path, path_len, etag, etag_len);
+    size_t i;
+
+    /* FIXME use binary search */
+    for (i = 0; i != casper->keys.size; ++i)
+        if (key <= casper->keys.entries[i])
+            break;
+    if (i != casper->keys.size && key == casper->keys.entries[i])
+        return 1;
+    if (!set)
+        return 0;
+
+    /* we need to set a new value */
+    h2o_vector_reserve(NULL, (void *)&casper->keys, sizeof(casper->keys.entries[0]), casper->keys.size + 1);
+    memmove(casper->keys.entries + i + 1, casper->keys.entries + i, casper->keys.size - i);
+    ++casper->keys.size;
+    casper->keys.entries[i] = key;
+    return 0;
+}
+
+void h2o_http2_casper_consume_cookie(h2o_http2_casper_t *casper, const char *cookie, size_t cookie_len)
+{
+    h2o_iovec_t binary = {};
+    unsigned tiny_keys_buf[128], *keys = tiny_keys_buf;
+
+    /* check the name of the cookie */
+    if (!(cookie_len > sizeof(COOKIE_NAME "=") - 1 && memcmp(cookie, H2O_STRLIT(COOKIE_NAME "=")) == 0))
+        goto Exit;
+
+    /* base64 decode */
+    if ((binary = h2o_decode_base64url(NULL, cookie + sizeof(COOKIE_NAME "=") - 1, cookie_len - (sizeof(COOKIE_NAME "=") - 1)))
+            .base == NULL)
+        goto Exit;
+
+    /* decode GCS, either using tiny_keys_buf or using heap */
+    size_t capacity = sizeof(tiny_keys_buf) / sizeof(tiny_keys_buf[0]), num_keys;
+    while (num_keys = capacity, golombset_decode(casper->remainder_bits, binary.base, binary.len, keys, &num_keys) != 0) {
+        if (keys != tiny_keys_buf) {
+            free(keys);
+            keys = tiny_keys_buf; /* reset to something that would not trigger call to free(3) */
+        }
+        if (capacity >= (size_t)1 << casper->capacity_bits)
+            goto Exit;
+        capacity *= 2;
+        keys = h2o_mem_alloc(capacity * sizeof(*keys));
+    }
+
+    /* copy or merge the entries */
+    if (num_keys == 0) {
+        /* nothing to do */
+    } else if (casper->keys.size == 0) {
+        h2o_vector_reserve(NULL, (void *)&casper->keys, sizeof(casper->keys.entries[0]), num_keys);
+        memcpy(casper->keys.entries, keys, num_keys * sizeof(*keys));
+        casper->keys.size = num_keys;
+    } else {
+        unsigned *orig_keys = casper->keys.entries;
+        size_t num_orig_keys = casper->keys.size, orig_index = 0, new_index = 0;
+        memset(&casper->keys, 0, sizeof(casper->keys));
+        h2o_vector_reserve(NULL, (void *)&casper->keys, sizeof(casper->keys.entries[0]), num_keys + num_orig_keys);
+        do {
+            if (orig_keys[orig_index] < keys[new_index]) {
+                casper->keys.entries[casper->keys.size++] = orig_keys[orig_index++];
+            } else if (orig_keys[orig_index] > keys[new_index]) {
+                casper->keys.entries[casper->keys.size++] = keys[new_index++];
+            } else {
+                casper->keys.entries[casper->keys.size++] = orig_keys[orig_index];
+                ++orig_index;
+                ++new_index;
+            }
+        } while (orig_index != num_orig_keys && new_index != num_keys);
+        if (orig_index != num_orig_keys) {
+            do {
+                casper->keys.entries[casper->keys.size++] = orig_keys[orig_index++];
+            } while (orig_index != num_orig_keys);
+        } else if (new_index != num_keys) {
+            do {
+                casper->keys.entries[casper->keys.size++] = keys[new_index++];
+            } while (new_index != num_keys);
+        }
+        free(orig_keys);
+    }
+
+Exit:
+    if (keys != tiny_keys_buf)
+        free(keys);
+    free(binary.base);
+}
+
+static size_t append_str(char *dst, const char *s, size_t l)
+{
+    memcpy(dst, s, l);
+    return l;
+}
+
+h2o_iovec_t h2o_http2_casper_build_cookie(h2o_http2_casper_t *casper, h2o_mem_pool_t *pool)
+{
+    if (casper->keys.size == 0)
+        return (h2o_iovec_t){};
+
+    /* encode as binary */
+    char tiny_bin_buf[128], *bin_buf = tiny_bin_buf;
+    size_t bin_capacity = sizeof(tiny_bin_buf), bin_size;
+    while (bin_size = bin_capacity,
+           golombset_encode(casper->remainder_bits, casper->keys.entries, casper->keys.size, bin_buf, &bin_size) != 0) {
+        if (bin_buf != tiny_bin_buf)
+            free(bin_buf);
+        bin_capacity *= 2;
+        bin_buf = h2o_mem_alloc(bin_capacity);
+    }
+
+    char *header_bytes = h2o_mem_alloc_pool(pool, sizeof(COOKIE_NAME "=" COOKIE_ATTRIBUTES) - 1 + (bin_size + 3) * 4 / 3);
+    size_t header_len = 0;
+
+    header_len += append_str(header_bytes + header_len, H2O_STRLIT(COOKIE_NAME "="));
+    header_len += h2o_base64_encode(header_bytes + header_len, bin_buf, bin_size, 1);
+    header_len += append_str(header_bytes + header_len, H2O_STRLIT(COOKIE_ATTRIBUTES));
+
+    if (bin_buf != tiny_bin_buf)
+        free(bin_buf);
+
+    return h2o_iovec_init(header_bytes, header_len);
+}

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -306,30 +306,6 @@ static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta
     return 0;
 }
 
-int h2o_http2_is_blocking_asset(h2o_context_t *ctx, const char *path, size_t pathlen)
-{
-    size_t i;
-
-    /* move pathlen to '?' */
-    for (i = 0; i != pathlen; ++i) {
-        if (path[i] == '?') {
-            pathlen = i;
-            break;
-        }
-    }
-
-    /* check if end of path is either ".js" or ".css" */
-    if (pathlen < 3)
-        return 0;
-    if (memcmp(path + pathlen - 3, ".js", 3) == 0)
-        return 1;
-    if (pathlen < 4)
-        return 0;
-    if (memcmp(path + pathlen - 4, ".css", 4) == 0)
-        return 1;
-    return 0;
-}
-
 static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, const uint8_t *src, size_t len,
                                    const char **err_desc)
 {
@@ -340,16 +316,6 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     if ((ret = h2o_hpack_parse_headers(&stream->req, &conn->_input_header_table, src, len, &header_exists_map,
                                        &stream->_expected_content_length, err_desc)) != 0)
         return ret;
-
-    /* raise the priority of asset files that block rendering to highest if the user-agent is not using sophisticated prioritization
-     * logic (e.g. that of Firefox)
-     */
-    if (conn->num_streams.open_priority == 0 && conn->super.ctx->globalconf->http2.reprioritize_blocking_assets &&
-        h2o_http2_scheduler_get_parent(&stream->_refs.scheduler) == &conn->scheduler &&
-        h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("GET")) &&
-        h2o_http2_is_blocking_asset(conn->super.ctx, stream->req.input.path.base, stream->req.input.path.len)) {
-        h2o_http2_scheduler_rebind(&stream->_refs.scheduler, &conn->scheduler, 257, 0);
-    }
 
     conn->_read_expect = expect_default;
 
@@ -1065,10 +1031,10 @@ void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http
     if (!can_run_requests(conn))
         return;
 
-    /* open the stream with heighest weight (TODO find a better way to determine the weight) */
+    /* open the stream */
     conn->push_stream_ids.max_open += 2;
     stream = h2o_http2_stream_open(conn, conn->push_stream_ids.max_open, NULL, src_stream->stream_id);
-    h2o_http2_scheduler_open(&stream->_refs.scheduler, &conn->scheduler, 257, 0);
+    h2o_http2_scheduler_open(&stream->_refs.scheduler, &src_stream->_refs.scheduler.node, 16, 0);
     h2o_http2_stream_prepare_for_request(conn, stream);
 
     /* setup request */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1105,6 +1105,11 @@ void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http
     }
 
     execute_or_enqueue_request(conn, stream);
+
+    /* send push-promise ASAP (before the parent stream gets closed), even if execute_or_enqueue_request did not trigger the
+     * invocation of send_headers */
+    if (!stream->push.promise_sent)
+        h2o_http2_stream_send_push_promise(conn, stream);
 }
 
 void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -361,16 +361,6 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     }
 #undef EXPECTED_MAP
 
-    { /* extract the client-side cache fingerprint */
-        size_t header_index = -1;
-        while ((header_index = h2o_find_header(&stream->req.headers, H2O_TOKEN_COOKIE, header_index)) != -1) {
-            if (conn->casper == NULL)
-                h2o_http2_conn_init_casper(conn);
-            h2o_header_t *header = stream->req.headers.entries + header_index;
-            h2o_http2_casper_consume_cookie(conn->casper, header->value.base, header->value.len);
-        }
-    }
-
     /* handle the request */
     if (conn->num_streams.open_pull > H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams) {
         ret = H2O_HTTP2_ERROR_REFUSED_STREAM;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -307,7 +307,7 @@ static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta
     return 0;
 }
 
-static int is_blocking_asset(const char *path, size_t pathlen)
+int h2o_http2_is_blocking_asset(h2o_context_t *ctx, const char *path, size_t pathlen)
 {
     size_t i;
 
@@ -348,7 +348,7 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     if (conn->num_streams.open_priority == 0 && conn->super.ctx->globalconf->http2.reprioritize_blocking_assets &&
         h2o_http2_scheduler_get_parent(&stream->_refs.scheduler) == &conn->scheduler &&
         h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("GET")) &&
-        is_blocking_asset(stream->req.input.path.base, stream->req.input.path.len)) {
+        h2o_http2_is_blocking_asset(conn->super.ctx, stream->req.input.path.base, stream->req.input.path.len)) {
         h2o_http2_scheduler_rebind(&stream->_refs.scheduler, &conn->scheduler, 257, 0);
     }
 

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -259,7 +259,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
         /* raise the priority of asset files that block rendering to highest if the user-agent is _not_ using dependency-based
          * prioritization (e.g. that of Firefox)
          */
-        if (conn->num_streams.open_priority == 0 && conn->super.ctx->globalconf->http2.reprioritize_blocking_assets &&
+        if (conn->num_streams.open_priority == 0 && stream->req.hostconf->http2.reprioritize_blocking_assets &&
             h2o_http2_scheduler_get_parent(&stream->_refs.scheduler) == &conn->scheduler && is_blocking_asset(&stream->req))
             h2o_http2_scheduler_rebind(&stream->_refs.scheduler, &conn->scheduler, 257, 0);
     }

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -217,10 +217,10 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
         h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-pushed"), 0, H2O_STRLIT("1"));
     }
 
-    if (stream->req.hostconf->http2.casper_capacity_bits != 0) {
+    if (stream->req.hostconf->http2.casper.capacity_bits != 0) {
         /* extract the client-side cache fingerprint */
         if (conn->casper == NULL)
-            h2o_http2_conn_init_casper(conn, stream->req.hostconf->http2.casper_capacity_bits);
+            h2o_http2_conn_init_casper(conn, stream->req.hostconf->http2.casper.capacity_bits);
         size_t header_index = -1;
         while ((header_index = h2o_find_header(&stream->req.headers, H2O_TOKEN_COOKIE, header_index)) != -1) {
             h2o_header_t *header = stream->req.headers.entries + header_index;
@@ -228,7 +228,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
         }
         num_casper_entries_before_push = h2o_http2_casper_num_entries(conn->casper);
         /* update casper if necessary */
-        if (is_blocking_asset(&stream->req)) {
+        if (stream->req.hostconf->http2.casper.track_all_types || is_blocking_asset(&stream->req)) {
             ssize_t etag_index = h2o_find_header(&stream->req.headers, H2O_TOKEN_ETAG, -1);
             h2o_iovec_t etag = etag_index != -1 ? stream->req.headers.entries[etag_index].value : (h2o_iovec_t){};
             if (h2o_http2_casper_lookup(conn->casper, stream->req.path.base, stream->req.path.len, etag.base, etag.len, 1)) {

--- a/t/00unit/lib/http2/casper.c
+++ b/t/00unit/lib/http2/casper.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <string.h>
+#include "../../test.h"
+#include "../../../../lib/http2/casper.c"
+
+static size_t get_end_of_cookie_value(char *cookie, size_t cookie_len)
+{
+    size_t i;
+    for (i = 0; i != cookie_len; ++i)
+        if (cookie[i] == ';')
+            break;
+    return i;
+}
+
+static void test_calc_key(void)
+{
+    h2o_http2_casper_t casper;
+    h2o_http2_casper_init(&casper, 13, 6);
+
+    unsigned key = calc_key(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0")), expected;
+    memcpy(&expected, "\x1a\xa6\xfc\x81", 4);
+    expected &= (1 << 13) - 1;
+    ok(key == expected);
+
+    h2o_http2_casper_dispose(&casper);
+}
+
+static void test_lookup(void)
+{
+    h2o_http2_casper_t casper;
+    h2o_http2_casper_init(&casper, 13, 6);
+
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 0);
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1) == 0);
+    ok(casper.keys.size == 1);
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1) == 1);
+    ok(casper.keys.size == 1);
+
+    h2o_http2_casper_dispose(&casper);
+}
+
+static void test_cookie(void)
+{
+    h2o_mem_pool_t pool;
+    h2o_http2_casper_t casper;
+
+    h2o_mem_init_pool(&pool);
+    h2o_http2_casper_init(&casper, 13, 6);
+
+    h2o_iovec_t cookie = h2o_http2_casper_build_cookie(&casper, &pool);
+    ok(cookie.base == NULL);
+    ok(cookie.len == 0);
+
+    h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
+    cookie = h2o_http2_casper_build_cookie(&casper, &pool);
+    ok(cookie.len != 0);
+
+    h2o_http2_casper_dispose(&casper);
+    h2o_http2_casper_init(&casper, 13, 6);
+
+    h2o_http2_casper_consume_cookie(&casper, cookie.base, get_end_of_cookie_value(cookie.base, cookie.len));
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 0) == 0);
+    h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 1);
+
+    h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
+    cookie = h2o_http2_casper_build_cookie(&casper, &pool);
+    ok(cookie.len != 0);
+
+    h2o_http2_casper_dispose(&casper);
+    h2o_http2_casper_init(&casper, 13, 6);
+
+    h2o_http2_casper_consume_cookie(&casper, cookie.base, get_end_of_cookie_value(cookie.base, cookie.len));
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 0) == 1);
+
+    h2o_http2_casper_dispose(&casper);
+    h2o_mem_clear_pool(&pool);
+}
+
+static void test_cookie_merge(void)
+{
+    h2o_mem_pool_t pool;
+    h2o_http2_casper_t casper;
+    h2o_mem_init_pool(&pool);
+
+    h2o_http2_casper_init(&casper, 13, 6);
+    h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
+    h2o_iovec_t cookie1 = h2o_http2_casper_build_cookie(&casper, &pool);
+    h2o_http2_casper_dispose(&casper);
+
+    h2o_http2_casper_init(&casper, 13, 6);
+    h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 1);
+    h2o_iovec_t cookie2 = h2o_http2_casper_build_cookie(&casper, &pool);
+    h2o_http2_casper_dispose(&casper);
+
+    h2o_http2_casper_init(&casper, 13, 6);
+    h2o_http2_casper_consume_cookie(&casper, cookie1.base, get_end_of_cookie_value(cookie1.base, cookie1.len));
+    h2o_http2_casper_consume_cookie(&casper, cookie1.base, get_end_of_cookie_value(cookie1.base, cookie1.len));
+    ok(casper.keys.size == 1);
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
+    h2o_http2_casper_consume_cookie(&casper, cookie2.base, get_end_of_cookie_value(cookie2.base, cookie2.len));
+    ok(casper.keys.size == 2);
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
+    ok(h2o_http2_casper_lookup(&casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 0) == 1);
+    h2o_http2_casper_dispose(&casper);
+
+    h2o_mem_clear_pool(&pool);
+}
+
+void test_lib__http2__casper(void)
+{
+    subtest("calc_key", test_calc_key);
+    subtest("test_lookup", test_lookup);
+    subtest("cookie", test_cookie);
+    subtest("cookie-merge", test_cookie_merge);
+}

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -163,6 +163,7 @@ int main(int argc, char **argv)
         subtest("lib/handler/mimemap.c", test_lib__handler__mimemap_c);
         subtest("lib/http2/hpack.c", test_lib__http2__hpack);
         subtest("lib/http2/scheduler.c", test_lib__http2__scheduler);
+        subtest("lib/http2/casper.c", test_lib__http2__casper);
     }
 
     { /* tests that use the run loop */

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -65,6 +65,7 @@ void test_lib__handler__mimemap_c(void);
 void test_lib__handler__redirect_c(void);
 void test_lib__http2__hpack(void);
 void test_lib__http2__scheduler(void);
+void test_lib__http2__casper(void);
 void test_src__ssl_c(void);
 void test_issues293(void);
 

--- a/t/40server-push.t
+++ b/t/40server-push.t
@@ -36,8 +36,11 @@ EOT
 sub doit {
     my ($proto, $opts, $port) = @_;
 
-    my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.txt>\%3b\%20rel=preload'`;
-    like $resp, qr{\nresponseEnd\s.*\s/assets/index\.txt\n.*\s/index\.txt\?}is, 'should receive pushed content from file hanlder before the main response';
+    my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.js>\%3b\%20rel=preload'`;
+    like $resp, qr{\nresponseEnd\s.*\s/assets/index\.js\n.*\s/index\.txt\?}is, 'should receive pushed blocking asset from file handler before the main response';
+
+    $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.txt>\%3b\%20rel=preload'`;
+    like $resp, qr{\nresponseEnd\s.*\s/index\.txt\?.*?\n.*\s/assets/index\.txt\n}is, 'should receive pushed non-blocking asset from file handler after the main response';
 
     $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</index.txt.gz>\%3b\%20rel=preload'`;
     like $resp, qr{\nresponseEnd\s.*\s/index\.txt\?.*\s/index\.txt.gz\n}is, 'pushed content on upstream would arrive after the main content';

--- a/t/assets/doc_root/index.js
+++ b/t/assets/doc_root/index.js
@@ -1,0 +1,1 @@
+alert("hello");


### PR DESCRIPTION
This PR implements cache-aware server push using cookies.

ToDo:
* [x] provide a configuration directive to turn on the feature (default should be OFF)
* [ ] provide a way to define the mime-types of files that need to be tracked
* [ ] implement a way to create positive list of the fingerprint that can be used to evict the negative ones (i.e. flags corresponding to files being removed or altered) from the client-side cookie
 * note: this is only necessary for cookie-based approach; when using SW we can build an accurate fingerprint on the client-side by iterating through the SW cache

part of #421