### PR TITLE
Keep modified headers on H2O.return

### DIFF
--- a/lib/handler/mruby/class/core.c
+++ b/lib/handler/mruby/class/core.c
@@ -44,7 +44,7 @@ static mrb_value h2o_mrb_return(mrb_state *mrb, mrb_value self)
         if (reason == NULL || body == NULL)
             mrb_raise(mrb, E_ARGUMENT_ERROR, "need both reason and body with status code");
         /* send response using h2o_send_error */
-        h2o_send_error(mruby_ctx->req, status, reason, body, 0);
+        h2o_send_error(mruby_ctx->req, status, reason, body, H2O_SEND_ERROR_KEEP_HEADERS);
         mruby_ctx->is_last = 1;
     }
 


### PR DESCRIPTION
Hi @matsumoto-r san, @kazuho san,

I want to change response headers with not only `H2O.return H2O::DECLINED` but `H2O.return [statuscode]`.

For example,
```
r = H2O::Request.new

r.headers_out["WWW-Authenticate"] = %Q(Basic realm="Enter your ID/Pass")
H2O.return 401, "Unauthorized", "See you in the next dimension!"
```

So why don't we keep modified headers with `h2o_send_error` in `h2o_mrb_return`?