### PR TITLE
`%U` must be mapped to URL-path

### DIFF
--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -357,10 +357,7 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
         case ELEMENT_TYPE_URL_PATH: /* %U */
         {
             size_t path_len = req->input.query_at == SIZE_MAX ? req->input.path.len : req->input.query_at;
-            RESERVE(req->input.scheme->name.len + (sizeof("://") - 1) + (req->input.authority.len + path_len) * 4);
-            pos = append_safe_string(pos, req->input.scheme->name.base, req->input.scheme->name.len);
-            pos = append_safe_string(pos, H2O_STRLIT("://"));
-            pos = append_unsafe_string(pos, req->input.authority.base, req->input.authority.len);
+            RESERVE(path_len * 4);
             pos = append_unsafe_string(pos, req->input.path.base, path_len);
         } break;
         case ELEMENT_TYPE_AUTHORITY: /* %V */

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -70,8 +70,8 @@ subtest 'ltsv-related' => sub {
             system("curl --silent http://127.0.0.1:$server->{port}/query?abc=d > /dev/null");
         },
         '%m::%U%q::%H::%V::%v',
-        qr{^GET::http://127\.0\.0\.1:[0-9]+/::HTTP/1\.1::127\.0\.0\.1:[0-9]+::default$},
-        qr{^GET::http://127\.0\.0\.1:[0-9]+/query\?abc=d::HTTP/1\.1::127\.0\.0\.1:[0-9]+::default$},
+        qr{^GET::/::HTTP/1\.1::127\.0\.0\.1:[0-9]+::default$},
+        qr{^GET::/query\?abc=d::HTTP/1\.1::127\.0\.0\.1:[0-9]+::default$},
     );
 };
 


### PR DESCRIPTION
According to http://httpd.apache.org/docs/2.4/mod/mod_log_config.html.en:
> %U 	The URL path requested, not including any query string.

however H2O emits protocol and authority as well.

This PR fixes the issue.