### PR TITLE
collect and log various timings

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -682,6 +682,15 @@ struct st_h2o_req_t {
      */
     h2o_timestamp_t processed_at;
     /**
+     * additional timestamps
+     */
+    struct {
+        struct timeval request_begin_at;
+        struct timeval request_body_begin_at;
+        struct timeval response_start_at;
+        struct timeval response_end_at;
+    } timestamps;
+    /**
      * the response
      */
     h2o_res_t res;
@@ -985,10 +994,11 @@ void h2o_context_dispose_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pa
 /**
  * returns current timestamp
  * @param ctx the context
- * @param pool memory pool
- * @param ts buffer to store the timestamp
+ * @param pool memory pool (used when ts != NULL)
+ * @param ts buffer to store the timestamp (optional)
+ * @return current time in UTC
  */
-void h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t *ts);
+struct timeval *h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t *ts);
 /**
  * returns per-module context set
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -544,6 +544,10 @@ struct st_h2o_conn_t {
      */
     h2o_hostconf_t **hosts;
     /**
+     * time when the connection was established
+     */
+    struct timeval connected_at;
+    /**
      * getsockname (return size of the obtained address, or 0 if failed)
      */
     socklen_t (*get_sockname)(h2o_conn_t *conn, struct sockaddr *sa);

--- a/include/h2o/http1.h
+++ b/include/h2o/http1.h
@@ -30,7 +30,7 @@ typedef void (*h2o_http1_upgrade_cb)(void *user_data, h2o_socket_t *sock, size_t
 
 extern const h2o_protocol_callbacks_t H2O_HTTP1_CALLBACKS;
 
-void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
+void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at);
 void h2o_http1_upgrade(h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_http1_upgrade_cb on_complete, void *user_data);
 
 #ifdef __cplusplus

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -57,8 +57,8 @@ typedef struct st_h2o_http2_priority_t {
 
 extern const h2o_http2_priority_t h2o_http2_default_priority;
 
-void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
-int h2o_http2_handle_upgrade(h2o_req_t *req);
+void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at);
+int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval connected_at);
 
 #ifdef __cplusplus
 }

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -362,9 +362,11 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         else
             h2o_http2_stream_update_open_slot(stream, &conn->num_streams.open_pull);
         stream->state = new_state;
+        stream->req.timestamps.request_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         break;
     case H2O_HTTP2_STREAM_STATE_RECV_BODY:
         stream->state = new_state;
+        stream->req.timestamps.request_body_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         break;
     case H2O_HTTP2_STREAM_STATE_REQ_PENDING:
         stream->state = new_state;
@@ -376,6 +378,7 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         break;
     case H2O_HTTP2_STREAM_STATE_SEND_BODY:
         stream->state = new_state;
+        stream->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         break;
     case H2O_HTTP2_STREAM_STATE_END_STREAM:
         switch (stream->state) {
@@ -394,6 +397,7 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
             break;
         }
         stream->state = new_state;
+        stream->req.timestamps.response_end_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         break;
     }
 }

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -162,31 +162,19 @@ void h2o_context_request_shutdown(h2o_context_t *ctx)
         ctx->globalconf->http2.callbacks.request_shutdown(ctx);
 }
 
