### PR TITLE
fix behavior when HEADERS frame specifies a stream not open as a dependency

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -404,7 +404,10 @@ static int open_stream(h2o_http2_conn_t *conn, uint32_t stream_id, h2o_http2_str
 {
     if (conn->num_streams.open_priority >= conn->super.ctx->globalconf->http2.max_streams_for_priority) {
         *err_desc = "too many streams in idle/closed state";
-        return H2O_HTTP2_ERROR_INTERNAL; /* FIXME? */
+        /* RFC 7540 10.5: An endpoint MAY treat activity that is suspicious as a connection error (Section 5.4.1) of type
+         * ENHANCE_YOUR_CALM.
+         */
+        return H2O_HTTP2_ERROR_ENHANCE_YOUR_CALM;
     }
     *stream = h2o_http2_stream_open(conn, stream_id, NULL, 0);
     return 0;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -400,38 +400,26 @@ static void update_input_window(h2o_http2_conn_t *conn, uint32_t stream_id, h2o_
     }
 }
 
-static int open_stream(h2o_http2_conn_t *conn, uint32_t stream_id, h2o_http2_stream_t **stream, const char **err_desc)
-{
-    if (conn->num_streams.open_priority >= conn->super.ctx->globalconf->http2.max_streams_for_priority) {
-        *err_desc = "too many streams in idle/closed state";
-        /* RFC 7540 10.5: An endpoint MAY treat activity that is suspicious as a connection error (Section 5.4.1) of type
-         * ENHANCE_YOUR_CALM.
-         */
-        return H2O_HTTP2_ERROR_ENHANCE_YOUR_CALM;
-    }
-    *stream = h2o_http2_stream_open(conn, stream_id, NULL, 0);
-    return 0;
-}
-
-static int set_priority(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, const h2o_http2_priority_t *priority,
-                        int scheduler_is_open, const char **err_desc)
+static void set_priority(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, const h2o_http2_priority_t *priority,
+                         int scheduler_is_open)
 {
     h2o_http2_scheduler_node_t *parent_sched;
-
-    /* cannot depend on itself */
-    if (stream->stream_id == priority->dependency)
-        return H2O_HTTP2_ERROR_PROTOCOL;
 
     /* determine the parent */
     if (priority->dependency != 0) {
         h2o_http2_stream_t *parent_stream = h2o_http2_conn_get_stream(conn, priority->dependency);
-        if (parent_stream == NULL) {
-            int ret = open_stream(conn, priority->dependency, &parent_stream, err_desc);
-            if (ret != 0)
-                return ret;
-            set_priority(conn, parent_stream, &h2o_http2_default_priority, 0, err_desc); /* guaranteed to succeed */
+        if (parent_stream != NULL) {
+            parent_sched = &parent_stream->_refs.scheduler.node;
+        } else {
+            /* A dependency on a stream that is not currently in the tree - such as a stream in the "idle" state - results in that
+             * stream being given a default priority. (RFC 7540 5.3.1)
+             * It is possible for a stream to become closed while prioritization information that creates a dependency on that
+             * stream is in transit. If a stream identified in a dependency has no associated priority information, then the
+             * dependent stream is instead assigned a default priority. (RFC 7540 5.3.4)
+             */
+            parent_sched = &conn->scheduler;
+            priority = &h2o_http2_default_priority;
         }
-        parent_sched = &parent_stream->_refs.scheduler.node;
     } else {
         parent_sched = &conn->scheduler;
     }
@@ -442,8 +430,6 @@ static int set_priority(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, cons
     } else {
         h2o_http2_scheduler_rebind(&stream->_refs.scheduler, parent_sched, priority->weight, priority->exclusive);
     }
-
-    return 0;
 }
 
 static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, const char **err_desc)
@@ -512,6 +498,10 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
         *err_desc = "invalid stream id in HEADERS frame";
         return H2O_HTTP2_ERROR_PROTOCOL;
     }
+    if (frame->stream_id == payload.priority.dependency) {
+        *err_desc = "stream cannot depend on itself";
+        return H2O_HTTP2_ERROR_PROTOCOL;
+    }
 
     if (conn->state >= H2O_HTTP2_CONN_STATE_HALF_CLOSED)
         return 0;
@@ -522,13 +512,10 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
     /* open or determine the stream and prepare */
     if ((stream = h2o_http2_conn_get_stream(conn, frame->stream_id)) != NULL) {
         if ((frame->flags & H2O_HTTP2_FRAME_FLAG_PRIORITY) != 0)
-            if ((ret = set_priority(conn, stream, &payload.priority, 1, err_desc)) != 0)
-                return ret;
+            set_priority(conn, stream, &payload.priority, 1);
     } else {
-        if ((ret = open_stream(conn, frame->stream_id, &stream, err_desc)) != 0)
-            return ret;
-        if ((ret = set_priority(conn, stream, &payload.priority, 0, err_desc)) != 0)
-            return ret;
+        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL, 0);
+        set_priority(conn, stream, &payload.priority, 0);
     }
     h2o_http2_stream_prepare_for_request(conn, stream);
 
@@ -567,14 +554,18 @@ static int handle_priority_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *fram
         /* ignore priority changes to pushed streams with weight=257, since that is where we are trying to be smarter than the web
          * browsers
          */
-        if (h2o_http2_scheduler_get_weight(&stream->_refs.scheduler) != 257 &&
-            (ret = set_priority(conn, stream, &payload, 1, err_desc)) != 0)
-            return ret;
+        if (h2o_http2_scheduler_get_weight(&stream->_refs.scheduler) != 257)
+            set_priority(conn, stream, &payload, 1);
     } else {
-        if ((ret = open_stream(conn, frame->stream_id, &stream, err_desc)) != 0)
-            return ret;
-        if ((ret = set_priority(conn, stream, &payload, 0, err_desc)) != 0)
-            return ret;
+        if (conn->num_streams.open_priority >= conn->super.ctx->globalconf->http2.max_streams_for_priority) {
+            *err_desc = "too many streams in idle/closed state";
+            /* RFC 7540 10.5: An endpoint MAY treat activity that is suspicious as a connection error (Section 5.4.1) of type
+             * ENHANCE_YOUR_CALM.
+             */
+            return H2O_HTTP2_ERROR_ENHANCE_YOUR_CALM;
+        }
+        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL, 0);
+        set_priority(conn, stream, &payload, 0);
     }
 
     return 0;


### PR DESCRIPTION
This PR fixes two issues:
* crash when H2O receives many HEADERS frames specifying streams not open as dependencies
* change the error code from INTERNAL_ERROR to ENHANCE_YOUR_CALM when too many idle streams receive PRIORITY frames