### PR TITLE
fix stall when only reprioritized stream is being transferred

### DIFF
--- a/lib/http2/scheduler.c
+++ b/lib/http2/scheduler.c
@@ -41,7 +41,7 @@ static void queue_init(h2o_http2_scheduler_queue_t *queue)
 
 static int queue_is_empty(h2o_http2_scheduler_queue_t *queue)
 {
-    return queue->bits == 0;
+    return queue->bits == 0 && h2o_linklist_is_empty(&queue->anchor257);
 }
 
 static void queue_set(h2o_http2_scheduler_queue_t *queue, h2o_http2_scheduler_queue_node_t *node, uint16_t weight)


### PR DESCRIPTION
Fixes stall when transferring reprioritized stream only (typically when sending only .js or .css on Chrome), after #550 being merged (i.e. version 1.5.1).
