### PR TITLE
write immediately after reading data from h2 connection

### DIFF
--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -31,10 +31,12 @@
 #define H2O_SOCKET_FLAG_IS_POLLED_FOR_WRITE 0x10
 #define H2O_SOCKET_FLAG_DONT_READ 0x20
 #define H2O_SOCKET_FLAG_IS_CONNECTING 0x40
+#define H2O_SOCKET_FLAG_IS_ACCEPTED_CONNECTION 0x80
 #define H2O_SOCKET_FLAG__EPOLL_IS_REGISTERED 0x1000
 
 typedef struct st_h2o_evloop_t {
-    struct st_h2o_evloop_socket_t *_pending;
+    struct st_h2o_evloop_socket_t *_pending_as_client;
+    struct st_h2o_evloop_socket_t *_pending_as_server;
     struct {
         struct st_h2o_evloop_socket_t *head;
         struct st_h2o_evloop_socket_t **tail_ref;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -810,6 +810,12 @@ static void on_read(h2o_socket_t *sock, int status)
 
     update_idle_timeout(conn);
     parse_input(conn);
+
+    /* write immediately, if there is no write in flight and if pending write exists */
+    if (h2o_timeout_is_linked(&conn->_write.timeout_entry)) {
+        h2o_timeout_unlink(&conn->_write.timeout_entry);
+        do_emit_writereq(conn);
+    }
 }
 
 static void on_upgrade_complete(void *_conn, h2o_socket_t *sock, size_t reqsize)


### PR DESCRIPTION
At the moment, write to an HTTP/2 connection is always delayed until all readable sockets are read.  The good point of the approach is that we can collect as much data as possible before deciding what to send (ref. HTTP/2 prioritization).

The downside is that the performance and memory footprint becomes worse, since we need to collect all incoming data to memory before emitting anything.

This PR tries to fix the downside without degrading the quality of prioritization, by sending data immediately if _only_ when we process incoming data on an H2 connection, and there is no write in-flight.

If the expectation is true that typically we will have a write in-flight when prioritization is at most necessary, this change will not cause negligible effect on the prioritization quality.