### PR TITLE
Fixed a bug that cannot specify multiple error documents

### DIFF
--- a/lib/handler/configurator/errordoc.c
+++ b/lib/handler/configurator/errordoc.c
@@ -103,7 +103,8 @@ static int on_config_errordoc(h2o_configurator_command_t *cmd, h2o_configurator_
             if (register_errordoc(cmd, ctx, e) != 0)
                 return -1;
         }
-    } break;
+        return 0;
+    }
     case YOML_TYPE_MAPPING:
         return register_errordoc(cmd, ctx, node);
     default:


### PR DESCRIPTION
```
    # Subtest: multi-error
killed (got 0)
spawning /home/ykzts/work/h2o/h2o... [/tmp/K8fHALM1vj:7] in command error-doc, argument must be either of: sequence, mapping
not ok 4 - multi-error
server failed to start (got 19968)
    # Child (multi-error) exited without calling finalize()

#   Failed test 'multi-error'
#   at /usr/share/perl/5.20/Test/Builder.pm line 276.
```

:cry::cry::cry: