### PR TITLE
[mruby] **breaking change** unify the way mruby handlers are named / applied

### DIFF
--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -70,7 +70,7 @@ static int on_config_mruby_handler(h2o_configurator_command_t *cmd, h2o_configur
     return 0;
 }
 
-static int on_config_mruby_handler_path(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+static int on_config_mruby_handler_file(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct mruby_configurator_t *self = (void *)cmd->configurator;
     FILE *fp = NULL;
@@ -147,8 +147,10 @@ void h2o_mruby_register_configurator(h2o_globalconf_t *conf)
     c->super.enter = on_config_enter;
     c->super.exit = on_config_exit;
 
-    h2o_configurator_define_command(&c->super, "mruby.handler", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+    h2o_configurator_define_command(&c->super, "mruby.handler", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_DEFERRED |
+                                                                    H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_mruby_handler);
-    h2o_configurator_define_command(&c->super, "mruby.handler_path",
-                                    H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_mruby_handler_path);
+    h2o_configurator_define_command(&c->super, "mruby.handler-file", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_DEFERRED |
+                                                                         H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_mruby_handler_file);
 }

--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -118,6 +118,12 @@ Exit:
     return ret;
 }
 
+static int on_config_mruby_handler_path(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    h2o_configurator_errprintf(cmd, node, "the command has been removed; see https://github.com/h2o/h2o/pull/467");
+    return -1;
+}
+
 static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct mruby_configurator_t *self = (void *)_self;
@@ -153,4 +159,6 @@ void h2o_mruby_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "mruby.handler-file", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_DEFERRED |
                                                                          H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_mruby_handler_file);
+    h2o_configurator_define_command(&c->super, "mruby.handler_path", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_DEFERRED,
+                                    on_config_mruby_handler_path);
 }

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -46,8 +46,7 @@ EOT
 }
 
 my ($resp, $port) = fetch(<< 'EOT');
-        file.dir: examples/doc_root
-        mruby.handler_path: t/50mruby/hello.rb
+        mruby.handler-file: t/50mruby/hello.rb
 EOT
 is $resp, "hello from h2o_mruby\n", "resoponse body from mruby (separate)";
 
@@ -60,14 +59,12 @@ EOT
 is $resp,"hello from h2o_mruby\n", "response body from mruby (inline)";
 
 ($resp, $port) = fetch(<< 'EOT');
-        file.dir: examples/doc_root
         mruby.handler: |
           H2O.max_headers.to_s
 EOT
 is $resp, "100", "H2O.max_headers method";
 
 ($resp, $port) = fetch(<< 'EOT');
-        file.dir: examples/doc_root
         mruby.handler: |
           r = H2O::Request.new
           ua = r.headers_in["User-Agent"]
@@ -77,79 +74,73 @@ EOT
 is $resp, "new-h2o_mruby_test", "H2O::Request#headers_in test";
 
 $resp = fetch_header(<< 'EOT');
-        file.dir: examples/doc_root
         mruby.handler: |
           r = H2O::Request.new
           r.headers_out["new-header"] = "h2o-mruby"
           # pass to next handler
           nil
+        file.dir: examples/doc_root
 EOT
 like $resp, qr/^new-header:.*\Wh2o-mruby\W/im, "H2O::Response#headers_out test";
 
 ($resp, $port) = fetch(<< 'EOT');
-        file.dir: examples/doc_root
         mruby.handler: |
           H2O.return 404, "not found", "not found"
+        file.dir: examples/doc_root
 EOT
 is $resp, "not found", "H2O.return with status code test";
 
 ($resp, $port)= fetch(<< 'EOT');
-        file.dir: t/50mruby/
         mruby.handler: |
           H2O.return H2O::DECLINED
+        file.dir: t/50mruby/
 EOT
 is $resp, "I'm index.html\n", "H2O.return with declined code test";
 
 ($resp, $port) = fetch(<< 'EOT');
-        file.dir: t/50mruby/
         mruby.handler: |
           H2O::Request.new.method
 EOT
 is $resp, "GET", "H2O::Request#method test";
 
 $resp = fetch_uri(<< 'EOT', 'index.html?a=1');
-        file.dir: t/50mruby/
         mruby.handler: |
           H2O::Request.new.query
 EOT
 is $resp, "?a=1", "H2O::Request#query test";
 
 $resp = fetch_uri(<< 'EOT', 'index.html?a=1');
-        file.dir: t/50mruby/
         mruby.handler: |
           H2O::Request.new.uri
 EOT
 is $resp, "/index.html?a=1", "H2O::Request#uri test";
 
 ($resp, $port) = fetch(<< 'EOT');
-        file.dir: t/50mruby/
         mruby.handler: |
           H2O::Request.new.authority
 EOT
 is $resp, "127.0.0.1:$port", "H2O::Request#authority test";
 
 ($resp, $port) = fetch(<< 'EOT');
-        file.dir: t/50mruby/
         mruby.handler: |
           H2O::Request.new.hostname
 EOT
 is $resp, "127.0.0.1", "H2O::Request#hostname test";
 
 ($resp, $port) = fetch(<< 'EOT');
-        file.dir: t/50mruby/
         mruby.handler: |
           H2O::Connection.new.remote_ip
 EOT
 is $resp, "127.0.0.1", "H2O::Connection#remote_ip test";
 
 $resp = fetch_uri(<< 'EOT', 'proxy.html');
-        file.dir: t/50mruby/
         mruby.handler: |
           r = H2O::Request.new
           url = "http://#{r.authority}/"
           if r.uri == "/proxy.html"
             r.reprocess_request "#{url}/proxy/"
           end
+        file.dir: t/50mruby/
 EOT
 is $resp, "I'm proxy.html\n", "H2O::Request#reprocess_request test";
 


### PR DESCRIPTION
This PR makes breaking changes to `mruby.handler` and `mruby.handler_path` in the following two ways.

* changes `mruby.handler_path` to `mruby.handler-file`
 * since other directives use `-`, and files are referred by _file_ rather than _path_ (ex. `certificate-file`)
* changes the preference in which the mruby directives are handled, so that they are processed along with the other handler definition directives (e.g. `file.dir`, `redirect`, ...)
 * in other words, if you want to apply mruby handler before other handler directives such as `file.dir`, you would need to define the mruby directives _above_ `file.dir`
 * one of the good effects of doing so is that you can now use mruby for recovering from 404 errors by the file handler (by defining the mruby handler below `file.dir`)

Hopefully this will be the only breaking change before making mruby support non-experimental.