### PR TITLE
Convert header name to lowercase in mruby handler

### DIFF
--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -470,7 +470,9 @@ static int handle_response_header(h2o_mruby_context_t *handler_ctx, h2o_iovec_t 
     h2o_req_t *req = _req;
     const h2o_token_t *token;
 
-    /* note: name of the header is lowercased by http1client */
+    /* convert name to lowercase */
+    name = h2o_strdup(&req->pool, name.base, name.len);
+    h2o_strtolower(name.base, name.len);
 
     if ((token = h2o_lookup_token(name.base, name.len)) != NULL) {
         if (token->proxy_should_drop) {


### PR DESCRIPTION
Hi @kazuho san,

I found that HTTP header names which are generated on mruby handler are not lowercased at this time.

For instance, when I use the code shown in [#624 (comment)](https://github.com/h2o/h2o/pull/624#issuecomment-165454959), Chrome stops page loading and returns "ERR_SPDY_PROTOCOL_ERROR".
In more detail, here is a debug log captured by the Chrome.

```
t=1664741 [st=   29]    HTTP2_SESSION_RECV_HEADERS
                        --> fin = false
                        --> :status: 401
                            server: h2o/1.7.0-alpha1
                            date: Tue, 29 Dec 2015 05:05:38 GMT
                            Content-Type: text/plain
                            WWW-Authenticate: Basic realm="Members only"
                            strict-transport-security: max-age=31536000
                            x-content-type-options: nosniff
                            content-security-policy: upgrade-insecure-requests
                            content-length: 24
                        --> stream_id = 1
t=1664741 [st=   29]    HTTP2_SESSION_SEND_RST_STREAM
                        --> description = "Upper case characters in header: Content-Type"
                        --> status = 1
                        --> stream_id = 1
```

In order to fix this problem, I don't know about `http1client` so much, however, I reverted a990c58 and it works correctly.

Could you please take a look?