### PR TITLE
configurable mime attributes

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1075,11 +1075,11 @@ int h2o_mimemap_has_dynamic_type(h2o_mimemap_t *mimemap);
 /**
  * sets the default mime-type
  */
-void h2o_mimemap_set_default_type(h2o_mimemap_t *mimemap, const char *mime);
+void h2o_mimemap_set_default_type(h2o_mimemap_t *mimemap, const char *mime, h2o_mime_attributes_t *attr);
 /**
  * adds a mime-type mapping
  */
-void h2o_mimemap_define_mimetype(h2o_mimemap_t *mimemap, const char *ext, const char *mime);
+void h2o_mimemap_define_mimetype(h2o_mimemap_t *mimemap, const char *ext, const char *mime, h2o_mime_attributes_t *attr);
 /**
  * adds a mime-type mapping
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1100,6 +1100,10 @@ h2o_mimemap_type_t *h2o_mimemap_get_type_by_extension(h2o_mimemap_t *mimemap, co
  * returns the mime-type corresponding to given mimetype
  */
 h2o_mimemap_type_t *h2o_mimemap_get_type_by_mimetype(h2o_mimemap_t *mimemap, h2o_iovec_t mime);
+/**
+ * returns the default mime attributes given a mime type
+ */
+void h2o_mimemap_get_default_attributes(const char *mime, h2o_mime_attributes_t *attr);
 
 /* various handlers */
 

--- a/lib/common/string.c
+++ b/lib/common/string.c
@@ -340,7 +340,7 @@ size_t h2o_strstr(const char *haysack, size_t haysack_len, const char *needle, s
 {
     /* TODO optimize */
     if (haysack_len >= needle_len) {
-        size_t off, max = haysack_len - needle_len;
+        size_t off, max = haysack_len - needle_len + 1;
         if (needle_len == 0)
             return 0;
         for (off = 0; off != max; ++off)

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -421,14 +421,14 @@ static int set_mimetypes(h2o_configurator_command_t *cmd, h2o_mimemap_t *mimemap
         case YOML_TYPE_SCALAR:
             if (assert_is_extension(cmd, value) != 0)
                 return -1;
-            h2o_mimemap_define_mimetype(mimemap, value->data.scalar + 1, key->data.scalar);
+            h2o_mimemap_define_mimetype(mimemap, value->data.scalar + 1, key->data.scalar, NULL);
             break;
         case YOML_TYPE_SEQUENCE:
             for (j = 0; j != value->data.sequence.size; ++j) {
                 yoml_t *ext_node = value->data.sequence.elements[j];
                 if (assert_is_extension(cmd, ext_node) != 0)
                     return -1;
-                h2o_mimemap_define_mimetype(mimemap, ext_node->data.scalar + 1, key->data.scalar);
+                h2o_mimemap_define_mimetype(mimemap, ext_node->data.scalar + 1, key->data.scalar, NULL);
             }
             break;
         default:
@@ -445,7 +445,7 @@ static int on_config_mime_settypes(h2o_configurator_command_t *cmd, h2o_configur
 {
     h2o_mimemap_t *newmap = h2o_mimemap_create();
 
-    h2o_mimemap_set_default_type(newmap, h2o_mimemap_get_default_type(*ctx->mimemap)->data.mimetype.base);
+    h2o_mimemap_set_default_type(newmap, h2o_mimemap_get_default_type(*ctx->mimemap)->data.mimetype.base, NULL);
     if (set_mimetypes(cmd, newmap, node) != 0) {
         h2o_mem_release_shared(newmap);
         return -1;
@@ -494,7 +494,7 @@ static int on_config_mime_setdefaulttype(h2o_configurator_command_t *cmd, h2o_co
         return -1;
 
     clone_mimemap_if_clean(ctx);
-    h2o_mimemap_set_default_type(*ctx->mimemap, node->data.scalar);
+    h2o_mimemap_set_default_type(*ctx->mimemap, node->data.scalar, NULL);
 
     return 0;
 }

--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -114,7 +114,7 @@ static void rebuild_typeset(h2o_mimemap_t *mimemap)
     });
 }
 
-static h2o_mimemap_type_t *create_extension_type(const char *mime)
+static h2o_mimemap_type_t *create_extension_type(const char *mime, h2o_mime_attributes_t *attr)
 {
     h2o_mimemap_type_t *type = h2o_mem_alloc_shared(NULL, sizeof(*type) + strlen(mime) + 1, NULL);
     size_t i, type_end_at;
@@ -133,18 +133,20 @@ static h2o_mimemap_type_t *create_extension_type(const char *mime)
     type->data.mimetype.base[i] = '\0';
     type->data.mimetype.len = i;
 
-    /* make a rough guess on whether the type is compressible or not */
-    if (strncmp(type->data.mimetype.base, "text/", 5) == 0 ||
-        h2o_strstr(type->data.mimetype.base, type_end_at, H2O_STRLIT("+xml")) != SIZE_MAX)
-        type->data.attr.is_compressible = 1;
-
-    /* make a rough guess on whether the type is blocking asset or not */
-    if (h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("text/css")) ||
-        h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("application/ecmascript")) ||
-        h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("application/javascript")) ||
-        h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("text/ecmascript")) ||
-        h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("text/javascript")))
-        type->data.attr.priority = H2O_MIME_ATTRIBUTE_PRIORITY_HIGHEST;
+    if (attr != NULL) {
+        type->data.attr = *attr;
+    } else {
+        /* make rough guesses */
+        if (strncmp(type->data.mimetype.base, "text/", 5) == 0 ||
+            h2o_strstr(type->data.mimetype.base, type_end_at, H2O_STRLIT("+xml")) != SIZE_MAX)
+            type->data.attr.is_compressible = 1;
+        if (h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("text/css")) ||
+            h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("application/ecmascript")) ||
+            h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("application/javascript")) ||
+            h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("text/ecmascript")) ||
+            h2o_memis(type->data.mimetype.base, type_end_at, H2O_STRLIT("text/javascript")))
+            type->data.attr.priority = H2O_MIME_ATTRIBUTE_PRIORITY_HIGHEST;
+    }
 
     return type;
 }
