### PR TITLE
no U option to Debian

### DIFF
--- a/t/40unix-socket.t
+++ b/t/40unix-socket.t
@@ -5,8 +5,8 @@ use File::Temp qw(tempdir);
 use Test::More;
 use t::Util;
 
-plan skip_all => 'nc not found'
-    unless prog_exists('nc');
+plan skip_all => 'nc -U not found'
+    unless prog_exists('nc') and `nc -h 2>&1` =~ /-U\t+Use UNIX domain socket/;
 
 my $tempdir = tempdir(CLEANUP => 1);
 my $sock_path = "$tempdir/h2o.sock";


### PR DESCRIPTION
Debian Jessie

````
#   Failed test at t/40unix-socket.t line 26.
#                   'nc: invalid option -- 'U'
# nc -h for help
# '
#     doesn't match '(?^s:^HTTP/1\.[0-9]+ 200 OK\r\n)'
````