### PR TITLE
do not request close of fd that is implicitly closed in `h2o_spawnp`

### DIFF
--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -413,7 +413,6 @@ int h2o_access_log_open_log(const char *path)
         }
         /* spawn the logger */
         int mapped_fds[] = {pipefds[0], 0,  /* map pipefds[0] to stdin */
-                            pipefds[0], -1, /* close pipefds[0] before exec */
                             -1};
         if ((pid = h2o_spawnp(argv[0], argv, mapped_fds, 0)) == -1) {
             fprintf(stderr, "failed to open logger: %s:%s\n", path + 1, strerror(errno));

--- a/src/main.c
+++ b/src/main.c
@@ -1092,7 +1092,6 @@ static int popen_annotate_backtrace_symbols(void)
     }
     /* spawn the logger */
     int mapped_fds[] = {pipefds[0], 0,  /* output of the pipe is connected to STDIN of the spawned process */
-                        pipefds[0], -1, /* close pipefds[0] before exec */
                         2,          1,  /* STDOUT of the spawned process in connected to STDERR of h2o */
                         -1};
     if (h2o_spawnp(cmd_fullpath, argv, mapped_fds, 0) == -1) {


### PR DESCRIPTION
Fixes `access-log: | ...` returning "bad file descriptor" error on startup when using OS X.