-struct timeval *h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t *ts)
+void h2o_context_update_timestamp_cache(h2o_context_t *ctx)
 {
-    uint64_t now = h2o_now(ctx->loop);
-    struct tm gmt;
-
-    if (ctx->_timestamp_cache.uv_now_at != now) {
-        time_t prev_sec = ctx->_timestamp_cache.tv_at.tv_sec;
-        ctx->_timestamp_cache.uv_now_at = now;
-        gettimeofday(&ctx->_timestamp_cache.tv_at, NULL);
-        if (ctx->_timestamp_cache.tv_at.tv_sec != prev_sec) {
-            /* update the string cache */
-            if (ctx->_timestamp_cache.value != NULL)
-                h2o_mem_release_shared(ctx->_timestamp_cache.value);
-            ctx->_timestamp_cache.value = h2o_mem_alloc_shared(NULL, sizeof(h2o_timestamp_string_t), NULL);
-            gmtime_r(&ctx->_timestamp_cache.tv_at.tv_sec, &gmt);
-            h2o_time2str_rfc1123(ctx->_timestamp_cache.value->rfc1123, &gmt);
-            h2o_time2str_log(ctx->_timestamp_cache.value->log, ctx->_timestamp_cache.tv_at.tv_sec);
-        }
+    time_t prev_sec = ctx->_timestamp_cache.tv_at.tv_sec;
+    ctx->_timestamp_cache.uv_now_at = h2o_now(ctx->loop);
+    gettimeofday(&ctx->_timestamp_cache.tv_at, NULL);
+    if (ctx->_timestamp_cache.tv_at.tv_sec != prev_sec) {
+        struct tm gmt;
+        /* update the string cache */
+        if (ctx->_timestamp_cache.value != NULL)
+            h2o_mem_release_shared(ctx->_timestamp_cache.value);
+        ctx->_timestamp_cache.value = h2o_mem_alloc_shared(NULL, sizeof(h2o_timestamp_string_t), NULL);
+        gmtime_r(&ctx->_timestamp_cache.tv_at.tv_sec, &gmt);
+        h2o_time2str_rfc1123(ctx->_timestamp_cache.value->rfc1123, &gmt);
+        h2o_time2str_log(ctx->_timestamp_cache.value->log, ctx->_timestamp_cache.tv_at.tv_sec);
     }
-
-    if (ts != NULL) {
-        ts->at = ctx->_timestamp_cache.tv_at;
-        h2o_mem_link_shared(pool, ctx->_timestamp_cache.value);
-        ts->str = ctx->_timestamp_cache.value;
-    }
-
-    return &ctx->_timestamp_cache.tv_at;
 }

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -162,7 +162,7 @@ void h2o_context_request_shutdown(h2o_context_t *ctx)
         ctx->globalconf->http2.callbacks.request_shutdown(ctx);
 }
 
-void h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t *ts)
+struct timeval *h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t *ts)
 {
     uint64_t now = h2o_now(ctx->loop);
     struct tm gmt;
@@ -182,7 +182,11 @@ void h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t
         }
     }
 
-    ts->at = ctx->_timestamp_cache.tv_at;
-    h2o_mem_link_shared(pool, ctx->_timestamp_cache.value);
-    ts->str = ctx->_timestamp_cache.value;
+    if (ts != NULL) {
+        ts->at = ctx->_timestamp_cache.tv_at;
+        h2o_mem_link_shared(pool, ctx->_timestamp_cache.value);
+        ts->str = ctx->_timestamp_cache.value;
+    }
+
+    return &ctx->_timestamp_cache.tv_at;
 }

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -184,6 +184,7 @@ void h2o_init_request(h2o_req_t *req, h2o_conn_t *conn, h2o_req_t *src)
         req->headers.size = src->headers.size;
         req->entity = src->entity;
         req->http1_is_persistent = src->http1_is_persistent;
