### PR TITLE
start push ASAP

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -536,6 +536,17 @@ typedef struct st_h2o_res_t {
     h2o_mime_attributes_t *mime_attr;
 } h2o_res_t;
 
+typedef struct st_h2o_conn_callbacks_t {
+    /**
+     * getsockname (return size of the obtained address, or 0 if failed)
+     */
+    socklen_t (*get_sockname)(h2o_conn_t *conn, struct sockaddr *sa);
+    /**
+     * getpeername (return size of the obtained address, or 0 if failed)
+     */
+    socklen_t (*get_peername)(h2o_conn_t *conn, struct sockaddr *sa);
+} h2o_conn_callbacks_t;
+
 /**
  * basic structure of an HTTP connection (HTTP/1, HTTP/2, etc.)
  */
@@ -553,13 +564,9 @@ struct st_h2o_conn_t {
      */
     struct timeval connected_at;
     /**
-     * getsockname (return size of the obtained address, or 0 if failed)
+     * callbacks
      */
-    socklen_t (*get_sockname)(h2o_conn_t *conn, struct sockaddr *sa);
-    /**
-     * getpeername (return size of the obtained address, or 0 if failed)
-     */
-    socklen_t (*get_peername)(h2o_conn_t *conn, struct sockaddr *sa);
+    const h2o_conn_callbacks_t *callbacks;
 };
 
 typedef struct st_h2o_req_overrides_t {

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1069,7 +1069,7 @@ void h2o_send_redirect_internal(h2o_req_t *req, int status, const char *url_str,
 /**
  * registers push path (if necessary) by parsing a Link header
  */
-int h2o_register_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len);
+int h2o_puth_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len);
 /**
  * logs an error
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -545,6 +545,10 @@ typedef struct st_h2o_conn_callbacks_t {
      * getpeername (return size of the obtained address, or 0 if failed)
      */
     socklen_t (*get_peername)(h2o_conn_t *conn, struct sockaddr *sa);
+    /**
+     * callback for server push (may be NULL)
+     */
+    void (*push_path)(h2o_req_t *req, const char *abspath, size_t abspath_len);
 } h2o_conn_callbacks_t;
 
 /**
@@ -736,10 +740,6 @@ struct st_h2o_req_t {
      */
     char res_is_delegated;
 
-    /**
-     * absolute paths to be pushed (using HTTP/2 server push)
-     */
-    H2O_VECTOR(h2o_iovec_t) http2_push_paths;
     /**
      * the Upgrade request header (or { NULL, 0 } if not available)
      */

--- a/include/h2o/http2_casper.h
+++ b/include/h2o/http2_casper.h
@@ -50,8 +50,8 @@ int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t
  */
 void h2o_http2_casper_consume_cookie(h2o_http2_casper_t *casper, const char *cookie, size_t cookie_len);
 /**
- * emits a `Set-Cookie` header that should be sent to the client
+ * returns the value of the `Set-Cookie` header that should be sent to the client
  */
-h2o_iovec_t h2o_http2_casper_build_cookie(h2o_http2_casper_t *casper, h2o_mem_pool_t *pool);
+h2o_iovec_t h2o_http2_casper_get_cookie(h2o_http2_casper_t *casper);
 
 #endif

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -152,6 +152,12 @@ typedef enum enum_h2o_http2_stream_state_t {
     H2O_HTTP2_STREAM_STATE_END_STREAM
 } h2o_http2_stream_state_t;
 
