### PR TITLE
Change ownership of domain socket for fastcgi

### DIFF
--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -25,6 +25,7 @@
 #include <inttypes.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <pwd.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/un.h>
@@ -147,7 +148,7 @@ static int on_config_connect(h2o_configurator_command_t *cmd, h2o_configurator_c
 }
 
 static int create_spawnproc(h2o_configurator_command_t *cmd, yoml_t *node, const char *dirname, char *const *argv,
-                            struct sockaddr_un *sa)
+                            struct sockaddr_un *sa, struct passwd *pw)
 {
     int listen_fd, pipe_fds[2] = {-1, -1};
 
@@ -167,6 +168,11 @@ static int create_spawnproc(h2o_configurator_command_t *cmd, yoml_t *node, const
     }
     if (listen(listen_fd, SOMAXCONN) != 0) {
         h2o_configurator_errprintf(cmd, node, "listen(2) failed: %s", strerror(errno));
+        goto Error;
+    }
+    /* change ownership of socket */
+    if (chown(sa->sun_path, pw->pw_uid, pw->pw_gid) != 0){
+        h2o_configurator_errprintf(cmd, node, "chown(2) failed to change ownership of socket:%s:%s", sa->sun_path, strerror(errno));
         goto Error;
     }
 
@@ -223,6 +229,8 @@ static int on_config_spawn(h2o_configurator_command_t *cmd, h2o_configurator_con
     struct sockaddr_un sa = {};
     h2o_fastcgi_config_vars_t config_vars;
     int ret = -1;
+    struct passwd pwbuf, *pw;
+    char buf[65536];
 
     switch (node->type) {
     case YOML_TYPE_SCALAR:
@@ -283,8 +291,21 @@ static int on_config_spawn(h2o_configurator_command_t *cmd, h2o_configurator_con
             dirname[0] = '\0';
             goto Exit;
         }
+        /* change ownership of temporary directory */
+        if (getpwnam_r(spawn_user, &pwbuf, buf, sizeof(buf), &pw) != 0) {
+            h2o_configurator_errprintf(cmd, node, "getpwnam_r(3) failed to get password file entry");
+            goto Exit;
+        }
+        if (pw == NULL) {
+            h2o_configurator_errprintf(cmd, node, "unknown user:%s", spawn_user);
+            goto Exit;
+        }
+        if (chown(dirname, pw->pw_uid, pw->pw_gid) != 0){
+            h2o_configurator_errprintf(cmd, node, "chown(2) failed to change ownership of temporary directory:%s:%s", dirname, strerror(errno));
+            goto Exit;
+        }
         /* launch spawnfcgi command */
-        if ((spawner_fd = create_spawnproc(cmd, node, dirname, argv, &sa)) == -1) {
+        if ((spawner_fd = create_spawnproc(cmd, node, dirname, argv, &sa, pw)) == -1) {
             goto Exit;
         }
     }


### PR DESCRIPTION
The temporary directory for fastcgi's domain socket is created before H2O calls `h2o_setuidgid`.
Therefore, its owner is `root` and different from `user` directive.

```
$ sudo h2o -c /usr/local/etc/h2o.conf -m daemon
start_server (pid:2265) starting now...
$ sudo ls -la /tmp/h2o.fcgisock.*
total 8
srwxr-xr-x  1 root root    0 Aug 16 19:40 _
drwx------  2 root root 4096 Aug 16 19:40 .
drwxrwxrwt 10 root root 4096 Aug 16 19:40 ..
$ stat -c %U h2o
masaki
```

In this case, H2O cannot read the file and show such message. 

```
[lib/handler/fastcgi.c] in request:/:connection failed:failed to connect to host
```

I think we should change the ownership of them to the user which is defined in `user` directive.