### PR TITLE
skip mruby layer when sending data obtained using `http_request`

### DIFF
--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -69,6 +69,8 @@ typedef struct st_h2o_mruby_context_t {
 } h2o_mruby_context_t;
 
 typedef struct st_h2o_mruby_chunked_t h2o_mruby_chunked_t;
+typedef struct st_h2o_mruby_http_request_context_t h2o_mruby_http_request_context_t;
+
 typedef struct st_h2o_mruby_generator_t {
     h2o_generator_t super;
     h2o_req_t *req; /* becomes NULL once the underlying connection gets terminated */
@@ -125,7 +127,7 @@ int h2o_mruby_iterate_headers(h2o_mruby_context_t *handler_ctx, mrb_value header
 /* handler/mruby/chunked.c */
 void h2o_mruby_send_chunked_init_context(h2o_mruby_context_t *ctx);
 void h2o_mruby_send_chunked_close(h2o_mruby_generator_t *generator);
-mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator);
+mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_value body);
 void h2o_mruby_send_chunked_dispose(h2o_mruby_generator_t *generator);
 mrb_value h2o_mruby_send_chunked_eos_callback(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value input,
                                               int *next_action);
@@ -136,6 +138,8 @@ mrb_value h2o_mruby_http_join_response_callback(h2o_mruby_generator_t *generator
                                                 int *next_action);
 mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value input,
                                               int *next_action);
+h2o_mruby_http_request_context_t *h2o_mruby_http_set_shortcut(mrb_state *mrb, mrb_value obj, void (*cb)(h2o_mruby_generator_t *));
+h2o_buffer_t **h2o_mruby_http_peek_content(h2o_mruby_http_request_context_t *ctx, int *is_final);
 
 /* handler/configurator/mruby.c */
 void h2o_mruby_register_configurator(h2o_globalconf_t *conf);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -606,9 +606,13 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
 
     /* use fiber in case we need to call #each */
     if (!mrb_nil_p(body)) {
-        mrb_value receiver = h2o_mruby_send_chunked_init(generator);
         h2o_start_response(generator->req, &generator->super);
-        h2o_mruby_run_fiber(generator, receiver, body, gc_arena, 0);
+        mrb_value receiver = h2o_mruby_send_chunked_init(generator, body);
+        if (mrb_nil_p(receiver)) {
+            mrb_gc_arena_restore(mrb, gc_arena);
+        } else {
+            h2o_mruby_run_fiber(generator, receiver, body, gc_arena, 0);
+        }
         return;
     }
 

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -563,6 +563,17 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
         goto GotException;
     }
 
+    /* fall through if possible */
+    if (generator->req->res.status == STATUS_FALLTHRU) {
+        if (is_delegate != NULL) {
+            *is_delegate = 1;
+            mrb_gc_arena_restore(mrb, gc_arena);
+            return;
+        }
+        h2o_req_log_error(generator->req, H2O_MRUBY_MODULE_NAME, "cannot (yet) handle async 399 response");
+        goto SendInternalError;
+    }
+
     /* obtain body */
     body = mrb_ary_entry(resp, 2);
 
@@ -591,17 +602,6 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
         }
         /* reset body to nil, now that we have read all data */
         body = mrb_nil_value();
-    }
-
-    /* fall through if possible */
-    if (generator->req->res.status == STATUS_FALLTHRU) {
-        if (is_delegate != NULL) {
-            *is_delegate = 1;
-            mrb_gc_arena_restore(mrb, gc_arena);
-            return;
-        }
-        h2o_req_log_error(generator->req, H2O_MRUBY_MODULE_NAME, "cannot (yet) handle async 399 response");
-        goto SendInternalError;
     }
 
     /* use fiber in case we need to call #each */


### PR DESCRIPTION
ToDo:
* [x] add test that partially reads the data in mruby-side, and then passes the rest to downstream

part of #643 