### PR TITLE
implement open file cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ SET(LIB_SOURCE_FILES
     deps/picohttpparser/picohttpparser.c
 
     lib/common/file.c
+    lib/common/filecache.c
     lib/common/hostinfo.c
     lib/common/http1client.c
     lib/common/memcached.c

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		101788B219B561AA0084C6D8 /* socket.c in Sources */ = {isa = PBXBuildFile; fileRef = 101788B119B561AA0084C6D8 /* socket.c */; };
 		101B670C19ADD3380084A351 /* access_log.c in Sources */ = {isa = PBXBuildFile; fileRef = 101B670B19ADD3380084A351 /* access_log.c */; };
 		103BAB361B130666000694F4 /* socket.c in Sources */ = {isa = PBXBuildFile; fileRef = 103BAB351B130666000694F4 /* socket.c */; };
+		1044812E1BFD0FBE0007863F /* filecache.h in Headers */ = {isa = PBXBuildFile; fileRef = 1044812D1BFD0FBE0007863F /* filecache.h */; };
+		104481301BFD10450007863F /* filecache.c in Sources */ = {isa = PBXBuildFile; fileRef = 1044812F1BFD10450007863F /* filecache.c */; };
 		104B9A261A4A5041009EEE64 /* serverutil.h in Headers */ = {isa = PBXBuildFile; fileRef = 104B9A231A4A4FAF009EEE64 /* serverutil.h */; };
 		104B9A281A4A5139009EEE64 /* serverutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 104B9A271A4A5139009EEE64 /* serverutil.c */; };
 		104B9A2D1A4BE029009EEE64 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 104B9A2C1A4BE029009EEE64 /* version.h */; };
@@ -265,6 +267,8 @@
 		101B670B19ADD3380084A351 /* access_log.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = access_log.c; sourceTree = "<group>"; };
 		1039A20A1BB89531005D3B8F /* mruby_directives.mt */ = {isa = PBXFileReference; lastKnownFileType = text; path = mruby_directives.mt; sourceTree = "<group>"; };
 		103BAB351B130666000694F4 /* socket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = socket.c; sourceTree = "<group>"; };
+		1044812D1BFD0FBE0007863F /* filecache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filecache.h; sourceTree = "<group>"; };
+		1044812F1BFD10450007863F /* filecache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filecache.c; sourceTree = "<group>"; };
 		104960151B9D3F9100FF136D /* dump-github-repository.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "dump-github-repository.pl"; sourceTree = "<group>"; };
 		104B9A221A47BBA1009EEE64 /* 40unix-socket.t */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "40unix-socket.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		104B9A231A4A4FAF009EEE64 /* serverutil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = serverutil.h; sourceTree = "<group>"; };