+        req->timestamps = src->timestamps;
         if (src->upgrade.base != NULL) {
             COPY(upgrade);
         } else {

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -34,11 +34,12 @@ struct st_h2o_accept_data_t {
     h2o_socket_t *sock;
     h2o_timeout_entry_t timeout;
     h2o_memcached_req_t *async_resumption_get_req;
+    struct timeval connected_at;
 };
 
 static void on_accept_timeout(h2o_timeout_entry_t *entry);
 
-static struct st_h2o_accept_data_t *create_accept_data(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
+static struct st_h2o_accept_data_t *create_accept_data(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at)
 {
     struct st_h2o_accept_data_t *data = h2o_mem_alloc(sizeof(*data));
 
@@ -48,18 +49,17 @@ static struct st_h2o_accept_data_t *create_accept_data(h2o_accept_ctx_t *ctx, h2
     data->timeout.cb = on_accept_timeout;
     h2o_timeout_link(ctx->ctx->loop, &ctx->ctx->handshake_timeout, &data->timeout);
     data->async_resumption_get_req = NULL;
+    data->connected_at = connected_at;
 
     sock->data = data;
     return data;
 }
 
-static h2o_accept_ctx_t *free_accept_data(struct st_h2o_accept_data_t *data)
+static void free_accept_data(struct st_h2o_accept_data_t *data)
 {
-    h2o_accept_ctx_t *ctx = data->ctx;
     assert(data->async_resumption_get_req == NULL);
     h2o_timeout_unlink(&data->timeout);
     free(data);
-    return ctx;
 }
 
 static struct {
@@ -117,28 +117,28 @@ void on_accept_timeout(h2o_timeout_entry_t *entry)
 
 static void on_ssl_handshake_complete(h2o_socket_t *sock, int status)
 {
-    h2o_accept_ctx_t *ctx = free_accept_data(sock->data);
+    struct st_h2o_accept_data_t *data = sock->data;
     sock->data = NULL;
 
     if (status != 0) {
         h2o_socket_close(sock);
-        return;
+        goto Exit;
     }
 
     h2o_iovec_t proto = h2o_socket_ssl_get_selected_protocol(sock);
     const h2o_iovec_t *ident;
     for (ident = h2o_http2_alpn_protocols; ident->len != 0; ++ident) {
         if (proto.len == ident->len && memcmp(proto.base, ident->base, proto.len) == 0) {
-            goto Is_Http2;
+            /* connect as http2 */
+            h2o_http2_accept(data->ctx, sock, data->connected_at);
+            goto Exit;
         }
     }
     /* connect as http1 */
-    h2o_http1_accept(ctx, sock);
-    return;
+    h2o_http1_accept(data->ctx, sock, data->connected_at);
 
-Is_Http2:
-    /* connect as http2 */
-    h2o_http2_accept(ctx, sock);
+Exit:
+    free_accept_data(data);
 }
 
 static ssize_t parse_proxy_line(char *src, size_t len, struct sockaddr *sa, socklen_t *salen)
@@ -265,23 +265,26 @@ static void on_read_proxy_line(h2o_socket_t *sock, int status)
     if (data->ctx->ssl_ctx != NULL) {
         h2o_socket_ssl_server_handshake(sock, data->ctx->ssl_ctx, on_ssl_handshake_complete);
     } else {
-        h2o_accept_ctx_t *ctx = free_accept_data(data);
+        struct st_h2o_accept_data_t *data = sock->data;
         sock->data = NULL;
-        h2o_http1_accept(ctx, sock);
+        h2o_http1_accept(data->ctx, sock, data->connected_at);
+        free_accept_data(data);
     }
 }
 
 void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
 {
+    struct timeval connected_at = *h2o_get_timestamp(ctx->ctx, NULL, NULL);
+
     if (ctx->expect_proxy_line || ctx->ssl_ctx != NULL) {
-        create_accept_data(ctx, sock);
+        create_accept_data(ctx, sock, connected_at);
         if (ctx->expect_proxy_line) {
             h2o_socket_read_start(sock, on_read_proxy_line);
         } else {
             h2o_socket_ssl_server_handshake(sock, ctx->ssl_ctx, on_ssl_handshake_complete);
         }
     } else {
-        h2o_http1_accept(ctx, sock);
+        h2o_http1_accept(ctx, sock, connected_at);
     }
 }
 

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -35,26 +35,33 @@
 #define LOG_ALLOCA_SIZE 4096
 
 enum {
-    ELEMENT_TYPE_EMPTY,             /* empty element (with suffix only) */
-    ELEMENT_TYPE_LOCAL_ADDR,        /* %A */
-    ELEMENT_TYPE_BYTES_SENT,        /* %b */
-    ELEMENT_TYPE_PROTOCOL,          /* %H */
-    ELEMENT_TYPE_REMOTE_ADDR,       /* %h */
-    ELEMENT_TYPE_LOGNAME,           /* %l */
-    ELEMENT_TYPE_METHOD,            /* %m */
-    ELEMENT_TYPE_LOCAL_PORT,        /* %p */
-    ELEMENT_TYPE_QUERY,             /* %q */
-    ELEMENT_TYPE_REQUEST_LINE,      /* %r */
-    ELEMENT_TYPE_STATUS,            /* %s */
-    ELEMENT_TYPE_TIMESTAMP,         /* %t */
-    ELEMENT_TYPE_URL_PATH,          /* %U */
-    ELEMENT_TYPE_REMOTE_USER,       /* %u */
-    ELEMENT_TYPE_AUTHORITY,         /* %V */
-    ELEMENT_TYPE_HOSTCONF,          /* %v */
-    ELEMENT_TYPE_IN_HEADER_TOKEN,   /* %{data.header_token}i */
-    ELEMENT_TYPE_IN_HEADER_STRING,  /* %{data.header_string}i */
-    ELEMENT_TYPE_OUT_HEADER_TOKEN,  /* %{data.header_token}o */
-    ELEMENT_TYPE_OUT_HEADER_STRING, /* %{data.header_string}i */
+    ELEMENT_TYPE_EMPTY,               /* empty element (with suffix only) */
+    ELEMENT_TYPE_LOCAL_ADDR,          /* %A */
+    ELEMENT_TYPE_BYTES_SENT,          /* %b */
+    ELEMENT_TYPE_PROTOCOL,            /* %H */
+    ELEMENT_TYPE_REMOTE_ADDR,         /* %h */
+    ELEMENT_TYPE_LOGNAME,             /* %l */
+    ELEMENT_TYPE_METHOD,              /* %m */
+    ELEMENT_TYPE_LOCAL_PORT,          /* %p */
+    ELEMENT_TYPE_QUERY,               /* %q */
+    ELEMENT_TYPE_REQUEST_LINE,        /* %r */
+    ELEMENT_TYPE_STATUS,              /* %s */
+    ELEMENT_TYPE_TIMESTAMP,           /* %t */
+    ELEMENT_TYPE_URL_PATH,            /* %U */
+    ELEMENT_TYPE_REMOTE_USER,         /* %u */
+    ELEMENT_TYPE_AUTHORITY,           /* %V */
+    ELEMENT_TYPE_HOSTCONF,            /* %v */
+    ELEMENT_TYPE_IN_HEADER_TOKEN,     /* %{data.header_token}i */
+    ELEMENT_TYPE_IN_HEADER_STRING,    /* %{data.name}i */
+    ELEMENT_TYPE_OUT_HEADER_TOKEN,    /* %{data.header_token}o */
+    ELEMENT_TYPE_OUT_HEADER_STRING,   /* %{data.name}o */
+    ELEMENT_TYPE_EXTENDED_VAR,        /* %{data.name}x */
+    ELEMENT_TYPE_REQUEST_HEADER_TIME, /* %{request-header-time}x */
+    ELEMENT_TYPE_REQUEST_BODY_TIME,   /* %{request-body-time}x */
+    ELEMENT_TYPE_REQUEST_TOTAL_TIME,  /* %{request-total-time}x */
+    ELEMENT_TYPE_PROCESS_TIME,        /* %{process-time}x */
+    ELEMENT_TYPE_RESPONSE_TIME,       /* %{response-total-time}x */
+    ELEMENT_TYPE_DURATION,            /* %{duration}x */
     NUM_ELEMENT_TYPES
 };
 
@@ -63,7 +70,7 @@ struct log_element_t {
     h2o_iovec_t suffix;
     union {
         const h2o_token_t *header_token;
-        h2o_iovec_t header_string;
+        h2o_iovec_t name;
     } data;
 };
 
@@ -112,32 +119,42 @@ static struct log_element_t *compile_log_format(const char *fmt, size_t *_num_el
                     fprintf(stderr, "failed to compile log format: unterminated header name starting at: \"%16s\"\n", pt);
                     goto Error;
                 }
-                h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
-                token = h2o_lookup_token(name.base, name.len);
-                switch (quote_end[1]) {
+                const char modifier = quote_end[1];
+                switch (modifier) {
                 case 'i':
+                case 'o': {
+                    h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
+                    token = h2o_lookup_token(name.base, name.len);
                     if (token != NULL) {
                         free(name.base);
-                        NEW_ELEMENT(ELEMENT_TYPE_IN_HEADER_TOKEN);
+                        NEW_ELEMENT(modifier == 'i' ? ELEMENT_TYPE_IN_HEADER_TOKEN : ELEMENT_TYPE_OUT_HEADER_TOKEN);
                         elements[num_elements - 1].data.header_token = token;
                     } else {
-                        NEW_ELEMENT(ELEMENT_TYPE_IN_HEADER_STRING);
-                        elements[num_elements - 1].data.header_string = name;
+                        NEW_ELEMENT(modifier == 'i' ? ELEMENT_TYPE_IN_HEADER_STRING : ELEMENT_TYPE_OUT_HEADER_STRING);
+                        elements[num_elements - 1].data.name = name;
                     }
-                    break;
-                case 'o':
-                    if (token != NULL) {
-                        free(name.base);
-                        NEW_ELEMENT(ELEMENT_TYPE_OUT_HEADER_TOKEN);
-                        elements[num_elements - 1].data.header_token = token;
+                } break;
+                case 'x':
+                    if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT("request-total-time"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_REQUEST_TOTAL_TIME);
+                    } else if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT("request-header-time"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_REQUEST_HEADER_TIME);
+                    } else if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT("request-body-time"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_REQUEST_BODY_TIME);
+                    } else if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT("process-time"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_PROCESS_TIME);
+                    } else if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT("response-time"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_RESPONSE_TIME);
+                    } else if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT("duration"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_DURATION);
                     } else {
-                        NEW_ELEMENT(ELEMENT_TYPE_OUT_HEADER_STRING);
-                        elements[num_elements - 1].data.header_string = name;
+                        h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
+                        NEW_ELEMENT(ELEMENT_TYPE_EXTENDED_VAR);
+                        elements[num_elements - 1].data.name = name;
                     }
                     break;
                 default:
