### PR TITLE
Warning fixes

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1349,6 +1349,7 @@ inline void h2o_setup_next_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostre
 {
     h2o_filter_t *next;
 
+    (void)(self);
     assert(self == req->pathconf->filters.entries[req->_ostr_init_index]);
     if (req->_ostr_init_index + 1 < req->pathconf->filters.size) {
         next = req->pathconf->filters.entries[++req->_ostr_init_index];

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -350,7 +350,15 @@ inline void h2o_buffer_set_prototype(h2o_buffer_t **buffer, h2o_buffer_prototype
 
 inline void h2o_buffer_link_to_pool(h2o_buffer_t *buffer, h2o_mem_pool_t *pool)
 {
-    h2o_buffer_t **slot = (h2o_buffer_t **)h2o_mem_alloc_shared(pool, sizeof(*slot), (void (*)(void *))(void *)h2o_buffer_dispose);
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
+#endif
+    void (*dispose)(void *) = h2o_buffer_dispose;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+    h2o_buffer_t **slot = (h2o_buffer_t **)h2o_mem_alloc_shared(pool, sizeof(*slot), dispose);
     *slot = buffer;
 }
 


### PR DESCRIPTION
These patches fix up a couple of warnings that occur when using `gcc` with `-Wall` `-Wextra`. It's not a huge issue if they don't go in as I can put the warning suppressions around the include. It would be nice to fix them upstream though.