### PR TITLE
support wildcard hostname

### DIFF
--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -213,6 +213,10 @@ const char *h2o_url_parse_hostport(const char *s, size_t len, h2o_iovec_t *host,
         token_start = token_end;
     }
 
+    /* disallow zero-length host */
+    if (host->len == 0)
+        return NULL;
+
     /* parse port */
     if (token_start != end && *token_start == ':') {
         size_t p;

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -128,6 +128,8 @@ h2o_hostconf_t *h2o_config_register_host(h2o_globalconf_t *config, h2o_iovec_t h
 {
     h2o_hostconf_t *hostconf;
 
+    assert(host.len != 0);
+
     /* create hostconf */
     hostconf = create_hostconf(config);
     hostconf->authority.host = h2o_strdup(NULL, host.base, host.len);

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -264,6 +264,12 @@ static int on_config_hosts(h2o_configurator_command_t *cmd, h2o_configurator_con
             h2o_configurator_errprintf(cmd, key, "invalid key (must be either `host` or `host:port`)");
             return -1;
         }
+        assert(hostname.len != 0);
+        if ((hostname.base[0] == '*' && !(hostname.len == 1 || hostname.base[1] == '.')) ||
+            memchr(hostname.base + 1, '*', hostname.len - 1) != NULL) {
+            h2o_configurator_errprintf(cmd, key, "wildcard (*) can only be used at the start of the hostname");
+            return -1;
+        }
         h2o_configurator_context_t host_ctx = *ctx;
         host_ctx.hostconf = h2o_config_register_host(host_ctx.globalconf, hostname, port);
         host_ctx.mimemap = &host_ctx.hostconf->mimemap;

--- a/t/00unit/lib/common/url.c
+++ b/t/00unit/lib/common/url.c
@@ -135,6 +135,14 @@ static void test_hostport(void)
     input = h2o_iovec_init(H2O_STRLIT("[::ffff:192.0.2.1:8081/"));
     ret = h2o_url_parse_hostport(input.base, input.len, &host, &port);
     ok(ret == NULL);
+
+    input = h2o_iovec_init(H2O_STRLIT(":8081/"));
+    ret = h2o_url_parse_hostport(input.base, input.len, &host, &port);
+    ok(ret == NULL);
+
+    input = h2o_iovec_init(H2O_STRLIT("[]:8081/"));
+    ret = h2o_url_parse_hostport(input.base, input.len, &host, &port);
+    ok(ret == NULL);
 }
 
 static void test_parse(void)

--- a/t/00unit/lib/common/url.c
+++ b/t/00unit/lib/common/url.c
@@ -102,6 +102,41 @@ static void test_normalize_path(void)
     h2o_mem_clear_pool(&pool);
 }
 
+static void test_hostport(void)
+{
+    h2o_iovec_t input, host;
+    uint16_t port;
+    const char *ret;
+
+    input = h2o_iovec_init(H2O_STRLIT("127.0.0.1"));
+    ret = h2o_url_parse_hostport(input.base, input.len, &host, &port);
+    ok(ret == input.base + input.len);
+    ok(h2o_memis(host.base, host.len, H2O_STRLIT("127.0.0.1")));
+    ok(port == 65535);
+
+    input = h2o_iovec_init(H2O_STRLIT("127.0.0.1/"));
+    ret = h2o_url_parse_hostport(input.base, input.len, &host, &port);
+    ok(strcmp(ret, "/") == 0);
+    ok(h2o_memis(host.base, host.len, H2O_STRLIT("127.0.0.1")));
+    ok(port == 65535);
+
+    input = h2o_iovec_init(H2O_STRLIT("127.0.0.1:8081/"));
+    ret = h2o_url_parse_hostport(input.base, input.len, &host, &port);
+    ok(strcmp(ret, "/") == 0);
+    ok(h2o_memis(host.base, host.len, H2O_STRLIT("127.0.0.1")));
+    ok(port == 8081);
+
+    input = h2o_iovec_init(H2O_STRLIT("[::ffff:192.0.2.1]:8081/"));
+    ret = h2o_url_parse_hostport(input.base, input.len, &host, &port);
+    ok(strcmp(ret, "/") == 0);
+    ok(h2o_memis(host.base, host.len, H2O_STRLIT("::ffff:192.0.2.1")));
+    ok(port == 8081);
+
+    input = h2o_iovec_init(H2O_STRLIT("[::ffff:192.0.2.1:8081/"));
+    ret = h2o_url_parse_hostport(input.base, input.len, &host, &port);
+    ok(ret == NULL);
+}
+
 static void test_parse(void)
 {
     h2o_url_t parsed;
@@ -355,6 +390,7 @@ static void test_resolve(void)
 void test_lib__common__url_c(void)
 {
     subtest("normalize_path", test_normalize_path);
+    subtest("hostport", test_hostport);
     subtest("parse", test_parse);
     subtest("parse_relative", test_parse_relative);
     subtest("resolve", test_resolve);

--- a/t/40virtual-host.t
+++ b/t/40virtual-host.t
@@ -9,10 +9,11 @@ use t::Util;
 plan skip_all => 'curl not found'
     unless prog_exists('curl');
 
-# create config
-my ($global_port, $alternate_port) = empty_ports(2);
-my ($conffh, $conffn) = tempfile(UNLINK => 1);
-print $conffh <<"EOT";
+subtest "basic" => sub {
+    # create config
+    my ($global_port, $alternate_port) = empty_ports(2);
+    my ($conffh, $conffn) = tempfile(UNLINK => 1);
+    print $conffh <<"EOT";
 listen:
   host: 127.0.0.1
   port: $global_port
@@ -30,24 +31,53 @@ hosts:
         file.dir: examples/doc_root.alternate
 EOT
 
-# start server
-my ($guard, $pid) = spawn_server(
-    argv     => [ bindir() . "/h2o", "-c", $conffn ],
-    is_ready => sub {
-        check_port($global_port) && check_port($alternate_port);
-    },
-);
+    # start server
+    my ($guard, $pid) = spawn_server(
+        argv     => [ bindir() . "/h2o", "-c", $conffn ],
+        is_ready => sub {
+            check_port($global_port) && check_port($alternate_port);
+        },
+    );
 
-my $resp = `curl --silent --resolve default:$global_port:127.0.0.1 http://default:$global_port/`;
-is md5_hex($resp), md5_file("examples/doc_root/index.html"), "'host: default' against default port";
+    my $resp = `curl --silent --resolve default:$global_port:127.0.0.1 http://default:$global_port/`;
+    is md5_hex($resp), md5_file("examples/doc_root/index.html"), "'host: default' against default port";
 
-$resp = `curl --silent --resolve alternate:$global_port:127.0.0.1 http://alternate:$global_port/`;
-is md5_hex($resp), md5_file("examples/doc_root.alternate/index.txt"), "'host: alternate' against default port";
+    $resp = `curl --silent --resolve alternate:$global_port:127.0.0.1 http://alternate:$global_port/`;
+    is md5_hex($resp), md5_file("examples/doc_root.alternate/index.txt"), "'host: alternate' against default port";
 
-$resp = `curl --silent --resolve default:$alternate_port:127.0.0.1 http://default:$alternate_port/`;
-is md5_hex($resp), md5_file("examples/doc_root.alternate/index.txt"), "'host: default' against alternate port";
+    $resp = `curl --silent --resolve default:$alternate_port:127.0.0.1 http://default:$alternate_port/`;
+    is md5_hex($resp), md5_file("examples/doc_root.alternate/index.txt"), "'host: default' against alternate port";
 
-$resp = `curl --silent --resolve alternate:$alternate_port:127.0.0.1 http://alternate:$alternate_port/`;
-is md5_hex($resp), md5_file("examples/doc_root.alternate/index.txt"), "'host: alternate' against alternate port";
+    $resp = `curl --silent --resolve alternate:$alternate_port:127.0.0.1 http://alternate:$alternate_port/`;
+    is md5_hex($resp), md5_file("examples/doc_root.alternate/index.txt"), "'host: alternate' against alternate port";
+};
+
+subtest "wildcard" => sub {
+    my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        return << "EOT";
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: examples/doc_root
+  "*.example.com:$port":
+    paths:
+      /:
+        file.dir: examples/doc_root.alternate
+EOT
+    });
+
+    my $fetch = sub {
+        my $host = shift;
+        my $resp = `curl --silent --resolve $host:$server->{port}:127.0.0.1 http://$host:$server->{port}/`;
+        md5_hex($resp);
+    };
+
+    is $fetch->("www.example.com"), md5_file("examples/doc_root.alternate/index.txt"), "www.example.com";
+    is $fetch->("xxx.example.com"), md5_file("examples/doc_root.alternate/index.txt"), "xxx.example.com";
+    is $fetch->("example.com"), md5_file("examples/doc_root/index.html"), "example.com";
+    is $fetch->("example.org"), md5_file("examples/doc_root/index.html"), "example.org";
+};
 
 done_testing();


### PR DESCRIPTION
This PR enhances the server to accept hostnames with wildcard in the first part of the FQDN.

Such support is essential when using wildcard SSL certificates as discussed in https://github.com/h2o/h2o/issues/543#issuecomment-158438938.