### PR TITLE
increase backlog size of unix socket created by `fastcgi.spawn`

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -60,6 +60,11 @@ extern "C" {
 #define H2O_MAX_TOKENS 100
 #endif
 
+#ifndef H2O_SOMAXCONN
+/* simply use a large value, and let the kernel clip it to the internal max */
+#define H2O_SOMAXCONN 65535
+#endif
+
 #define H2O_DEFAULT_MAX_REQUEST_ENTITY_SIZE (1024 * 1024 * 1024)
 #define H2O_DEFAULT_MAX_DELEGATIONS 5
 #define H2O_DEFAULT_HANDSHAKE_TIMEOUT_IN_SECS 10

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -166,7 +166,7 @@ static int create_spawnproc(h2o_configurator_command_t *cmd, yoml_t *node, const
         h2o_configurator_errprintf(cmd, node, "bind(2) failed: %s", strerror(errno));
         goto Error;
     }
-    if (listen(listen_fd, SOMAXCONN) != 0) {
+    if (listen(listen_fd, H2O_SOMAXCONN) != 0) {
         h2o_configurator_errprintf(cmd, node, "listen(2) failed: %s", strerror(errno));
         goto Error;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -63,9 +63,6 @@
 #endif
 #include "standalone.h"
 
-/* simply use a large value, and let the kernel clip it to the internal max */
-#define H2O_SOMAXCONN (65535)
-
 #ifdef TCP_FASTOPEN
 #define H2O_DEFAULT_LENGTH_TCP_FASTOPEN_QUEUE 4096
 #else


### PR DESCRIPTION
Changes the value to 65535 (was 128).

ref. http://uzulla.hateblo.jp/entry/2015/10/07/021122