+typedef struct st_h2o_http2_conn_num_streams_t {
+    uint32_t open;
+    uint32_t half_closed;
+    uint32_t send_body;
+} h2o_http2_conn_num_streams_t;
+
 struct st_h2o_http2_stream_t {
     uint32_t stream_id;
     h2o_ostream_t _ostr_final;
@@ -163,12 +169,20 @@ struct st_h2o_http2_stream_t {
     size_t _expected_content_length; /* SIZE_MAX if unknown */
     H2O_VECTOR(h2o_iovec_t) _data;
     h2o_ostream_pull_cb _pull_cb;
-    uint32_t *
-        _num_streams_open_slot; /* points http2_conn_t::num_streams::open_(priority|push|pull) in which the stream is counted */
-    struct {
-        uint32_t parent_stream_id;
-        int promise_sent : 1;
-    } push;
+    h2o_http2_conn_num_streams_t *_num_streams_slot; /* points http2_conn_t::num_streams::* in which the stream is counted */
+    union {
+        struct {
+            uint32_t parent_stream_id;
+            int promise_sent : 1;
+        } push;
+        struct {
+            enum {
+                H2O_HTTP2_STREAM_CASPER_STATE_TBD = 0,
+                H2O_HTTP2_STREAM_CASPER_READY,
+                H2O_HTTP2_STREAM_CASPER_DISABLED
+            } casper_state;
+        } pull;
+    };
     /* references governed by connection.c for handling various things */
     struct {
         h2o_linklist_t link;
@@ -201,10 +215,9 @@ struct st_h2o_http2_conn_t {
         uint32_t max_open;
     } push_stream_ids;
     struct {
-        uint32_t open_priority;
-        uint32_t open_pull;
-        uint32_t open_push;
-        uint32_t responding;
+        h2o_http2_conn_num_streams_t priority;
+        h2o_http2_conn_num_streams_t pull;
+        h2o_http2_conn_num_streams_t push;
     } num_streams;
     /* internal */
     h2o_http2_scheduler_node_t scheduler;
@@ -259,9 +272,8 @@ static void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn, unsigned capacity
 
 /* stream */
 static int h2o_http2_stream_is_push(uint32_t stream_id);
-h2o_http2_stream_t *h2o_http2_stream_open(h2o_http2_conn_t *conn, uint32_t stream_id, h2o_req_t *src_req,
-                                          uint32_t push_parent_stream_id);
-static void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, uint32_t *slot);
+h2o_http2_stream_t *h2o_http2_stream_open(h2o_http2_conn_t *conn, uint32_t stream_id, h2o_req_t *src_req);
+static void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, h2o_http2_conn_num_streams_t *slot);
 static void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_http2_stream_state_t new_state);
 static void h2o_http2_stream_prepare_for_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 void h2o_http2_stream_close(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
@@ -342,11 +354,11 @@ inline void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn, unsigned capacity
     conn->casper = h2o_http2_casper_create(capacity_bits, 6);
 }
 
-inline void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, uint32_t *slot)
+inline void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, h2o_http2_conn_num_streams_t *slot)
 {
-    --*stream->_num_streams_open_slot;
-    ++*slot;
-    stream->_num_streams_open_slot = slot;
+    --stream->_num_streams_slot->open;
+    ++slot->open;
+    stream->_num_streams_slot = slot;
 }
 
 inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_http2_stream_state_t new_state)
@@ -358,9 +370,9 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
     case H2O_HTTP2_STREAM_STATE_RECV_HEADERS:
         assert(stream->state == H2O_HTTP2_STREAM_STATE_IDLE);
         if (h2o_http2_stream_is_push(stream->stream_id))
-            h2o_http2_stream_update_open_slot(stream, &conn->num_streams.open_push);
+            h2o_http2_stream_update_open_slot(stream, &conn->num_streams.push);
         else
-            h2o_http2_stream_update_open_slot(stream, &conn->num_streams.open_pull);
+            h2o_http2_stream_update_open_slot(stream, &conn->num_streams.pull);
         stream->state = new_state;
         stream->req.timestamps.request_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         break;
@@ -373,11 +385,12 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         break;
     case H2O_HTTP2_STREAM_STATE_SEND_HEADERS:
         assert(stream->state == H2O_HTTP2_STREAM_STATE_REQ_PENDING);
-        ++conn->num_streams.responding;
+        ++stream->_num_streams_slot->half_closed;
         stream->state = new_state;
         break;
     case H2O_HTTP2_STREAM_STATE_SEND_BODY:
         stream->state = new_state;
+        ++stream->_num_streams_slot->send_body;
         stream->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         break;
     case H2O_HTTP2_STREAM_STATE_END_STREAM:
@@ -389,8 +402,11 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         case H2O_HTTP2_STREAM_STATE_REQ_PENDING:
             break;
         case H2O_HTTP2_STREAM_STATE_SEND_HEADERS:
+            --stream->_num_streams_slot->half_closed;
+            break;
         case H2O_HTTP2_STREAM_STATE_SEND_BODY:
-            --conn->num_streams.responding;
+            --stream->_num_streams_slot->half_closed;
+            --stream->_num_streams_slot->send_body;
             break;
         case H2O_HTTP2_STREAM_STATE_END_STREAM:
             assert(!"FIXME");

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -92,7 +92,7 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive)
     h2o_iovec_t cookie_buf = {}, xff_buf = {}, via_buf = {};
 
     /* for x-f-f */
