### PR TITLE
NUL emitted in access log after `%{...}i` and `%{...}o`

### DIFF
--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -138,6 +138,7 @@ static struct log_element_t *compile_log_format(const char *fmt, size_t *_num_el
                     goto Error;
                 }
                 pt = quote_end + 2;
+                continue;
             } else {
                 unsigned type = NUM_ELEMENT_TYPES;
                 switch (*pt++) {

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -62,4 +62,23 @@ subtest 'ltsv-related' => sub {
     );
 };
 
+subtest 'header-termination (issue 462)' => sub {
+    doit(
+        sub {
+            my $server = shift;
+            system("curl --user-agent foobar/1 --silent http://127.0.0.1:$server->{port} > /dev/null");
+        },
+        '%{user-agent}i',
+        qr{^foobar/1$},
+    );
+    doit(
+        sub {
+            my $server = shift;
+            system("curl --user-agent foobar/1 --silent http://127.0.0.1:$server->{port} > /dev/null");
+        },
+        '%{content-type}o',
+        qr{^text/plain$},
+    );
+};
+
 done_testing;


### PR DESCRIPTION
As reported in #462, unnecessary NUL character is emitted when the `format` attribute of `access-log` directive ends with a header substitution instruction (e.g. `%{...}i` or `%{...}o`).

This happens only if the substitution instruction exists at the end of the format attribute; i.e. `format: "%{user-agent}i"` is affected, but `format: "\"%{user-agent}i\""` is not.