### PR TITLE
fix build error when oniguruma is installed

### DIFF
--- a/misc/mruby_config.rb
+++ b/misc/mruby_config.rb
@@ -15,7 +15,13 @@ MRuby::Build.new do |conf|
   # use mrbgems
   Dir.glob("../mruby-*/mrbgem.rake") do |x|
     g = File.basename File.dirname x
-    conf.gem "../deps/#{g}"
+    if g == 'mruby-onig-regexp'
+      conf.gem "../deps/#{g}" do |c|
+        c.bundle_onigmo
+      end
+    else
+      conf.gem "../deps/#{g}"
+    end
   end
 
   # include all the core GEMs


### PR DESCRIPTION
If oniguruma.h is installed, H2O (with mruby support enabled) fails to build mruby with an error stating that `libonig.a` could not be found.

This PR fixes the issue by calling `#bundle_onigmo` method of mruby-onig-regexp.

fixes: #501
refs: http://twitter.com/take_cheeze/status/643020697762070528