### PR TITLE
disable cache-aware server-push if proxy is detected

### DIFF
--- a/include/h2o/token.h
+++ b/include/h2o/token.h
@@ -81,6 +81,7 @@
 #define H2O_TOKEN_VARY (h2o__tokens + 54)
 #define H2O_TOKEN_VIA (h2o__tokens + 55)
 #define H2O_TOKEN_WWW_AUTHENTICATE (h2o__tokens + 56)
-#define H2O_TOKEN_X_REPROXY_URL (h2o__tokens + 57)
+#define H2O_TOKEN_X_FORWARDED_FOR (h2o__tokens + 57)
+#define H2O_TOKEN_X_REPROXY_URL (h2o__tokens + 58)
 
 #endif

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -162,14 +162,13 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive)
                 } else if (token == H2O_TOKEN_VIA) {
                     via_buf = build_request_merge_headers(&req->pool, via_buf, h->value, ',');
                     continue;
+                } else if (token == H2O_TOKEN_X_FORWARDED_FOR) {
+                    xff_buf = build_request_merge_headers(&req->pool, xff_buf, h->value, ',');
+                    continue;
                 }
             }
             if (h2o_lcstris(h->name->base, h->name->len, H2O_STRLIT("x-forwarded-proto")))
                 continue;
-            if (h2o_lcstris(h->name->base, h->name->len, H2O_STRLIT("x-forwarded-for"))) {
-                xff_buf = build_request_merge_headers(&req->pool, xff_buf, h->value, ',');
-                continue;
-            }
             RESERVE(h->name->len + h->value.len + 2);
             APPEND(h->name->base, h->name->len);
             buf.base[offset++] = ':';

--- a/lib/core/token_table.h
+++ b/lib/core/token_table.h
@@ -78,8 +78,9 @@ h2o_token_t h2o__tokens[] = {{{H2O_STRLIT(":authority")}, 1, 0, 0, 0, 0},
                              {{H2O_STRLIT("vary")}, 59, 0, 0, 0, 0},
                              {{H2O_STRLIT("via")}, 60, 0, 0, 0, 0},
                              {{H2O_STRLIT("www-authenticate")}, 61, 0, 0, 0, 0},
+                             {{H2O_STRLIT("x-forwarded-for")}, 0, 0, 0, 0, 0},
                              {{H2O_STRLIT("x-reproxy-url")}, 0, 0, 0, 0, 0}};
-size_t h2o__num_tokens = 58;
+size_t h2o__num_tokens = 59;
 
 const h2o_token_t *h2o_lookup_token(const char *name, size_t len)
 {
@@ -307,6 +308,10 @@ const h2o_token_t *h2o_lookup_token(const char *name, size_t len)
         case 'g':
             if (memcmp(name, "accept-encodin", 14) == 0)
                 return H2O_TOKEN_ACCEPT_ENCODING;
+            break;
+        case 'r':
+            if (memcmp(name, "x-forwarded-fo", 14) == 0)
+                return H2O_TOKEN_X_FORWARDED_FOR;
             break;
         }
         break;

--- a/misc/tokens.pl
+++ b/misc/tokens.pl
@@ -217,3 +217,4 @@ __DATA__
 0 1 0 1 0 http2-settings
 0 1 0 1 0 te
 0 1 0 0 0 keep-alive
+0 0 0 0 0 x-forwarded-for


### PR DESCRIPTION
This is necessary, since the cookie-based implementation of cache-aware server-push will not work unless it is guaranteed that responses arrive in the order they are sent (by the server).

part of #421
