### PR TITLE
fix error when building with libressl on OSX

### DIFF
--- a/misc/libressl.mk
+++ b/misc/libressl.mk
@@ -2,10 +2,11 @@ SOURCE_DIR=.
 VERSION=2.2.2
 ARCHIVE=$(SOURCE_DIR)/libressl-$(VERSION).tar.gz
 DEST=libressl-build
+UNAME=$(shell uname -s)
 
 all: $(DEST)/lib/libssl.a
 
 $(DEST)/lib/libssl.a:
 	if [ ! -e "libressl-$(VERSION)" ] ; then tar xzf "$(ARCHIVE)" ; fi
-	if [ ! -e "libressl-$(VERSION)/Makefile" ] ; then (P=`pwd`/$(DEST); cd libressl-$(VERSION) && ./configure --prefix="$$P" --libdir="$$P/lib" --disable-shared) ; fi
+	if [ ! -e "libressl-$(VERSION)/Makefile" ] ; then (P=`pwd`/$(DEST); cd libressl-$(VERSION) && ./configure --prefix="$$P" --libdir="$$P/lib" --disable-shared `test "$(UNAME)" = "Darwin" && echo '--disable-asm'`) ; fi
 	(cd libressl-$(VERSION) && make && make install)


### PR DESCRIPTION
set `--disable-asm` to avoid compile error of libressl 2.2.2 on OSX.

see also: https://github.com/libressl-portable/portable/issues/121