-    if ((sslen = req->conn->get_peername(req->conn, (void *)&ss)) != 0)
+    if ((sslen = req->conn->callbacks->get_peername(req->conn, (void *)&ss)) != 0)
         remote_addr_len = h2o_socket_getnumerichost((void *)&ss, sslen, remote_addr);
 
     /* build response */

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -326,7 +326,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                 }
                 goto AddHeaderDuped;
             } else if (token == H2O_TOKEN_LINK) {
-                h2o_register_push_path_in_link_header(req, headers[i].value, headers[i].value_len);
+                h2o_puth_path_in_link_header(req, headers[i].value, headers[i].value_len);
             }
         /* default behaviour, transfer the header downstream */
         AddHeaderDuped:

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -489,7 +489,7 @@ void h2o_send_redirect_internal(h2o_req_t *req, int status, const char *url_str,
 
 int h2o_register_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
 {
-    if (req->version < 0x200 || req->res_is_delegated)
+    if (req->conn->callbacks->push_path == NULL || req->res_is_delegated)
         return -1;
 
     h2o_iovec_t path =
@@ -497,8 +497,6 @@ int h2o_register_push_path_in_link_header(h2o_req_t *req, const char *value, siz
     if (path.base == NULL)
         return -1;
 
-    h2o_vector_reserve(&req->pool, (h2o_vector_t *)&req->http2_push_paths, sizeof(req->http2_push_paths.entries[0]),
-                       req->http2_push_paths.size + 1);
-    req->http2_push_paths.entries[req->http2_push_paths.size++] = path;
+    req->conn->callbacks->push_path(req, path.base, path.len);
     return 0;
 }

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -487,7 +487,7 @@ void h2o_send_redirect_internal(h2o_req_t *req, int status, const char *url_str,
     h2o_reprocess_request_deferred(req, method, url.scheme, url.authority, url.path, authority_changed ? req->overrides : NULL, 1);
 }
 
-int h2o_register_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
+int h2o_puth_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
 {
     if (req->conn->callbacks->push_path == NULL || req->res_is_delegated)
         return -1;

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -382,7 +382,7 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
             break;
         case ELEMENT_TYPE_LOCAL_ADDR: /* %A */
             RESERVE(NI_MAXHOST);
-            pos = append_addr(pos, req->conn->get_sockname, req->conn);
+            pos = append_addr(pos, req->conn->callbacks->get_sockname, req->conn);
             break;
         case ELEMENT_TYPE_BYTES_SENT: /* %b */
             RESERVE(sizeof("18446744073709551615") - 1);
@@ -394,7 +394,7 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
             break;
         case ELEMENT_TYPE_REMOTE_ADDR: /* %h */
             RESERVE(NI_MAXHOST);
-            pos = append_addr(pos, req->conn->get_peername, req->conn);
+            pos = append_addr(pos, req->conn->callbacks->get_peername, req->conn);
             break;
         case ELEMENT_TYPE_METHOD: /* %m */
             RESERVE(req->input.method.len * 4);
@@ -402,7 +402,7 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
             break;
         case ELEMENT_TYPE_LOCAL_PORT: /* %p */
             RESERVE(sizeof("65535") - 1);
-            pos = append_port(pos, req->conn->get_sockname, req->conn);
+            pos = append_port(pos, req->conn->callbacks->get_sockname, req->conn);
             break;
         case ELEMENT_TYPE_QUERY: /* %q */
             if (req->input.query_at != SIZE_MAX) {

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -246,7 +246,7 @@ static void append_params(h2o_req_t *req, iovec_vector_t *vecs, h2o_fastcgi_conf
         append_pair(&req->pool, vecs, H2O_STRLIT("QUERY_STRING"), NULL, 0);
     }
     /* REMOTE_ADDR & REMOTE_PORT */
-    append_address_info(req, vecs, H2O_STRLIT("REMOTE_ADDR"), H2O_STRLIT("REMOTE_PORT"), req->conn->get_peername);
+    append_address_info(req, vecs, H2O_STRLIT("REMOTE_ADDR"), H2O_STRLIT("REMOTE_PORT"), req->conn->callbacks->get_peername);
     /* REQUEST_METHOD */
     append_pair(&req->pool, vecs, H2O_STRLIT("REQUEST_METHOD"), req->method.base, req->method.len);
     /* HTTP_HOST & REQUEST_URI */
@@ -258,7 +258,7 @@ static void append_params(h2o_req_t *req, iovec_vector_t *vecs, h2o_fastcgi_conf
         append_pair(&req->pool, vecs, H2O_STRLIT("REQUEST_URI"), req->input.path.base, req->input.path.len);
     }
     /* SERVER_ADDR & SERVER_PORT */
-    append_address_info(req, vecs, H2O_STRLIT("SERVER_ADDR"), H2O_STRLIT("SERVER_PORT"), req->conn->get_sockname);
+    append_address_info(req, vecs, H2O_STRLIT("SERVER_ADDR"), H2O_STRLIT("SERVER_PORT"), req->conn->callbacks->get_sockname);
     /* SERVER_NAME */
     append_pair(&req->pool, vecs, H2O_STRLIT("SERVER_NAME"), req->hostconf->authority.host.base, req->hostconf->authority.host.len);
     { /* SERVER_PROTOCOL */

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -497,7 +497,7 @@ static int fill_headers(h2o_req_t *req, struct phr_header *headers, size_t num_h
                 h2o_add_header(&req->pool, &req->res.headers, token,
                                h2o_strdup(&req->pool, headers[i].value, headers[i].value_len).base, headers[i].value_len);
                 if (token == H2O_TOKEN_LINK)
-                    h2o_register_push_path_in_link_header(req, headers[i].value, headers[i].value_len);
+                    h2o_puth_path_in_link_header(req, headers[i].value, headers[i].value_len);
             }
         } else if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("status"))) {
             h2o_iovec_t value = h2o_iovec_init(headers[i].value, headers[i].value_len);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -397,7 +397,7 @@ static int parse_rack_header(h2o_req_t *req, mrb_state *mrb, mrb_value name, mrb
             if (*eol == '\n')
                 break;
         if (h2o_memis(lcname.base, lcname.len, H2O_STRLIT("link")) &&
-            h2o_register_push_path_in_link_header(req, vstart, eol - vstart)) {
+            h2o_puth_path_in_link_header(req, vstart, eol - vstart)) {
             /* do not send the link header that is going to be pushed */
         } else {
             h2o_iovec_t vdup = h2o_strdup(&req->pool, vstart, eol - vstart);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -312,7 +312,7 @@ static mrb_value build_env(h2o_req_t *req, mrb_state *mrb, mrb_value constants)
                  mrb_str_new(mrb, req->hostconf->authority.host.base, req->hostconf->authority.host.len));
     {
         mrb_value h, p;
-        stringify_address(req->conn, req->conn->get_sockname, mrb, &h, &p);
+        stringify_address(req->conn, req->conn->callbacks->get_sockname, mrb, &h, &p);
         if (!mrb_nil_p(h))
             mrb_hash_set(mrb, env, mrb_ary_entry(constants, LIT_SERVER_ADDR), h);
         if (!mrb_nil_p(p))
@@ -327,7 +327,7 @@ static mrb_value build_env(h2o_req_t *req, mrb_state *mrb, mrb_value constants)
     }
     {
         mrb_value h, p;
-        stringify_address(req->conn, req->conn->get_peername, mrb, &h, &p);
+        stringify_address(req->conn, req->conn->callbacks->get_peername, mrb, &h, &p);
         if (!mrb_nil_p(h))
             mrb_hash_set(mrb, env, mrb_ary_entry(constants, LIT_REMOTE_ADDR), h);
         if (!mrb_nil_p(p))

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -700,6 +700,7 @@ static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
 
 void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at)
 {
+    static const h2o_conn_callbacks_t callbacks = {get_sockname, get_peername};
     struct st_h2o_http1_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
     /* zero-fill all properties expect req */
@@ -709,8 +710,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
     conn->super.ctx = ctx->ctx;
     conn->super.hosts = ctx->hosts;
     conn->super.connected_at = connected_at;
-    conn->super.get_sockname = get_sockname;
-    conn->super.get_peername = get_peername;
+    conn->super.callbacks = &callbacks;
     conn->sock = sock;
     sock->data = conn;
 

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -977,6 +977,7 @@ static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
 
 static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock, struct timeval connected_at)
 {
+    static const h2o_conn_callbacks_t callbacks = {get_sockname, get_peername};
     h2o_http2_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
     /* init the connection */
@@ -984,8 +985,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
     conn->super.ctx = ctx;
     conn->super.hosts = hosts;
     conn->super.connected_at = connected_at;
-    conn->super.get_sockname = get_sockname;
-    conn->super.get_peername = get_peername;
+    conn->super.callbacks = &callbacks;
     conn->sock = sock;
     conn->peer_settings = H2O_HTTP2_SETTINGS_DEFAULT;
     conn->streams = kh_init(h2o_http2_stream_t);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -60,6 +60,7 @@ static void send_stream_error(h2o_http2_conn_t *conn, uint32_t stream_id, int er
 static ssize_t expect_default(h2o_http2_conn_t *conn, const uint8_t *src, size_t len, const char **err_desc);
 static int do_emit_writereq(h2o_http2_conn_t *conn);
 static void on_read(h2o_socket_t *sock, int status);
+static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_len);
 
 const h2o_protocol_callbacks_t H2O_HTTP2_CALLBACKS = {initiate_graceful_shutdown};
 
@@ -128,7 +129,7 @@ static void update_idle_timeout(h2o_http2_conn_t *conn)
 {
     h2o_timeout_unlink(&conn->_timeout_entry);
 
-    if (conn->num_streams.responding == 0) {
+    if (conn->num_streams.pull.half_closed + conn->num_streams.push.half_closed == 0) {
         assert(h2o_linklist_is_empty(&conn->_pending_reqs));
         conn->_timeout_entry.cb = on_idle_timeout;
         h2o_timeout_link(conn->super.ctx->loop, &conn->super.ctx->http2.idle_timeout, &conn->_timeout_entry);
@@ -137,7 +138,8 @@ static void update_idle_timeout(h2o_http2_conn_t *conn)
 
 static int can_run_requests(h2o_http2_conn_t *conn)
 {
-    return conn->num_streams.responding < conn->super.ctx->globalconf->http2.max_concurrent_requests_per_connection;
+    return conn->num_streams.pull.half_closed + conn->num_streams.push.half_closed <
+           conn->super.ctx->globalconf->http2.max_concurrent_requests_per_connection;
 }
 
 static void run_pending_requests(h2o_http2_conn_t *conn)
@@ -229,9 +231,12 @@ static void close_connection_now(h2o_http2_conn_t *conn)
     assert(!h2o_timeout_is_linked(&conn->_write.timeout_entry));
 
     kh_foreach_value(conn->streams, stream, { h2o_http2_stream_close(conn, stream); });
-    assert(conn->num_streams.open_pull == 0);
-    assert(conn->num_streams.responding == 0);
-    assert(conn->num_streams.open_priority == 0);
+    assert(conn->num_streams.pull.open == 0);
+    assert(conn->num_streams.pull.half_closed == 0);
+    assert(conn->num_streams.pull.send_body == 0);
+    assert(conn->num_streams.push.half_closed == 0);
+    assert(conn->num_streams.push.send_body == 0);
+    assert(conn->num_streams.priority.open == 0);
     kh_destroy(h2o_http2_stream_t, conn->streams);
     assert(conn->_http1_req_input == NULL);
     h2o_hpack_dispose_header_table(&conn->_input_header_table);
@@ -315,7 +320,7 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
 #undef EXPECTED_MAP
 
     /* handle the request */
-    if (conn->num_streams.open_pull > H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams) {
+    if (conn->num_streams.pull.open > H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams) {
         ret = H2O_HTTP2_ERROR_REFUSED_STREAM;
         goto SendRSTStream;
     }
@@ -503,7 +508,7 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
         if ((frame->flags & H2O_HTTP2_FRAME_FLAG_PRIORITY) != 0)
             set_priority(conn, stream, &payload.priority, 1);
     } else {
-        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL, 0);
+        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL);
         set_priority(conn, stream, &payload.priority, 0);
     }
     h2o_http2_stream_prepare_for_request(conn, stream);
@@ -546,14 +551,14 @@ static int handle_priority_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *fram
         if (h2o_http2_scheduler_get_weight(&stream->_refs.scheduler) != 257)
             set_priority(conn, stream, &payload, 1);
     } else {
-        if (conn->num_streams.open_priority >= conn->super.ctx->globalconf->http2.max_streams_for_priority) {
+        if (conn->num_streams.priority.open >= conn->super.ctx->globalconf->http2.max_streams_for_priority) {
             *err_desc = "too many streams in idle/closed state";
             /* RFC 7540 10.5: An endpoint MAY treat activity that is suspicious as a connection error (Section 5.4.1) of type
              * ENHANCE_YOUR_CALM.
              */
             return H2O_HTTP2_ERROR_ENHANCE_YOUR_CALM;
         }
-        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL, 0);
+        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL);
         set_priority(conn, stream, &payload, 0);
     }
 
@@ -765,12 +770,13 @@ static void parse_input(h2o_http2_conn_t *conn)
     size_t http2_max_concurrent_requests_per_connection = conn->super.ctx->globalconf->http2.max_concurrent_requests_per_connection;
     int perform_early_exit = 0;
 
-    if (conn->num_streams.responding != http2_max_concurrent_requests_per_connection)
+    if (conn->num_streams.pull.half_closed + conn->num_streams.push.half_closed != http2_max_concurrent_requests_per_connection)
         perform_early_exit = 1;
 
     /* handle the input */
     while (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING && conn->sock->input->size != 0) {
-        if (perform_early_exit == 1 && conn->num_streams.responding == http2_max_concurrent_requests_per_connection)
+        if (perform_early_exit == 1 &&
+            conn->num_streams.pull.half_closed + conn->num_streams.push.half_closed == http2_max_concurrent_requests_per_connection)
             goto EarlyExit;
         /* process a frame */
         const char *err_desc = NULL;
@@ -899,7 +905,7 @@ static void on_write_complete(h2o_socket_t *sock, int status)
     case H2O_HTTP2_CONN_STATE_OPEN:
         break;
     case H2O_HTTP2_CONN_STATE_HALF_CLOSED:
-        if (conn->num_streams.responding != 0)
+        if (conn->num_streams.pull.half_closed + conn->num_streams.push.half_closed != 0)
             break;
         conn->state = H2O_HTTP2_CONN_STATE_IS_CLOSING;
     /* fall-thru */
@@ -977,7 +983,7 @@ static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
 
 static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock, struct timeval connected_at)
 {
-    static const h2o_conn_callbacks_t callbacks = {get_sockname, get_peername};
+    static const h2o_conn_callbacks_t callbacks = {get_sockname, get_peername, push_path};
     h2o_http2_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
     /* init the connection */
@@ -1006,20 +1012,49 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
     return conn;
 }
 
-void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http2_stream_t *src_stream)
+static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_len)
 {
-    h2o_http2_stream_t *stream;
+    h2o_http2_conn_t *conn = (void *)src_req->conn;
+    h2o_http2_stream_t *src_stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, src_req);
 
-    if (!conn->peer_settings.enable_push || conn->num_streams.open_push >= conn->peer_settings.max_concurrent_streams)
+    if (!conn->peer_settings.enable_push || conn->num_streams.push.open >= conn->peer_settings.max_concurrent_streams)
         return;
     if (conn->push_stream_ids.max_open >= 0x7ffffff0)
         return;
     if (!can_run_requests(conn))
         return;
 
+    /* casper-related code */
+    if (src_stream->req.hostconf->http2.casper.capacity_bits != 0 && !h2o_http2_stream_is_push(src_stream->stream_id)) {
+        size_t header_index;
+        switch (src_stream->pull.casper_state) {
+        case H2O_HTTP2_STREAM_CASPER_STATE_TBD:
+            /* disable casper for this request if intermediary exists */
+            if (h2o_find_header(&src_stream->req.headers, H2O_TOKEN_X_FORWARDED_FOR, -1) != -1) {
+                src_stream->pull.casper_state = H2O_HTTP2_STREAM_CASPER_DISABLED;
+                return;
+            }
+            /* casper enabled for this request */
+            if (conn->casper == NULL)
+                h2o_http2_conn_init_casper(conn, src_stream->req.hostconf->http2.casper.capacity_bits);
+            /* consume casper cookie */
+            for (header_index = -1;
+                 (header_index = h2o_find_header(&src_stream->req.headers, H2O_TOKEN_COOKIE, header_index)) != -1;) {
+                h2o_header_t *header = src_stream->req.headers.entries + header_index;
+                h2o_http2_casper_consume_cookie(conn->casper, header->value.base, header->value.len);
+            }
+            src_stream->pull.casper_state = H2O_HTTP2_STREAM_CASPER_READY;
+        case H2O_HTTP2_STREAM_CASPER_READY:
+            break;
+        case H2O_HTTP2_STREAM_CASPER_DISABLED:
+            return;
+        }
+    }
+
     /* open the stream */
     conn->push_stream_ids.max_open += 2;
-    stream = h2o_http2_stream_open(conn, conn->push_stream_ids.max_open, NULL, src_stream->stream_id);
+    h2o_http2_stream_t *stream = h2o_http2_stream_open(conn, conn->push_stream_ids.max_open, NULL);
+    stream->push.parent_stream_id = src_stream->stream_id;
     h2o_http2_scheduler_open(&stream->_refs.scheduler, &src_stream->_refs.scheduler.node, 16, 0);
     h2o_http2_stream_prepare_for_request(conn, stream);
 
@@ -1028,7 +1063,7 @@ void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http
     stream->req.input.scheme = src_stream->req.input.scheme;
     stream->req.input.authority =
         h2o_strdup(&stream->req.pool, src_stream->req.input.authority.base, src_stream->req.input.authority.len);
-    stream->req.input.path = h2o_strdup(&stream->req.pool, path.base, path.len);
+    stream->req.input.path = h2o_strdup(&stream->req.pool, abspath, abspath_len);
     stream->req.version = 0x200;
 
     { /* copy headers that may affect the response (of a cacheable response) */
@@ -1096,7 +1131,7 @@ int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval connected_at)
     }
 
     /* open the stream, now that the function is guaranteed to succeed */
-    stream = h2o_http2_stream_open(http2conn, 1, req, 0);
+    stream = h2o_http2_stream_open(http2conn, 1, req);
     h2o_http2_scheduler_open(&stream->_refs.scheduler, &http2conn->scheduler, h2o_http2_default_priority.weight, 0);
     h2o_http2_stream_prepare_for_request(http2conn, stream);
 

--- a/t/00unit/lib/http2/casper.c
+++ b/t/00unit/lib/http2/casper.c
@@ -61,20 +61,18 @@ static void test_lookup(void)
 
 static void test_cookie(void)
 {
-    h2o_mem_pool_t pool;
     h2o_http2_casper_t *casper;
 
-    h2o_mem_init_pool(&pool);
     casper = h2o_http2_casper_create(13, 6);
 
-    h2o_iovec_t cookie = h2o_http2_casper_build_cookie(casper, &pool);
+    h2o_iovec_t cookie = h2o_http2_casper_get_cookie(casper);
     ok(cookie.base == NULL);
     ok(cookie.len == 0);
 
     h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
-    cookie = h2o_http2_casper_build_cookie(casper, &pool);
+    cookie = h2o_http2_casper_get_cookie(casper);
     ok(cookie.len != 0);
-
+    cookie = h2o_strdup(NULL, cookie.base, cookie.len);
     h2o_http2_casper_destroy(casper);
     casper = h2o_http2_casper_create(13, 6);
 
@@ -84,8 +82,9 @@ static void test_cookie(void)
     h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 1);
 
     h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
-    cookie = h2o_http2_casper_build_cookie(casper, &pool);
+    cookie = h2o_http2_casper_get_cookie(casper);
     ok(cookie.len != 0);
+    cookie = h2o_strdup(NULL, cookie.base, cookie.len);
 
     h2o_http2_casper_destroy(casper);
     casper = h2o_http2_casper_create(13, 6);
@@ -95,23 +94,22 @@ static void test_cookie(void)
     ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 0) == 1);
 
     h2o_http2_casper_destroy(casper);
