### PR TITLE
determine whether or not to use accept4 using macro

### DIFF
--- a/deps/cloexec/cloexec.c
+++ b/deps/cloexec/cloexec.c
@@ -29,11 +29,11 @@ static int set_cloexec(int fd)
     return fcntl(fd, F_SETFD, FD_CLOEXEC) != -1 ? 0 : -1;
 }
 
+/*
+ * note: the socket must be in non-blocking mode, or the call might block while the mutex is being locked
+ */
 int cloexec_accept(int socket, struct sockaddr *addr, socklen_t *addrlen)
 {
-#ifdef __linux__
-    return accept4(socket, addr, addrlen, SOCK_CLOEXEC);
-#else
     int fd = -1;
     pthread_mutex_lock(&cloexec_mutex);
 
@@ -48,7 +48,6 @@ int cloexec_accept(int socket, struct sockaddr *addr, socklen_t *addrlen)
 Exit:
     pthread_mutex_unlock(&cloexec_mutex);
     return fd;
-#endif
 }
 
 int cloexec_pipe(int fds[2])

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -28,6 +28,16 @@
 #include "cloexec.h"
 #include "h2o/linklist.h"
 
+#if !defined(H2O_USE_ACCEPT4)
+#ifdef __linux__
+#define H2O_USE_ACCEPT4 1
+#elif __FreeBSD__ >= 10
+#define H2O_USE_ACCEPT4 1
+#else
+#define H2O_USE_ACCEPT4 0
+#endif
+#endif
+
 struct st_h2o_evloop_socket_t {
     h2o_socket_t super;
     int fd;
@@ -378,7 +388,7 @@ h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *_listener)
     struct st_h2o_evloop_socket_t *listener = (struct st_h2o_evloop_socket_t *)_listener;
     int fd;
 
-#ifdef __linux__
+#if H2O_USE_ACCEPT4
     if ((fd = accept4(listener->fd, NULL, NULL, SOCK_NONBLOCK | SOCK_CLOEXEC)) == -1)
         return NULL;
 #else


### PR DESCRIPTION
Respects macro named `H2O_USE_ACCEPT4` on whether or not to use `accept4`.
* if the value is `0`, `accept4` is not used
* if the value is `1`, `accept4` is used
* if the value is unset, it is determined by the default rule (i.e. enable on Linux or FreeBSD>=10)

partial fix to #524 