### PR TITLE
ignore SIGINT in `kill-on-close` (and wait until parent shuts down)

### DIFF
--- a/share/h2o/kill-on-close
+++ b/share/h2o/kill-on-close
@@ -46,9 +46,11 @@ if ($pid == 0) {
     die "failed to exec $ARGV[0]:$!";
 }
 
+$SIG{INT} = sub {};
+
 while (1) {
     my $r = sysread $wait_fh, my $buf, 1;
-    last if $r == 0 || ($r == -1 && $! != EINTR);
+    last if !defined($r) || $r == 0 || ($r == -1 && $! != EINTR);
 }
 
 kill 'TERM', $pid;


### PR DESCRIPTION
When the standalone server is invoked in foreground and if Ctrl-C is pressed, shell sends SIGINT to the process group, which kills the `kill-on-close` script along with the standalone server, therefore leaving `php-cgi` processes running as orphans.

This PR fixes the issue.