### PR TITLE
Doc: Fix relative base tags ignored in IE

### DIFF
--- a/srcdoc/snippets/wrapper.mt
+++ b/srcdoc/snippets/wrapper.mt
@@ -23,7 +23,7 @@ my $create_tab = sub {
 ? my $base = "../" x (scalar(split '/', $main::context->{filename}) - 1);
 ? if ($base ne '') {
 <base href="<?= $base ?>" />
-<!--[if IE]><script type="text/javascript">
+<!--[if lte IE 9]><script type="text/javascript">
     // Fix for IE ignoring relative base tags.
     (function() {
         var baseTag = document.getElementsByTagName('base')[0];

--- a/srcdoc/snippets/wrapper.mt
+++ b/srcdoc/snippets/wrapper.mt
@@ -23,6 +23,13 @@ my $create_tab = sub {
 ? my $base = "../" x (scalar(split '/', $main::context->{filename}) - 1);
 ? if ($base ne '') {
 <base href="<?= $base ?>" />
+<!--[if IE]><script type="text/javascript">
+    // Fix for IE ignoring relative base tags.
+    (function() {
+        var baseTag = document.getElementsByTagName('base')[0];
+        baseTag.href = baseTag.href;
+    })();
+</script><![endif]-->
 ? }
 
 <!-- oktavia -->


### PR DESCRIPTION
... as discussed in https://stackoverflow.com/questions/3926197/html-base-tag-and-local-folder-path-with-internet-explorer#13373180 (code snippet adapted from the "answer" to the thread)

Trying to make it look nicer, restoring its intended look (less eyesores) to users in IE.

This affects htmls residing in a sub-folder, like `/configure`, where the `<base href="../" />` tag kicks in.

As discussed in the thread, the culprit is that IE ignores relative urls in `base` tags when it issues requests (despite being able to correctly parse it in js). This workaround reinstates the correct url, in its absolute form, in javascript, on load; before other resources are requested and loaded.

(It's possible that later versions of IE, and Edge, don't need that fix; haven't had the chance to try it though)

Personally tested this in IE 9, without breaking Firefox.

[As the thread suggests, it uses conditional comments, so it probably won't affect other browsers]