### PR TITLE
mimemap with attributes

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -863,6 +863,10 @@ void h2o_ostream_send_next(h2o_ostream_t *ostr, h2o_req_t *req, h2o_iovec_t *buf
  * called by the connection layer to request additional data to the generator
  */
 static void h2o_proceed_response(h2o_req_t *req);
+/**
+ * if NULL, supplements h2o_req_t::mime_attr
+ */
+void h2o_req_fill_mime_attributes(h2o_req_t *req, h2o_mimemap_t *mimemap);
 
 /* config */
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1005,7 +1005,11 @@ h2o_mimemap_type_t *h2o_mimemap_get_default_type(h2o_mimemap_t *mimemap);
 /**
  * returns the mime-type corresponding to given extension
  */
-h2o_mimemap_type_t *h2o_mimemap_get_type(h2o_mimemap_t *mimemap, const char *ext);
+h2o_mimemap_type_t *h2o_mimemap_get_type_by_extension(h2o_mimemap_t *mimemap, const char *ext);
+/**
+ * returns the mime-type corresponding to given mimetype
+ */
+h2o_mimemap_type_t *h2o_mimemap_get_type_by_mimetype(h2o_mimemap_t *mimemap, h2o_iovec_t mime);
 
 /* various handlers */
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -170,6 +170,10 @@ typedef struct st_h2o_pathconf_t {
      * list of loggers (h2o_logger_t)
      */
     H2O_VECTOR(h2o_logger_t *) loggers;
+    /**
+     * mimemap
+     */
+    h2o_mimemap_t *mimemap;
 } h2o_pathconf_t;
 
 struct st_h2o_hostconf_t {
@@ -202,6 +206,10 @@ struct st_h2o_hostconf_t {
      * catch-all path configuration
      */
     h2o_pathconf_t fallback_path;
+    /**
+     * mimemap
+     */
+    h2o_mimemap_t *mimemap;
 };
 
 typedef struct st_h2o_protocol_callbacks_t {
@@ -285,6 +293,11 @@ struct st_h2o_globalconf_t {
          */
         uint64_t io_timeout;
     } proxy;
+
+    /**
+     * mimemap
+     */
+    h2o_mimemap_t *mimemap;
 
     size_t _num_config_slots;
 };
@@ -830,8 +843,9 @@ static void h2o_proceed_response(h2o_req_t *req);
 /**
  * initializes pathconf
  * @param path path to serve, or NULL if fallback or extension-level
+ * @param mimemap mimemap to use, or NULL if fallback or extension-level
  */
-void h2o_config_init_pathconf(h2o_pathconf_t *pathconf, h2o_globalconf_t *globalconf, const char *path);
+void h2o_config_init_pathconf(h2o_pathconf_t *pathconf, h2o_globalconf_t *globalconf, const char *path, h2o_mimemap_t *mimemap);
 /**
  *
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -302,10 +302,32 @@ struct st_h2o_globalconf_t {
     size_t _num_config_slots;
 };
 
+/**
+ * holds various attributes related to the mime-type
+ */
+typedef struct st_h2o_mime_attributes_t {
+    /**
+     * whether if the content can be compressed by using gzip
+     */
+    char is_compressible;
+    /**
+     * how the resource should be prioritized
+     */
+    enum { H2O_MIME_ATTRIBUTE_PRIORITY_NORMAL = 0, H2O_MIME_ATTRIBUTE_PRIORITY_HIGHEST } priority;
+} h2o_mime_attributes_t;
+
+extern h2o_mime_attributes_t h2o_mime_attributes_as_is;
+
+/**
+ * represents either a mime-type (and associated info), or contains pathinfo in case of a dynamic type (e.g. .php files)
+ */
 typedef struct st_h2o_mimemap_type_t {
     enum { H2O_MIMEMAP_TYPE_MIMETYPE = 0, H2O_MIMEMAP_TYPE_DYNAMIC = 1 } type;
     union {
-        h2o_iovec_t mimetype;
+        struct {
+            h2o_iovec_t mimetype;
+            h2o_mime_attributes_t attr;
+        };
         struct {
             h2o_pathconf_t pathconf;
         } dynamic;
@@ -482,6 +504,10 @@ typedef struct st_h2o_res_t {
      * list of response headers
      */
     h2o_headers_t headers;
+    /**
+     * mime-related attributes (may be NULL)
+     */
+    h2o_mime_attributes_t *mime_attr;
 } h2o_res_t;
 
 /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -959,14 +959,6 @@ void h2o__proxy_process_request(h2o_req_t *req);
 /* mime mapper */
 
 /**
- *
- */
-h2o_mimemap_type_t *h2o_mimemap_create_extension_type(const char *ext);
-/**
- *
- */
-h2o_mimemap_type_t *h2o_mimemap_create_dynamic_type(h2o_globalconf_t *globalconf);
-/**
  * initializes the mimemap (the returned chunk is refcounted)
  */
 h2o_mimemap_t *h2o_mimemap_create(void);
@@ -989,11 +981,15 @@ int h2o_mimemap_has_dynamic_type(h2o_mimemap_t *mimemap);
 /**
  * sets the default mime-type
  */
-void h2o_mimemap_set_default_type(h2o_mimemap_t *mimemap, h2o_mimemap_type_t *type, int incref);
+void h2o_mimemap_set_default_type(h2o_mimemap_t *mimemap, const char *mime);
 /**
  * adds a mime-type mapping
  */
-void h2o_mimemap_set_type(h2o_mimemap_t *mimemap, const char *ext, h2o_mimemap_type_t *type, int incref);
+void h2o_mimemap_define_mimetype(h2o_mimemap_t *mimemap, const char *ext, const char *mime);
+/**
+ * adds a mime-type mapping
+ */
+h2o_mimemap_type_t *h2o_mimemap_define_dynamic(h2o_mimemap_t *mimemap, const char **exts, h2o_globalconf_t *globalconf);
 /**
  * removes a mime-type mapping
  */

--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -40,11 +40,13 @@ enum {
 
 #define H2O_CONFIGURATOR_NUM_LEVELS 4
 
-typedef struct h2o_configurator_context_t {
+typedef struct st_h2o_configurator_context_t {
     h2o_globalconf_t *globalconf;
     h2o_hostconf_t *hostconf;
     h2o_pathconf_t *pathconf;
+    h2o_mimemap_t **mimemap;
     int dry_run;
+    struct st_h2o_configurator_context_t *parent;
 } h2o_configurator_context_t;
 
 typedef int (*h2o_configurator_dispose_cb)(h2o_configurator_t *configurator);

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -32,7 +32,9 @@ static h2o_hostconf_t *create_hostconf(h2o_globalconf_t *globalconf)
 {
     h2o_hostconf_t *hostconf = h2o_mem_alloc(sizeof(*hostconf));
     *hostconf = (h2o_hostconf_t){globalconf};
-    h2o_config_init_pathconf(&hostconf->fallback_path, globalconf, NULL);
+    h2o_config_init_pathconf(&hostconf->fallback_path, globalconf, NULL, NULL);
+    hostconf->mimemap = globalconf->mimemap;
+    h2o_mem_addref_shared(hostconf->mimemap);
     return hostconf;
 }
 
@@ -48,17 +50,22 @@ static void destroy_hostconf(h2o_hostconf_t *hostconf)
         h2o_config_dispose_pathconf(pathconf);
     }
     h2o_config_dispose_pathconf(&hostconf->fallback_path);
+    h2o_mem_release_shared(hostconf->mimemap);
 
     free(hostconf);
 }
 
-void h2o_config_init_pathconf(h2o_pathconf_t *pathconf, h2o_globalconf_t *globalconf, const char *path)
+void h2o_config_init_pathconf(h2o_pathconf_t *pathconf, h2o_globalconf_t *globalconf, const char *path, h2o_mimemap_t *mimemap)
 {
     memset(pathconf, 0, sizeof(*pathconf));
     pathconf->global = globalconf;
     h2o_chunked_register(pathconf);
     if (path != NULL)
         pathconf->path = h2o_strdup_slashed(NULL, path, SIZE_MAX);
+    if (mimemap != NULL) {
+        h2o_mem_addref_shared(mimemap);
+        pathconf->mimemap = mimemap;
+    }
 }
 
 void h2o_config_dispose_pathconf(h2o_pathconf_t *pathconf)
@@ -74,12 +81,13 @@ void h2o_config_dispose_pathconf(h2o_pathconf_t *pathconf)
         }                                                                                                                          \
         free(list.entries);                                                                                                        \
     } while (0)
-
     DESTROY_LIST(h2o_handler_t, pathconf->handlers);
     DESTROY_LIST(h2o_filter_t, pathconf->filters);
     DESTROY_LIST(h2o_logger_t, pathconf->loggers);
-
 #undef DESTROY_LIST
+
+    if (pathconf->mimemap != NULL)
+        h2o_mem_release_shared(pathconf->mimemap);
 }
 
 void h2o_config_init(h2o_globalconf_t *config)
@@ -100,6 +108,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http2.max_concurrent_requests_per_connection = H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams;
     config->http2.max_streams_for_priority = 16;
     config->http2.callbacks = H2O_HTTP2_CALLBACKS;
+    config->mimemap = h2o_mimemap_create();
 
     h2o_configurator__init_core(config);
 }
