### PR TITLE
mruby: support env[rack.input]

### DIFF
--- a/deps/mruby-input-steam/.travis.yml
+++ b/deps/mruby-input-steam/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+script:
+  - export MRUBY_CONFIG="$TRAVIS_BUILD_DIR/build_config.rb"
+  - git clone --depth 1 "https://github.com/mruby/mruby.git"
+  - cd mruby
+  - ./minirake test

--- a/deps/mruby-input-steam/LICENSE
+++ b/deps/mruby-input-steam/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Masayoshi Takahashi
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/deps/mruby-input-steam/README.md
+++ b/deps/mruby-input-steam/README.md
@@ -1,0 +1,28 @@
+# mruby-input-stream
+
+[![Build Status](https://travis-ci.org/takahashim/mruby-input-stream.svg?branch=master)](https://travis-ci.org/takahashim/mruby-input-stream)
+
+Input Stream class for Rack.
+
+
+## Install
+
+add conf.gem to `build_config.rb`:
+
+    MRuby::Build.new do |conf|
+    
+      # ... (snip) ...
+    
+      conf.gem :github => 'takahashim/mruby-input-stream'
+    end
+
+## License
+
+MIT
+
+## Author
+
+Masayoshi Takahashi
+
+
+

--- a/deps/mruby-input-steam/Rakefile
+++ b/deps/mruby-input-steam/Rakefile
@@ -1,0 +1,15 @@
+MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || "./build_config.rb")
+
+file :mruby do
+  sh "git clone --depth 1 git://github.com/mruby/mruby.git"
+end
+
+desc "test"
+task :test => :mruby do
+  sh "cd mruby && MRUBY_CONFIG=#{MRUBY_CONFIG} rake test"
+end
+
+desc "cleanup"
+task :clean do
+  sh "cd mruby && rake deep_clean"
+end

--- a/deps/mruby-input-steam/build_config.rb
+++ b/deps/mruby-input-steam/build_config.rb
@@ -1,0 +1,17 @@
+MRuby::Build.new do |conf|
+  toolchain :gcc
+
+  conf.gembox 'default'
+  conf.gem File.expand_path(File.dirname(__FILE__))
+end
+
+MRuby::Build.new('test') do |conf|
+  toolchain :gcc
+
+  enable_debug
+  #conf.enable_bintest
+  conf.enable_test
+
+  conf.gembox 'default'
+  conf.gem File.expand_path(File.dirname(__FILE__))
+end

--- a/deps/mruby-input-steam/mrbgem.rake
+++ b/deps/mruby-input-steam/mrbgem.rake
@@ -1,0 +1,5 @@
+MRuby::Gem::Specification.new('mruby-input-stream') do |spec|
+  spec.license = 'MIT'
+  spec.authors = 'Masayoshi Takahashi'
+  spec.summary = 'Input Stream class for Rack'
+end

--- a/deps/mruby-input-steam/mrblib/input_stream.rb
+++ b/deps/mruby-input-steam/mrblib/input_stream.rb
@@ -1,0 +1,16 @@
+class InputStream
+  include Enumerable
+
+  #
+  # from String#each
+  def each(&block)
+    self.rewind
+    while pos = self.byteindex(0x0a)
+      block.call(self.read(pos+1))
+    end
+    rest = self.read()
+    if rest
+      block.call(rest)
+    end
+  end
+end

--- a/deps/mruby-input-steam/src/input_stream.c
+++ b/deps/mruby-input-steam/src/input_stream.c
@@ -1,0 +1,196 @@
+#include <string.h>
+#include "mruby.h"
+#include "mruby/value.h"
+#include "mruby/data.h"
+#include "mruby/string.h"
+#include "input_stream.h"
+
+const static struct mrb_data_type mrb_input_stream_type = {
+  "InputStream",
+  mrb_mruby_input_stream_free,
+};
+
+static mrb_value
+mrb_input_stream_init(mrb_state *mrb, mrb_value self)
+{
+  mrb_value str;
+  mrb_int len;
+  char *ptr;
+  mrb_input_stream_t *stream;
+  mrb_int n = mrb_get_args(mrb, "|S", &str);
+  if (n > 1) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%S for 1)", mrb_fixnum_value(n));
+  }
+
+  if (n == 1) {
+    len = RSTRING_LEN(str);
+    ptr = RSTRING_PTR(str);
+    stream = mrb_input_stream_create(mrb, ptr, len);
+  } else {
+    stream = mrb_input_stream_create(mrb, NULL, 0);
+  }
+
+  DATA_TYPE(self) = &mrb_input_stream_type;
+  DATA_PTR(self) = stream;
+  return self;
+}
+
+static void
+mrb_mruby_input_stream_free(mrb_state *mrb, void *ptr)
+{
+  mrb_input_stream_t *stream = (mrb_input_stream_t *)ptr;
+  char *base = stream->base;
+  if (base) {
+    mrb_free(mrb, base);
+  }
+  mrb_free(mrb, stream);
+}
+
+mrb_input_stream_t*
+mrb_input_stream_create(mrb_state *mrb, char *base, mrb_int len)
+{
+  mrb_input_stream_t *stream = (mrb_input_stream_t *)mrb_malloc(mrb, sizeof(mrb_input_stream_t));
+
+  if (len > 0) {
+    char *dst_base = (char *)mrb_malloc(mrb, sizeof(char)*len);
+    memcpy(dst_base, base, len);
+    stream->base = dst_base;
+    stream->len = len;
+  } else {
+    stream->base = NULL;
+    stream->len = 0;
+  }
+
+  stream->pos = 0;
+  return stream;
+}
+
+mrb_value
+mrb_input_stream_value(mrb_state *mrb, char *base, mrb_int len)
+{
+  mrb_input_stream_t *stream = mrb_input_stream_create(mrb, base, len);
+  struct RClass *c = mrb_class_get(mrb, "InputStream");
+  struct RData *d = mrb_data_object_alloc(mrb, c, stream, &mrb_input_stream_type);
+
+  return mrb_obj_value(d);
+}
+
+mrb_value
+mrb_input_stream_gets(mrb_state *mrb, mrb_value self)
+{
+  mrb_input_stream_t *stream = DATA_PTR(self);
+  mrb_int pos = stream->pos;
+  mrb_int len = seek_char(stream, '\n');
+  if (len < 0) {
+    return mrb_nil_value();
+  }
+  if (stream->pos + len < stream->len) {
+    len++;
+  }
+  stream->pos += len;
+  return mrb_str_new(mrb, (stream->base + pos), len);
+}
+
+static mrb_int
+seek_char(mrb_input_stream_t *stream, char chr){
+  char *base = stream->base;
+  size_t len = stream->len;
+  mrb_int pos = stream->pos;
+
+  if (pos >= len) {
+    return -1;
+  }
+  const char *end = base + len;
+  char *start = base + pos;
+  char *s = start;
+
+  while (s < end) {
+    if (*s == chr) {
+      break;
+    }
+    s++;
+  }
+  return (s - start);
+}
+
+mrb_value
+mrb_input_stream_read(mrb_state *mrb, mrb_value self)
+{
+  mrb_int len;
+  mrb_value buf;
+  mrb_int n = mrb_get_args(mrb, "|iS", &len, &buf);
+
+  mrb_input_stream_t *stream = DATA_PTR(self);
+  mrb_int pos = stream->pos;
+  const char *start = stream->base + pos;
+
+  if (pos >= stream->len) {
+    return mrb_nil_value();
+  }
+  if (n == 0) {
+    stream->pos = stream->len;
+    return mrb_str_new(mrb, start, stream->len - pos);
+  } else {
+    mrb_int newpos = pos + len;
+    if (newpos > stream->len) {
+      newpos = stream->len;
+    }
+    stream->pos = newpos;
+    if (n == 1) {
+      return mrb_str_new(mrb, start, newpos - pos);
+    } else {
+      return mrb_str_cat(mrb, buf, start, newpos - pos);
+    }
+  }
+}
+
+mrb_value
+mrb_input_stream_rewind(mrb_state *mrb, mrb_value self)
+{
+  mrb_input_stream_t *stream = DATA_PTR(self);
+  stream->pos = 0;
+  return self;
+}
+
+
+mrb_value
+mrb_input_stream_byteindex(mrb_state *mrb, mrb_value self)
+{
+  mrb_int chr;
+  mrb_int n;
+
+  n = mrb_get_args(mrb, "i", &chr);
+  if (n != 1) {
+    mrb_raisef(mrb, E_ARGUMENT_ERROR, "wrong number of arguments (%S for 1)", mrb_fixnum_value(n));
+  }
+  if (chr < 0 || chr > 255) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "index should be a byte (0 - 255)");
+  }
+
+  mrb_input_stream_t *stream = DATA_PTR(self);
+
+  mrb_int len = seek_char(stream, chr);
+  if (len < 0) {
+    return mrb_nil_value();
+  }
+
+  return mrb_fixnum_value(len);
+}
+
+
+void
+mrb_mruby_input_stream_gem_init(mrb_state* mrb)
+{
+  struct RClass * c = mrb_define_class(mrb, "InputStream", mrb->object_class);
+
+  mrb_define_method(mrb, c, "gets",  mrb_input_stream_gets,  MRB_ARGS_NONE());
+  mrb_define_method(mrb, c, "read",  mrb_input_stream_read,  MRB_ARGS_ANY());
+  mrb_define_method(mrb, c, "initialize",  mrb_input_stream_init,  MRB_ARGS_BLOCK());
+  mrb_define_method(mrb, c, "rewind",  mrb_input_stream_rewind,  MRB_ARGS_NONE());
+  mrb_define_method(mrb, c, "byteindex",  mrb_input_stream_byteindex,  MRB_ARGS_ANY());
+}
+
+void
+mrb_mruby_input_stream_gem_final(mrb_state* mrb)
+{
+}

