### PR TITLE
support basic-authentication using .htpasswd

### DIFF
--- a/deps/mruby-digest/.gitignore
+++ b/deps/mruby-digest/.gitignore
@@ -1,0 +1,5 @@
+gem_*
+gem-*
+mrb-*.a
+src/*.o
+/tmp

--- a/deps/mruby-digest/.travis.yml
+++ b/deps/mruby-digest/.travis.yml
@@ -1,0 +1,2 @@
+script:
+  - "ruby run_test.rb all test"

--- a/deps/mruby-digest/Makefile
+++ b/deps/mruby-digest/Makefile
@@ -1,0 +1,14 @@
+GEM := mruby-digest
+
+include $(MAKEFILE_4_GEM)
+
+GEM_C_FILES := $(wildcard $(SRC_DIR)/*.c)
+GEM_OBJECTS := $(patsubst %.c, %.o, $(GEM_C_FILES))
+
+GEM_RB_FILES := $(wildcard $(MRB_DIR)/*.rb)
+
+gem-all : $(GEM_OBJECTS) gem-c-and-rb-files
+
+gem-clean : gem-clean-c-and-rb-files
+
+gem-test : gem-test-c-and-rb-files

--- a/deps/mruby-digest/README.md
+++ b/deps/mruby-digest/README.md
@@ -1,0 +1,56 @@
+mruby-digest
+=========
+
+## Features
+
+Message Digest and HMAC classes are available.  They are compatible with CRuby's ones.
+
+- Digest::MD5, Digest::RMD160, Digest::SHA1, Digest::SHA256, Digest::SHA384 and
+  Digest::SHA512
+  - Note: some of them are not available if libcrypto.a does not support them on your system.
+- Digest::HMAC
+
+## Install
+ - add conf.gem line to `build_config.rb`
+
+```ruby
+MRuby::Build.new do |conf|
+
+    # ... (snip) ...
+
+    conf.gem :git => 'https://github.com/iij/mruby-digest.git'
+end
+```
+
+## Usage
+```ruby
+Digest::MD5.digest('ruby')
+Digest::MD5.hexdigest('ruby')
+```
+
+## Requirement
+- OpenSSL library (libcrypto.a) on Unix systems
+- Common Crypto library on MacOSX
+
+## License
+
+Copyright (c) 2012 Internet Initiative Japan Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a 
+copy of this software and associated documentation files (the "Software"), 
+to deal in the Software without restriction, including without limitation 
+the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the 
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE.
+

--- a/deps/mruby-digest/mrbgem.rake
+++ b/deps/mruby-digest/mrbgem.rake
@@ -1,6 +1,4 @@
 MRuby::Gem::Specification.new('mruby-digest') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Internet Initiative Japan Inc.'
-
-  spec.linker.libraries << 'crypto' unless RUBY_PLATFORM =~ /darwin/
 end

--- a/deps/mruby-digest/mrbgem.rake
+++ b/deps/mruby-digest/mrbgem.rake
@@ -1,0 +1,6 @@
+MRuby::Gem::Specification.new('mruby-digest') do |spec|
+  spec.license = 'MIT'
+  spec.authors = 'Internet Initiative Japan Inc.'
+
+  spec.linker.libraries << 'crypto' unless RUBY_PLATFORM =~ /darwin/
+end

--- a/deps/mruby-digest/mrblib/digest.rb
+++ b/deps/mruby-digest/mrblib/digest.rb
@@ -1,0 +1,46 @@
+if Object.const_defined? :Digest
+module Digest
+  class Base
+    def self.digest(data)
+      self.new.update(data).digest
+    end
+    def self.file(path)
+      self.new.update(File.open(path).read)
+    end
+    def self.hexdigest(data)
+      self.new.update(data).hexdigest
+    end
+    def ==(other)
+      if other.kind_of? String
+        self.hexdigest == other
+      else 
+        self.digest == other.digest
+      end
+    end
+    def file(path)
+      self.update(File.open(path).read)
+    end
+    def hexdigest!
+      x = self.hexdigest
+      self.reset
+      x
+    end
+
+    alias length digest_length
+    alias size digest_length
+    alias to_s hexdigest
+    alias << update
+  end
+
+  class HMAC
+    def self.digest(data, key, digest)
+      self.new(key, digest).update(data).digest
+    end
+    def self.hexdigest(data, key, digest)
+      self.new(key, digest).update(data).hexdigest
+    end
+
+    alias << update
+  end
+end
+end

--- a/deps/mruby-digest/run_test.rb
+++ b/deps/mruby-digest/run_test.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+#
+# mrbgems test runner
+#
+
+gemname = File.basename(File.dirname(File.expand_path __FILE__))
+
+if __FILE__ == $0
+  repository, dir = 'https://github.com/mruby/mruby.git', 'tmp/mruby'
+  build_args = ARGV
+  build_args = ['all', 'test']  if build_args.nil? or build_args.empty?
+
+  Dir.mkdir 'tmp'  unless File.exist?('tmp')
+  unless File.exist?(dir)
+    system "git clone #{repository} #{dir}"
+  end
+
+  exit system(%Q[cd #{dir}; MRUBY_CONFIG=#{File.expand_path __FILE__} ruby minirake #{build_args.join(' ')}])
+end
+
+MRuby::Build.new do |conf|
+  toolchain :gcc
+  conf.gembox 'default'
+
+  conf.gem File.expand_path(File.dirname(__FILE__))
+end

--- a/deps/mruby-digest/src/digest.c
+++ b/deps/mruby-digest/src/digest.c
@@ -1,0 +1,843 @@
+/*
+** digest.c - Digest and subclasses
+**
+** See Copyright Notice in mruby.h
+*/
+
+#include "mruby.h"
+
+#ifdef __APPLE__
+#define USE_DIGEST_OSX_COMMONCRYPTO
+#else
+#define USE_DIGEST_OPENSSL
+#endif
+
+#if defined(USE_DIGEST_OPENSSL)
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#elif defined(USE_DIGEST_OSX_COMMONCRYPTO)
+#include <CommonCrypto/CommonDigest.h>
+#include <CommonCrypto/CommonHMAC.h>
+#else
+#error "define USE_DIGEST_OPENSSL or USE_DIGEST_OSX_COMMONCRYPTO"
+#endif
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include "mruby/array.h"
+#include "mruby/class.h"
+#include "mruby/data.h"
+#include "mruby/string.h"
+#include "mruby/variable.h"
+
+#define TYPESYM "__type__"
+
+
+/*
+ * library-independent layer API
+ */
+enum {
+	MD_TYPE_MD5,
+	MD_TYPE_RMD160,
+	MD_TYPE_SHA1,
+	MD_TYPE_SHA256,
+	MD_TYPE_SHA384,
+	MD_TYPE_SHA512,
+};
+
+struct mrb_md;
+struct mrb_hmac;
+
+static void lib_init(void);
+static int lib_md_block_length(const struct mrb_md *);
+static mrb_value lib_md_digest(mrb_state *, const struct mrb_md *);
+static mrb_value lib_md_digest_bang(mrb_state *, struct mrb_md *);
+static int lib_md_digest_length(const struct mrb_md *);
+static void lib_md_free(mrb_state *, void *);
+static void lib_md_init(mrb_state *, struct mrb_md *, int);
+static void lib_md_init_copy(mrb_state *, struct mrb_md *, struct mrb_md *);
+static void lib_md_reset(mrb_state *, struct mrb_md *);
+static void lib_md_update(mrb_state *, struct mrb_md *, unsigned char *, mrb_int);
+
+static mrb_value lib_hmac_digest(mrb_state *, const struct mrb_hmac *);
+static int lib_hmac_block_length(const struct mrb_hmac *);
+static int lib_hmac_digest_length(const struct mrb_hmac *);
+static void lib_hmac_free(mrb_state *, void *);
+static void lib_hmac_init(mrb_state *, struct mrb_hmac *, int, const unsigned char *, mrb_int);
+static void lib_hmac_update(mrb_state *, struct mrb_hmac *, unsigned char *, mrb_int);
+
+
+#if defined(USE_DIGEST_OPENSSL)
+/*
+ * OpenSSL Implementation
+ */
+
+#define HAVE_MD5
+
+#ifndef OPENSSL_NO_RIPEMD
+#define HAVE_RMD160
+#endif
+
+#define HAVE_SHA1
+#ifdef SHA256_DIGEST_LENGTH
+#define HAVE_SHA256
+#endif
+#ifdef SHA512_DIGEST_LENGTH
+#define HAVE_SHA384
+#define HAVE_SHA512
+#endif
+
+struct mrb_md {
+  EVP_MD_CTX *ctx;
+};
+
+struct mrb_hmac {
+  HMAC_CTX ctx;
+  const EVP_MD *md;
+};
+
+static void
+lib_md_free(mrb_state *mrb, void *ptr)
+{
+  struct mrb_md *md = ptr;
+
+  if (md != NULL) {
+    if (md->ctx != NULL) {
+      EVP_MD_CTX_destroy(md->ctx);
+    }
+    mrb_free(mrb, md);
+  }
+}
+
+static void
+lib_hmac_free(mrb_state *mrb, void *ptr)
+{
+  struct mrb_hmac *hmac = ptr;
+
+  if (hmac != NULL) {
+    HMAC_CTX_cleanup(&hmac->ctx);
+    mrb_free(mrb, hmac);
+  }
+}
+
+static struct mrb_data_type mrb_md_type = { "MD", lib_md_free };
+static struct mrb_data_type mrb_hmac_type = { "HMAC", lib_hmac_free };
+
+static void
+lib_init(void)
+{
+  OpenSSL_add_all_digests();
+}
+
+static int
+lib_md_block_length(const struct mrb_md *md)
+{
+  return EVP_MD_CTX_block_size(md->ctx);
+}
+
+static mrb_value
+lib_md_digest(mrb_state *mrb, const struct mrb_md *md)
+{
+  EVP_MD_CTX ctx;
+  unsigned int mdlen;
+  unsigned char mdstr[EVP_MAX_MD_SIZE];
+
+  EVP_MD_CTX_copy(&ctx, md->ctx);
+  EVP_DigestFinal_ex(&ctx, mdstr, &mdlen);
+  return mrb_str_new(mrb, (char *)mdstr, mdlen);
+}
+
+static mrb_value
+lib_md_digest_bang(mrb_state *mrb, struct mrb_md *md)
+{
+  unsigned int mdlen;
+  unsigned char mdstr[EVP_MAX_MD_SIZE];
+
+  EVP_DigestFinal_ex(md->ctx, mdstr, &mdlen);
+  EVP_DigestInit_ex(md->ctx, EVP_MD_CTX_md(md->ctx), NULL);
+  return mrb_str_new(mrb, (char *)mdstr, mdlen);
+}
+
+static int
+lib_md_digest_length(const struct mrb_md *md)
+{
+  return EVP_MD_CTX_size(md->ctx);
+}
+
+const EVP_MD *
+md_type_md(int type)
+{
+  switch (type) {
+  case MD_TYPE_MD5:	return EVP_md5();
+#ifdef HAVE_RMD160
+  case MD_TYPE_RMD160:	return EVP_ripemd160();
+#endif
+  case MD_TYPE_SHA1:	return EVP_sha1();
+#ifdef HAVE_SHA256
+  case MD_TYPE_SHA256:	return EVP_sha256();
+#endif
+#ifdef HAVE_SHA512
+  case MD_TYPE_SHA384:	return EVP_sha384();
+  case MD_TYPE_SHA512:	return EVP_sha512();
+#endif
+  default:		return NULL;
+  }
+}
+
+static void
+lib_md_init(mrb_state *mrb, struct mrb_md *md, int type)
+{
+  const EVP_MD *evpmd;
+
+  md->ctx = NULL;
+  evpmd = md_type_md(type);
+  if (!evpmd) {
+    mrb_raise(mrb, E_NOTIMP_ERROR, "not supported");
+  }
+  md->ctx = EVP_MD_CTX_create();
+  EVP_DigestInit_ex(md->ctx, evpmd, NULL);
+}
+
+static void
+lib_md_init_copy(mrb_state *mrb, struct mrb_md *mdnew, struct mrb_md *mdold)
+{
+  mdnew->ctx = EVP_MD_CTX_create();
+  EVP_DigestInit_ex(mdnew->ctx, EVP_MD_CTX_md(mdold->ctx), NULL);
+}
+
+static void
+lib_md_reset(mrb_state *mrb, struct mrb_md *md)
+{
+  //EVP_MD_CTX_init(&md->ctx);
+  EVP_DigestInit_ex(md->ctx, EVP_MD_CTX_md(md->ctx), NULL);
+}
+
+static void
+lib_md_update(mrb_state *mrb, struct mrb_md *md, unsigned char *str, mrb_int len)
+{
+#if MRB_INT_MAX > SIZE_MAX
+  if (len > SIZE_MAX) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "too long string (not supported yet)");
+  }
+#endif
+  EVP_DigestUpdate(md->ctx, str, len);
+}
+
+static mrb_value
+lib_hmac_digest(mrb_state *mrb, const struct mrb_hmac *hmac)
+{
+  HMAC_CTX ctx;
+  unsigned int mdlen;
+  unsigned char mdstr[EVP_MAX_MD_SIZE];
+
+  memcpy(&ctx, &hmac->ctx, sizeof(ctx));
+  HMAC_Final(&ctx, mdstr, &mdlen);
+  return mrb_str_new(mrb, (char *)mdstr, mdlen);
+}
+
+static int
+lib_hmac_block_length(const struct mrb_hmac *hmac)
+{
+  return EVP_MD_block_size(hmac->md);
+}
+
+static int
+lib_hmac_digest_length(const struct mrb_hmac *hmac)
+{
+  return EVP_MD_size(hmac->md);
+}
+
+static void
+lib_hmac_init(mrb_state *mrb, struct mrb_hmac *hmac, int type, const unsigned char *key, mrb_int keylen)
+{
+#if MRB_INT_MAX > INT_MAX
+  if (keylen > INT_MAX) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "too long key");
+  }
+#endif
+  hmac->md = md_type_md(type);
+  HMAC_CTX_init(&hmac->ctx);
+  HMAC_Init_ex(&hmac->ctx, key, keylen, hmac->md, NULL);
+}
+
+static void
+lib_hmac_update(mrb_state *mrb, struct mrb_hmac *hmac, unsigned char *data, mrb_int len)
+{
+#if MRB_INT_MAX > INT_MAX
+  if (len > INT_MAX) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "too long string (not supported yet)");
+  }
+#endif
+  HMAC_Update(&hmac->ctx, data, len);
+}
+
+#elif defined(USE_DIGEST_OSX_COMMONCRYPTO)
+/*
+ * Mac OS X CommonCrypto Implementation
+ */
+
+#define HAVE_MD5
+/* #define HAVE_RMD160 */
+#define HAVE_SHA1
+#define HAVE_SHA256
+#define HAVE_SHA384
+#define HAVE_SHA512
+
+struct mrb_md {
+  int type;
+  void *ctx;
+  int ctx_size;
+};
+
+struct mrb_hmac {
+  int type;
+  CCHmacContext ctx;
+};
+
+static int
+md_ctx_size(int type)
+{
+  switch (type) {
+  case MD_TYPE_MD5:	return sizeof(CC_MD5_CTX);
+  case MD_TYPE_SHA1:	return sizeof(CC_SHA1_CTX);
+  case MD_TYPE_SHA256:	return sizeof(CC_SHA256_CTX);
+  case MD_TYPE_SHA384:	return sizeof(CC_SHA512_CTX);	/* ! */
+  case MD_TYPE_SHA512:	return sizeof(CC_SHA512_CTX);
+  default:		return 0;
+  }
+}
+
+static void
+lib_md_free(mrb_state *mrb, void *ptr)
+{
+  struct mrb_md *md = ptr;
+
+  memset(md->ctx, 0, md_ctx_size(md->type));
+  mrb_free(mrb, md->ctx);
+  mrb_free(mrb, md);
+}
+
+static void
+lib_hmac_free(mrb_state *mrb, void *ptr)
+{
+  struct mrb_hmac *hmac = ptr;
+
+  memset(&hmac->ctx, 0, sizeof(hmac->ctx));
+  mrb_free(mrb, hmac);
+}
+
+static struct mrb_data_type mrb_md_type = { "MD", lib_md_free };
+static struct mrb_data_type mrb_hmac_type = { "HMAC", lib_hmac_free };
+
+#define MAX_DIGEST_LENGTH	CC_SHA512_DIGEST_LENGTH
+
+union ctx_union {
+  CC_MD5_CTX md5;
+  CC_SHA1_CTX sha1;
+  CC_SHA256_CTX sha256;
+  /* we don't have CC_SHA384_CTX! */
+  CC_SHA512_CTX sha512;
+};
+
+static void
+lib_init(void)
+{
+}
+
+static int
+md_block_length(int type)
+{
+  switch (type) {
+  case MD_TYPE_MD5:	return CC_MD5_BLOCK_BYTES;
+  case MD_TYPE_SHA1:	return CC_SHA1_BLOCK_BYTES;
+  case MD_TYPE_SHA256:	return CC_SHA256_BLOCK_BYTES;
+  case MD_TYPE_SHA384:	return CC_SHA384_BLOCK_BYTES;
+  case MD_TYPE_SHA512:	return CC_SHA512_BLOCK_BYTES;
+  default:		return 0;
+  }
+}
+
+static int
+lib_md_block_length(const struct mrb_md *md)
+{
+  return md_block_length(md->type);
+}
+
+static void
+md_init(int type, void *ctxp)
+{
+  switch (type) {
+  case MD_TYPE_MD5:	CC_MD5_Init(ctxp);    break;
+  case MD_TYPE_SHA1:	CC_SHA1_Init(ctxp);   break;
+  case MD_TYPE_SHA256:	CC_SHA256_Init(ctxp); break;
+  case MD_TYPE_SHA384:	CC_SHA384_Init(ctxp); break;
+  case MD_TYPE_SHA512:	CC_SHA512_Init(ctxp); break;
+  default:				      break;
+  }
+}
+
+static void
+md_final(int type, unsigned char *str, void *ctx)
+{
+  switch (type) {
+  case MD_TYPE_MD5:	CC_MD5_Final(str, ctx);		break;
+  case MD_TYPE_SHA1:	CC_SHA1_Final(str, ctx);	break;
+  case MD_TYPE_SHA256:	CC_SHA256_Final(str, ctx);	break;
+  case MD_TYPE_SHA384:	CC_SHA384_Final(str, ctx);	break;
+  case MD_TYPE_SHA512:	CC_SHA512_Final(str, ctx);	break;
+  default:						break;
+  }
+}
+
+static int
+md_digest_length(int type)
+{
+  switch (type) {
+  case MD_TYPE_MD5:	return 16;
+  case MD_TYPE_SHA1:	return 20;
+  case MD_TYPE_SHA256:	return 32;
+  case MD_TYPE_SHA384:	return 48;
+  case MD_TYPE_SHA512:	return 64;
+  default:		return 0;
+  }
+}
+
+static mrb_value
+lib_md_digest(mrb_state *mrb, const struct mrb_md *md)
+{
+  union ctx_union ctx;
+  unsigned char mdstr[MAX_DIGEST_LENGTH];
+
+  memcpy(&ctx, md->ctx, md_ctx_size(md->type));
+  md_final(md->type, mdstr, &ctx);
+  return mrb_str_new(mrb, (char *)mdstr, md_digest_length(md->type));
+}
+
+static mrb_value
+lib_md_digest_bang(mrb_state *mrb, struct mrb_md *md)
+{
+  unsigned char mdstr[MAX_DIGEST_LENGTH];
+
+  md_final(md->type, mdstr, md->ctx);
+  md_init(md->type, md->ctx);
+  return mrb_str_new(mrb, (char *)mdstr, md_digest_length(md->type));
+}
+
+static int
+lib_md_digest_length(const struct mrb_md *md)
+{
+  return md_digest_length(md->type);
+}
+
+static void
+lib_md_init(mrb_state *mrb, struct mrb_md *md, int type)
+{
+  int ctxsize;
+
+  ctxsize = md_ctx_size(type);
+  if (ctxsize == 0) {
+    mrb_raise(mrb, E_NOTIMP_ERROR, "not supported");
+  }
+  md->type = type;
+  md->ctx = NULL;
+  md->ctx = mrb_malloc(mrb, ctxsize);
+  md_init(type, md->ctx);
+}
+
+static void
+lib_md_init_copy(mrb_state *mrb, struct mrb_md *mdnew, struct mrb_md *mdold)
+{
+  lib_md_init(mrb, mdnew, mdold->type);
+}
+
+static void
+lib_md_reset(mrb_state *mrb, struct mrb_md *md)
+{
+  md_init(md->type, md->ctx);
+}
+
+static void
+lib_md_update(mrb_state *mrb, struct mrb_md *md, unsigned char *data, mrb_int len)
+{
+  if (sizeof(len) > sizeof(CC_LONG)) {
+    if (len != (CC_LONG)len) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "too long string (not supported yet)");
+    }
+  }
+  switch (md->type) {
+  case MD_TYPE_MD5:	CC_MD5_Update(md->ctx, data, len);	break;
+  case MD_TYPE_SHA1:	CC_SHA1_Update(md->ctx, data, len);	break;
+  case MD_TYPE_SHA256:	CC_SHA256_Update(md->ctx, data, len);	break;
+  case MD_TYPE_SHA384:	CC_SHA384_Update(md->ctx, data, len);	break;
+  case MD_TYPE_SHA512:	CC_SHA512_Update(md->ctx, data, len);	break;
+  default: break;
+  }
+}
+
+static int
+lib_hmac_block_length(const struct mrb_hmac *hmac)
+{
+  return md_block_length(hmac->type);
+}
+
+static mrb_value
+lib_hmac_digest(mrb_state *mrb, const struct mrb_hmac *hmac)
+{
+  CCHmacContext ctx;
+  unsigned char str[MAX_DIGEST_LENGTH];
+
+  memcpy(&ctx, &hmac->ctx, sizeof(ctx));
+  CCHmacFinal(&ctx, str);
+  return mrb_str_new(mrb, (const char *)str, md_digest_length(hmac->type));
+}
+
+static int
+lib_hmac_digest_length(const struct mrb_hmac *hmac)
+{
+  return md_digest_length(hmac->type);
+}
+
+static void
+lib_hmac_init(mrb_state *mrb, struct mrb_hmac *hmac, int type, const unsigned char *key, mrb_int keylen)
+{
+  CCHmacAlgorithm algorithm;
+
+#if MRB_INT_MAX > SIZE_MAX
+  if (len > SIZE_MAX) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "too long key");
+  }
+#endif
+  switch (type) {
+  case MD_TYPE_MD5:    algorithm = kCCHmacAlgMD5;    break;
+  case MD_TYPE_SHA1:   algorithm = kCCHmacAlgSHA1;   break;
+  case MD_TYPE_SHA256: algorithm = kCCHmacAlgSHA256; break;
+  case MD_TYPE_SHA384: algorithm = kCCHmacAlgSHA384; break;
+  case MD_TYPE_SHA512: algorithm = kCCHmacAlgSHA512; break;
+  default:
+    mrb_raisef(mrb, E_RUNTIME_ERROR, "mruby-digest: internal error: unexpected HMAC type: %S", mrb_fixnum_value(type));
+    algorithm = 0;
+    break;
+  }
+  hmac->type = type;
+  CCHmacInit(&hmac->ctx, algorithm, key, keylen);
+}
+
+static void
+lib_hmac_update(mrb_state *mrb, struct mrb_hmac *hmac, unsigned char *data, mrb_int len)
+{
+#if MRB_INT_MAX > SIZE_MAX
+  if (len > SIZE_MAX) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "too long string");
+  }
+#endif
+  CCHmacUpdate(&hmac->ctx, data, len);
+}
+
+#endif
+
+static void
+basecheck(mrb_state *mrb, mrb_value self, struct mrb_md **mdp)
+{
+  struct RClass *c;
+  struct mrb_md *md;
+  mrb_value t;
+
+  c = mrb_obj_class(mrb, self);
+  t = mrb_const_get(mrb, mrb_obj_value(c), mrb_intern_lit(mrb, TYPESYM));
+  if (mrb_nil_p(t)) {
+    mrb_raise(mrb, E_NOTIMP_ERROR, "Digest::Base is an abstract class");
+  }
+  md = (struct mrb_md *)DATA_PTR(self);
+  if (!md) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "no md found (BUG?)");
+  }
+  if (mdp) *mdp = md;
+}
+
+static mrb_value
+mrb_digest_block_length(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_md *md;
+
+  basecheck(mrb, self, &md);
+  return mrb_fixnum_value(lib_md_block_length(md));
+}
+
+static mrb_value
+mrb_digest_digest(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_md *md;
+
+  md = (struct mrb_md *)DATA_PTR(self);
+  if (!md) return mrb_nil_value();
+  return lib_md_digest(mrb, md);
+}
+
+static mrb_value
+mrb_digest_digest_bang(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_md *md;
+
+  md = (struct mrb_md *)DATA_PTR(self);
+  if (!md) return mrb_nil_value();
+  return lib_md_digest_bang(mrb, md);
+}
+
+static mrb_value
+mrb_digest_digest_length(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_md *md;
+
+  basecheck(mrb, self, &md);
+  return mrb_fixnum_value(lib_md_digest_length(md));
+}
+
+static mrb_value
+digest2hexdigest(mrb_state *mrb, mrb_value b)
+{
+  mrb_value h;
+  int i, len;
+  char *bp, buf[3];
+
+  bp = RSTRING_PTR(b);
+  len = RSTRING_LEN(b);
+  h = mrb_str_buf_new(mrb, len * 2);
+  for (i = 0; i < len; i++) {
+    snprintf(buf, sizeof(buf), "%02x", (unsigned char )bp[i]);
+    mrb_str_buf_cat(mrb, h, buf, 2);
+  }
+  return h;
+}
+
+static mrb_value
+mrb_digest_hexdigest(mrb_state *mrb, mrb_value self)
+{
+  return digest2hexdigest(mrb, mrb_digest_digest(mrb, self));
+}
+
+static mrb_value
+mrb_digest_init(mrb_state *mrb, mrb_value self)
+{
+  struct RClass *c;
+  struct mrb_md *md;
+  mrb_value t;
+
+  md = (struct mrb_md *)DATA_PTR(self);
+  if (md) {
+    lib_md_free(mrb, md);
+  }
+  DATA_TYPE(self) = &mrb_md_type;
+  DATA_PTR(self) = NULL;
+
+  c = mrb_obj_class(mrb, self);
+  if (!mrb_const_defined(mrb, mrb_obj_value(c), mrb_intern_lit(mrb, TYPESYM))) {
+    mrb_raise(mrb, E_NOTIMP_ERROR, "Digest::Base is an abstract class");
+  }
+  t = mrb_const_get(mrb, mrb_obj_value(c), mrb_intern_lit(mrb, TYPESYM));
+#if 0
+  if (lib_md_supported(t)) {
+    mrb_raise(mrb, E_NOTIMP_ERROR, "unknown algorithm");
+  }
+#endif
+
+  md = (struct mrb_md *)mrb_malloc(mrb, sizeof(*md));
+  DATA_PTR(self) = md;
+  lib_md_init(mrb, md, mrb_fixnum(t));
+  return self;
+}
+
+static mrb_value
+mrb_digest_init_copy(mrb_state *mrb, mrb_value copy)
+{
+  struct mrb_md *m1, *m2;
+  mrb_value src;
+
+  mrb_get_args(mrb, "o", &src);
+  if (mrb_obj_equal(mrb, copy, src)) return copy;
+  if (!mrb_obj_is_instance_of(mrb, src, mrb_obj_class(mrb, copy))) {
+    mrb_raise(mrb, E_TYPE_ERROR, "wrong argument class");
+  }
+  if (!DATA_PTR(copy)) {
+    DATA_PTR(copy) = mrb_malloc(mrb, sizeof(struct mrb_md));
+    DATA_TYPE(copy) = &mrb_md_type;
+  }
+  m1 = DATA_PTR(src);
+  m2 = DATA_PTR(copy);
+  lib_md_init_copy(mrb, m2, m1);
+  return copy;
+}
+
+static mrb_value
+mrb_digest_reset(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_md *md;
+
+  md = (struct mrb_md *)DATA_PTR(self);
+  if (!md) return mrb_nil_value();
+  lib_md_reset(mrb, md);
+  return self;
+}
+
+static mrb_value
+mrb_digest_update(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_md *md;
+  mrb_int len;
+  char *str;
+
+  md = (struct mrb_md *)DATA_PTR(self);
+  if (!md) return mrb_nil_value();
+  mrb_get_args(mrb, "s", &str, &len);
+  lib_md_update(mrb, md, (unsigned char *)str, len);
+  return self;
+}
+
+static mrb_value
+mrb_hmac_block_length(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_hmac *hmac;
+
+  hmac = (struct mrb_hmac *)DATA_PTR(self);
+  if (!hmac) return mrb_nil_value();
+  return mrb_fixnum_value(lib_hmac_block_length(hmac));
+}
+
+static mrb_value
+mrb_hmac_digest(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_hmac *hmac;
+
+  hmac = (struct mrb_hmac *)DATA_PTR(self);
+  if (!hmac) return mrb_nil_value();
+  return lib_hmac_digest(mrb, hmac);
+}
+
+static mrb_value
+mrb_hmac_digest_length(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_hmac *hmac;
+
+  hmac = (struct mrb_hmac *)DATA_PTR(self);
+  if (!hmac) return mrb_nil_value();
+  return mrb_fixnum_value(lib_hmac_digest_length(hmac));
+}
+
+static mrb_value
+mrb_hmac_hexdigest(mrb_state *mrb, mrb_value self)
+{
+  return digest2hexdigest(mrb, mrb_hmac_digest(mrb, self));
+}
+
+static mrb_value
+mrb_hmac_init(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_hmac *hmac;
+  mrb_value digest, t;
+  mrb_int keylen;
+  char *key;
+
+  hmac = (struct mrb_hmac *)DATA_PTR(self);
+  if (hmac) {
+    lib_hmac_free(mrb, hmac);
+  }
+  DATA_TYPE(self) = &mrb_hmac_type;
+  DATA_PTR(self) = NULL;
+
+  mrb_get_args(mrb, "so", &key, &keylen, &digest);
+  t = mrb_const_get(mrb, digest, mrb_intern_lit(mrb, TYPESYM));
+  if (mrb_nil_p(t)) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "not a digester");
+  }
+
+  hmac = (struct mrb_hmac *)mrb_malloc(mrb, sizeof(*hmac));
+  DATA_PTR(self) = hmac;
+  lib_hmac_init(mrb, hmac, mrb_fixnum(t), (unsigned char *)key, keylen);
+  return self;
+}
+
+static mrb_value
+mrb_hmac_init_copy(mrb_state *mrb, mrb_value copy)
+{
+  mrb_raise(mrb, E_RUNTIME_ERROR, "cannot duplicate HMAC");
+  return copy;
+}
+
+static mrb_value
+mrb_hmac_update(mrb_state *mrb, mrb_value self)
+{
+  struct mrb_hmac *hmac;
+  mrb_int len;
+  char *str;
+
+  hmac = (struct mrb_hmac *)DATA_PTR(self);
+  if (!hmac) return mrb_nil_value();
+  mrb_get_args(mrb, "s", &str, &len);
+  lib_hmac_update(mrb, hmac, (unsigned char *)str, len);
+  return self;
+}
+
+
+void
+mrb_mruby_digest_gem_init(mrb_state *mrb)
+{
+  struct RClass *b, *d, *h;
+
+  lib_init();
+
+  d = mrb_define_module(mrb, "Digest");
+
+  b = mrb_define_class_under(mrb, d, "Base", mrb->object_class);
+  mrb_define_method(mrb, b, "block_length",    mrb_digest_block_length,  MRB_ARGS_NONE());
+  mrb_define_method(mrb, b, "digest",          mrb_digest_digest,        MRB_ARGS_NONE());
+  mrb_define_method(mrb, b, "digest!",         mrb_digest_digest_bang,   MRB_ARGS_NONE()); /* XXX: can be defined in mrblib... */
+  mrb_define_method(mrb, b, "digest_length",   mrb_digest_digest_length, MRB_ARGS_NONE());
+  //mrb_define_method(mrb, b, "file",            mrb_digest_file,          MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, b, "hexdigest",       mrb_digest_hexdigest,     MRB_ARGS_NONE());
+  //mrb_define_method(mrb, b, "hexdigest!",      mrb_digest_hexdigest_bang, MRB_ARGS_NONE()); /* XXX: can be defined in mrblib... */
+  mrb_define_method(mrb, b, "initialize",      mrb_digest_init,          MRB_ARGS_NONE());
+  mrb_define_method(mrb, b, "initialize_copy", mrb_digest_init_copy,     MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, b, "reset",           mrb_digest_reset,         MRB_ARGS_NONE());
+  mrb_define_method(mrb, b, "update",          mrb_digest_update,        MRB_ARGS_REQ(1));
+
+#define DEFCLASS(n)						\
+do {								\
+  struct RClass *a = mrb_define_class_under(mrb, d, #n, b);	\
+  MRB_SET_INSTANCE_TT(a, MRB_TT_DATA);				\
+  mrb_define_const(mrb, a, TYPESYM, mrb_fixnum_value(MD_TYPE_##n));	\
+} while (0)
+
+#ifdef HAVE_MD5
+  DEFCLASS(MD5);
+#endif
+#ifdef HAVE_RMD160
+  DEFCLASS(RMD160);
+#endif
+#ifdef HAVE_SHA1
+  DEFCLASS(SHA1);
+#endif
+#ifdef HAVE_SHA256
+  DEFCLASS(SHA256);
+#endif
+#ifdef HAVE_SHA384
+  DEFCLASS(SHA384);
+#endif
+#ifdef HAVE_SHA512
+  DEFCLASS(SHA512);
+#endif
+
+  h = mrb_define_class_under(mrb, d, "HMAC", mrb->object_class);
+  MRB_SET_INSTANCE_TT(h, MRB_TT_DATA);
+  mrb_define_method(mrb, h, "block_length",    mrb_hmac_block_length,  MRB_ARGS_NONE());
+  mrb_define_method(mrb, h, "digest",          mrb_hmac_digest,        MRB_ARGS_NONE());
+  mrb_define_method(mrb, h, "digest_length",   mrb_hmac_digest_length, MRB_ARGS_NONE());
+  mrb_define_method(mrb, h, "hexdigest",       mrb_hmac_hexdigest,     MRB_ARGS_NONE());
+  mrb_define_method(mrb, h, "initialize",      mrb_hmac_init,          MRB_ARGS_REQ(2));
+  mrb_define_method(mrb, h, "initialize_copy", mrb_hmac_init_copy,     MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, h, "update",          mrb_hmac_update,        MRB_ARGS_REQ(1));
+}
+
+void
+mrb_mruby_digest_gem_final(mrb_state *mrb)
+{
+}

--- a/deps/mruby-digest/src/picohash.h
+++ b/deps/mruby-digest/src/picohash.h
@@ -1,0 +1,685 @@
+/*
+ * Copyright (c) 2015 Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *
+ * The MD5 implementation is based on the reference implementation found in RFC
+ * 1321, provided under the following license:
+ *
+ * Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
+ * rights reserved.
+ *
+ * License to copy and use this software is granted provided that it
+ * is identified as the "RSA Data Security, Inc. MD5 Message-Digest
+ * Algorithm" in all material mentioning or referencing this software
+ * or this function.
+ *
+ * License is also granted to make and use derivative works provided
+ * that such works are identified as "derived from the RSA Data
+ * Security, Inc. MD5 Message-Digest Algorithm" in all material
+ * mentioning or referencing the derived work.
+ *
+ * RSA Data Security, Inc. makes no representations concerning either
+ * the merchantability of this software or the suitability of this
+ * software for any particular purpose. It is provided "as is"
+ * without express or implied warranty of any kind.
+ *
+ * These notices must be retained in any copies of any part of this
+ * documentation and/or software.
+ *
+ *
+ * The SHA1 implementation is based on the reference implementation found in RFC
+ * 6234, provided under the following license:
+ *
+ * Copyright (c) 2011 IETF Trust and the persons identified as
+ * authors of the code.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above
+ *   copyright notice, this list of conditions and
+ *   the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of Internet Society, IETF or IETF Trust, nor
+ *   the names of specific contributors, may be used to endorse or
+ *   promote products derived from this software without specific
+ *   prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _picohash_h_
+#define _picohash_h_
+
+#include <assert.h>
+#include <inttypes.h>
+#include <string.h>
+
+#define PICOHASH_MD5_BLOCK_LENGTH 64
+#define PICOHASH_MD5_DIGEST_LENGTH 16
+
+typedef struct {
+    uint32_t state[4];
+    uint32_t count[2];
+    unsigned char buffer[64];
+} _picohash_md5_ctx_t;
+
+static void _picohash_md5_init(_picohash_md5_ctx_t *ctx);
+static void _picohash_md5_update(_picohash_md5_ctx_t *ctx, const void *input, size_t len);
+static void _picohash_md5_final(_picohash_md5_ctx_t *ctx, void *digest);
+
+#define PICOHASH_SHA1_BLOCK_LENGTH 64
+#define PICOHASH_SHA1_DIGEST_LENGTH 20
+
+typedef struct {
+    uint32_t Intermediate_Hash[PICOHASH_SHA1_DIGEST_LENGTH / 4];
+    uint32_t Length_Low;
+    uint32_t Length_High;
+    int_least16_t Message_Block_Index;
+    uint8_t Message_Block[64];
+} _picohash_sha1_ctx_t;
+
+static void _picohash_sha1_init(_picohash_sha1_ctx_t *ctx);
+static void _picohash_sha1_update(_picohash_sha1_ctx_t *ctx, const void *input, size_t len);
+static void _picohash_sha1_final(_picohash_sha1_ctx_t *ctx, void *digest);
+
+#define PICOHASH_MAX_BLOCK_LENGTH 64
+#define PICOHASH_MAX_DIGEST_LENGTH 20
+
+typedef struct {
+    union {
+        _picohash_md5_ctx_t _md5;
+        _picohash_sha1_ctx_t _sha1;
+    };
+    size_t block_length;
+    size_t digest_length;
+    void (*_reset)(void *ctx);
+    void (*_update)(void *ctx, const void *input, size_t len);
+    void (*_final)(void *ctx, void *digest);
+    struct {
+        unsigned char key[PICOHASH_MAX_BLOCK_LENGTH];
+        void (*hash_reset)(void *ctx);
+        void (*hash_final)(void *ctx, void *digest);
+    } _hmac;
+} picohash_ctx_t;
+
+static void picohash_init_md5(picohash_ctx_t *ctx);
+static void picohash_init_sha1(picohash_ctx_t *ctx);
+static void picohash_update(picohash_ctx_t *ctx, const void *input, size_t len);
+static void picohash_final(picohash_ctx_t *ctx, void *digest);
+static void picohash_reset(picohash_ctx_t *ctx);
+
+static void picohash_init_hmac(picohash_ctx_t *ctx, void (*initf)(picohash_ctx_t *), const void *key, size_t key_len);
+
+/* following are private definitions */
+
+/* Encodes input (uint32_t) into output (unsigned char). Assumes len is
+  a multiple of 4.
+ */
+static inline void _picohash_md5_encode(unsigned char *output, const uint32_t *input, unsigned int len)
+{
+    unsigned int i, j;
+
+    for (i = 0, j = 0; j < len; i++, j += 4) {
+        output[j] = (unsigned char)(input[i] & 0xff);
+        output[j + 1] = (unsigned char)((input[i] >> 8) & 0xff);
+        output[j + 2] = (unsigned char)((input[i] >> 16) & 0xff);
+        output[j + 3] = (unsigned char)((input[i] >> 24) & 0xff);
+    }
+}
+
+/* Decodes input (unsigned char) into output (uint32_t). Assumes len is
+  a multiple of 4.
+ */
+static inline void _picohash_md5_decode(uint32_t *output, const unsigned char *input, unsigned int len)
+{
+    unsigned int i, j;
+
+    for (i = 0, j = 0; j < len; i++, j += 4)
+        output[i] = ((uint32_t)input[j]) | (((uint32_t)input[j + 1]) << 8) | (((uint32_t)input[j + 2]) << 16) |
+                    (((uint32_t)input[j + 3]) << 24);
+}
+
+/* MD5 basic transformation. Transforms state based on block.
+ */
+static inline void _picohash_md5_transform(uint32_t state[4], const unsigned char block[64])
+{
+#define _PICOHASH_MD5_S11 7
+#define _PICOHASH_MD5_S12 12
+#define _PICOHASH_MD5_S13 17
+#define _PICOHASH_MD5_S14 22
+#define _PICOHASH_MD5_S21 5
+#define _PICOHASH_MD5_S22 9
+#define _PICOHASH_MD5_S23 14
+#define _PICOHASH_MD5_S24 20
+#define _PICOHASH_MD5_S31 4
+#define _PICOHASH_MD5_S32 11
+#define _PICOHASH_MD5_S33 16
+#define _PICOHASH_MD5_S34 23
+#define _PICOHASH_MD5_S41 6
+#define _PICOHASH_MD5_S42 10
+#define _PICOHASH_MD5_S43 15
+#define _PICOHASH_MD5_S44 21
+
+/* F, G, H and I are basic MD5 functions.
+ */
+#define _PICOHASH_MD5_F(x, y, z) (((x) & (y)) | ((~x) & (z)))
+#define _PICOHASH_MD5_G(x, y, z) (((x) & (z)) | ((y) & (~z)))
+#define _PICOHASH_MD5_H(x, y, z) ((x) ^ (y) ^ (z))
+#define _PICOHASH_MD5_I(x, y, z) ((y) ^ ((x) | (~z)))
+
+/* ROTATE_LEFT rotates x left n bits.
+ */
+#define _PICOHASH_MD5_ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+
+/* FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
+Rotation is separate from addition to prevent recomputation.
+ */
+#define _PICOHASH_MD5_FF(a, b, c, d, x, s, ac)                                                                                     \
+    {                                                                                                                              \
+        (a) += _PICOHASH_MD5_F((b), (c), (d)) + (x) + (uint32_t)(ac);                                                              \
+        (a) = _PICOHASH_MD5_ROTATE_LEFT((a), (s));                                                                                 \
+        (a) += (b);                                                                                                                \
+    }
+#define _PICOHASH_MD5_GG(a, b, c, d, x, s, ac)                                                                                     \
+    {                                                                                                                              \
+        (a) += _PICOHASH_MD5_G((b), (c), (d)) + (x) + (uint32_t)(ac);                                                              \
+        (a) = _PICOHASH_MD5_ROTATE_LEFT((a), (s));                                                                                 \
+        (a) += (b);                                                                                                                \
+    }
+#define _PICOHASH_MD5_HH(a, b, c, d, x, s, ac)                                                                                     \
+    {                                                                                                                              \
+        (a) += _PICOHASH_MD5_H((b), (c), (d)) + (x) + (uint32_t)(ac);                                                              \
+        (a) = _PICOHASH_MD5_ROTATE_LEFT((a), (s));                                                                                 \
+        (a) += (b);                                                                                                                \
+    }
+#define _PICOHASH_MD5_II(a, b, c, d, x, s, ac)                                                                                     \
+    {                                                                                                                              \
+        (a) += _PICOHASH_MD5_I((b), (c), (d)) + (x) + (uint32_t)(ac);                                                              \
+        (a) = _PICOHASH_MD5_ROTATE_LEFT((a), (s));                                                                                 \
+        (a) += (b);                                                                                                                \
+    }
+
+    uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+
+    _picohash_md5_decode(x, block, 64);
+
+    /* Round 1 */
+    _PICOHASH_MD5_FF(a, b, c, d, x[0], _PICOHASH_MD5_S11, 0xd76aa478);  /* 1 */
+    _PICOHASH_MD5_FF(d, a, b, c, x[1], _PICOHASH_MD5_S12, 0xe8c7b756);  /* 2 */
+    _PICOHASH_MD5_FF(c, d, a, b, x[2], _PICOHASH_MD5_S13, 0x242070db);  /* 3 */
+    _PICOHASH_MD5_FF(b, c, d, a, x[3], _PICOHASH_MD5_S14, 0xc1bdceee);  /* 4 */
+    _PICOHASH_MD5_FF(a, b, c, d, x[4], _PICOHASH_MD5_S11, 0xf57c0faf);  /* 5 */
+    _PICOHASH_MD5_FF(d, a, b, c, x[5], _PICOHASH_MD5_S12, 0x4787c62a);  /* 6 */
+    _PICOHASH_MD5_FF(c, d, a, b, x[6], _PICOHASH_MD5_S13, 0xa8304613);  /* 7 */
+    _PICOHASH_MD5_FF(b, c, d, a, x[7], _PICOHASH_MD5_S14, 0xfd469501);  /* 8 */
+    _PICOHASH_MD5_FF(a, b, c, d, x[8], _PICOHASH_MD5_S11, 0x698098d8);  /* 9 */
+    _PICOHASH_MD5_FF(d, a, b, c, x[9], _PICOHASH_MD5_S12, 0x8b44f7af);  /* 10 */
+    _PICOHASH_MD5_FF(c, d, a, b, x[10], _PICOHASH_MD5_S13, 0xffff5bb1); /* 11 */
+    _PICOHASH_MD5_FF(b, c, d, a, x[11], _PICOHASH_MD5_S14, 0x895cd7be); /* 12 */
+    _PICOHASH_MD5_FF(a, b, c, d, x[12], _PICOHASH_MD5_S11, 0x6b901122); /* 13 */
+    _PICOHASH_MD5_FF(d, a, b, c, x[13], _PICOHASH_MD5_S12, 0xfd987193); /* 14 */
+    _PICOHASH_MD5_FF(c, d, a, b, x[14], _PICOHASH_MD5_S13, 0xa679438e); /* 15 */
+    _PICOHASH_MD5_FF(b, c, d, a, x[15], _PICOHASH_MD5_S14, 0x49b40821); /* 16 */
+
+    /* Round 2 */
+    _PICOHASH_MD5_GG(a, b, c, d, x[1], _PICOHASH_MD5_S21, 0xf61e2562);  /* 17 */
+    _PICOHASH_MD5_GG(d, a, b, c, x[6], _PICOHASH_MD5_S22, 0xc040b340);  /* 18 */
+    _PICOHASH_MD5_GG(c, d, a, b, x[11], _PICOHASH_MD5_S23, 0x265e5a51); /* 19 */
+    _PICOHASH_MD5_GG(b, c, d, a, x[0], _PICOHASH_MD5_S24, 0xe9b6c7aa);  /* 20 */
+    _PICOHASH_MD5_GG(a, b, c, d, x[5], _PICOHASH_MD5_S21, 0xd62f105d);  /* 21 */
+    _PICOHASH_MD5_GG(d, a, b, c, x[10], _PICOHASH_MD5_S22, 0x2441453);  /* 22 */
+    _PICOHASH_MD5_GG(c, d, a, b, x[15], _PICOHASH_MD5_S23, 0xd8a1e681); /* 23 */
+    _PICOHASH_MD5_GG(b, c, d, a, x[4], _PICOHASH_MD5_S24, 0xe7d3fbc8);  /* 24 */
+    _PICOHASH_MD5_GG(a, b, c, d, x[9], _PICOHASH_MD5_S21, 0x21e1cde6);  /* 25 */
+    _PICOHASH_MD5_GG(d, a, b, c, x[14], _PICOHASH_MD5_S22, 0xc33707d6); /* 26 */
+    _PICOHASH_MD5_GG(c, d, a, b, x[3], _PICOHASH_MD5_S23, 0xf4d50d87);  /* 27 */
+    _PICOHASH_MD5_GG(b, c, d, a, x[8], _PICOHASH_MD5_S24, 0x455a14ed);  /* 28 */
+    _PICOHASH_MD5_GG(a, b, c, d, x[13], _PICOHASH_MD5_S21, 0xa9e3e905); /* 29 */
+    _PICOHASH_MD5_GG(d, a, b, c, x[2], _PICOHASH_MD5_S22, 0xfcefa3f8);  /* 30 */
+    _PICOHASH_MD5_GG(c, d, a, b, x[7], _PICOHASH_MD5_S23, 0x676f02d9);  /* 31 */
+    _PICOHASH_MD5_GG(b, c, d, a, x[12], _PICOHASH_MD5_S24, 0x8d2a4c8a); /* 32 */
+
+    /* Round 3 */
+    _PICOHASH_MD5_HH(a, b, c, d, x[5], _PICOHASH_MD5_S31, 0xfffa3942);  /* 33 */
+    _PICOHASH_MD5_HH(d, a, b, c, x[8], _PICOHASH_MD5_S32, 0x8771f681);  /* 34 */
+    _PICOHASH_MD5_HH(c, d, a, b, x[11], _PICOHASH_MD5_S33, 0x6d9d6122); /* 35 */
+    _PICOHASH_MD5_HH(b, c, d, a, x[14], _PICOHASH_MD5_S34, 0xfde5380c); /* 36 */
+    _PICOHASH_MD5_HH(a, b, c, d, x[1], _PICOHASH_MD5_S31, 0xa4beea44);  /* 37 */
+    _PICOHASH_MD5_HH(d, a, b, c, x[4], _PICOHASH_MD5_S32, 0x4bdecfa9);  /* 38 */
+    _PICOHASH_MD5_HH(c, d, a, b, x[7], _PICOHASH_MD5_S33, 0xf6bb4b60);  /* 39 */
+    _PICOHASH_MD5_HH(b, c, d, a, x[10], _PICOHASH_MD5_S34, 0xbebfbc70); /* 40 */
+    _PICOHASH_MD5_HH(a, b, c, d, x[13], _PICOHASH_MD5_S31, 0x289b7ec6); /* 41 */
+    _PICOHASH_MD5_HH(d, a, b, c, x[0], _PICOHASH_MD5_S32, 0xeaa127fa);  /* 42 */
+    _PICOHASH_MD5_HH(c, d, a, b, x[3], _PICOHASH_MD5_S33, 0xd4ef3085);  /* 43 */
+    _PICOHASH_MD5_HH(b, c, d, a, x[6], _PICOHASH_MD5_S34, 0x4881d05);   /* 44 */
+    _PICOHASH_MD5_HH(a, b, c, d, x[9], _PICOHASH_MD5_S31, 0xd9d4d039);  /* 45 */
+    _PICOHASH_MD5_HH(d, a, b, c, x[12], _PICOHASH_MD5_S32, 0xe6db99e5); /* 46 */
+    _PICOHASH_MD5_HH(c, d, a, b, x[15], _PICOHASH_MD5_S33, 0x1fa27cf8); /* 47 */
+    _PICOHASH_MD5_HH(b, c, d, a, x[2], _PICOHASH_MD5_S34, 0xc4ac5665);  /* 48 */
+
+    /* Round 4 */
+    _PICOHASH_MD5_II(a, b, c, d, x[0], _PICOHASH_MD5_S41, 0xf4292244);  /* 49 */
+    _PICOHASH_MD5_II(d, a, b, c, x[7], _PICOHASH_MD5_S42, 0x432aff97);  /* 50 */
+    _PICOHASH_MD5_II(c, d, a, b, x[14], _PICOHASH_MD5_S43, 0xab9423a7); /* 51 */
+    _PICOHASH_MD5_II(b, c, d, a, x[5], _PICOHASH_MD5_S44, 0xfc93a039);  /* 52 */
+    _PICOHASH_MD5_II(a, b, c, d, x[12], _PICOHASH_MD5_S41, 0x655b59c3); /* 53 */
+    _PICOHASH_MD5_II(d, a, b, c, x[3], _PICOHASH_MD5_S42, 0x8f0ccc92);  /* 54 */
+    _PICOHASH_MD5_II(c, d, a, b, x[10], _PICOHASH_MD5_S43, 0xffeff47d); /* 55 */
+    _PICOHASH_MD5_II(b, c, d, a, x[1], _PICOHASH_MD5_S44, 0x85845dd1);  /* 56 */
+    _PICOHASH_MD5_II(a, b, c, d, x[8], _PICOHASH_MD5_S41, 0x6fa87e4f);  /* 57 */
+    _PICOHASH_MD5_II(d, a, b, c, x[15], _PICOHASH_MD5_S42, 0xfe2ce6e0); /* 58 */
+    _PICOHASH_MD5_II(c, d, a, b, x[6], _PICOHASH_MD5_S43, 0xa3014314);  /* 59 */
+    _PICOHASH_MD5_II(b, c, d, a, x[13], _PICOHASH_MD5_S44, 0x4e0811a1); /* 60 */
+    _PICOHASH_MD5_II(a, b, c, d, x[4], _PICOHASH_MD5_S41, 0xf7537e82);  /* 61 */
+    _PICOHASH_MD5_II(d, a, b, c, x[11], _PICOHASH_MD5_S42, 0xbd3af235); /* 62 */
+    _PICOHASH_MD5_II(c, d, a, b, x[2], _PICOHASH_MD5_S43, 0x2ad7d2bb);  /* 63 */
+    _PICOHASH_MD5_II(b, c, d, a, x[9], _PICOHASH_MD5_S44, 0xeb86d391);  /* 64 */
+
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+
+    /* Zeroize sensitive information. */
+    memset(x, 0, sizeof(x));
+
+#undef _PICOHASH_MD5_S11
+#undef _PICOHASH_MD5_S12
+#undef _PICOHASH_MD5_S13
+#undef _PICOHASH_MD5_S14
+#undef _PICOHASH_MD5_S21
+#undef _PICOHASH_MD5_S22
+#undef _PICOHASH_MD5_S23
+#undef _PICOHASH_MD5_S24
+#undef _PICOHASH_MD5_S31
+#undef _PICOHASH_MD5_S32
+#undef _PICOHASH_MD5_S33
+#undef _PICOHASH_MD5_S34
+#undef _PICOHASH_MD5_S41
+#undef _PICOHASH_MD5_S42
+#undef _PICOHASH_MD5_S43
+#undef _PICOHASH_MD5_S44
+#undef _PICOHASH_MD5_F
+#undef _PICOHASH_MD5_G
+#undef _PICOHASH_MD5_H
+#undef _PICOHASH_MD5_I
+#undef _PICOHASH_MD5_ROTATE_LEFT
+#undef _PICOHASH_MD5_FF
+#undef _PICOHASH_MD5_GG
+#undef _PICOHASH_MD5_HH
+#undef _PICOHASH_MD5_II
+}
+
+/* MD5 initialization. Begins an MD5 operation, writing a new context.
+ */
+inline void _picohash_md5_init(_picohash_md5_ctx_t *context)
+{
+    context->count[0] = context->count[1] = 0;
+    /* Load magic initialization constants. */
+    context->state[0] = 0x67452301;
+    context->state[1] = 0xefcdab89;
+    context->state[2] = 0x98badcfe;
+    context->state[3] = 0x10325476;
+}
+
+/* MD5 block update operation. Continues an MD5 message-digest
+  operation, processing another message block, and updating the
+  context.
+ */
+inline void _picohash_md5_update(_picohash_md5_ctx_t *context, const void *_input, size_t inputLen)
+{
+    const unsigned char *input = _input;
+    size_t i, index, partLen;
+
+    /* Compute number of bytes mod 64 */
+    index = (unsigned int)((context->count[0] >> 3) & 0x3F);
+
+    /* Update number of bits */
+    if ((context->count[0] += ((uint32_t)inputLen << 3)) < ((uint32_t)inputLen << 3))
+        context->count[1]++;
+    context->count[1] += ((uint32_t)inputLen >> 29);
+
+    partLen = 64 - index;
+
+    /* Transform as many times as possible. */
+    if (inputLen >= partLen) {
+        memcpy(&context->buffer[index], input, partLen);
+        _picohash_md5_transform(context->state, context->buffer);
+
+        for (i = partLen; i + 63 < inputLen; i += 64)
+            _picohash_md5_transform(context->state, &input[i]);
+
+        index = 0;
+    } else
+        i = 0;
+
+    /* Buffer remaining input */
+    memcpy(&context->buffer[index], &input[i], inputLen - i);
+}
+
+/* MD5 finalization. Ends an MD5 message-digest operation, writing the
+  the message digest and zeroizing the context.
+ */
+inline void _picohash_md5_final(_picohash_md5_ctx_t *context, void *_digest)
+{
+    static const unsigned char PADDING[64] = {0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                              0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                              0,    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    unsigned char bits[8], *digest = _digest;
+    unsigned int index, padLen;
+
+    /* Save number of bits */
+    _picohash_md5_encode(bits, context->count, 8);
+
+    /* Pad out to 56 mod 64. */
+    index = (unsigned int)((context->count[0] >> 3) & 0x3f);
+    padLen = (index < 56) ? (56 - index) : (120 - index);
+    _picohash_md5_update(context, PADDING, padLen);
+
+    /* Append length (before padding) */
+    _picohash_md5_update(context, bits, 8);
+
+    /* Store state in digest */
+    _picohash_md5_encode(digest, context->state, 16);
+
+    /* Zeroize sensitive information. */
+    memset(context, 0, sizeof(*context));
+}
+
+static inline void _picohash_sha1_process_message_block(_picohash_sha1_ctx_t *context)
+{
+#define _PICOHASH_SHA1_Ch(x, y, z) (((x) & ((y) ^ (z))) ^ (z))
+#define _PICOHASH_SHA1_Maj(x, y, z) (((x) & ((y) | (z))) | ((y) & (z)))
+#define _PICOHASH_SHA1_Parity(x, y, z) ((x) ^ (y) ^ (z))
+#define _PICOHASH_SHA1_ROTL(bits, word) (((word) << (bits)) | ((word) >> (32 - (bits))))
+
+    /* Constants defined in FIPS 180-3, section 4.2.1 */
+    const uint32_t K[4] = {0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6};
+    int t;                  /* Loop counter */
+    uint32_t temp;          /* Temporary word value */
+    uint32_t W[80];         /* Word sequence */
+    uint32_t A, B, C, D, E; /* Word buffers */
+
+    /*
+     * Initialize the first 16 words in the array W
+     */
+    for (t = 0; t < 16; t++) {
+        W[t] = ((uint32_t)context->Message_Block[t * 4]) << 24;
+        W[t] |= ((uint32_t)context->Message_Block[t * 4 + 1]) << 16;
+        W[t] |= ((uint32_t)context->Message_Block[t * 4 + 2]) << 8;
+        W[t] |= ((uint32_t)context->Message_Block[t * 4 + 3]);
+    }
+
+    for (t = 16; t < 80; t++)
+        W[t] = _PICOHASH_SHA1_ROTL(1, W[t - 3] ^ W[t - 8] ^ W[t - 14] ^ W[t - 16]);
+
+    A = context->Intermediate_Hash[0];
+    B = context->Intermediate_Hash[1];
+    C = context->Intermediate_Hash[2];
+    D = context->Intermediate_Hash[3];
+    E = context->Intermediate_Hash[4];
+
+    for (t = 0; t < 20; t++) {
+        temp = _PICOHASH_SHA1_ROTL(5, A) + _PICOHASH_SHA1_Ch(B, C, D) + E + W[t] + K[0];
+        E = D;
+        D = C;
+        C = _PICOHASH_SHA1_ROTL(30, B);
+        B = A;
+        A = temp;
+    }
+
+    for (t = 20; t < 40; t++) {
+        temp = _PICOHASH_SHA1_ROTL(5, A) + _PICOHASH_SHA1_Parity(B, C, D) + E + W[t] + K[1];
+        E = D;
+        D = C;
+        C = _PICOHASH_SHA1_ROTL(30, B);
+        B = A;
+        A = temp;
+    }
+
+    for (t = 40; t < 60; t++) {
+        temp = _PICOHASH_SHA1_ROTL(5, A) + _PICOHASH_SHA1_Maj(B, C, D) + E + W[t] + K[2];
+        E = D;
+        D = C;
+        C = _PICOHASH_SHA1_ROTL(30, B);
+        B = A;
+        A = temp;
+    }
+
+    for (t = 60; t < 80; t++) {
+        temp = _PICOHASH_SHA1_ROTL(5, A) + _PICOHASH_SHA1_Parity(B, C, D) + E + W[t] + K[3];
+        E = D;
+        D = C;
+        C = _PICOHASH_SHA1_ROTL(30, B);
+        B = A;
+        A = temp;
+    }
+
+    context->Intermediate_Hash[0] += A;
+    context->Intermediate_Hash[1] += B;
+    context->Intermediate_Hash[2] += C;
+    context->Intermediate_Hash[3] += D;
+    context->Intermediate_Hash[4] += E;
+    context->Message_Block_Index = 0;
+
+#undef _PICOHASH_SHA1_Ch
+#undef _PICOHASH_SHA1_Maj
+#undef _PICOHASH_SHA1_Parity
+#undef _PICOHASH_SHA1_ROTL
+}
+
+static inline void _picohash_sha1_pad_message(_picohash_sha1_ctx_t *context, uint8_t Pad_Byte)
+{
+    /*
+     * Check to see if the current message block is too small to hold
+     * the initial padding bits and length.  If so, we will pad the
+     * block, process it, and then continue padding into a second
+     * block.
+     */
+    if (context->Message_Block_Index >= (PICOHASH_SHA1_BLOCK_LENGTH - 8)) {
+        context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+        while (context->Message_Block_Index < PICOHASH_SHA1_BLOCK_LENGTH)
+            context->Message_Block[context->Message_Block_Index++] = 0;
+
+        _picohash_sha1_process_message_block(context);
+    } else
+        context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+
+    while (context->Message_Block_Index < (PICOHASH_SHA1_BLOCK_LENGTH - 8))
+        context->Message_Block[context->Message_Block_Index++] = 0;
+
+    /*
+     * Store the message length as the last 8 octets
+     */
+    context->Message_Block[56] = (uint8_t)(context->Length_High >> 24);
+    context->Message_Block[57] = (uint8_t)(context->Length_High >> 16);
+    context->Message_Block[58] = (uint8_t)(context->Length_High >> 8);
+    context->Message_Block[59] = (uint8_t)(context->Length_High);
+    context->Message_Block[60] = (uint8_t)(context->Length_Low >> 24);
+    context->Message_Block[61] = (uint8_t)(context->Length_Low >> 16);
+    context->Message_Block[62] = (uint8_t)(context->Length_Low >> 8);
+    context->Message_Block[63] = (uint8_t)(context->Length_Low);
+
+    _picohash_sha1_process_message_block(context);
+}
+
+static inline void _picohash_sha1_finalize(_picohash_sha1_ctx_t *context, uint8_t Pad_Byte)
+{
+    int i;
+    _picohash_sha1_pad_message(context, Pad_Byte);
+    /* message may be sensitive, clear it out */
+    for (i = 0; i < PICOHASH_SHA1_BLOCK_LENGTH; ++i)
+        context->Message_Block[i] = 0;
+    context->Length_High = 0; /* and clear length */
+    context->Length_Low = 0;
+}
+
+inline void _picohash_sha1_init(_picohash_sha1_ctx_t *context)
+{
+    context->Length_High = context->Length_Low = 0;
+    context->Message_Block_Index = 0;
+
+    /* Initial Hash Values: FIPS 180-3 section 5.3.1 */
+    context->Intermediate_Hash[0] = 0x67452301;
+    context->Intermediate_Hash[1] = 0xEFCDAB89;
+    context->Intermediate_Hash[2] = 0x98BADCFE;
+    context->Intermediate_Hash[3] = 0x10325476;
+    context->Intermediate_Hash[4] = 0xC3D2E1F0;
+}
+
+inline void _picohash_sha1_update(_picohash_sha1_ctx_t *context, const void *_message_array, size_t length)
+{
+    const uint8_t *message_array = _message_array;
+    uint32_t addTemp;
+
+    while (length--) {
+        context->Message_Block[context->Message_Block_Index++] = *message_array;
+        addTemp = context->Length_Low;
+        if ((context->Length_Low += 8) < addTemp)
+            ++context->Length_High;
+        if (context->Message_Block_Index == PICOHASH_SHA1_BLOCK_LENGTH)
+            _picohash_sha1_process_message_block(context);
+
+        message_array++;
+    }
+}
+
+inline void _picohash_sha1_final(_picohash_sha1_ctx_t *context, void *_Message_Digest)
+{
+    unsigned char *Message_Digest = _Message_Digest;
+    int i;
+
+    _picohash_sha1_finalize(context, 0x80);
+
+    for (i = 0; i < PICOHASH_SHA1_DIGEST_LENGTH; ++i)
+        Message_Digest[i] = (uint8_t)(context->Intermediate_Hash[i >> 2] >> (8 * (3 - (i & 0x03))));
+}
+
+inline void picohash_init_md5(picohash_ctx_t *ctx)
+{
+    ctx->block_length = PICOHASH_MD5_BLOCK_LENGTH;
+    ctx->digest_length = PICOHASH_MD5_DIGEST_LENGTH;
+    ctx->_reset = (void *)_picohash_md5_init;
+    ctx->_update = (void *)_picohash_md5_update;
+    ctx->_final = (void *)_picohash_md5_final;
+
+    _picohash_md5_init(&ctx->_md5);
+}
+
+inline void picohash_init_sha1(picohash_ctx_t *ctx)
+{
+    ctx->block_length = PICOHASH_SHA1_BLOCK_LENGTH;
+    ctx->digest_length = PICOHASH_SHA1_DIGEST_LENGTH;
+    ctx->_reset = (void *)_picohash_sha1_init;
+    ctx->_update = (void *)_picohash_sha1_update;
+    ctx->_final = (void *)_picohash_sha1_final;
+    _picohash_sha1_init(&ctx->_sha1);
+}
+
+inline void picohash_update(picohash_ctx_t *ctx, const void *input, size_t len)
+{
+    ctx->_update(ctx, input, len);
+}
+
+inline void picohash_final(picohash_ctx_t *ctx, void *digest)
+{
+    ctx->_final(ctx, digest);
+}
+
+inline void picohash_reset(picohash_ctx_t *ctx)
+{
+    ctx->_reset(ctx);
+}
+
+static inline void _picohash_hmac_apply_key(picohash_ctx_t *ctx, unsigned char delta)
+{
+    size_t i;
+    for (i = 0; i != ctx->block_length; ++i)
+        ctx->_hmac.key[i] ^= delta;
+    picohash_update(ctx, ctx->_hmac.key, ctx->block_length);
+    for (i = 0; i != ctx->block_length; ++i)
+        ctx->_hmac.key[i] ^= delta;
+}
+
+static void _picohash_hmac_final(picohash_ctx_t *ctx, void *digest)
+{
+    unsigned char inner_digest[PICOHASH_MAX_DIGEST_LENGTH];
+
+    ctx->_hmac.hash_final(ctx, inner_digest);
+
+    ctx->_hmac.hash_reset(ctx);
+    _picohash_hmac_apply_key(ctx, 0x5c);
+    picohash_update(ctx, inner_digest, ctx->digest_length);
+    memset(inner_digest, 0, ctx->digest_length);
+
+    ctx->_hmac.hash_final(ctx, digest);
+}
+
+static inline void _picohash_hmac_reset(picohash_ctx_t *ctx)
+{
+    ctx->_hmac.hash_reset(ctx);
+    _picohash_hmac_apply_key(ctx, 0x36);
+}
+
+inline void picohash_init_hmac(picohash_ctx_t *ctx, void (*initf)(picohash_ctx_t *), const void *key, size_t key_len)
+{
+    initf(ctx);
+
+    memset(ctx->_hmac.key, 0, ctx->block_length);
+    if (key_len > ctx->block_length) {
+        /* hash the key if it is too long */
+        picohash_update(ctx, key, key_len);
+        picohash_final(ctx, ctx->_hmac.key);
+        ctx->_hmac.hash_reset(ctx);
+    } else {
+        memcpy(ctx->_hmac.key, key, key_len);
+    }
+
+    /* replace reset and final function */
+    ctx->_hmac.hash_reset = ctx->_reset;
+    ctx->_hmac.hash_final = ctx->_final;
+    ctx->_reset = (void *)_picohash_hmac_reset;
+    ctx->_final = (void *)_picohash_hmac_final;
+
+    /* start calculating the inner hash */
+    _picohash_hmac_apply_key(ctx, 0x36);
+}
+
+#endif

--- a/deps/mruby-digest/test/digest.rb
+++ b/deps/mruby-digest/test/digest.rb
@@ -1,0 +1,203 @@
+##
+# Digest Test
+
+if Object.const_defined?(:Digest)
+  assert('Digest') do
+    Digest.class == Module
+  end
+
+  assert('Digest::Base') do
+    Digest::Base.class == Class
+  end
+
+  assert('Digest::Base#new') do
+    e1 = nil
+    begin
+      Digest::Base.new
+    rescue NotImplementedError => e
+      e1 = e
+    end
+    e1.class == NotImplementedError
+  end
+
+  assert('Digest::MD5') do
+    Digest::MD5.class == Class
+  end
+
+  assert('Digest::MD5 superclass') do
+    Digest::MD5.superclass == Digest::Base
+  end
+
+  assert('Digest::MD5.digest') do
+    Digest::MD5.digest('ruby') == "X\xE5=\x13$\xEE\xF6&_\xDB\x97\xB0\x8E\xD9\xAA\xDF"
+  end
+
+  #assert('Digest::MD5.file')
+
+  assert('Digest::MD5.hexdigest') do
+    Digest::MD5.hexdigest('ruby') == "58e53d1324eef6265fdb97b08ed9aadf"
+  end
+
+  assert('Digest::MD5#update') do
+    d = Digest::MD5.new
+    d.update('ruby')
+    d.hexdigest == "58e53d1324eef6265fdb97b08ed9aadf"
+  end
+
+  assert('Digest::MD5#update 2') do
+    d = Digest::MD5.new
+    d.update('ruby')
+    d.update('digest')
+    d.hexdigest == "2ac1b3e3db06239e3244817f281450f1"
+  end
+
+  assert('Digest::MD5#<<') do
+    a = Digest::MD5.new
+    b = Digest::MD5.new
+    a.update('ruby')
+    b << "r" << "u" << "b" << "y"
+    a.hexdigest == b.hexdigest
+  end
+
+  assert('Digest::MD5#== with Digest::XXX') do
+    x1 = Digest::MD5.new.update("ruby")
+    x2 = Digest::MD5.new.update("ruby")
+    x3 = Digest::MD5.new.update("RUBY")
+    (x1 == x2) == true and
+    (x1 == x3) == false
+  end
+
+  assert('Digest::MD5#== with String') do
+    Digest::MD5.new.update("ruby") == "58e53d1324eef6265fdb97b08ed9aadf"
+  end
+
+  assert('Digest::MD5#block_length') do
+    Digest::MD5.new.block_length == 64
+  end
+
+  assert('Digest::MD5#digest') do
+    Digest::MD5.new.update("ruby").digest == "X\xE5=\x13$\xEE\xF6&_\xDB\x97\xB0\x8E\xD9\xAA\xDF"
+  end
+
+  assert('Digest::MD5#digest!') do
+    d = Digest::MD5.new.update("ruby")
+    d.digest!
+    #d.digest! == "\xD4\x1D\x8C\xD9\x8F\x00\xB2\x04\xE9\x80\t\x98\xEC\xF8B~"
+    # XXX: mrbtest dumps core!
+    d.digest! == Digest::MD5.new.digest
+  end
+
+  assert('Digest::MD5#digest_length') do
+    d = Digest::MD5.new
+    n = 16
+    d.digest_length == n and
+    d.length == n and
+    d.size == n
+  end
+
+  #assert('Digest::MD5#file')
+
+  assert('Digest::MD5#hexdigest') do
+    d = Digest::MD5.new.update("ruby")
+    s = "58e53d1324eef6265fdb97b08ed9aadf"
+    d.hexdigest == s and
+    d.to_s == s
+  end
+
+  assert('Digest::MD5#hexdigest!') do
+    d = Digest::MD5.new.update("ruby")
+    d.hexdigest!
+    d.hexdigest! == "d41d8cd98f00b204e9800998ecf8427e"
+  end
+
+  assert('Digest::MD5#reset') do
+    d = Digest::MD5.new.update("ruby")
+    d.reset
+    d.hexdigest! == "d41d8cd98f00b204e9800998ecf8427e"
+  end
+
+  if Digest.const_defined? :RMD160
+    assert('Digest::RMD160#hexdigest') do
+      d = Digest::RMD160.new.update("ruby")
+      s = "29d9b710bc50866fa2399c3061cd02c0c8ffa197"
+      d.hexdigest == s
+    end
+  end
+
+  if Digest.const_defined? :SHA1
+    assert('Digest::SHA1#hexdigest') do
+      d = Digest::SHA1.new.update("ruby")
+      s = "18e40e1401eef67e1ae69efab09afb71f87ffb81"
+      d.hexdigest == s
+    end
+  end
+
+  if Digest.const_defined? :SHA256
+    assert('Digest::SHA256#hexdigest') do
+      d = Digest::SHA256.new.update("ruby")
+      s = "b9138194ffe9e7c8bb6d79d1ed56259553d18d9cb60b66e3ba5aa2e5b078055a"
+      d.hexdigest == s
+    end
+  end
+
+  if Digest.const_defined? :SHA384
+    assert('Digest::SHA384#hexdigest') do
+      d = Digest::SHA384.new.update("ruby")
+      s = "635365ef93ebf2c7a4e40b0b497da727ab8c2914eb9f052e6be40476f95d3daf44786790f5f0e843fab419b43022e069"
+      d.hexdigest == s
+    end
+  end
+
+  if Digest.const_defined? :SHA512
+    assert('Digest::SHA512#hexdigest') do
+      d = Digest::SHA512.new.update("ruby")
+      s = "423408d7723a3d80baefa804bd50b61a89667efec1713386a7b8efe28e5d13968307a908778cad210d7aa2dfe7db9a2aa86895f9fc1eeefcc99814310b207a6b"
+      d.hexdigest == s
+    end
+  end
+
+  assert('Digest::HMAC') do
+    Digest::HMAC.class == Class
+  end
+
+  assert('Digest::HMAC.digest') do
+    Digest::HMAC.digest("data", "hash key", Digest::SHA1) == "\xFD \xECC=\xFD\x97\x0E\xEC!FW\xCF\xB5Gl]\x913f"
+  end
+
+  assert('Digest::HMAC.hexdigest') do
+    Digest::HMAC.hexdigest("data", "hash key", Digest::SHA1) == "fd20ec433dfd970eec214657cfb5476c5d913366"
+  end
+
+  assert('Digest::HMAC#<<') do
+    a = Digest::HMAC.new('hash key', Digest::SHA1)
+    b = Digest::HMAC.new('hash key', Digest::SHA1)
+    a.update('ruby')
+    b << "r" << "u" << "b" << "y"
+    a.hexdigest == b.hexdigest
+  end
+
+  assert('Digest::HMAC#block_length') do
+    d = Digest::HMAC.new("hash key", Digest::SHA1)
+    d.block_length == 64
+  end
+
+  assert('Digest::HMAC#digest_length') do
+    d = Digest::HMAC.new("hash key", Digest::SHA1)
+    d.digest_length == 20
+  end
+
+  # assert('Digest::HMAC#reset')
+
+  assert('Digest::HMAC#update') do
+    d = Digest::HMAC.new("hash key", Digest::SHA1)
+    d.update('data')
+    d.hexdigest == "fd20ec433dfd970eec214657cfb5476c5d913366"
+  end
+
+  assert('Digest::HMAC#update 2') do
+    d = Digest::HMAC.new("hash key", Digest::SHA1)
+    d.update('ruby')
+    d.update('digest')
+    d.hexdigest == "e4be3728777e43deba3aa522a4247ea83b19a1c7"
+  end
+end

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 		10F4EB831C165B92003DA150 /* fastcgi-cgi.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "fastcgi-cgi.pl"; sourceTree = "<group>"; };
 		10F4EB841C16BADD003DA150 /* 50fastcgi-cgi.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50fastcgi-cgi.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10F4EB861C177A12003DA150 /* hello.cgi */ = {isa = PBXFileReference; lastKnownFileType = text; path = hello.cgi; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		10F4EB891C195B9E003DA150 /* htpasswd.rb */ = {isa = PBXFileReference; lastKnownFileType = text.script.ruby; path = htpasswd.rb; sourceTree = "<group>"; };
 		10F9F2641AF4795D0056F26B /* redirect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = redirect.c; sourceTree = "<group>"; };
 		10F9F2661AFC5F550056F26B /* hostinfo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hostinfo.c; sourceTree = "<group>"; };
 		10FCC13C1B2E4A4500F13674 /* cloexec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cloexec.c; sourceTree = "<group>"; };
@@ -590,6 +591,7 @@
 		104B9A431A5D0028009EEE64 /* h2o */ = {
 			isa = PBXGroup;
 			children = (
+				10F4EB881C195B5C003DA150 /* mruby */,
 				10A60DE91B0D87FE006E38EC /* annotate-backtrace-symbols */,
 				104B9A401A5CD69B009EEE64 /* fetch-ocsp-response */,
 				10FCC1411B2FCC6B00F13674 /* kill-on-close */,
@@ -1217,6 +1219,14 @@
 				10F4EB861C177A12003DA150 /* hello.cgi */,
 			);
 			path = doc_root;
+			sourceTree = "<group>";
+		};
+		10F4EB881C195B5C003DA150 /* mruby */ = {
+			isa = PBXGroup;
+			children = (
+				10F4EB891C195B9E003DA150 /* htpasswd.rb */,
+			);
+			path = mruby;
 			sourceTree = "<group>";
 		};
 		10FCC13B1B2E4A2C00F13674 /* cloexec */ = {

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		100A550C1C22857B00C4E3E0 /* 50mruby-htpasswd.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50mruby-htpasswd.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		100AE41A1B27D74800CE18BB /* 50file-range.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50file-range.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		101788B119B561AA0084C6D8 /* socket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = socket.c; sourceTree = "<group>"; };
 		101B670B19ADD3380084A351 /* access_log.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = access_log.c; sourceTree = "<group>"; };
@@ -1157,6 +1158,7 @@
 				1058C87F1AA42568008D6180 /* 50headers.t */,
 				105534F71A460F2E00627ECB /* 50mimemap.t */,
 				10A3D3D61B4F1E3200327CF9 /* 50mruby.t */,
+				100A550C1C22857B00C4E3E0 /* 50mruby-htpasswd.t */,
 				105534F81A460F2E00627ECB /* 50post-size-limit.t */,
 				10AA2EA81A8DAFD4004322AC /* 50redirect.t */,
 				108215061AAD41A000D27E66 /* 50reverse-proxy */,

--- a/share/h2o/mruby/htpasswd.rb
+++ b/share/h2o/mruby/htpasswd.rb
@@ -1,0 +1,129 @@
+# based on public-domain code by cho45
+#
+# Copyright (c) 2015 DeNA Co., Ltd., Kazuho Oku
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+class Htpasswd
+
+  attr_accessor :path
+  attr_accessor :realm
+
+  def initialize(path, realm)
+    @path = path
+    @realm = realm
+  end
+
+  def call(env)
+    if /\/\.ht/.match(env['PATH_INFO'])
+      return [ 404, { "Conetnt-Type" => "text/plain" }, [ "not found" ] ]
+    end
+    auth = env['HTTP_AUTHORIZATION']
+    if auth
+      method, cred = *auth.split(' ')
+      if method.casecmp("basic") == 0
+        user, pass = cred.unpack("m")[0].split(':', 2)
+        begin
+          if lookup(user, pass)
+            return [ 399, {}, [] ]
+          end
+        rescue => e
+          $stderr.puts "failed to validate password using file:#{@path}:#{e.message}"
+          return [ 500, { "Content-Type" => "text/plain" }, [ "Internal Server Error" ] ]
+        end
+      end
+    end
+    return [ 401, { "Content-Type" => "text/plain", "WWW-Authenticate" => "Basic realm=\"#{@realm}\"" }, [ "Authorization Required" ] ]
+  end
+
+  def lookup(user, pass)
+    File.open(@path) do |file|
+      file.each_line do |line|
+        line_user, hash = line.chomp.split(':', 2)
+        if user == line_user && self.class.validate(pass, hash)
+          return true
+        end
+      end
+    end
+    return false
+  end
+
+  def Htpasswd.crypt_md5(pass, salt)
+    ctx = Digest::MD5.new.update("#{pass}$apr1$#{salt}")
+    final = Digest::MD5.new.update("#{pass}#{salt}#{pass}").digest!.bytes
+
+    l = pass.length
+    while l > 0
+      ctx.update(final[0 .. (l > 16 ? 16 : l) - 1].pack("C*"))
+      l -= 16
+    end
+
+    l = pass.length
+    while l > 0
+      ctx.update(l % 2 != 0 ? "\0" : pass[0])
+      l >>= 1
+    end
+
+    final = ctx.digest!
+
+    1000.times do |i|
+      ctx = Digest::MD5.new
+      ctx.update(i % 2 != 0 ? pass : final)
+      ctx.update(salt) if i % 3 != 0
+      ctx.update(pass) if i % 7 != 0
+      ctx.update(i % 2 != 0 ? final : pass)
+      final = ctx.digest!
+    end
+
+    final = final.bytes
+    hash = ""
+    for a, b, c in [[0, 6, 12], [1, 7, 13], [2, 8, 14], [3, 9, 15], [4, 10, 5]]
+      hash << _to64(final[a] << 16 | final[b] << 8 | final[c], 4)
+    end
+    hash << _to64(final[11], 2)
+
+    "$apr1$#{salt}$#{hash}"
+  end
+
+  def Htpasswd._to64(v, n)
+    chars = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    output = ""
+    n.times do
+      output << chars[v & 0x3f]
+      v >>= 6
+    end
+    output
+  end
+
+  def Htpasswd.crypt_sha1(pass)
+    "{SHA}" + [Digest::SHA1.new.update(pass).digest!].pack("m").chomp
+  end
+
+  def Htpasswd.validate(pass, hash)
+    if /^\$apr1\$(.*)\$/.match(hash)
+      encoded = crypt_md5(pass, $1)
+    elsif /^{SHA}/.match(hash)
+      encoded = crypt_sha1(pass)
+    else
+      raise "crypt-style password hash is not supported"
+    end
+    return encoded == hash
+  end
+
+end

--- a/t/50mruby-htpasswd.t
+++ b/t/50mruby-htpasswd.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+subtest "basic" => sub {
+    my $server = spawn_h2o(<< 'EOT');
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          require "share/h2o/mruby/htpasswd.rb"
+          Htpasswd.new("t/assets/.htpasswd", "protected space")
+        file.dir: t/assets/doc_root
+EOT
+    subtest "no-auth" => sub {
+        my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+        like $headers, qr{^HTTP/1\.1 401 }s, "status";
+        like $headers, qr{\r\nwww-authenticate: basic realm="protected space"\r}is, "www-authenticate header";
+    };
+
+    subtest "fail" => sub {
+        my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://aaa:aaa\@127.0.0.1:$server->{port}/");
+        like $headers, qr{^HTTP/1\.1 401 }s, "status";
+        like $headers, qr{\r\nwww-authenticate: basic realm="protected space"\r}is, "www-authenticate header";
+    };
+
+    subtest "success" => sub {
+        my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://dankogai:kogaidan\@127.0.0.1:$server->{port}/");
+        like $headers, qr{^HTTP/1\.1 200 }s, "status";
+        is $body, "hello\n", "content";
+    };
+};
+
+done_testing();

--- a/t/assets/.htpasswd
+++ b/t/assets/.htpasswd
@@ -1,0 +1,1 @@
+dankogai:$apr1$UZu91fLT$LZuXFeu3wSYdgLY6Wez5m/


### PR DESCRIPTION
Tasks:
* [ ] bundle [mruby-string-crypt](https://github.com/mattn/mruby-string-crypt)
* [ ] adjust http://lowreal.net/2015/11/17/1 to read the password file, and bundle it

Format of htpasswd file is specified in https://httpd.apache.org/docs/2.2/misc/password_encryptions.html.

relates to #203