### PR TITLE
Consider wildcard hostnames on SNI

### DIFF
--- a/t/50sni.t
+++ b/t/50sni.t
@@ -13,9 +13,10 @@ plan skip_all => 'wget not found'
 plan skip_all => 'only wget >= 1.14 supports SNI'
     unless `wget --version` =~ /^GNU Wget 1\.([0-9]+)/ && $1 >= 14;
 
-my $server = spawn_h2o(sub {
-    my ($port, $tls_port) = @_;
-    return << "EOT";
+subtest "basic" => sub {
+    my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        return << "EOT";
 hosts:
   "127.0.0.1.xip.io:$tls_port":
     paths:
@@ -31,20 +32,51 @@ hosts:
       /:
         file.dir: examples/doc_root.alternate
 EOT
-});
+    });
 
-subtest 'default-host' => sub {
     do_test(
         "127.0.0.1.xip.io:$server->{tls_port}",
         md5_file("examples/doc_root/index.html"),
     );
-};
-subtest 'alternate-host' => sub {
+
     do_test(
         "alternate.127.0.0.1.xip.io:$server->{tls_port}",
         md5_file("examples/doc_root.alternate/index.txt"),
     );
 };
+
+subtest "wildcard" => sub {
+    my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        return << "EOT";
+hosts:
+  "127.0.0.1.xip.io:$tls_port":
+    paths:
+      /:
+        file.dir: examples/doc_root
+  "*.127.0.0.1.xip.io:$tls_port":
+    listen:
+      port: $tls_port
+      ssl:
+        key-file: examples/h2o/alternate.key
+        certificate-file: examples/h2o/alternate.crt
+    paths:
+      /:
+        file.dir: examples/doc_root.alternate
+EOT
+    });
+
+    do_test(
+        "127.0.0.1.xip.io:$server->{tls_port}",
+        md5_file("examples/doc_root/index.html"),
+    );
+
+    do_test(
+        "alternate.127.0.0.1.xip.io:$server->{tls_port}",
+        md5_file("examples/doc_root.alternate/index.txt"),
+    );
+};
+
 
 done_testing();
 


### PR DESCRIPTION
Follows #634

As I said in https://github.com/h2o/h2o/issues/543#issuecomment-158438938 , I'm planning to use the wildcard support for wildcard certificates with SNI, but change in #634 seems not to support SNI.