-                    free(name.base);
-                    fprintf(stderr, "failed to compile log format: header name is not followed by either `i` or `o`\n");
+                    fprintf(stderr, "failed to compile log format: header name is not followed by either `i`, `o`, `x`\n");
                     goto Error;
                 }
                 pt = quote_end + 2;
@@ -254,6 +271,37 @@ Fail:
     return pos;
 }
 
+static inline int timeval_is_null(struct timeval *tv)
+{
+    return tv->tv_sec == 0;
+}
+
+#define DURATION_MAX_LEN (sizeof("-2147483648.999999") - 1)
+
+static char *append_duration(char *pos, struct timeval *from, struct timeval *until)
+{
+    if (timeval_is_null(from) || timeval_is_null(until)) {
+        *pos++ = '-';
+    } else {
+        int32_t delta_sec = (int32_t)until->tv_sec - (int32_t)from->tv_sec;
+        int32_t delta_usec = (int32_t)until->tv_usec - (int32_t)from->tv_usec;
+        if (delta_usec < 0) {
+            delta_sec -= 1;
+            delta_usec += 1000000;
+        }
+        pos += sprintf(pos, "%" PRId32, delta_sec);
+        if (delta_usec != 0) {
+            int i;
+            *pos++ = '.';
+            for (i = 5; i >= 0; --i) {
+                pos[i] = '0' + delta_usec % 10;
+                delta_usec /= 10;
+            }
+            pos += 6;
+        }
+    }
+    return pos;
+}
 
 static char *expand_line_buf(char *line, size_t cur_size, size_t required)
 {
@@ -394,17 +442,49 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
             EMIT_HEADER(&req->headers, h2o_find_header(&req->headers, element->data.header_token, SIZE_MAX));
             break;
         case ELEMENT_TYPE_IN_HEADER_STRING:
-            EMIT_HEADER(&req->headers, h2o_find_header_by_str(&req->headers, element->data.header_string.base,
-                                                              element->data.header_string.len, SIZE_MAX));
+            EMIT_HEADER(&req->headers,
+                        h2o_find_header_by_str(&req->headers, element->data.name.base, element->data.name.len, SIZE_MAX));
             break;
         case ELEMENT_TYPE_OUT_HEADER_TOKEN:
             EMIT_HEADER(&req->res.headers, h2o_find_header(&req->res.headers, element->data.header_token, SIZE_MAX));
             break;
         case ELEMENT_TYPE_OUT_HEADER_STRING:
-            EMIT_HEADER(&req->res.headers, h2o_find_header_by_str(&req->res.headers, element->data.header_string.base,
-                                                                  element->data.header_string.len, SIZE_MAX));
+            EMIT_HEADER(&req->res.headers,
+                        h2o_find_header_by_str(&req->res.headers, element->data.name.base, element->data.name.len, SIZE_MAX));
             break;
 #undef EMIT_HEADER
+
+        case ELEMENT_TYPE_REQUEST_HEADER_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.request_begin_at, timeval_is_null(&req->timestamps.request_body_begin_at)
+                                                                              ? &req->processed_at.at
+                                                                              : &req->timestamps.request_body_begin_at);
+            break;
+
+        case ELEMENT_TYPE_REQUEST_BODY_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.request_body_begin_at, &req->processed_at.at);
+            break;
+
+        case ELEMENT_TYPE_REQUEST_TOTAL_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.request_begin_at, &req->processed_at.at);
+            break;
+
+        case ELEMENT_TYPE_PROCESS_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->processed_at.at, &req->timestamps.response_start_at);
+            break;
+
+        case ELEMENT_TYPE_RESPONSE_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
+            break;
+
+        case ELEMENT_TYPE_DURATION:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
+            break;
 
         default:
             assert(!"unknown type");
