### PR TITLE
add ServiceWorker support to cache-aware server-push

### DIFF
--- a/deps/golombset/Makefile
+++ b/deps/golombset/Makefile
@@ -1,0 +1,15 @@
+all: test.exe golombset
+
+check: test.exe
+	./test.exe
+
+test.exe: test.c golombset.h
+	$(CC) -Wall -g test.c -o $@
+
+golombset: cmd.c golombset.h
+	$(CC) -Wall -g cmd.c -o $@
+
+clean:
+	rm -f test.exe golombset
+
+.PHONY: check clean

--- a/deps/golombset/README.md
+++ b/deps/golombset/README.md
@@ -1,15 +1,15 @@
 golombset
 ===
 
-Golombset is a pure-C, header-file-only implementation of Golomb coded set, which is an compressed form of [Bloom filter](https://en.wikipedia.org/Bloom_filter).
+Golombset is a pure-C, header-file-only implementation of Golomb compressed set, which is an compressed form of [Bloom filter](https://en.wikipedia.org/Bloom_filter).
 
-It is compresses every zero-range of Bloom filter (e.g. `0000...1`) using [Golomb coding](https://en.wikipedia.org/wiki/Golomb_coding).
+It compresses every zero-range of Bloom filter (e.g. `0000...1`) using [Golomb coding](https://en.wikipedia.org/wiki/Golomb_coding).
 Please refer to [Golomb-coded sets: smaller than Bloom filters](http://giovanni.bajo.it/post/47119962313/golomb-coded-sets-smaller-than-bloom-filters) for more information about the algorithm.
 
 API
 ---
 
-__`int golombset_encode(unsigned fixed_bits, const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize);`__
+__`int golombset_encode(const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize);`__
 
 The function encodes an pre-sorted array of keys into given buffer.
 
@@ -18,7 +18,7 @@ The function returns zero if successful, or -1 if otherwise (e.g. the size of th
 Upon calling the function the value of the pointer must specify the size of the buffer being supplied.
 When the function returns successfully, the value is updated the length of the bytes actually used to store the encoded data.
 
-__`int golombset_decode(unsigned fixed_bits, const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys);`__
+__`int golombset_decode(const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys);`__
 
 The function decodes the compressed data into an array of keys.
 

--- a/deps/golombset/cmd.c
+++ b/deps/golombset/cmd.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2015 Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <stdio.h>
+#include <string.h>
+#include "golombset.h"
+
+static int encode(void)
+{
+    unsigned keys[4096];
+    size_t num_keys = 0;
+    unsigned char buf[65536];
+    size_t buf_size = sizeof(buf);
+
+    while (1) {
+        unsigned v;
+        if (fscanf(stdin, "%u\n", &v) != 1)
+            break;
+        keys[num_keys++] = v;
+    }
+    if (!feof(stdin)) {
+        perror("failed to parse input");
+        return 111;
+    }
+
+    if (golombset_encode(keys, num_keys, buf, &buf_size) != 0) {
+        fprintf(stderr, "failed to encode the values\n");
+        return 111;
+    }
+
+    fwrite(buf, 1, buf_size, stdout);
+    return 0;
+}
+
+static int decode(void)
+{
+    unsigned char buf[65536];
+    size_t buf_size;
+    unsigned keys[4096];
+    size_t i, num_keys = sizeof(keys) / sizeof(keys[0]);
+
+    buf_size = fread(buf, 1, sizeof(buf), stdin);
+    if (ferror(stdin) || !feof(stdin)) {
+        perror("failed to read input");
+        return 111;
+    }
+
+    if (golombset_decode(buf, buf_size, keys, &num_keys) != 0) {
+        fprintf(stderr, "failed to decode the values\n");
+        return 111;
+    }
+
+    for (i = 0; i != num_keys; ++i)
+        printf("%u\n", keys[i]);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2) {
+        fprintf(stderr,
+                "Usage: %s [--encode|--decode]\n"
+                "\n"
+                "When --encode option is specified, reads a line-separated list of unsigned\n"
+                "numbers from stdin and emits the compressed representation of the numbers to\n"
+                "stdout.  Or does the reverse when --decode is used.\n"
+                "\n",
+                argv[0]);
+        return 111;
+    }
+
+    if (strcmp(argv[1], "--encode") == 0) {
+        return encode();
+    } else if (strcmp(argv[1], "--decode") == 0) {
+        return decode();
+    } else {
+        fprintf(stderr, "unknown argument: %s\n", argv[1]);
+        return 111;
+    }
+}

--- a/deps/golombset/golombset.h
+++ b/deps/golombset/golombset.h
@@ -22,18 +22,23 @@
 #ifndef GOLOMBSET_H
 #define GOLOMBSET_H
 
+#ifndef GOLOMBSET_FIXED_BITS_LENGTH
+#define GOLOMBSET_FIXED_BITS_LENGTH 5
+#endif
+#define GOLOMBSET_MAX_FIXED_BITS ((1 << (GOLOMBSET_FIXED_BITS_LENGTH)) - 1)
+
 struct st_golombset_encode_t {
-    const unsigned fixed_bits;
     unsigned char *dst;
     unsigned char *dst_max;
     unsigned dst_shift;
+    unsigned fixed_bits;
 };
 
 struct st_golombset_decode_t {
-    const unsigned fixed_bits;
     const unsigned char *src;
     const unsigned char *src_max;
     unsigned src_shift;
+    unsigned fixed_bits;
 };
 
 static int golombset_encode_bit(struct st_golombset_encode_t *ctx, int bit)
@@ -71,10 +76,10 @@ static int golombset_encode_value(struct st_golombset_encode_t *ctx, unsigned va
         return -1;
     /* emit the rest */
     unsigned shift = ctx->fixed_bits;
-    do {
+    while (shift != 0) {
         if (golombset_encode_bit(ctx, (value >> --shift) & 1) != 0)
             return -1;
-    } while (shift != 0);
+    }
 
     return 0;
 }
@@ -94,22 +99,46 @@ static int golombset_decode_value(struct st_golombset_decode_t *ctx, unsigned *v
     }
     /* decode the rest */
     unsigned shift = ctx->fixed_bits;
-    do {
+    while (shift != 0) {
         if ((bit = golombset_decode_bit(ctx)) == -1)
             return -1;
         *value |= bit << --shift;
-    } while (shift != 0);
+    }
 
     return 0;
 }
 
-static int golombset_encode(unsigned fixed_bits, const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize)
+static unsigned golombset_calc_fixed_bits(unsigned max_key, size_t num_keys)
 {
-    struct st_golombset_encode_t ctx = {fixed_bits, buf, buf + *bufsize, 8};
+    unsigned delta, bits;
+
+    delta = max_key / num_keys;
+    if (delta < 1)
+        return 0;
+    bits = sizeof(unsigned) * 8 - __builtin_clz(delta) - 1;
+    if (bits > GOLOMBSET_MAX_FIXED_BITS)
+        bits = GOLOMBSET_MAX_FIXED_BITS;
+    return bits;
+}
+
+static int golombset_encode(const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize)
+{
+    struct st_golombset_encode_t ctx = {buf, buf + *bufsize, 8};
     size_t i;
     unsigned next_min = 0;
 
-    *(unsigned char *)buf = 0xff;
+    if (num_keys == 0) {
+        *bufsize = 0;
+        return 0;
+    }
+
+    ctx.fixed_bits = golombset_calc_fixed_bits(keys[num_keys - 1], num_keys);
+
+    *(unsigned char *)ctx.dst = 0xff;
+    for (i = 0; i != GOLOMBSET_FIXED_BITS_LENGTH; ++i) {
+        if (golombset_encode_bit(&ctx, (ctx.fixed_bits >> (GOLOMBSET_FIXED_BITS_LENGTH - 1 - i)) & 1) != 0)
+            return -1;
+    }
     for (i = 0; i != num_keys; ++i) {
         if (golombset_encode_value(&ctx, keys[i] - next_min) != 0)
             return -1;
@@ -123,12 +152,23 @@ static int golombset_encode(unsigned fixed_bits, const unsigned *keys, size_t nu
     return 0;
 }
 
-static int golombset_decode(unsigned fixed_bits, const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys)
+static int golombset_decode(const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys)
 {
-    struct st_golombset_decode_t ctx = {fixed_bits, buf, buf + bufsize, 8};
-    size_t index = 0;
+    struct st_golombset_decode_t ctx = {buf, buf + bufsize, 8};
+    size_t i, index = 0;
     unsigned next_min = 0;
 
+    if (bufsize == 0) {
+        *num_keys = 0;
+        return 0;
+    }
+
+    for (i = 0; i != GOLOMBSET_FIXED_BITS_LENGTH; ++i) {
+        int bit = golombset_decode_bit(&ctx);
+        if (bit == -1)
+            return -1;
+        ctx.fixed_bits = (ctx.fixed_bits << 1) | bit;
+    }
     while (1) {
         unsigned value;
         if (golombset_decode_value(&ctx, &value) != 0)

--- a/deps/golombset/test.c
+++ b/deps/golombset/test.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015 Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <stdio.h>
+#include <string.h>
+#include "golombset.h"
+
+int main(int argc, char **argv)
+{
+    const unsigned keys[] = {151, 192,  208,  269,  461,  512,  526,  591,  662,  806,  831,  866,  890,
+                       997, 1005, 1017, 1134, 1207, 1231, 1327, 1378, 1393, 1418, 1525, 1627, 1630};
+    const size_t num_keys = sizeof(keys) / sizeof(keys[0]);
+    unsigned char buf[1024];
+    size_t i, bufsize = sizeof(buf);
+
+    if (golombset_encode(keys, num_keys, buf, &bufsize) != 0) {
+        fprintf(stderr, "golombset_encode failed\n");
+        return 111;
+    }
+    printf("encoded %zu entries into %zu bytes: ", num_keys, bufsize);
+    for (i = 0; i != bufsize; ++i)
+        printf("%02x", buf[i]);
+    printf("\n");
+    
+    unsigned decoded_keys[num_keys];
+    size_t num_decoded_keys = num_keys;
+    if (golombset_decode(buf, bufsize, decoded_keys, &num_decoded_keys) != 0) {
+        fprintf(stderr, "golombset_decode failed\n");
+        return 111;
+    }
+
+    if (num_decoded_keys != num_keys) {
+        fprintf(stderr, "unexpected number of outputs\n");
+        return 111;
+    }
+    if (memcmp(keys, decoded_keys, sizeof(keys[0]) * num_keys) != 0) {
+        fprintf(stderr, "output mismatch\n");
+        return 111;
+    }
+
+    return 0;
+}

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -364,6 +364,7 @@
 		106C22FE1C05436100405689 /* errordoc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = errordoc.c; sourceTree = "<group>"; };
 		106C23001C0544CE00405689 /* errordoc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = errordoc.c; sourceTree = "<group>"; };
 		106C23021C06AB2F00405689 /* 50errordoc.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 50errordoc.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		106C23031C0C144100405689 /* 50casper.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 50casper.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		107086691B70A00F002B8F18 /* casper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = casper.c; sourceTree = "<group>"; };
 		1070866B1B787D06002B8F18 /* gzip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gzip.c; sourceTree = "<group>"; };
 		1070866F1B7925D5002B8F18 /* gzip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gzip.c; sourceTree = "<group>"; };
@@ -1137,6 +1138,7 @@
 				10AA2EB31A94B66D004322AC /* 40virtual-host.t */,
 				106C22FB1C0413DA00405689 /* 40websocket.t */,
 				10AA2EB11A931409004322AC /* 50access-log.t */,
+				106C23031C0C144100405689 /* 50casper.t */,
 				106C23021C06AB2F00405689 /* 50errordoc.t */,
 				104B9A541A60773E009EEE64 /* 50expires.t */,
 				10C5A6311B268632006094A6 /* 50fastcgi.t */,

--- a/include/h2o/http2_casper.h
+++ b/include/h2o/http2_casper.h
@@ -29,6 +29,10 @@
 typedef struct st_h2o_http2_casper_t h2o_http2_casper_t;
 
 /**
+ * calculates the casper key
+ */
+unsigned h2o_http2_casper_calc_key(unsigned capacity_bits, const char *path, size_t path_len, const char *etag, size_t etag_len);
+/**
  * creates an object with provided parameters
  */
 h2o_http2_casper_t *h2o_http2_casper_create(unsigned capacity_bits, unsigned remainder_bits);
@@ -43,12 +47,15 @@ size_t h2o_http2_casper_num_entries(h2o_http2_casper_t *casper);
 /**
  * checks if a key is (was) marked as cached at the moment the fuction is invoked
  */
-int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len,
-                            int set);
+int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, unsigned key, int set);
 /**
  * consumes the `Cookie` headers in requests and updates the structure
  */
 void h2o_http2_casper_consume_cookie(h2o_http2_casper_t *casper, const char *cookie, size_t cookie_len);
+/**
+ * consumes a base64-encoded casper fingerprint
+ */
+void h2o_http2_casper_consume_base64_fingerprint(h2o_http2_casper_t *casper, const char *value, size_t len);
 /**
  * returns the value of the `Set-Cookie` header that should be sent to the client
  */

--- a/lib/http2/casper.c
+++ b/lib/http2/casper.c
@@ -118,7 +118,7 @@ void h2o_http2_casper_consume_base64_fingerprint(h2o_http2_casper_t *casper, con
 
     /* decode GCS, either using tiny_keys_buf or using heap */
     size_t capacity = sizeof(tiny_keys_buf) / sizeof(tiny_keys_buf[0]), num_keys;
-    while (num_keys = capacity, golombset_decode(casper->remainder_bits, binary.base, binary.len, keys, &num_keys) != 0) {
+    while (num_keys = capacity, golombset_decode(binary.base, binary.len, keys, &num_keys) != 0) {
         if (keys != tiny_keys_buf) {
             free(keys);
             keys = tiny_keys_buf; /* reset to something that would not trigger call to free(3) */
@@ -187,8 +187,7 @@ h2o_iovec_t h2o_http2_casper_get_cookie(h2o_http2_casper_t *casper)
     /* encode as binary */
     char tiny_bin_buf[128], *bin_buf = tiny_bin_buf;
     size_t bin_capacity = sizeof(tiny_bin_buf), bin_size;
-    while (bin_size = bin_capacity,
-           golombset_encode(casper->remainder_bits, casper->keys.entries, casper->keys.size, bin_buf, &bin_size) != 0) {
+    while (bin_size = bin_capacity, golombset_encode(casper->keys.entries, casper->keys.size, bin_buf, &bin_size) != 0) {
         if (bin_buf != tiny_bin_buf)
             free(bin_buf);
         bin_capacity *= 2;

--- a/t/50casper.t
+++ b/t/50casper.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+plan skip_all => 'nghttp not found'
+    unless prog_exists('nghttp');
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          lambda do |env|
+            push_paths = []
+            if env["PATH_INFO"] == "/"
+              push_paths << "/index.js"
+            end
+            return [
+              399,
+              push_paths.empty? ? {} : {"link" => push_paths.map{|p| "<#{p}>; rel=preload"}.join("\\n")},
+              [],
+            ]
+          end
+        file.dir: @{[ DOC_ROOT ]}
+http2-casper: ON
+EOT
+
+my $doit = sub {
+    my ($proto, $port) = @_;
+
+    subtest "without-fingerprint" => sub {
+        my $resp = `nghttp -n -v --stat $proto://127.0.0.1:$port/`;
+        like $resp, qr{\nid\s*responseEnd\s.*\s/index\.js\n.*\s/\n}is, "js pushed before html";
+        like $resp, qr{recv \(stream_id=2\) cache-fingerprint-key: 5399\n}is, "has fingerprint for pushed js";
+    };
+};
+
+$doit->('http', $server->{port});
+
+done_testing;


### PR DESCRIPTION
adds support for `cache-fingerprint-key` response header, and `cache-fingerprint` request header.