### PR TITLE
use `#each` when parsing the result returned by mruby handler

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		107D4D531B5B2412004A9B21 /* file.h in Headers */ = {isa = PBXBuildFile; fileRef = 107D4D521B5B2412004A9B21 /* file.h */; };
 		107D4D551B5B30EE004A9B21 /* file.c in Sources */ = {isa = PBXBuildFile; fileRef = 107D4D541B5B30EE004A9B21 /* file.c */; };
 		108867751AD9069900987967 /* defaults.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 108867741AD9069900987967 /* defaults.c.h */; };
+		108DD0861BA22E46004167DC /* mruby.c in Sources */ = {isa = PBXBuildFile; fileRef = 10B38A651B8D345D007DC191 /* mruby.c */; };
 		10A3D3D21B4CDBDC00327CF9 /* memcached.c in Sources */ = {isa = PBXBuildFile; fileRef = 10A3D3D11B4CDBDC00327CF9 /* memcached.c */; };
 		10A3D3D31B4CDF1200327CF9 /* memcached.h in Headers */ = {isa = PBXBuildFile; fileRef = 10A3D3D01B4CDBC700327CF9 /* memcached.h */; };
 		10A3D4081B50DAB700327CF9 /* close.c in Sources */ = {isa = PBXBuildFile; fileRef = 10A3D3ED1B4FAAEC00327CF9 /* close.c */; };
@@ -133,7 +134,6 @@
 		10AA2EC41AA0403A004322AC /* reproxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AA2EC31AA0403A004322AC /* reproxy.c */; };
 		10AAAC631B6C7A7D004487C3 /* http2_casper.h in Headers */ = {isa = PBXBuildFile; fileRef = 10AAAC621B6C7A7D004487C3 /* http2_casper.h */; };
 		10AAAC651B6C9275004487C3 /* casper.c in Sources */ = {isa = PBXBuildFile; fileRef = 10AAAC641B6C9275004487C3 /* casper.c */; };
-		10B38A661B8D345D007DC191 /* mruby.c in Sources */ = {isa = PBXBuildFile; fileRef = 10B38A651B8D345D007DC191 /* mruby.c */; };
 		10B38A721B8D34BB007DC191 /* mruby_.h in Headers */ = {isa = PBXBuildFile; fileRef = 10B38A711B8D34BB007DC191 /* mruby_.h */; };
 		10B38A741B8D3544007DC191 /* mruby.c in Sources */ = {isa = PBXBuildFile; fileRef = 10B38A731B8D3544007DC191 /* mruby.c */; };
 		10BA72AA19AAD6300059392A /* stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 10BA72A919AAD6300059392A /* stream.c */; };
@@ -1403,7 +1403,6 @@
 				1058C87E1AA41A1F008D6180 /* headers.c in Sources */,
 				10AA2E961A80A612004322AC /* time.c in Sources */,
 				107923C319A3217300C52AD6 /* file.c in Sources */,
-				10B38A661B8D345D007DC191 /* mruby.c in Sources */,
 				10583BF11AE5A37B004A3AD6 /* Makefile in Sources */,
 				107923CD19A3217300C52AD6 /* memory.c in Sources */,
 				107923CC19A3217300C52AD6 /* context.c in Sources */,
@@ -1544,6 +1543,7 @@
 				10756E361AC1264D0009BF57 /* writer.c in Sources */,
 				10756E351AC1264D0009BF57 /* scanner.c in Sources */,
 				10756E331AC1264D0009BF57 /* parser.c in Sources */,
+				108DD0861BA22E46004167DC /* mruby.c in Sources */,
 				10F417D619C190F800B6E31A /* main.c in Sources */,
 				10756E341AC1264D0009BF57 /* reader.c in Sources */,
 			);
@@ -2338,12 +2338,14 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					deps/mruby/include,
 					"/usr/local/openssl-1.0.2/include",
 					/usr/local/include,
 					include,
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"/usr/local/openssl-1.0.2/lib",
+					build/osx/mruby/host/lib,
 					/usr/local/lib,
 				);
 				OTHER_CFLAGS = "";
@@ -2368,12 +2370,14 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					deps/mruby/include,
 					"/usr/local/openssl-1.0.2/include",
 					/usr/local/include,
 					include,
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"/usr/local/openssl-1.0.2/lib",
+					build/osx/mruby/host/lib,
 					/usr/local/lib,
 				);
 				OTHER_CFLAGS = "";
@@ -2394,12 +2398,14 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					deps/mruby/include,
 					"/usr/local/openssl-1.0.2/include",
 					/usr/local/include,
 					include,
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"/usr/local/openssl-1.0.2/lib",
+					build/osx/mruby/host/lib,
 					/usr/local/lib,
 				);
 				OTHER_CFLAGS = "";
