### PR TITLE
fix broken mutex

### DIFF
--- a/lib/common/socket/evloop/epoll.c.h
+++ b/lib/common/socket/evloop/epoll.c.h
@@ -135,7 +135,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
             }
         }
         if (!notified) {
-            pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+            static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
             static time_t last_reported = 0;
             time_t now = time(NULL);
             pthread_mutex_lock(&lock);


### PR DESCRIPTION
Fixes the issue pointed out in https://github.com/h2o/h2o/pull/603#issuecomment-167414622.

Fortunately the impact of this bug is considered low, since the code path that gets affected by the reported issue solely exists to detect logic flaw in the server and never actually gets executed.