-    h2o_mem_clear_pool(&pool);
 }
 
 static void test_cookie_merge(void)
 {
-    h2o_mem_pool_t pool;
     h2o_http2_casper_t *casper;
-    h2o_mem_init_pool(&pool);
 
     casper = h2o_http2_casper_create(13, 6);
     h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
-    h2o_iovec_t cookie1 = h2o_http2_casper_build_cookie(casper, &pool);
+    h2o_iovec_t cookie1 = h2o_http2_casper_get_cookie(casper);
+    cookie1 = h2o_strdup(NULL, cookie1.base, cookie1.len);
     h2o_http2_casper_destroy(casper);
 
     casper = h2o_http2_casper_create(13, 6);
     h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 1);
-    h2o_iovec_t cookie2 = h2o_http2_casper_build_cookie(casper, &pool);
+    h2o_iovec_t cookie2 = h2o_http2_casper_get_cookie(casper);
+    cookie2 = h2o_strdup(NULL, cookie2.base, cookie2.len);
     h2o_http2_casper_destroy(casper);
 
     casper = h2o_http2_casper_create(13, 6);
@@ -124,8 +122,6 @@ static void test_cookie_merge(void)
     ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
     ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 0) == 1);
     h2o_http2_casper_destroy(casper);
-
-    h2o_mem_clear_pool(&pool);
 }
 
 void test_lib__http2__casper(void)

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -61,13 +61,13 @@ static socklen_t get_peername(h2o_conn_t *conn, struct sockaddr *sa)
 
 h2o_loopback_conn_t *h2o_loopback_create(h2o_context_t *ctx, h2o_hostconf_t **hosts)
 {
+    static const h2o_conn_callbacks_t callbacks = {get_sockname, get_peername};
     h2o_loopback_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
     memset(conn, 0, offsetof(struct st_h2o_loopback_conn_t, req));
     conn->super.ctx = ctx;
     conn->super.hosts = hosts;
-    conn->super.get_sockname = get_sockname;
-    conn->super.get_peername = get_peername;
+    conn->super.callbacks = &callbacks;
     h2o_init_request(&conn->req, &conn->super, NULL);
     h2o_buffer_init(&conn->body, &h2o_socket_buffer_prototype);
     conn->req._ostr_top = &conn->_ostr_final;

--- a/t/40server-push.t
+++ b/t/40server-push.t
@@ -39,9 +39,6 @@ sub doit {
     my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.js>\%3b\%20rel=preload'`;
     like $resp, qr{\nresponseEnd\s.*\s/assets/index\.js\n.*\s/index\.txt\?}is, 'should receive pushed blocking asset from file handler before the main response';
 
-    $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.txt>\%3b\%20rel=preload'`;
-    like $resp, qr{\nresponseEnd\s.*\s/index\.txt\?.*?\n.*\s/assets/index\.txt\n}is, 'should receive pushed non-blocking asset from file handler after the main response';
-
     $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</index.txt.gz>\%3b\%20rel=preload'`;
     like $resp, qr{\nresponseEnd\s.*\s/index\.txt\?.*\s/index\.txt.gz\n}is, 'pushed content on upstream would arrive after the main content';
 }

--- a/t/40server-push.t
+++ b/t/40server-push.t
@@ -29,6 +29,12 @@ hosts:
     paths:
       /:
         proxy.reverse.url: http://127.0.0.1:$upstream_port
+      /mruby:
+        mruby.handler: |
+          Proc.new do |env|
+            [399, { "link" => "</index.txt.gz>; rel=preload" }, [] ]
+          end
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
       /assets:
         file.dir: @{[DOC_ROOT]}
 EOT
@@ -36,11 +42,22 @@ EOT
 sub doit {
     my ($proto, $opts, $port) = @_;
 
-    my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.js>\%3b\%20rel=preload'`;
-    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.js\n.*\s/index\.txt\?}is, 'should receive pushed blocking asset from file handler before the main response';
+    subtest 'push-prioritized' => sub {
+        my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.js>\%3b\%20rel=preload'`;
+        like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.js\n.*\s/index\.txt\?}is;
+    };
 
-    $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</index.txt.gz>\%3b\%20rel=preload'`;
-    like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\?.*\s/index\.txt.gz\n}is, 'pushed content on upstream would arrive after the main content';
+    subtest 'push-unprioritized' => sub {
+        my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</index.txt.gz>\%3b\%20rel=preload'`;
+        like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\?.*\s/index\.txt.gz\n}is;
+    };
+
+    subtest 'push-while-sleep' => sub {
+        plan skip_all => 'mruby support is off'
+            unless server_features()->{mruby};
+        my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/mruby/sleep-and-respond?sleep=1'`;
+        like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\.gz\n.*\s/mruby/sleep-and-respond}is;
+    };
 }
 
 subtest 'h2 direct' => sub {


### PR DESCRIPTION
Thanks to the mruby handler it has now become practical to specify resources to push, and then request backend server to process the response.  And that means that the server can push resources while the request is processed by the backend.

This PR modifies the internals to do so, instead of keeping a list of paths pushed until the response headers are finalized.