### PR TITLE
send `etag` (and `vary` if necessary) within 304 response

### DIFF
--- a/t/00unit/lib/handler/file.c
+++ b/t/00unit/lib/handler/file.c
@@ -292,6 +292,7 @@ static void test_if_modified_since(void)
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 304);
         ok(conn->body->size == 0);
+        ok(h2o_find_header(&conn->req.res.headers, H2O_TOKEN_ETAG, -1) != -1);
         h2o_loopback_destroy(conn);
     }
 
@@ -315,6 +316,7 @@ static void test_if_modified_since(void)
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 304);
         ok(conn->body->size == 0);
+        ok(h2o_find_header(&conn->req.res.headers, H2O_TOKEN_ETAG, -1) != -1);
         h2o_loopback_destroy(conn);
     }
 }


### PR DESCRIPTION
For conformance with RFC 7232 section 4.1; quote:

> The server generating a 304 response MUST generate any of the following header fields that would have been sent in a 200 (OK) response to the same request: Cache-Control, Content-Location, Date, ETag, Expires, and Vary.
> 
> Since the goal of a 304 response is to minimize information transfer when the recipient already has one or more cached representations, a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates (e.g., Last-Modified might be useful if the response does not have an ETag field).