--- a/deps/mruby-input-steam/src/input_stream.h
+++ b/deps/mruby-input-steam/src/input_stream.h
@@ -1,0 +1,26 @@
+/*
+ * input_stream.h
+ *
+ */
+#ifndef input_stream_h
+#define input_stream_h
+
+typedef struct mrb_input_stream_t {
+  char *base;
+  mrb_int len;
+  mrb_int pos;
+} mrb_input_stream_t;
+
+mrb_input_stream_t*
+mrb_input_stream_create(mrb_state *mrb, char *base, mrb_int len);
+
+mrb_value
+mrb_input_stream_value(mrb_state *mrb, char *base, mrb_int len);
+
+static void
+mrb_mruby_input_stream_free(mrb_state *mrb, void *ptr);
+
+static mrb_int
+seek_char(mrb_input_stream_t *stream, const char chr);
+
+#endif /* input_stream_h */

--- a/deps/mruby-input-steam/test/input_stream.rb
+++ b/deps/mruby-input-steam/test/input_stream.rb
@@ -1,0 +1,111 @@
+assert('InputStream.new()') do
+  vec = InputStream.new
+  assert_equal InputStream, vec.class
+end
+
+assert('InputStream.new("foo")') do
+  vec = InputStream.new("foo")
+  assert_equal InputStream, vec.class
+end
+
+assert('InputStream#read') do
+  vec = InputStream.new("foo")
+  assert_equal "foo", vec.read
+end
+
+assert('InputStream#read(2)') do
+  vec = InputStream.new("abcdef")
+  assert_equal "ab", vec.read(2)
+  assert_equal "cde", vec.read(3)
+  assert_equal "f", vec.read(4)
+  assert_equal nil, vec.read(5)
+end
+
+assert('InputStream#read(2, "")') do
+  vec = InputStream.new("abcdef")
+  s1 = ""
+  assert_equal "ab", vec.read(2, s1)
+  assert_equal "ab", s1
+  assert_equal "abcde", vec.read(3, s1)
+  assert_equal "abcde", s1
+  assert_equal "abcdef", vec.read(4, s1)
+  assert_equal "abcdef", s1
+  assert_equal nil, vec.read(5, s1)
+  assert_equal "abcdef", s1
+end
+
+assert('InputStream#read(10)') do
+  vec = InputStream.new("abc")
+  assert_equal "abc", vec.read(10)
+  assert_equal nil, vec.read(10)
+end
+
+assert('InputStream#read ""') do
+  vec = InputStream.new("")
+  assert_equal nil, vec.read(2)
+  assert_equal nil, vec.read(0)
+  assert_equal nil, vec.read(2)
+end
+
+assert('InputStream#read(0)') do
+  vec = InputStream.new("foo")
+  assert_equal "", vec.read(0)
+  assert_equal "", vec.read(0)
+  assert_equal "f", vec.read(1)
+end
+
+
+assert('InputStream#gets') do
+  vec = InputStream.new("foo")
+  assert_equal "foo", vec.gets
+  assert_equal nil, vec.gets
+end
+
+assert('InputStream#gets ""') do
+  vec = InputStream.new("")
+  assert_equal nil, vec.gets
+end
+
+assert('InputStream#gets long') do
+  vec = InputStream.new("foo\nbar\nbuz\n")
+  assert_equal "foo\n", vec.gets
+  assert_equal "bar\n", vec.gets
+  assert_equal "buz\n", vec.gets
+  assert_equal nil, vec.gets
+end
+
+assert('InputStream#gets NN') do
+  vec = InputStream.new("\n\nbuz")
+  assert_equal "\n", vec.gets
+  assert_equal "\n", vec.gets
+  assert_equal "buz", vec.gets
+  assert_equal nil, vec.gets
+end
+
+assert('InputStream#each') do
+  vec = InputStream.new("foo\nbar\nbuz\nzzz")
+  buf = []
+  vec.each do |line|
+    buf << line
+  end
+  assert_equal ["foo\n", "bar\n", "buz\n", "zzz"], buf
+end
+
+assert('InputStream#each ""') do
+  vec = InputStream.new("")
+  buf = []
+  vec.each do |line|
+    buf << line
+  end
+  assert_equal [], buf
+end
+
+assert('InputStream#rewind') do
+  vec = InputStream.new("abcdef")
+  assert_equal "ab", vec.read(2)
+  assert_equal "cde", vec.read(3)
+  vec.rewind
+  assert_equal "abcd", vec.read(4)
+  assert_equal "ef", vec.read(5)
+end
+