@@ -171,7 +173,7 @@ h2o_mimemap_t *h2o_mimemap_create()
 
     mimemap->extmap = kh_init(extmap);
     mimemap->typeset = kh_init(typeset);
-    mimemap->default_type = create_extension_type("application/octet-stream");
+    mimemap->default_type = create_extension_type("application/octet-stream", NULL);
     mimemap->num_dynamic = 0;
     on_link(mimemap, mimemap->default_type);
 
@@ -183,7 +185,7 @@ h2o_mimemap_t *h2o_mimemap_create()
             NULL};
         const char **p;
         for (p = default_types; *p != NULL; p += 2)
-            h2o_mimemap_define_mimetype(mimemap, p[0], p[1]);
+            h2o_mimemap_define_mimetype(mimemap, p[0], p[1], NULL);
     }
     rebuild_typeset(mimemap);
 
@@ -251,15 +253,16 @@ int h2o_mimemap_has_dynamic_type(h2o_mimemap_t *mimemap)
     return mimemap->num_dynamic != 0;
 }
 
-void h2o_mimemap_set_default_type(h2o_mimemap_t *mimemap, const char *mime)
+void h2o_mimemap_set_default_type(h2o_mimemap_t *mimemap, const char *mime, h2o_mime_attributes_t *attr)
 {
     h2o_mimemap_type_t *new_type;
 
     /* obtain or create new type */
-    if ((new_type = h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(mime, strlen(mime)))) != NULL) {
+    if ((new_type = h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(mime, strlen(mime)))) != NULL &&
+        (attr == NULL || memcmp(&new_type->data.attr, attr, sizeof(*attr)) == 0)) {
         h2o_mem_addref_shared(new_type);
     } else {
-        new_type = create_extension_type(mime);
+        new_type = create_extension_type(mime, attr);
     }
 
     /* unlink the old one */
@@ -293,14 +296,15 @@ static void set_type(h2o_mimemap_t *mimemap, const char *ext, h2o_mimemap_type_t
     rebuild_typeset(mimemap);
 }
 
-void h2o_mimemap_define_mimetype(h2o_mimemap_t *mimemap, const char *ext, const char *mime)
+void h2o_mimemap_define_mimetype(h2o_mimemap_t *mimemap, const char *ext, const char *mime, h2o_mime_attributes_t *attr)
 {
     h2o_mimemap_type_t *new_type;
 
-    if ((new_type = h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(mime, strlen(mime)))) != NULL) {
+    if ((new_type = h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(mime, strlen(mime)))) != NULL &&
+        (attr == NULL || memcmp(&new_type->data.attr, attr, sizeof(*attr)) == 0)) {
         h2o_mem_addref_shared(new_type);
     } else {
-        new_type = create_extension_type(mime);
+        new_type = create_extension_type(mime, attr);
     }
     set_type(mimemap, ext, new_type);
     h2o_mem_release_shared(new_type);

--- a/t/00unit/lib/common/string.c
+++ b/t/00unit/lib/common/string.c
@@ -22,6 +22,13 @@
 #include "../../test.h"
 #include "../../../../lib/common/string.c"
 
