### PR TITLE
drop special headers passed from FastCGI application

### DIFF
--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -476,7 +476,9 @@ static int fill_headers(h2o_req_t *req, struct phr_header *headers, size_t num_h
         const h2o_token_t *token;
         h2o_strtolower((char *)headers[i].name, headers[i].name_len);
         if ((token = h2o_lookup_token(headers[i].name, headers[i].name_len)) != NULL) {
-            if (token == H2O_TOKEN_CONTENT_LENGTH) {
+            if (token->proxy_should_drop) {
+                /* skip */
+            } else if (token == H2O_TOKEN_CONTENT_LENGTH) {
                 if (req->res.content_length != SIZE_MAX) {
                     h2o_req_log_error(req, MODULE_NAME, "received multiple content-length headers from fcgi");
                     return -1;


### PR DESCRIPTION
Special headers must not be transferred; e.g. transfer-encoding header should be dropped, since it is the task of the HTTP server (not fastcgi app) to apply such encoding.

Such filtering already existed in the HTTP proxy, but did not in the FastCGI implementation.