@@ -2419,12 +2425,14 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					deps/mruby/include,
 					"/usr/local/openssl-1.0.2/include",
 					/usr/local/include,
 					include,
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"/usr/local/openssl-1.0.2/lib",
+					build/osx/mruby/host/lib,
 					/usr/local/lib,
 				);
 				OTHER_CFLAGS = "";

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -65,11 +65,7 @@ typedef struct st_h2o_mruby_context_t {
     mrb_value literals;
 } h2o_mruby_context_t;
 
-#ifdef RSTR_SET_FROZEN_FLAG
 #define FREEZE_STRING(v) RSTR_SET_FROZEN_FLAG(mrb_str_ptr(v))
-#else
-#define FREEZE_STRING(v)
-#endif
 
 mrb_value h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config, char *errbuf)
 {

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -51,6 +51,11 @@ hosts:
           Proc.new do |env|
             [200, {}, [JSON.generate(env)]]
           end
+      /headers-each:
+        mruby.handler: |
+          Proc.new do |env|
+            [200, [["content-type", "text/plain"], ["hello", "world"]], []]
+          end
 EOT
     my $fetch = sub {
         my $path = shift;
@@ -83,6 +88,11 @@ EOT
         like $body, qr{"HTTP_USER_AGENT":"h2o_mruby_test"}, "HTTP_USER_AGENT";
         like $body, qr{"rack.url_scheme":"http"}, "url_scheme";
         like $body, qr{"server.name":"h2o"}, "server.name";
+    };
+    subtest "headers-each" => sub {
+        ($headers, $body) = $fetch->("/headers-each/");
+        like $headers, qr{^content-type: text/plain\r$}mi;
+        like $headers, qr{^hello: world\r$}mi;
     };
 };
 

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -165,61 +165,19 @@ EOT
 };
 
 subtest "send-file" => sub {
-    plan skip_all => "temporary disable";
     my $server = spawn_h2o(<< "EOT");
 hosts:
   default:
     paths:
-      /auto-content-type:
+      /:
         mruby.handler: |
-          r = H2O::Request.new
-          r.send_file("t/50mruby/index.html")
-      /explicit-content-type:
-        mruby.handler: |
-          r = H2O::Request.new
-          r.headers_out["content-type"] = "text/plain"
-          r.send_file("t/50mruby/index.html")
-      /404:
-        mruby.handler: |
-          r = H2O::Request.new
-          r.status = 404
-          r.send_file("t/50mruby/index.html")
-      /nonexistent:
-        mruby.handler: |
-          r = H2O::Request.new
-          if !r.send_file("t/50mruby/nonexistent")
-            r.status = 404
-            "never mind!!!"
+          Proc.new do |env|
+            [200,{}, File::open("t/50mruby/index.html")]
           end
 EOT
-    my $fetch = sub {
-        my $path = shift;
-        run_prog("curl --silent -A h2o_mruby_test --dump-header /dev/stderr http://127.0.0.1:$server->{port}$path");
-    };
-    subtest "auto-content-type" => sub {
-        my ($headers, $body) = $fetch->("/auto-content-type/");
-        like $headers, qr{^HTTP/1\.1 200 OK\r\n}is;
-        like $headers, qr{^content-type: text/html\r$}im;
-        is md5_hex($body), md5_file("t/50mruby/index.html");
-    };
-    subtest "explicit-content-type" => sub {
-        my ($headers, $body) = $fetch->("/explicit-content-type/");
-        like $headers, qr{^HTTP/1\.1 200 OK\r\n}is;
-        like $headers, qr{^content-type: text/plain\r$}im;
-        is md5_hex($body), md5_file("t/50mruby/index.html");
-    };
-    subtest "404-page" => sub {
-        my ($headers, $body) = $fetch->("/404/");
-        like $headers, qr{^HTTP/1\.1 404 OK\r\n}is;
-        like $headers, qr{^content-type: text/html\r$}im;
-        is md5_hex($body), md5_file("t/50mruby/index.html");
-    };
-    subtest "nonexistent" => sub {
-        my ($headers, $body) = $fetch->("/nonexistent/");
-        like $headers, qr{^HTTP/1\.1 404 OK\r\n}is;
-        like $headers, qr{^content-type: text/plain; charset=utf-8\r$}im;
-        is $body, "never mind!!!";
-    };
+    my ($headers, $body) = run_prog("curl --silent -A h2o_mruby_test --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+    like $headers, qr{^HTTP/1\.1 200 OK\r\n}is;
+    is md5_hex($body), md5_file("t/50mruby/index.html");
 };
 
 done_testing();


### PR DESCRIPTION
[The specification of Rack](http://www.rubydoc.info/github/rack/rack/file/SPEC) states that the existence of `#each` is the only requirement for the headers and body objects returned by a Rack handler (in other words we should not expect that they are a hash or an array).

This PR fixes the issue by calling the `each` method of the objects if necessary.  And the good effect of it is that with the change it becomes possible to pass `File` objects as the body.

part of #478