@@ -451,7 +531,7 @@ int h2o_access_log_open_log(const char *path)
             return -1;
         }
         /* spawn the logger */
-        int mapped_fds[] = {pipefds[0], 0,  /* map pipefds[0] to stdin */
+        int mapped_fds[] = {pipefds[0], 0, /* map pipefds[0] to stdin */
                             -1};
         if ((pid = h2o_spawnp(argv[0], argv, mapped_fds, 0)) == -1) {
             fprintf(stderr, "failed to open logger: %s:%s\n", path + 1, strerror(errno));

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -425,6 +425,7 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
 
         case ELEMENT_TYPE_LOGNAME:     /* %l */
         case ELEMENT_TYPE_REMOTE_USER: /* %u */
+        case ELEMENT_TYPE_EXTENDED_VAR: /* %{...}x */
             RESERVE(1);
             *pos++ = '-';
             break;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -384,6 +384,10 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
     ssize_t entity_body_header_index;
     h2o_iovec_t expect;
 
+    /* need to set request_begin_at here for keep-alive connection */
+    if (conn->req.timestamps.request_begin_at.tv_sec == 0)
+        conn->req.timestamps.request_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+
     reqlen = phr_parse_request(conn->sock->input->bytes, inreqlen, (const char **)&conn->req.input.method.base,
                                &conn->req.input.method.len, (const char **)&conn->req.input.path.base, &conn->req.input.path.len,
                                &minor_version, headers, &num_headers, conn->_prevreqlen);
@@ -393,6 +397,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
     default: // parse complete
         conn->_reqsize = reqlen;
         if ((entity_body_header_index = fixup_request(conn, headers, num_headers, minor_version, &expect)) != -1) {
+            conn->req.timestamps.request_body_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
             if (expect.base != NULL) {
                 if (!h2o_lcstris(expect.base, expect.len, H2O_STRLIT("100-continue"))) {
                     set_timeout(conn, NULL, NULL);
@@ -503,6 +508,8 @@ static void on_send_complete(h2o_socket_t *sock, int status)
     struct st_h2o_http1_conn_t *conn = sock->data;
 
     assert(conn->req._ostr_top == &conn->_ostr_final.super);
+
+    conn->req.timestamps.response_end_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
 
     if (!conn->req.http1_is_persistent) {
         /* TODO use lingering close */
@@ -626,6 +633,8 @@ static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb
     assert(conn->req._ostr_top == &conn->_ostr_final.super);
     assert(!conn->_ostr_final.sent_headers);
 
+    conn->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+
     /* register the pull callback */
     conn->_ostr_final.pull.cb = cb;
 
@@ -657,6 +666,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
     assert(self == &conn->_ostr_final);
 
     if (!self->sent_headers) {
+        conn->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         /* build headers and send */
         const char *connection = req->http1_is_persistent ? "keep-alive" : "close";
         bufs[bufcnt].base = h2o_mem_alloc_pool(
@@ -703,6 +713,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
     sock->data = conn;
 
     init_request(conn, 0);
+    conn->req.timestamps.request_begin_at = *h2o_get_timestamp(ctx->ctx, NULL, NULL);
     reqread_start(conn);
 }
 

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -133,7 +133,7 @@ static void process_request(struct st_h2o_http1_conn_t *conn)
         (conn->req.upgrade.len == 3 ||
          (conn->req.upgrade.len == 6 && (memcmp(conn->req.upgrade.base + 3, H2O_STRLIT("-14")) == 0 ||
                                          memcmp(conn->req.upgrade.base + 3, H2O_STRLIT("-16")) == 0)))) {
-        if (h2o_http2_handle_upgrade(&conn->req) == 0) {
+        if (h2o_http2_handle_upgrade(&conn->req, conn->super.connected_at) == 0) {
             return;
         }
     }
@@ -438,11 +438,12 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
             if (conn->sock->input->size >= HTTP2_SIG.len && memcmp(conn->sock->input->bytes, HTTP2_SIG.base, HTTP2_SIG.len) == 0) {
                 h2o_accept_ctx_t accept_ctx = {conn->super.ctx, conn->super.hosts};
                 h2o_socket_t *sock = conn->sock;
+                struct timeval connected_at = conn->super.connected_at;
                 /* destruct the connection after detatching the socket */
                 conn->sock = NULL;
                 close_connection(conn);
                 /* and accept as http2 connection */
-                h2o_http2_accept(&accept_ctx, sock);
+                h2o_http2_accept(&accept_ctx, sock, connected_at);
                 return;
             }
         }
@@ -697,7 +698,7 @@ static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
     return h2o_socket_getpeername(conn->sock, sa);
 }
 
-void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
+void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at)
 {
     struct st_h2o_http1_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
@@ -707,6 +708,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
     /* init properties that need to be non-zero */
     conn->super.ctx = ctx->ctx;
     conn->super.hosts = ctx->hosts;
+    conn->super.connected_at = connected_at;
     conn->super.get_sockname = get_sockname;
     conn->super.get_peername = get_peername;
     conn->sock = sock;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -715,7 +715,6 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
     sock->data = conn;
 
     init_request(conn, 0);
-    conn->req.timestamps.request_begin_at = *h2o_get_timestamp(ctx->ctx, NULL, NULL);
     reqread_start(conn);
 }
 


### PR DESCRIPTION
implements:
* `%{request-header-time}x` - time spent receiving request headers
* `%{request-body-time}x` - time spent receiving request body
* `%{request-total-time}x` - sum of request-header-time and request-body-time
* `%{process-time}x` - time spent after receiving request, before starting to send response
* `%{response-time}x` - time spent sending response
* `%{duration}x` sum of request-total-time, process-time, response-time

edit:
* added `%{connect-time}x` - time spent for connection establishment (i.e. since connection gets accept(2)-ed until first octet of the request is received)