+static void test_strstr(void)
+{
+    ok(h2o_strstr("abcd", 4, "bc", 2) == 1);
+    ok(h2o_strstr("abcd", 3, "bc", 2) == 1);
+    ok(h2o_strstr("abcd", 2, "bc", 2) == -1);
+}
+
 static void test_stripws(void)
 {
     h2o_iovec_t t;
@@ -169,6 +176,7 @@ static void test_htmlescape(void)
 
 void test_lib__common__string_c(void)
 {
+    subtest("strstr", test_strstr);
     subtest("stripws", test_stripws);
     subtest("next_token", test_next_token);
     subtest("next_token2", test_next_token2);

--- a/t/00unit/lib/handler/mimemap.c
+++ b/t/00unit/lib/handler/mimemap.c
@@ -22,6 +22,39 @@
 #include "../../test.h"
 #include "../../../../lib/handler/mimemap.c"
 
+static void test_default_attributes(void)
+{
+    h2o_mime_attributes_t attr;
+
+    h2o_mimemap_get_default_attributes("text/plain", &attr);
+    ok(attr.is_compressible);
+    ok(attr.priority == H2O_MIME_ATTRIBUTE_PRIORITY_NORMAL);
+
+    h2o_mimemap_get_default_attributes("text/plain; charset=utf-8", &attr);
+    ok(attr.is_compressible);
+    ok(attr.priority == H2O_MIME_ATTRIBUTE_PRIORITY_NORMAL);
+
+    h2o_mimemap_get_default_attributes("application/xhtml+xml", &attr);
+    ok(attr.is_compressible);
+    ok(attr.priority == H2O_MIME_ATTRIBUTE_PRIORITY_NORMAL);
+
+    h2o_mimemap_get_default_attributes("application/xhtml+xml; charset=utf-8", &attr);
+    ok(attr.is_compressible);
+    ok(attr.priority == H2O_MIME_ATTRIBUTE_PRIORITY_NORMAL);
+
+    h2o_mimemap_get_default_attributes("text/css", &attr);
+    ok(attr.is_compressible);
+    ok(attr.priority == H2O_MIME_ATTRIBUTE_PRIORITY_HIGHEST);
+
+    h2o_mimemap_get_default_attributes("text/css; charset=utf-8", &attr);
+    ok(attr.is_compressible);
+    ok(attr.priority == H2O_MIME_ATTRIBUTE_PRIORITY_HIGHEST);
+
+    h2o_mimemap_get_default_attributes("application/octet-stream", &attr);
+    ok(!attr.is_compressible);
+    ok(attr.priority == H2O_MIME_ATTRIBUTE_PRIORITY_NORMAL);
+}
+
 static int is_mimetype(h2o_mimemap_type_t *type, const char *expected)
 {
     return type->type == H2O_MIMEMAP_TYPE_MIMETYPE && type->data.mimetype.len == strlen(expected) &&
@@ -31,6 +64,8 @@ static int is_mimetype(h2o_mimemap_type_t *type, const char *expected)
 void test_lib__handler__mimemap_c()
 {
     h2o_mimemap_t *mimemap = h2o_mimemap_create(), *mimemap2;
+
+    subtest("default-attributes", test_default_attributes);
 
     /* default and set default */
     ok(is_mimetype(h2o_mimemap_get_default_type(mimemap), "application/octet-stream"));

--- a/t/00unit/lib/handler/mimemap.c
+++ b/t/00unit/lib/handler/mimemap.c
@@ -37,17 +37,17 @@ void test_lib__handler__mimemap_c()
     {
         char buf[sizeof("text/plain")];
         strcpy(buf, "text/plain");
-        h2o_mimemap_set_default_type(mimemap, buf);
+        h2o_mimemap_set_default_type(mimemap, buf, NULL);
         memset(buf, 0, sizeof(buf));
     }
     ok(is_mimetype(h2o_mimemap_get_default_type(mimemap), "text/plain"));
 
     /* set and overwrite */
-    h2o_mimemap_define_mimetype(mimemap, "foo", "example/foo");
+    h2o_mimemap_define_mimetype(mimemap, "foo", "example/foo", NULL);
     ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "example/foo"));
     ok(h2o_mimemap_get_type_by_extension(mimemap, "foo") ==
        h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/foo"))));
-    h2o_mimemap_define_mimetype(mimemap, "foo", "example/overwritten");
+    h2o_mimemap_define_mimetype(mimemap, "foo", "example/overwritten", NULL);
     ok(is_mimetype(h2o_mimemap_get_type_by_extension(mimemap, "foo"), "example/overwritten"));
     ok(h2o_mimemap_get_type_by_extension(mimemap, "foo") ==
        h2o_mimemap_get_type_by_mimetype(mimemap, h2o_iovec_init(H2O_STRLIT("example/overwritten"))));

--- a/t/50gzip.t
+++ b/t/50gzip.t
@@ -16,6 +16,13 @@ hosts:
       /on:
         file.dir: @{[DOC_ROOT]}
         gzip: ON
+      /off-by-mime:
+        file.dir: @{[DOC_ROOT]}
+        gzip: ON
+        file.mime.settypes:
+          text/plain:
+            extensions: [".txt"]
+            is_compressible: NO
 EOT
 
 my $doit = sub {
@@ -44,6 +51,9 @@ my $doit = sub {
     is md5_hex($resp), $expected, "on with accept-encoding: deflate, gzip";
     $resp = $fetch_orig->("/on", "-H accept-encoding:deflate");
     is md5_hex($resp), $expected, "on with accept-encoding, deflate only";
+
+    $resp = $fetch_orig->("/off-by-mime", "-H accept-encoding:gzip");
+    is md5_hex($resp), $expected, "off due to is_compressible:NO";
 
     $resp = run_prog("curl --silent --insecure -H accept-encoding:gzip $proto://127.0.0.1:$port/on/index.txt");
     is md5_hex($resp), md5_file("@{[DOC_ROOT]}/index.txt"), "tiny file not compressed";


### PR DESCRIPTION
MIME-map attributes (`is_compressible` flag and priority) should be configurable by end user.

part of #421 