### PR TITLE
include "http/1.1" in npn protocol selection

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -816,6 +816,11 @@ ssize_t h2o_delete_header(h2o_headers_t *headers, ssize_t cursor);
 
 /* util */
 
+extern const char *h2o_http2_npn_protocols;
+extern const char *h2o_npn_protocols;
+extern const h2o_iovec_t *h2o_http2_alpn_protocols;
+extern const h2o_iovec_t *h2o_alpn_protocols;
+
 /**
  * accepts a connection
  */

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -355,3 +355,17 @@ h2o_iovec_t h2o_extract_push_path_from_link_header(h2o_mem_pool_t *pool, const c
 None:
     return (h2o_iovec_t){};
 }
+
+/* h2-14 and h2-16 are kept for backwards compatibility, as they are often used */
+#define H2O_HTTP2_ALPN_PROTOCOLS_CORE {H2O_STRLIT("h2")},{H2O_STRLIT("h2-16")},{H2O_STRLIT("h2-14")}
+#define H2O_HTTP2_NPN_PROTOCOLS_CORE "\x02" "h2" "\x05" "h2-16" "\x05" "h2-14"
+
+static const h2o_iovec_t http2_alpn_protocols[] = {H2O_HTTP2_ALPN_PROTOCOLS_CORE, {}};
+const h2o_iovec_t *h2o_http2_alpn_protocols = http2_alpn_protocols;
+
+static const h2o_iovec_t alpn_protocols[] = {H2O_HTTP2_ALPN_PROTOCOLS_CORE, {H2O_STRLIT("http/1.1")}, {}};
+const h2o_iovec_t *h2o_alpn_protocols = alpn_protocols;
+
+const char *h2o_http2_npn_protocols = H2O_HTTP2_NPN_PROTOCOLS_CORE;
+const char *h2o_npn_protocols = H2O_HTTP2_NPN_PROTOCOLS_CORE "\x08"
+                                                             "http/1.1";

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -28,17 +28,6 @@
 
 static const h2o_iovec_t CONNECTION_PREFACE = {H2O_STRLIT("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")};
 
-/* h2-14 and h2-16 are kept for backwards compatibility, as they are often used */
-static const h2o_iovec_t alpn_protocols[] = {{H2O_STRLIT("h2")}, {H2O_STRLIT("h2-16")}, {H2O_STRLIT("h2-14")}, {NULL, 0}};
-const h2o_iovec_t *h2o_http2_alpn_protocols = alpn_protocols;
-/* npn defs should match the definition of alpn_protocols */
-const char *h2o_http2_npn_protocols = "\x02"
-                                      "h2"
-                                      "\x05"
-                                      "h2-16"
-                                      "\x05"
-                                      "h2-14";
-
 const h2o_http2_priority_t h2o_http2_default_priority = {
     0, /* exclusive */
     0, /* dependency */

--- a/src/main.c
+++ b/src/main.c
@@ -556,10 +556,10 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
 
 /* setup protocol negotiation methods */
 #if H2O_USE_NPN
-    h2o_ssl_register_npn_protocols(ssl_ctx, h2o_http2_npn_protocols);
+    h2o_ssl_register_npn_protocols(ssl_ctx, h2o_npn_protocols);
 #endif
 #if H2O_USE_ALPN
-    h2o_ssl_register_alpn_protocols(ssl_ctx, h2o_http2_alpn_protocols);
+    h2o_ssl_register_alpn_protocols(ssl_ctx, h2o_alpn_protocols);
 #endif
 
     /* set SNI callback to the first SSL context, when and only when it should be used */


### PR DESCRIPTION
H2O does not include "http/1.1" in the NPN protocol selection list (which is sent to client).  Clients may consider that the server does not support "http/1.1" even though it does.

This PR adds "http/1.1" to the list of the protocols to fix the issue.

The server should also send ALPN response when "http/1.1" is selected (since doing so would prevent OpenSSL from sending NPN protocol selection list).