### PR TITLE
fix null access when upgrading to HTTP/2 fails

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -255,7 +255,8 @@ static void close_connection_now(h2o_http2_conn_t *conn)
         h2o_http2_casper_destroy(conn->casper);
     h2o_linklist_unlink(&conn->_conns);
 
-    h2o_socket_close(conn->sock);
+    if (conn->sock != NULL)
+        h2o_socket_close(conn->sock);
     free(conn);
 }
 


### PR DESCRIPTION
Though unlikely, HTTP/1 handler might fail to send upgrade response.  And in such case, HTTP/2 connection object must be closed without calling `h2o_socket_close`.