@@ -111,7 +120,7 @@ h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *p
     h2o_vector_reserve(NULL, (void *)&hostconf->paths, sizeof(hostconf->paths.entries[0]), hostconf->paths.size + 1);
     pathconf = hostconf->paths.entries + hostconf->paths.size++;
 
-    h2o_config_init_pathconf(pathconf, hostconf->global, pathname);
+    h2o_config_init_pathconf(pathconf, hostconf->global, pathname, hostconf->mimemap);
 
     return pathconf;
 }

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -325,6 +325,21 @@ void h2o_ostream_send_next(h2o_ostream_t *ostream, h2o_req_t *req, h2o_iovec_t *
     ostream->next->do_send(ostream->next, req, bufs, bufcnt, is_final);
 }
 
+void h2o_req_fill_mime_attributes(h2o_req_t *req, h2o_mimemap_t *mimemap)
+{
+    ssize_t content_type_index;
+    h2o_mimemap_type_t *mime;
+
+    if (req->res.mime_attr != NULL)
+        return;
+
+    if ((content_type_index = h2o_find_header(&req->res.headers, H2O_TOKEN_CONTENT_TYPE, -1)) != -1 &&
+        (mime = h2o_mimemap_get_type_by_mimetype(mimemap, req->res.headers.entries[content_type_index].value)) != NULL)
+        req->res.mime_attr = &mime->data.attr;
+    else
+        req->res.mime_attr = &h2o_mime_attributes_as_is;
+}
+
 void h2o_send_inline(h2o_req_t *req, const char *body, size_t len)
 {
     static h2o_generator_t generator = {NULL, NULL};

--- a/lib/handler/configurator/file.c
+++ b/lib/handler/configurator/file.c
@@ -91,7 +91,6 @@ static int assert_is_extension(h2o_configurator_command_t *cmd, yoml_t *node)
 static int set_mimetypes(h2o_configurator_command_t *cmd, h2o_mimemap_t *mimemap, yoml_t *node)
 {
     size_t i, j;
-    h2o_mimemap_type_t *type = NULL;
 
     assert(node->type == YOML_TYPE_MAPPING);
 
@@ -100,36 +99,28 @@ static int set_mimetypes(h2o_configurator_command_t *cmd, h2o_mimemap_t *mimemap
         yoml_t *value = node->data.mapping.elements[i].value;
         if (assert_is_mimetype(cmd, key) != 0)
             return -1;
-        type = h2o_mimemap_create_extension_type(key->data.scalar);
         switch (value->type) {
         case YOML_TYPE_SCALAR:
             if (assert_is_extension(cmd, value) != 0)
-                goto Error;
-            h2o_mimemap_set_type(mimemap, value->data.scalar + 1, type, 1);
+                return -1;
+            h2o_mimemap_define_mimetype(mimemap, value->data.scalar + 1, key->data.scalar);
             break;
         case YOML_TYPE_SEQUENCE:
             for (j = 0; j != value->data.sequence.size; ++j) {
                 yoml_t *ext_node = value->data.sequence.elements[j];
                 if (assert_is_extension(cmd, ext_node) != 0)
-                    goto Error;
-                h2o_mimemap_set_type(mimemap, ext_node->data.scalar + 1, type, 1);
+                    return -1;
+                h2o_mimemap_define_mimetype(mimemap, ext_node->data.scalar + 1, key->data.scalar);
             }
             break;
         default:
             h2o_configurator_errprintf(cmd, value,
                                        "only scalar or sequence of scalar is permitted at the value part of the argument");
-            goto Error;
+            return -1;
         }
-        h2o_mem_release_shared(type);
-        type = NULL;
     }
 
     return 0;
-
-Error:
-    if (type != NULL)
-        h2o_mem_release_shared(type);
-    return -1;
 }
 
 static int on_config_mime_settypes(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
@@ -137,7 +128,7 @@ static int on_config_mime_settypes(h2o_configurator_command_t *cmd, h2o_configur
     struct st_h2o_file_configurator_t *self = (void *)cmd->configurator;
     h2o_mimemap_t *newmap = h2o_mimemap_create();
 
-    h2o_mimemap_set_default_type(newmap, h2o_mimemap_get_default_type(self->vars->mimemap), 1);
+    h2o_mimemap_set_default_type(newmap, h2o_mimemap_get_default_type(self->vars->mimemap)->data.mimetype.base);
     if (set_mimetypes(cmd, newmap, node) != 0) {
         h2o_mem_release_shared(newmap);
         return -1;
@@ -190,7 +181,7 @@ static int on_config_mime_setdefaulttype(h2o_configurator_command_t *cmd, h2o_co
         return -1;
 
     clone_mimemap_if_clean(self);
-    h2o_mimemap_set_default_type(self->vars->mimemap, h2o_mimemap_create_extension_type(node->data.scalar), 0);
+    h2o_mimemap_set_default_type(self->vars->mimemap, node->data.scalar);
 
     return 0;
 }
@@ -201,6 +192,7 @@ static int on_config_custom_handler(h2o_configurator_command_t *cmd, h2o_configu
     struct st_h2o_file_configurator_t *self = (void *)cmd->configurator;
     h2o_pathconf_t *prev_pathconf = ctx->pathconf;
     yoml_t *ext_node;
+    const char **exts;
     h2o_mimemap_type_t *type = NULL;
     int ret = -1;
 
@@ -213,8 +205,36 @@ static int on_config_custom_handler(h2o_configurator_command_t *cmd, h2o_configu
         goto Exit;
     }
 
-    type = h2o_mimemap_create_dynamic_type(ctx->globalconf);
+    clone_mimemap_if_clean(self);
+
+    switch (ext_node->type) {
+    case YOML_TYPE_SCALAR:
+        if (assert_is_extension(cmd, ext_node) != 0)
+            goto Exit;
+        exts = alloca(2 * sizeof(*exts));
+        exts[0] = ext_node->data.scalar + 1;
+        exts[1] = NULL;
+        break;
+    case YOML_TYPE_SEQUENCE: {
+        exts = alloca((ext_node->data.sequence.size + 1) * sizeof(*exts));
+        size_t i;
+        for (i = 0; i != ext_node->data.sequence.size; ++i) {
+            yoml_t *n = ext_node->data.sequence.elements[i];
+            if (assert_is_extension(cmd, n) != 0)
+                goto Exit;
+            exts[i] = n->data.scalar + 1;
+        }
+        exts[i] = NULL;
+    } break;
+    default:
+        h2o_configurator_errprintf(cmd, ext_node,
+                                   "only scalar or sequence of scalar is permitted at the value part of the argument");
+        goto Exit;
+    }
+
+    type = h2o_mimemap_define_dynamic(self->vars->mimemap, exts, ctx->globalconf);
     ctx->pathconf = &type->data.dynamic.pathconf;
+
     if (h2o_configurator_apply_commands(ctx, node, H2O_CONFIGURATOR_FLAG_EXTENSION, ignore_commands) != 0)
         goto Exit;
     switch (type->data.dynamic.pathconf.handlers.size) {
@@ -228,33 +248,8 @@ static int on_config_custom_handler(h2o_configurator_command_t *cmd, h2o_configu
         goto Exit;
     }
 
-    clone_mimemap_if_clean(self);
-
-    switch (ext_node->type) {
-    case YOML_TYPE_SCALAR:
-        if (assert_is_extension(cmd, ext_node) != 0)
-            goto Exit;
-        h2o_mimemap_set_type(self->vars->mimemap, ext_node->data.scalar + 1, type, 1);
-        break;
-    case YOML_TYPE_SEQUENCE: {
-        size_t i;
-        for (i = 0; i != ext_node->data.sequence.size; ++i) {
-            yoml_t *n = ext_node->data.sequence.elements[i];
-            if (assert_is_extension(cmd, n) != 0)
-                goto Exit;
-            h2o_mimemap_set_type(self->vars->mimemap, n->data.scalar + 1, type, 1);
-        }
-    } break;
-    default:
-        h2o_configurator_errprintf(cmd, ext_node,
-                                   "only scalar or sequence of scalar is permitted at the value part of the argument");
-        goto Exit;
-    }
-
     ret = 0;
 Exit:
-    if (type != NULL)
-        h2o_mem_release_shared(type);
     ctx->pathconf = prev_pathconf;
     return ret;
 }

--- a/lib/handler/configurator/file.c
+++ b/lib/handler/configurator/file.c
@@ -24,7 +24,6 @@
 
 struct st_h2o_file_config_vars_t {
     const char **index_files;
-    h2o_mimemap_t *mimemap;
     int flags;
 };
 
@@ -38,7 +37,7 @@ static int on_config_dir(h2o_configurator_command_t *cmd, h2o_configurator_conte
 {
     struct st_h2o_file_configurator_t *self = (void *)cmd->configurator;
 
-    h2o_file_register(ctx->pathconf, node->data.scalar, self->vars->index_files, self->vars->mimemap, self->vars->flags);
+    h2o_file_register(ctx->pathconf, node->data.scalar, self->vars->index_files, *ctx->mimemap, self->vars->flags);
     return 0;
 }
 
@@ -60,198 +59,6 @@ static int on_config_index(h2o_configurator_command_t *cmd, h2o_configurator_con
     self->vars->index_files[i] = NULL;
 
     return 0;
-}
-
-static int assert_is_mimetype(h2o_configurator_command_t *cmd, yoml_t *node)
-{
-    if (node->type != YOML_TYPE_SCALAR) {
-        h2o_configurator_errprintf(cmd, node, "expected a scalar (mime-type)");
-        return -1;
-    }
-    if (strchr(node->data.scalar, '/') == NULL) {
-        h2o_configurator_errprintf(cmd, node, "the string \"%s\" does not look like a mime-type", node->data.scalar);
-        return -1;
-    }
-    return 0;
-}
-
-static int assert_is_extension(h2o_configurator_command_t *cmd, yoml_t *node)
-{
-    if (node->type != YOML_TYPE_SCALAR) {
-        h2o_configurator_errprintf(cmd, node, "expected a scalar (extension)");
-        return -1;
-    }
-    if (node->data.scalar[0] != '.') {
-        h2o_configurator_errprintf(cmd, node, "given extension \"%s\" does not start with a \".\"", node->data.scalar);
-        return -1;
-    }
-    return 0;
-}
-
-static int set_mimetypes(h2o_configurator_command_t *cmd, h2o_mimemap_t *mimemap, yoml_t *node)
-{
-    size_t i, j;
-
-    assert(node->type == YOML_TYPE_MAPPING);
-
-    for (i = 0; i != node->data.mapping.size; ++i) {
-        yoml_t *key = node->data.mapping.elements[i].key;
-        yoml_t *value = node->data.mapping.elements[i].value;
-        if (assert_is_mimetype(cmd, key) != 0)
-            return -1;
-        switch (value->type) {
-        case YOML_TYPE_SCALAR:
-            if (assert_is_extension(cmd, value) != 0)
-                return -1;
-            h2o_mimemap_define_mimetype(mimemap, value->data.scalar + 1, key->data.scalar);
-            break;
-        case YOML_TYPE_SEQUENCE:
-            for (j = 0; j != value->data.sequence.size; ++j) {
-                yoml_t *ext_node = value->data.sequence.elements[j];
-                if (assert_is_extension(cmd, ext_node) != 0)
-                    return -1;
-                h2o_mimemap_define_mimetype(mimemap, ext_node->data.scalar + 1, key->data.scalar);
-            }
-            break;
-        default:
-            h2o_configurator_errprintf(cmd, value,
-                                       "only scalar or sequence of scalar is permitted at the value part of the argument");
-            return -1;
-        }
-    }
-
-    return 0;
-}
-
-static int on_config_mime_settypes(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    struct st_h2o_file_configurator_t *self = (void *)cmd->configurator;
-    h2o_mimemap_t *newmap = h2o_mimemap_create();
-
-    h2o_mimemap_set_default_type(newmap, h2o_mimemap_get_default_type(self->vars->mimemap)->data.mimetype.base);
-    if (set_mimetypes(cmd, newmap, node) != 0) {
-        h2o_mem_release_shared(newmap);
-        return -1;
-    }
-
-    h2o_mem_release_shared(self->vars->mimemap);
-    self->vars->mimemap = newmap;
-    return 0;
-}
-
-static void clone_mimemap_if_clean(struct st_h2o_file_configurator_t *self)
-{
-    if (self->vars->mimemap != self->vars[-1].mimemap)
-        return;
-    h2o_mem_release_shared(self->vars->mimemap);
-    self->vars->mimemap = h2o_mimemap_clone(self->vars->mimemap);
-}
-
-static int on_config_mime_addtypes(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    struct st_h2o_file_configurator_t *self = (void *)cmd->configurator;
-
-    clone_mimemap_if_clean(self);
-
-    return set_mimetypes(cmd, self->vars->mimemap, node);
-}
-
-static int on_config_mime_removetypes(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    struct st_h2o_file_configurator_t *self = (void *)cmd->configurator;
-    size_t i;
-
-    clone_mimemap_if_clean(self);
-
-    for (i = 0; i != node->data.sequence.size; ++i) {
-        yoml_t *ext_node = node->data.sequence.elements[i];
-        if (assert_is_extension(cmd, ext_node) != 0)
-            return -1;
-        h2o_mimemap_remove_type(self->vars->mimemap, ext_node->data.scalar + 1);
-    }
-
-    return 0;
-}
-
-static int on_config_mime_setdefaulttype(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    struct st_h2o_file_configurator_t *self = (void *)cmd->configurator;
-
-    if (assert_is_mimetype(cmd, node) != 0)
-        return -1;
-
-    clone_mimemap_if_clean(self);
-    h2o_mimemap_set_default_type(self->vars->mimemap, node->data.scalar);
-
-    return 0;
-}
-
-static int on_config_custom_handler(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    static const char *ignore_commands[] = {"extension", NULL};
-    struct st_h2o_file_configurator_t *self = (void *)cmd->configurator;
-    h2o_pathconf_t *prev_pathconf = ctx->pathconf;
-    yoml_t *ext_node;
-    const char **exts;
-    h2o_mimemap_type_t *type = NULL;
-    int ret = -1;
-
-    if (node->type != YOML_TYPE_MAPPING) {
-        h2o_configurator_errprintf(cmd, node, "argument must be a MAPPING");
-        goto Exit;
-    }
-    if ((ext_node = yoml_get(node, "extension")) == NULL) {
-        h2o_configurator_errprintf(cmd, node, "mandatory key `extension` is missing");
-        goto Exit;
-    }
-
-    clone_mimemap_if_clean(self);
-
-    switch (ext_node->type) {
-    case YOML_TYPE_SCALAR:
-        if (assert_is_extension(cmd, ext_node) != 0)
-            goto Exit;
-        exts = alloca(2 * sizeof(*exts));
-        exts[0] = ext_node->data.scalar + 1;
-        exts[1] = NULL;
-        break;
-    case YOML_TYPE_SEQUENCE: {
-        exts = alloca((ext_node->data.sequence.size + 1) * sizeof(*exts));
-        size_t i;
-        for (i = 0; i != ext_node->data.sequence.size; ++i) {
-            yoml_t *n = ext_node->data.sequence.elements[i];
-            if (assert_is_extension(cmd, n) != 0)
-                goto Exit;
-            exts[i] = n->data.scalar + 1;
-        }
-        exts[i] = NULL;
-    } break;
-    default:
-        h2o_configurator_errprintf(cmd, ext_node,
-                                   "only scalar or sequence of scalar is permitted at the value part of the argument");
-        goto Exit;
-    }
-
-    type = h2o_mimemap_define_dynamic(self->vars->mimemap, exts, ctx->globalconf);
-    ctx->pathconf = &type->data.dynamic.pathconf;
-
-    if (h2o_configurator_apply_commands(ctx, node, H2O_CONFIGURATOR_FLAG_EXTENSION, ignore_commands) != 0)
-        goto Exit;
-    switch (type->data.dynamic.pathconf.handlers.size) {
-    case 1:
-        break;
-    case 0:
-        h2o_configurator_errprintf(cmd, node, "no handler declared for given extension");
-        goto Exit;
-    default:
-        h2o_configurator_errprintf(cmd, node, "cannot assign more than one handler for given extension");
-        goto Exit;
-    }
-
-    ret = 0;
-Exit:
-    ctx->pathconf = prev_pathconf;
-    return ret;
 }
 
 static int on_config_etag(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
@@ -328,9 +135,7 @@ static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t
     struct st_h2o_file_configurator_t *self = (void *)_self;
     ++self->vars;
     self->vars[0].index_files = dup_strlist(self->vars[-1].index_files);
-    self->vars[0].mimemap = self->vars[-1].mimemap;
     self->vars[0].flags = self->vars[-1].flags;
-    h2o_mem_addref_shared(self->vars[0].mimemap);
     return 0;
 }
 
@@ -338,7 +143,6 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 {
     struct st_h2o_file_configurator_t *self = (void *)_self;
     free(self->vars->index_files);
-    h2o_mem_release_shared(self->vars->mimemap);
     --self->vars;
     return 0;
 }
@@ -350,7 +154,6 @@ void h2o_file_register_configurator(h2o_globalconf_t *globalconf)
     self->super.enter = on_config_enter;
     self->super.exit = on_config_exit;
     self->vars = self->_vars_stack;
-    self->vars->mimemap = h2o_mimemap_create();
     self->vars->index_files = h2o_file_default_index_files;
 
     h2o_configurator_define_command(&self->super, "file.dir", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR |
@@ -360,26 +163,6 @@ void h2o_file_register_configurator(h2o_globalconf_t *globalconf)
                                     (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                         H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE,
                                     on_config_index);
-    h2o_configurator_define_command(&self->super, "file.mime.settypes",
-                                    (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
-                                        H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,
-                                    on_config_mime_settypes);
-    h2o_configurator_define_command(&self->super, "file.mime.addtypes",
-                                    (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
-                                        H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,
-                                    on_config_mime_addtypes);
-    h2o_configurator_define_command(&self->super, "file.mime.removetypes",
-                                    (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
-                                        H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE,
-                                    on_config_mime_removetypes);
-    h2o_configurator_define_command(&self->super, "file.mime.setdefaulttype",
-                                    (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
-                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
-                                    on_config_mime_setdefaulttype);
-    h2o_configurator_define_command(&self->super, "file.custom-handler",
-                                    (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
-                                        H2O_CONFIGURATOR_FLAG_SEMI_DEFERRED,
-                                    on_config_custom_handler);
     h2o_configurator_define_command(&self->super, "file.etag",
                                     (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                         H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -269,7 +269,7 @@ Opened:
 }
 
 static void do_send_file(struct st_h2o_sendfile_generator_t *self, h2o_req_t *req, int status, const char *reason,
-                         h2o_iovec_t mime_type, int is_get)
+                         h2o_iovec_t mime_type, h2o_mime_attributes_t *mime_attr, int is_get)
 {
     /* link the request */
     self->req = req;
@@ -278,6 +278,7 @@ static void do_send_file(struct st_h2o_sendfile_generator_t *self, h2o_req_t *re
     req->res.status = status;
     req->res.reason = reason;
     req->res.content_length = self->bytesleft;
+    req->res.mime_attr = mime_attr;
 
     if (self->ranged.range_count > 1) {
         mime_type.base = h2o_mem_alloc_pool(&req->pool, 52);
@@ -348,7 +349,7 @@ int h2o_file_send(h2o_req_t *req, int status, const char *reason, const char *pa
     if ((self = create_generator(req, path, strlen(path), &is_dir, flags)) == NULL)
         return -1;
     /* note: is_dir is not handled */
-    do_send_file(self, req, status, reason, mime_type, 1);
+    do_send_file(self, req, status, reason, mime_type, NULL, 1);
     return 0;
 }
 
@@ -720,12 +721,13 @@ Opened:
                                  (sizeof("\r\n") - 1);
             generator->bytesleft = final_content_len;
         }
-        do_send_file(generator, req, 206, "Partial Content", mime_type->data.mimetype, method_type == METHOD_IS_GET);
+        do_send_file(generator, req, 206, "Partial Content", mime_type->data.mimetype, &h2o_mime_attributes_as_is,
+                     method_type == METHOD_IS_GET);
         return 0;
     }
 
     /* return file */
-    do_send_file(generator, req, 200, "OK", mime_type->data.mimetype, method_type == METHOD_IS_GET);
+    do_send_file(generator, req, 200, "OK", mime_type->data.mimetype, &mime_type->data.attr, method_type == METHOD_IS_GET);
     return 0;
 
 NotModified:

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -532,7 +532,7 @@ static int try_dynamic_request(h2o_file_handler_t *self, h2o_req_t *req, char *r
     }
 
     /* file found! */
-    h2o_mimemap_type_t *mime_type = h2o_mimemap_get_type(self->mimemap, h2o_get_filext(rpath, slash_at));
+    h2o_mimemap_type_t *mime_type = h2o_mimemap_get_type_by_extension(self->mimemap, h2o_get_filext(rpath, slash_at));
     switch (mime_type->type) {
     case H2O_MIMEMAP_TYPE_MIMETYPE:
         return -1;
@@ -646,7 +646,7 @@ Opened:
     }
 
     /* obtain mime type */
-    mime_type = h2o_mimemap_get_type(self->mimemap, h2o_get_filext(rpath, rpath_len));
+    mime_type = h2o_mimemap_get_type_by_extension(self->mimemap, h2o_get_filext(rpath, rpath_len));
     switch (mime_type->type) {
     case H2O_MIMEMAP_TYPE_MIMETYPE:
         break;

--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -133,7 +133,7 @@ static h2o_mimemap_type_t *create_extension_type(const char *mime)
     type->data.mimetype.len = i;
 
     /* make a rough guess on whether the type is compressible or not */
-    if (strncmp(type->data.mimetype.base, "text/", 5) == 0 || strstr(type->data.mimetype.base, "+xml") == 0)
+    if (strncmp(type->data.mimetype.base, "text/", 5) == 0 || strnstr(type->data.mimetype.base, "+xml", type_end_at) != NULL)
         type->data.attr.is_compressible = 1;
 
     /* make a rough guess on whether the type is blocking asset or not */

--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -124,13 +124,18 @@ static h2o_mimemap_type_t *create_extension_type(const char *mime)
     return type;
 }
 
+static void dispose_dynamic_type(h2o_mimemap_type_t *type)
+{
+    h2o_config_dispose_pathconf(&type->data.dynamic.pathconf);
+}
+
 static h2o_mimemap_type_t *create_dynamic_type(h2o_globalconf_t *globalconf)
 {
-    h2o_mimemap_type_t *type = h2o_mem_alloc_shared(NULL, sizeof(*type), NULL);
+    h2o_mimemap_type_t *type = h2o_mem_alloc_shared(NULL, sizeof(*type), (void *)dispose_dynamic_type);
 
     type->type = H2O_MIMEMAP_TYPE_DYNAMIC;
     memset(&type->data.dynamic, 0, sizeof(type->data.dynamic));
-    h2o_config_init_pathconf(&type->data.dynamic.pathconf, globalconf, (void *)h2o_config_dispose_pathconf);
+    h2o_config_init_pathconf(&type->data.dynamic.pathconf, globalconf, NULL, NULL);
 
     return type;
 }

--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -20,6 +20,7 @@
  * IN THE SOFTWARE.
  */
 #include <assert.h>
+#include <string.h>
 #include "khash.h"
 #include "h2o.h"
 
@@ -133,7 +134,8 @@ static h2o_mimemap_type_t *create_extension_type(const char *mime)
     type->data.mimetype.len = i;
 
     /* make a rough guess on whether the type is compressible or not */
-    if (strncmp(type->data.mimetype.base, "text/", 5) == 0 || strnstr(type->data.mimetype.base, "+xml", type_end_at) != NULL)
+    if (strncmp(type->data.mimetype.base, "text/", 5) == 0 ||
+        h2o_strstr(type->data.mimetype.base, type_end_at, H2O_STRLIT("+xml")) != SIZE_MAX)
         type->data.attr.is_compressible = 1;
 
     /* make a rough guess on whether the type is blocking asset or not */

--- a/t/00unit/lib/handler/mimemap.c
+++ b/t/00unit/lib/handler/mimemap.c
@@ -37,22 +37,21 @@ void test_lib__handler__mimemap_c()
     {
         char buf[sizeof("text/plain")];
         strcpy(buf, "text/plain");
-        h2o_mimemap_set_default_type(mimemap, h2o_mimemap_create_extension_type(buf), 0);
+        h2o_mimemap_set_default_type(mimemap, buf);
         memset(buf, 0, sizeof(buf));
     }
     ok(is_mimetype(h2o_mimemap_get_default_type(mimemap), "text/plain"));
 
     /* set and overwrite */
-    h2o_mimemap_set_type(mimemap, "foo", h2o_mimemap_create_extension_type("example/foo"), 0);
+    h2o_mimemap_define_mimetype(mimemap, "foo", "example/foo");
     ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "example/foo"));
     ok(h2o_mimemap_get_type_by_extension(mimemap, "foo") ==
        h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/foo"))));
-    h2o_mimemap_set_type(mimemap, "foo", h2o_mimemap_create_extension_type("example/overwritten"), 0);
+    h2o_mimemap_define_mimetype(mimemap, "foo", "example/overwritten");
     ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "example/overwritten"));
     ok(h2o_mimemap_get_type_by_extension(mimemap, "foo") ==
        h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/overwritten"))));
-    ok(h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/foo"))) ==
-       h2o_mimemap_get_default_type(mimemap));
+    ok(h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/foo"))) == NULL);
 
     /* clone and release */
     mimemap2 = h2o_mimemap_clone(mimemap);
@@ -69,8 +68,7 @@ void test_lib__handler__mimemap_c()
     /* remove */
     h2o_mimemap_remove_type(mimemap, "foo");
     ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "text/plain"));
-    ok(h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/overwritten"))) ==
-       h2o_mimemap_get_default_type(mimemap));
+    ok(h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/overwritten"))) == NULL);
     h2o_mimemap_remove_type(mimemap, "foo");
     ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "text/plain"));
 

--- a/t/00unit/lib/handler/mimemap.c
+++ b/t/00unit/lib/handler/mimemap.c
@@ -44,25 +44,35 @@ void test_lib__handler__mimemap_c()
 
     /* set and overwrite */
     h2o_mimemap_set_type(mimemap, "foo", h2o_mimemap_create_extension_type("example/foo"), 0);
-    ok(is_mimetype(h2o_mimemap_get_type(mimemap, "foo"), "example/foo"));
+    ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "example/foo"));
+    ok(h2o_mimemap_get_type_by_extension(mimemap, "foo") ==
+       h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/foo"))));
     h2o_mimemap_set_type(mimemap, "foo", h2o_mimemap_create_extension_type("example/overwritten"), 0);
-    ok(is_mimetype(h2o_mimemap_get_type(mimemap, "foo"), "example/overwritten"));
+    ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "example/overwritten"));
+    ok(h2o_mimemap_get_type_by_extension(mimemap, "foo") ==
+       h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/overwritten"))));
+    ok(h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/foo"))) ==
+       h2o_mimemap_get_default_type(mimemap));
 
     /* clone and release */
     mimemap2 = h2o_mimemap_clone(mimemap);
     ok(is_mimetype(h2o_mimemap_get_default_type(mimemap2), "text/plain"));
-    ok(is_mimetype(h2o_mimemap_get_type(mimemap2, "foo"), "example/overwritten"));
+    ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap2, "foo"), "example/overwritten"));
+    ok(h2o_mimemap_get_type_by_extension(mimemap, "foo") ==
+       h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/overwritten"))));
     h2o_mem_release_shared(mimemap2);
 
     /* check original */
     ok(is_mimetype(h2o_mimemap_get_default_type(mimemap), "text/plain"));
-    ok(is_mimetype(h2o_mimemap_get_type(mimemap, "foo"), "example/overwritten"));
+    ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "example/overwritten"));
 
     /* remove */
     h2o_mimemap_remove_type(mimemap, "foo");
-    ok(is_mimetype(h2o_mimemap_get_type(mimemap, "foo"), "text/plain"));
+    ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "text/plain"));
+    ok(h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/overwritten"))) ==
+       h2o_mimemap_get_default_type(mimemap));
     h2o_mimemap_remove_type(mimemap, "foo");
-    ok(is_mimetype(h2o_mimemap_get_type(mimemap, "foo"), "text/plain"));
+    ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "text/plain"));
 
     h2o_mem_release_shared(mimemap);
 }


### PR DESCRIPTION
Still WIP; blocker of: #413 #432

For on-the-fly gzip, we need a flag in mimemap declaring whether if certain type is compressible (e.g. text/html) or not (e.g. image/jpeg).  For cache-aware server push, we need a flag declaring whether if certain type is likely a blocking asset (e.g. JavaScript or CSS) or not (e.g. images).

This PR adds such flags to the mimemap.