### PR TITLE
emit push status to `x-http2-push` header

### DIFF
--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -214,7 +214,6 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     if (h2o_http2_stream_is_push(stream->stream_id)) {
         if (400 <= stream->req.res.status)
             goto CancelPush;
-        h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-pushed"), 0, H2O_STRLIT("1"));
     }
 
     if (stream->req.hostconf->http2.casper.capacity_bits != 0) {
@@ -267,6 +266,8 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     }
 
     /* send HEADERS, as well as start sending body */
+    if (h2o_http2_stream_is_push(stream->stream_id))
+        h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, H2O_STRLIT("pushed"));
     h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
                                conn->peer_settings.max_frame_size, &stream->req.res, &ts, &conn->super.ctx->globalconf->server_name,
                                stream->req.res.content_length);
@@ -276,6 +277,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     return 0;
 
 CancelPush:
+    h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, H2O_STRLIT("cancelled"));
     h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);
     h2o_linklist_insert(&conn->_write.streams_to_proceed, &stream->_refs.link);
     if (stream->push.promise_sent) {


### PR DESCRIPTION
Push status (including ones cancelled by casper (see #421)) is now stored in `x-http2-push` header.

You can distinguish them in the logs by emitting the header to the logs (by using `%{x-http2-push}o` directive, see https://h2o.examp1e.net/configure/access_log_directives.html#access-log).

* if the value is `-` then it is an ordinary request
* if the value is `pushed` then it is a pushed request
* if the value is `cancelled` then it is a push request cancelled by casper
