### PR TITLE
accept non-absolute forms of URLs in `reprocess_request`

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -690,6 +690,10 @@ struct st_h2o_req_t {
      */
     size_t bytes_sent;
     /**
+     * counts the number of times the request has been reprocessed (excluding delegation)
+     */
+    unsigned num_reprocessed;
+    /**
      * counts the number of times the request has been delegated
      */
     unsigned num_delegated;

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -39,9 +39,9 @@ h2o_mruby_handler_t *h2o_mruby_register(h2o_pathconf_t *pathconf, h2o_mruby_conf
 /* handler/configurator/mruby.c */
 void h2o_mruby_register_configurator(h2o_globalconf_t *conf);
 
-static mrb_value h2o_mrb_str_new(mrb_state *mrb, h2o_iovec_t *str);
+static mrb_value h2o_mrb_str_new(mrb_state *mrb, const h2o_iovec_t *str);
 
-inline mrb_value h2o_mrb_str_new(mrb_state *mrb, h2o_iovec_t *str)
+inline mrb_value h2o_mrb_str_new(mrb_state *mrb, const h2o_iovec_t *str)
 {
     return mrb_str_new(mrb, str->base, str->len);
 }

--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -76,7 +76,7 @@ int h2o_url_parse_relative(const char *url, size_t url_len, h2o_url_t *result);
  */
 const char *h2o_url_parse_hostport(const char *s, size_t len, h2o_iovec_t *host, uint16_t *port);
 /**
- * resolves the URL
+ * resolves the URL (stored to `dest` as well as returning the stringified representation (always allocated using pool)
  */
 h2o_iovec_t h2o_url_resolve(h2o_mem_pool_t *pool, const h2o_url_t *base, const h2o_url_t *relative, h2o_url_t *dest);
 /**

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -69,6 +69,13 @@ static mrb_value h2o_mrb_req_authority(mrb_state *mrb, mrb_value self)
     return h2o_mrb_str_new(mrb, &mruby_ctx->req->authority);
 }
 
+static mrb_value h2o_mrb_req_scheme(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
+
+    return h2o_mrb_str_new(mrb, &mruby_ctx->req->scheme->name);
+}
+
 static mrb_value h2o_mrb_req_method(mrb_state *mrb, mrb_value self)
 {
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
@@ -251,6 +258,7 @@ void h2o_mrb_request_class_init(mrb_state *mrb, struct RClass *class)
     mrb_define_method(mrb, class_request, "path", h2o_mrb_req_uri, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "hostname", h2o_mrb_req_hostname, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "authority", h2o_mrb_req_authority, MRB_ARGS_NONE());
+    mrb_define_method(mrb, class_request, "scheme", h2o_mrb_req_scheme, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "method", h2o_mrb_req_method, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "query", h2o_mrb_req_query, MRB_ARGS_NONE());
     mrb_define_method(mrb, class_request, "reprocess_request", h2o_mrb_req_reprocess_request, MRB_ARGS_REQ(1));

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -200,7 +200,6 @@ static mrb_value h2o_mrb_req_reprocess_request(mrb_state *mrb, mrb_value self)
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
     char *upstream;
     h2o_url_t parsed;
-    h2o_req_overrides_t *overrides = h2o_mem_alloc_pool(&mruby_ctx->req->pool, sizeof(*overrides));
 
     mrb_get_args(mrb, "z", &upstream);
 
@@ -210,11 +209,6 @@ static mrb_value h2o_mrb_req_reprocess_request(mrb_state *mrb, mrb_value self)
     if (parsed.scheme != &H2O_URL_SCHEME_HTTP) {
         mrb_raise(mrb, E_ARGUMENT_ERROR, "only HTTP URLs are supported");
     }
-
-    /* setup overrides */
-    *overrides = (h2o_req_overrides_t){};
-    overrides->location_rewrite.match = &parsed;
-    overrides->location_rewrite.path_prefix = mruby_ctx->req->pathconf->path;
 
     /* request reprocess */
     h2o_reprocess_request_deferred(mruby_ctx->req, mruby_ctx->req->method, parsed.scheme, parsed.authority,

--- a/lib/handler/mruby/class/request.c
+++ b/lib/handler/mruby/class/request.c
@@ -47,7 +47,7 @@ static mrb_value h2o_mrb_req_uri(mrb_state *mrb, mrb_value self)
 {
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
 
-    return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.path);
+    return h2o_mrb_str_new(mrb, &mruby_ctx->req->path);
 }
 
 static mrb_value h2o_mrb_req_hostname(mrb_state *mrb, mrb_value self)
@@ -56,7 +56,7 @@ static mrb_value h2o_mrb_req_hostname(mrb_state *mrb, mrb_value self)
     h2o_iovec_t hostname;
     uint16_t port;
 
-    if (h2o_url_parse_hostport(mruby_ctx->req->input.authority.base, mruby_ctx->req->input.authority.len, &hostname, &port) == NULL)
+    if (h2o_url_parse_hostport(mruby_ctx->req->authority.base, mruby_ctx->req->authority.len, &hostname, &port) == NULL)
         return mrb_nil_value();
 
     return h2o_mrb_str_new(mrb, &hostname);
@@ -66,21 +66,21 @@ static mrb_value h2o_mrb_req_authority(mrb_state *mrb, mrb_value self)
 {
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
 
-    return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.authority);
+    return h2o_mrb_str_new(mrb, &mruby_ctx->req->authority);
 }
 
 static mrb_value h2o_mrb_req_method(mrb_state *mrb, mrb_value self)
 {
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
 
-    return h2o_mrb_str_new(mrb, &mruby_ctx->req->input.method);
+    return h2o_mrb_str_new(mrb, &mruby_ctx->req->method);
 }
 
 static mrb_value h2o_mrb_req_query(mrb_state *mrb, mrb_value self)
 {
     h2o_mruby_internal_context_t *mruby_ctx = (h2o_mruby_internal_context_t *)mrb->ud;
-    h2o_iovec_t *path = &mruby_ctx->req->input.path;
-    size_t offset = mruby_ctx->req->input.query_at;
+    h2o_iovec_t *path = &mruby_ctx->req->path;
+    size_t offset = mruby_ctx->req->query_at;
     if (offset == SIZE_MAX)
         return mrb_nil_value();
 

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -139,16 +139,63 @@ is $resp, "http", "H2O::Request#scheme test";
 EOT
 is $resp, "127.0.0.1", "H2O::Connection#remote_ip test";
 
-$resp = fetch_uri(<< 'EOT', 'proxy.html');
+subtest "reprocess_request" => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
         mruby.handler: |
           r = H2O::Request.new
-          url = "http://#{r.authority}/"
-          if r.uri == "/proxy.html"
-            r.reprocess_request "#{url}/proxy/"
-          end
-        file.dir: t/50mruby/
+          r.reprocess_request "/dest#{r.path}"
+      /scheme-abs-path:
+        mruby.handler: |
+          r = H2O::Request.new
+          r.reprocess_request "http:/dest#{r.path[16..-1]}"
+      /dest/rel:
+        mruby.handler: |
+          r = H2O::Request.new
+          r.reprocess_request "..#{r.path[9..-1]}"
+      /dest:
+        mruby.handler: |
+          r = H2O::Request.new
+          "#{r.scheme}://#{r.authority}#{r.path}"
+      /abs:
+        mruby.handler: |
+          r = H2O::Request.new
+          r.reprocess_request "https://vhost#{r.path[4..-1]}"
+  vhost:
+    paths:
+      /:
+        mruby.handler: |
+          r = H2O::Request.new
+          "#{r.scheme}://#{r.authority}#{r.path}"
 EOT
-is $resp, "I'm proxy.html\n", "H2O::Request#reprocess_request test";
+    subtest "abs-path" => sub {
+        my ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+        is $stdout, "http://default/dest/";
+        ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/hoge");
+        is $stdout, "http://default/dest/hoge";
+    };
+    subtest "scheme-abs-path" => sub {
+        my ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/scheme-abs-path/");
+        is $stdout, "http://default/dest/";
+        ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/scheme-abs-path/hoge");
+        is $stdout, "http://default/dest/hoge";
+    };
+    subtest "rel-path" => sub {
+        my ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/dest/rel/");
+        is $stdout, "http://default/dest/";
+        ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/dest/rel/hoge");
+        is $stdout, "http://default/dest/hoge";
+    };
+    subtest "abs" => sub {
+        my ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/abs/");
+        is $stdout, "https://vhost/";
+        ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/abs/hoge");
+        is $stdout, "https://vhost/hoge";
+    };
+};
 
 subtest "server-push" => sub {
     plan skip_all => 'nghttp not found'

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -129,6 +129,12 @@ is $resp, "127.0.0.1", "H2O::Request#hostname test";
 
 ($resp, $port) = fetch(<< 'EOT');
         mruby.handler: |
+          H2O::Request.new.scheme
+EOT
+is $resp, "http", "H2O::Request#scheme test";
+
+($resp, $port) = fetch(<< 'EOT');
+        mruby.handler: |
           H2O::Connection.new.remote_ip
 EOT
 is $resp, "127.0.0.1", "H2O::Connection#remote_ip test";

--- a/t/50mruby/proxy/proxy.html
+++ b/t/50mruby/proxy/proxy.html
@@ -1,1 +1,0 @@
-I'm proxy.html


### PR DESCRIPTION
makes following changes:

* `reprocess_request` now follows the interface of `h2o_reprocess_request` it internally redirects the request to given URL (instead of using the supplied URL as a prefix)
* accept non-absolute forms of URLs in `reprocess_request`
* accept https URLs as well
* refer to `req->(authority|hostname|path)` instead of `req->input.*`, so that mruby handler can work on URLs being rewritten
* detect and return 502 error if the mruby handler internally redirects to itself