--- a/examples/h2o_mruby/hello.rb
+++ b/examples/h2o_mruby/hello.rb
@@ -14,8 +14,9 @@ class HelloApp
     host = env["HTTP_HOST"]
     method = env["REQUEST_METHOD"]
     query = env["QUERY_STRING"]
+    input = env["rack.input"] ? env["rack.input"].read : ""
 
-    msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{path} host:#{host} method:#{method} query:#{query}"
+    msg = "#{h} #{m}. User-Agent:#{ua} New User-Agent:#{new_ua} path:#{path} host:#{host} method:#{method} query:#{query} input:#{input}"
 
     [200,
      {

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -51,6 +51,7 @@ enum {
     LIT_RACK_MULTIPROCESS,
     LIT_RACK_RUN_ONCE,
     LIT_RACK_HIJACK_,
+    LIT_RACK_INPUT,
     LIT_RACK_ERRORS,
     LIT_SERVER__NAME,
     LIT_SERVER__NAME_VALUE,
@@ -200,6 +201,7 @@ static mrb_value build_constants(mrb_state *mrb)
     SET_LITERAL(LIT_RACK_MULTIPROCESS, "rack.multiprocess");
     SET_LITERAL(LIT_RACK_RUN_ONCE, "rack.run_once");
     SET_LITERAL(LIT_RACK_HIJACK_, "rack.hijack?");
+    SET_LITERAL(LIT_RACK_INPUT, "rack.input");
     SET_LITERAL(LIT_RACK_ERRORS, "rack.errors");
     SET_LITERAL(LIT_SERVER__NAME, "server.name");
     SET_LITERAL(LIT_SERVER__NAME_VALUE, "h2o");
@@ -291,6 +293,8 @@ static void stringify_address(h2o_conn_t *conn, socklen_t (*cb)(h2o_conn_t *conn
     }
 }
 
+mrb_value mrb_input_stream_value(mrb_state *mrb, char *base, mrb_int len);
+
 static mrb_value build_env(h2o_req_t *req, mrb_state *mrb, mrb_value constants)
 {
     mrb_value env = mrb_hash_new_capa(mrb, 16);
@@ -324,6 +328,9 @@ static mrb_value build_env(h2o_req_t *req, mrb_state *mrb, mrb_value constants)
         char buf[32];
         int l = sprintf(buf, "%zu", req->entity.len);
         mrb_hash_set(mrb, env, mrb_ary_entry(constants, LIT_CONTENT_LENGTH), mrb_str_new(mrb, buf, l));
+        mrb_hash_set(mrb, env, mrb_ary_entry(constants, LIT_RACK_INPUT),
+                     mrb_input_stream_value(mrb, req->entity.base, req->entity.len));
+
     }
     {
         mrb_value h, p;


### PR DESCRIPTION
I made a patch to support `rack.input` on rack-based API.

`rack.input` is IO-like object to use request body. (see http://www.rubydoc.info/github/rack/rack/file/SPEC#The_Input_Stream )
In CRuby, `rack.input` is usually an StringIO object.  There is a StringIO gem in mruby (https://github.com/ksss/mruby-stringio), but Input Stream does not need much methods and does need speed, so I made new mrbgem mruby-input-stream. 