@@ -582,6 +586,7 @@
 			isa = PBXGroup;
 			children = (
 				107D4D541B5B30EE004A9B21 /* file.c */,
+				1044812F1BFD10450007863F /* filecache.c */,
 				1058C8891AA6E5E3008D6180 /* hostinfo.c */,
 				10D0905419F102C70043D458 /* http1client.c */,
 				10A3D3D11B4CDBDC00327CF9 /* memcached.c */,
@@ -940,6 +945,7 @@
 			children = (
 				105534D71A3C785000627ECB /* configurator.h */,
 				107D4D521B5B2412004A9B21 /* file.h */,
+				1044812D1BFD0FBE0007863F /* filecache.h */,
 				1058C8871AA6DE4B008D6180 /* hostinfo.h */,
 				107923A019A3215F00C52AD6 /* http1.h */,
 				10D0905619F102DA0043D458 /* http1client.h */,
@@ -1215,6 +1221,7 @@
 				10AA2E9F1A8807CF004322AC /* url.h in Headers */,
 				10B38A721B8D34BB007DC191 /* mruby_.h in Headers */,
 				10FCC13F1B2E4A4500F13674 /* cloexec.h in Headers */,
+				1044812E1BFD0FBE0007863F /* filecache.h in Headers */,
 				107923A619A3215F00C52AD6 /* http2.h in Headers */,
 				107923A719A3215F00C52AD6 /* token.h in Headers */,
 				107923A919A3215F00C52AD6 /* h2o.h in Headers */,
@@ -1462,6 +1469,7 @@
 				10E299581A67E68500701AA6 /* scheduler.c in Sources */,
 				107923D319A3217300C52AD6 /* util.c in Sources */,
 				105534CA1A3BB46900627ECB /* string.c in Sources */,
+				104481301BFD10450007863F /* filecache.c in Sources */,
 				10583BF21AE5A37B004A3AD6 /* README.md in Sources */,
 				10BCF2FD1B168CAE0076939D /* fastcgi.c in Sources */,
 				10A3D40B1B50DAB700327CF9 /* send.c in Sources */,
@@ -2432,6 +2440,7 @@
 				);
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
+					"-lmruby",
 					"-lmemcached",
 					"-lssl",
 					"-lcrypto",

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <time.h>
 #include <unistd.h>
 #include <openssl/ssl.h>
+#include "h2o/filecache.h"
 #include "h2o/hostinfo.h"
 #include "h2o/memcached.h"
 #include "h2o/linklist.h"
@@ -325,6 +326,14 @@ struct st_h2o_globalconf_t {
      */
     h2o_mimemap_t *mimemap;
 
+    /**
+     * filecache
+     */
+    struct {
+        /* capacity of the filecache */
+        size_t capacity;
+    } filecache;
+
     size_t _num_config_slots;
 };
 
@@ -390,6 +399,10 @@ struct st_h2o_context_t {
     struct {
         h2o_multithread_receiver_t hostinfo_getaddr;
     } receivers;
+    /**
+     * open file cache
+     */
+    h2o_filecache_t *filecache;
     /**
      * flag indicating if shutdown has been requested
      */

--- a/include/h2o/filecache.h
+++ b/include/h2o/filecache.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef h2o__filecache_h
+#define h2o__filecache_h
+
+#include <stddef.h>
+#include <sys/stat.h>
+#include "h2o/linklist.h"
+#include "h2o/time_.h"
+
+typedef struct st_h2o_filecache_ref_t {
+    int fd;
+    struct stat st;
+/*
+    char last_modified[H2O_TIMESTR_RFC1123_LEN + 1];
+    char etag[sizeof("\"deadbeef-deadbeefdeadbeef\"")];
+*/
+    size_t _refcnt;
+    h2o_linklist_t _lru;
+    char _path[1];
+} h2o_filecache_ref_t;
+
+typedef struct st_h2o_filecache_t h2o_filecache_t;
+
+h2o_filecache_t *h2o_filecache_create(size_t capacity);
+void h2o_filecache_destroy(h2o_filecache_t *cache);
+void h2o_filecache_clear(h2o_filecache_t *cache);
+
+h2o_filecache_ref_t *h2o_filecache_open_file(h2o_filecache_t *cache, const char *path, int oflag);
+void h2o_filecache_close_file(h2o_filecache_ref_t *ref);
+
+#endif

--- a/include/h2o/filecache.h
+++ b/include/h2o/filecache.h
@@ -24,16 +24,22 @@
 
 #include <stddef.h>
 #include <sys/stat.h>
+#include <time.h>
 #include "h2o/linklist.h"
+#include "h2o/memory.h"
 #include "h2o/time_.h"
 
 typedef struct st_h2o_filecache_ref_t {
     int fd;
     struct stat st;
-/*
-    char last_modified[H2O_TIMESTR_RFC1123_LEN + 1];
-    char etag[sizeof("\"deadbeef-deadbeefdeadbeef\"")];
-*/
+    struct {
+        struct tm gm;
+        char str[H2O_TIMESTR_RFC1123_LEN + 1];
+    } _last_modified;
+    struct {
+        char buf[sizeof("\"deadbeef-deadbeefdeadbeef\"")];
+        size_t len;
+    } _etag;
     size_t _refcnt;
     h2o_linklist_t _lru;
     char _path[1];
@@ -47,5 +53,7 @@ void h2o_filecache_clear(h2o_filecache_t *cache);
 
 h2o_filecache_ref_t *h2o_filecache_open_file(h2o_filecache_t *cache, const char *path, int oflag);
 void h2o_filecache_close_file(h2o_filecache_ref_t *ref);
+const char *h2o_filecache_get_last_modified(h2o_filecache_ref_t *ref, struct tm **gm);
+h2o_iovec_t h2o_filecache_get_etag(h2o_filecache_ref_t *ref);
 
 #endif

--- a/lib/common/filecache.c
+++ b/lib/common/filecache.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <assert.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <unistd.h>
+#include "khash.h"
+#include "h2o/memory.h"
+#include "h2o/filecache.h"
+
+KHASH_SET_INIT_STR(opencache_set);
+
+struct st_h2o_filecache_t {
+    khash_t(opencache_set) * hash;
+    h2o_linklist_t lru;
+    size_t capacity;
+};
+
+static inline void release_from_cache(h2o_filecache_t *cache, khiter_t iter)
+{
+    const char *path = kh_key(cache->hash, iter);
+    h2o_filecache_ref_t *ref = H2O_STRUCT_FROM_MEMBER(h2o_filecache_ref_t, _path, path);
+
+    /* detach from list */
+    kh_del(opencache_set, cache->hash, iter);
+    h2o_linklist_unlink(&ref->_lru);
+
+    /* and close */
+    h2o_filecache_close_file(ref);
+}
+
+h2o_filecache_t *h2o_filecache_create(size_t capacity)
+{
+    h2o_filecache_t *cache = h2o_mem_alloc(sizeof(*cache));
+
+    cache->hash = kh_init(opencache_set);
+    h2o_linklist_init_anchor(&cache->lru);
+    cache->capacity = capacity;
+
+    return cache;
+}
+
+void h2o_filecache_destroy(h2o_filecache_t *cache)
+{
+    h2o_filecache_clear(cache);
+    assert(kh_size(cache->hash) == 0);
+    assert(h2o_linklist_is_empty(&cache->lru));
+    kh_destroy(opencache_set, cache->hash);
+    free(cache);
+}
+
+void h2o_filecache_clear(h2o_filecache_t *cache)
+{
+    khiter_t iter;
+    for (iter = kh_begin(cache->hash); iter != kh_end(cache->hash); ++iter) {
+        if (!kh_exist(cache->hash, iter))
+            continue;
+        release_from_cache(cache, iter);
+    }
+    assert(kh_size(cache->hash) == 0);
+}
+
+h2o_filecache_ref_t *h2o_filecache_open_file(h2o_filecache_t *cache, const char *path, int oflag)
+{
+    khiter_t iter = kh_get(opencache_set, cache->hash, path);
+    h2o_filecache_ref_t *ref;
+    int fd, dummy;
+
+    /* lookup cache, and return the one if found */
+    if (iter != kh_end(cache->hash)) {
+        ref = H2O_STRUCT_FROM_MEMBER(h2o_filecache_ref_t, _path, kh_key(cache->hash, iter));
+        ++ref->_refcnt;
+        return ref;
+    }
+
+    /* not found, try to open the new file */
+    if ((fd = open(path, oflag)) == -1)
+        return NULL;
+    ref = h2o_mem_alloc(offsetof(h2o_filecache_ref_t, _path) + strlen(path) + 1);
+    ref->fd = fd;
+    ref->_refcnt = 1;
+    ref->_lru = (h2o_linklist_t){};
+    strcpy(ref->_path, path);
+    if (fstat(fd, &ref->st) != 0) {
+        close(fd);
+        free(ref);
+        return NULL;
+    }
+    /* if cache is used, then... */
+    if (cache->capacity != 0) {
+        /* purge one entry from LRU if cache is full */
+        if (kh_size(cache->hash) == cache->capacity) {
+            h2o_filecache_ref_t *purge_ref = H2O_STRUCT_FROM_MEMBER(h2o_filecache_ref_t, _lru, cache->lru.prev);
+            khiter_t purge_iter = kh_get(opencache_set, cache->hash, purge_ref->_path);
+            assert(purge_iter != kh_end(cache->hash));
+            release_from_cache(cache, purge_iter);
+        }
+        /* assign the new entry */
+        ++ref->_refcnt;
+        kh_put(opencache_set, cache->hash, ref->_path, &dummy);
+        h2o_linklist_insert(cache->lru.next, &ref->_lru);
+    }
+
+    return ref;
+}
+
+void h2o_filecache_close_file(h2o_filecache_ref_t *ref)
+{
+    if (--ref->_refcnt != 0)
+        return;
+    assert(!h2o_linklist_is_linked(&ref->_lru));
+    close(ref->fd);
+    ref->fd = -1;
+    free(ref);
+}

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -94,6 +94,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     h2o_timeout_init(ctx->loop, &ctx->one_sec_timeout, 1000);
     ctx->queue = h2o_multithread_create_queue(loop);
     h2o_multithread_register_receiver(ctx->queue, &ctx->receivers.hostinfo_getaddr, h2o_hostinfo_getaddr_receiver);
+    ctx->filecache = h2o_filecache_create(config->filecache.capacity);
 
     h2o_timeout_init(ctx->loop, &ctx->handshake_timeout, config->handshake_timeout);
     h2o_timeout_init(ctx->loop, &ctx->http1.req_timeout, config->http1.req_timeout);
@@ -142,6 +143,9 @@ void h2o_context_dispose(h2o_context_t *ctx)
     h2o_timeout_dispose(ctx->loop, &ctx->http2.idle_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->proxy.io_timeout);
     /* what should we do here? assert(!h2o_linklist_is_empty(&ctx->http2._conns); */
+
+    h2o_filecache_destroy(ctx->filecache);
+    ctx->filecache = NULL;
 
     /* TODO assert that the all the getaddrinfo threads are idle */
     h2o_multithread_unregister_receiver(ctx->queue, &ctx->receivers.hostinfo_getaddr);

--- a/src/main.c
+++ b/src/main.c
@@ -1257,6 +1257,7 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
         update_listener_state(listeners);
         /* run the loop once */
         h2o_evloop_run(conf.threads[thread_index].ctx.loop);
+        h2o_filecache_clear(conf.threads[thread_index].ctx.filecache);
     }
 
     if (thread_index == 0)
@@ -1524,6 +1525,8 @@ int main(int argc, char **argv)
             exit(EX_CONFIG);
         yoml_free(yoml, NULL);
     }
+    /* calculate defaults (note: open file cached is purged once every loop) */
+    conf.globalconf.filecache.capacity = conf.globalconf.http2.max_concurrent_requests_per_connection * 2;
 
     /* check if all the fds passed in by server::starter were bound */
     if (conf.server_starter.fds != NULL) {


### PR DESCRIPTION
For devices using 10ge connection but not-so-powerful CPU serving static files, the cost of open(2) and close(2) becomes an issue.

Implementing an in-memory cache is one way to address the issue, but doing so does consume memory and therefore cannot be enabled by default.

OTOH a file descriptor cache that shares a file descriptor _only when a file is opened more than once_ is a good approach for the following reasons:
* reduces the number of open(2) / close(2) being called
* MAY reduce the number of files opened at the same time

The cache implemented by this PR also have following characteristics:
* file descriptor cache is freed every once the event loop
* the maximum entries kept open by the file desriptor cache is 2x the max. concurrency of HTTP/2 connection

relates to: #139