### PR TITLE
[h2o_mruby] Fix bug; headers object sometimes break or varnish

### DIFF
--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -135,11 +135,17 @@ static mrb_value h2o_mrb_set_request_headers_in(mrb_state *mrb, mrb_value self)
 {
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
     mrb_value key, val;
+    char *key_cstr, *val_cstr;
 
     mrb_get_args(mrb, "oo", &key, &val);
     key = mrb_funcall(mrb, key, "downcase", 0);
 
-    h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->headers, RSTRING_PTR(key), RSTRING_LEN(key), 0, RSTRING_PTR(val),
+    key_cstr = h2o_mem_alloc_pool(&mruby_ctx->req->pool, RSTRING_LEN(key));
+    val_cstr = h2o_mem_alloc_pool(&mruby_ctx->req->pool, RSTRING_LEN(val));
+    memcpy(key_cstr, RSTRING_PTR(key), RSTRING_LEN(key));
+    memcpy(val_cstr, RSTRING_PTR(val), RSTRING_LEN(val));
+
+    h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->headers, key_cstr, RSTRING_LEN(key), 0, val_cstr,
                           RSTRING_LEN(val), 1);
 
     return key;
@@ -168,12 +174,18 @@ static mrb_value h2o_mrb_set_request_headers_out(mrb_state *mrb, mrb_value self)
 {
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
     mrb_value key, val;
+    char *key_cstr, *val_cstr;
 
     mrb_get_args(mrb, "oo", &key, &val);
     key = mrb_funcall(mrb, key, "downcase", 0);
 
-    h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->res.headers, RSTRING_PTR(key), RSTRING_LEN(key), 0,
-                          RSTRING_PTR(val), RSTRING_LEN(val), 1);
+    key_cstr = h2o_mem_alloc_pool(&mruby_ctx->req->pool, RSTRING_LEN(key));
+    val_cstr = h2o_mem_alloc_pool(&mruby_ctx->req->pool, RSTRING_LEN(val));
+    memcpy(key_cstr, RSTRING_PTR(key), RSTRING_LEN(key));
+    memcpy(val_cstr, RSTRING_PTR(val), RSTRING_LEN(val));
+
+    h2o_set_header_by_str(&mruby_ctx->req->pool, &mruby_ctx->req->res.headers, key_cstr, RSTRING_LEN(key), 0, val_cstr,
+                          RSTRING_LEN(val), 1);
 
     return key;
 }


### PR DESCRIPTION
When `H2O::Request#headers_{in,out}` method created `H2O::Headers_{in,out}` object, the object like `r.headers_out["x-hogehoge"]` sometimes break or varnish. It seems that the object was sometimes collected as garbage by mruby. This PR fixed this issue. h2o_mruby allocate memory in h2o memory pool instead of using the ptr of mruby object. Same problem was issued in ngx_mruby. 

ref: https://github.com/matsumoto-r/ngx_mruby/issues/125
ref: https://github.com/matsumoto-r/ngx_mruby/pull/126

- reproduse

```ruby
r = H2O::Request.new

# create H2O::Headers_out object 
r.headers_out["x-hogehoge"] = "hello"

r.log_error "x-hogehoge:  #{r.headers_out['x-hogehoge']}"

H2O.return H2O::DECLINED
```

```
./h2o -c examples/h2o_mruby/h2o.conf 2>&1 | grep x-hogehoge
```

and run this command:

```
ab -k -c 100 -n 100000 127.0.0.1:8080/index.html
```

`r.headers_out["x-hogehoge"]` sometimes break or varnish in error log.