### PR TITLE
implement InputStream#as_str

### DIFF
--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -416,6 +416,13 @@ void h2o_mruby_http_request_init_context(h2o_mruby_context_t *ctx)
                              "        yield c\n"
                              "      end\n"
                              "    end\n"
+                             "    def as_str\n"
+                             "      s = \"\"\n"
+                             "      each do |c|\n"
+                             "        s << c\n"
+                             "      end\n"
+                             "      s\n"
+                             "    end\n"
                              "  end\n"
                              "end");
     h2o_mruby_assert(mrb);

--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -52,6 +52,11 @@ hosts:
               env["rack.input"],
             )
           end
+      /as_str:
+        mruby.handler: |
+          Proc.new do |env|
+            [200, {}, [http_request("GET", "http://$upstream_hostport/index.txt")[2].as_str]]
+          end
 EOT
 });
 
@@ -77,6 +82,11 @@ sub doit {
         my ($headers, $body) = run_prog("$curl_cmd $proto://127.0.0.1:$port/streaming-body");
         like $headers, qr{HTTP/1\.1 200 }is;
         is $body, (join "", 1..30);
+    };
+    subtest "as_str" => sub {
+        my ($headers, $body) = run_prog("$curl_cmd $proto://127.0.0.1:$port/as_str/");
+        like $headers, qr{HTTP/1\.1 200 }is;
+        is $body, "hello\n";
     };
 }
 


### PR DESCRIPTION
Implements `InputStream#as_str` for converting content obtained by `http_request` to string.

Since the method triggers a fiber switch, I have evaded naming it `#to_str` so that it would not be called via C functions.

part of #643