### PR TITLE
fix too-many-streams error with h2load

### DIFF
--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -414,6 +414,8 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         }
         stream->state = new_state;
         stream->req.timestamps.response_end_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+        --stream->_num_streams_slot->open;
+        stream->_num_streams_slot = NULL;
         break;
     }
 }

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -149,6 +149,7 @@ typedef enum enum_h2o_http2_stream_state_t {
     H2O_HTTP2_STREAM_STATE_REQ_PENDING,
     H2O_HTTP2_STREAM_STATE_SEND_HEADERS,
     H2O_HTTP2_STREAM_STATE_SEND_BODY,
+    H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL,
     H2O_HTTP2_STREAM_STATE_END_STREAM
 } h2o_http2_stream_state_t;
 
@@ -393,6 +394,10 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         ++stream->_num_streams_slot->send_body;
         stream->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         break;
+    case H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL:
+        assert(stream->state == H2O_HTTP2_STREAM_STATE_SEND_BODY);
+        stream->state = new_state;
+        break;
     case H2O_HTTP2_STREAM_STATE_END_STREAM:
         switch (stream->state) {
         case H2O_HTTP2_STREAM_STATE_IDLE:
@@ -405,6 +410,7 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
             --stream->_num_streams_slot->half_closed;
             break;
         case H2O_HTTP2_STREAM_STATE_SEND_BODY:
+        case H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL:
             --stream->_num_streams_slot->half_closed;
             --stream->_num_streams_slot->send_body;
             break;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -63,7 +63,6 @@ h2o_http2_stream_t *h2o_http2_stream_open(h2o_http2_conn_t *conn, uint32_t strea
 void h2o_http2_stream_close(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
 {
     h2o_http2_conn_unregister_stream(conn, stream);
-    --stream->_num_streams_slot->open;
     if (stream->_req_body != NULL)
         h2o_buffer_dispose(&stream->_req_body);
     h2o_dispose_request(&stream->req);

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -82,6 +82,7 @@ void h2o_http2_stream_reset(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
         break;
     case H2O_HTTP2_STREAM_STATE_SEND_HEADERS:
     case H2O_HTTP2_STREAM_STATE_SEND_BODY:
+    case H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL:
         h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);
     /* continues */
     case H2O_HTTP2_STREAM_STATE_END_STREAM:
@@ -316,7 +317,7 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, s
     /* fallthru */
     case H2O_HTTP2_STREAM_STATE_SEND_BODY:
         if (is_final)
-            h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);
+            h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
         break;
     case H2O_HTTP2_STREAM_STATE_END_STREAM:
         /* might get set by h2o_http2_stream_reset */
@@ -351,10 +352,12 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
     } else {
         /* push mode */
         h2o_iovec_t *nextbuf = send_data_push(conn, stream, stream->_data.entries, stream->_data.size,
-                                              stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM);
+                                              stream->state >= H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
         if (nextbuf == stream->_data.entries + stream->_data.size) {
             /* sent all data */
             stream->_data.size = 0;
+            if (stream->state == H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL)
+                h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);
         } else if (nextbuf != stream->_data.entries) {
             /* adjust the buffer */
             size_t newsize = stream->_data.size - (nextbuf - stream->_data.entries);


### PR DESCRIPTION
Fixes regression caused by #352 (originally fixed in #132).