### PR TITLE
detect upstream close of a pooled socket before reuse

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 		107D4D521B5B2412004A9B21 /* file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file.h; sourceTree = "<group>"; };
 		107D4D541B5B30EE004A9B21 /* file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = file.c; sourceTree = "<group>"; };
 		107D4D5D1B5F143B004A9B21 /* setuidgid.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = setuidgid.c; sourceTree = "<group>"; };
+		108102151C3DB05100C024CD /* 50reverse-proxy-disconnected-keepalive.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50reverse-proxy-disconnected-keepalive.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		108214FE1AAD34DD00D27E66 /* 50reverse-proxy-0.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50reverse-proxy-0.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		108215071AAD41CE00D27E66 /* test.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; name = test.pl; path = "50reverse-proxy/test.pl"; sourceTree = "<group>"; };
 		108215081AB14B1100D27E66 /* 40server-push.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40server-push.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -1179,6 +1180,7 @@
 				10AA2EA81A8DAFD4004322AC /* 50redirect.t */,
 				108215061AAD41A000D27E66 /* 50reverse-proxy */,
 				108214FE1AAD34DD00D27E66 /* 50reverse-proxy-0.t */,
+				108102151C3DB05100C024CD /* 50reverse-proxy-disconnected-keepalive.t */,
 				104C65021A6DF36B000AC190 /* 50reverse-proxy-config.t */,
 				10AA2EB21A9479B4004322AC /* 50reverse-proxy-upstream-down.t */,
 				104B9A2B1A4BBDA4009EEE64 /* 50server-starter.t */,

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -257,11 +257,11 @@ void h2o_socketpool_connect(h2o_socketpool_connect_request_t **_req, h2o_socketp
         if (rret <= 0) {
             static long counter = 0;
             if (__sync_fetch_and_add(&counter, 1) == 0)
-                fprintf(stderr, "[WARN] detected close by upstream before the timeout specified in `proxy.timeout.keepalive`\n");
+                fprintf(stderr, "[WARN] detected close by upstream before the expected timeout (see issue #679)\n");
         } else {
             static long counter = 0;
             if (__sync_fetch_and_add(&counter, 1) == 0)
-                fprintf(stderr, "[WARN] unexpectedly received data to a pooled socket\n");
+                fprintf(stderr, "[WARN] unexpectedly received data to a pooled socket (see issue #679)\n");
         }
         destroy_detached(entry);
         pthread_mutex_lock(&pool->_shared.mutex);

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -20,6 +20,7 @@
  * IN THE SOFTWARE.
  */
 #include <assert.h>
+#include <errno.h>
 #include <netdb.h>
 #include <stdlib.h>
 #include <sys/socket.h>
@@ -46,11 +47,16 @@ struct st_h2o_socketpool_connect_request_t {
     h2o_socket_t *sock;
 };
 
+static void destroy_detached(struct pool_entry_t *entry)
+{
+    h2o_socket_dispose_export(&entry->sockinfo);
+    free(entry);
+}
+
 static void destroy_attached(struct pool_entry_t *entry)
 {
     h2o_linklist_unlink(&entry->link);
-    h2o_socket_dispose_export(&entry->sockinfo);
-    free(entry);
+    destroy_detached(entry);
 }
 
 static void destroy_expired(h2o_socketpool_t *pool)
@@ -224,24 +230,43 @@ void h2o_socketpool_connect(h2o_socketpool_connect_request_t **_req, h2o_socketp
     if (_req != NULL)
         *_req = NULL;
 
-    /* fetch an entry */
+    /* fetch an entry and return it */
     pthread_mutex_lock(&pool->_shared.mutex);
     destroy_expired(pool);
-    if (!h2o_linklist_is_empty(&pool->_shared.sockets)) {
+    while (1) {
+        if (h2o_linklist_is_empty(&pool->_shared.sockets))
+            break;
         entry = H2O_STRUCT_FROM_MEMBER(struct pool_entry_t, link, pool->_shared.sockets.next);
         h2o_linklist_unlink(&entry->link);
+        pthread_mutex_unlock(&pool->_shared.mutex);
+
+        /* test if the connection is still alive */
+        char buf[1];
+        ssize_t rret = recv(entry->sockinfo.fd, buf, 1, MSG_PEEK);
+        if (rret == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            /* yes! return it */
+            h2o_socket_t *sock = h2o_socket_import(loop, &entry->sockinfo);
+            free(entry);
+            sock->on_close.cb = on_close;
+            sock->on_close.data = pool;
+            cb(sock, NULL, data);
+            return;
+        }
+
+        /* connection is dead, report, close, and retry */
+        if (rret <= 0) {
+            static long counter = 0;
+            if (__sync_fetch_and_add(&counter, 1) == 0)
+                fprintf(stderr, "[WARN] detected close by upstream before the timeout specified in `proxy.timeout.keepalive`\n");
+        } else {
+            static long counter = 0;
+            if (__sync_fetch_and_add(&counter, 1) == 0)
+                fprintf(stderr, "[WARN] unexpectedly received data to a pooled socket\n");
+        }
+        destroy_detached(entry);
+        pthread_mutex_lock(&pool->_shared.mutex);
     }
     pthread_mutex_unlock(&pool->_shared.mutex);
-
-    /* return the socket, if any */
-    if (entry != NULL) {
-        h2o_socket_t *sock = h2o_socket_import(loop, &entry->sockinfo);
-        free(entry);
-        sock->on_close.cb = on_close;
-        sock->on_close.data = pool;
-        cb(sock, NULL, data);
-        return;
-    }
 
     /* FIXME repsect `capacity` */
     __sync_add_and_fetch(&pool->_shared.count, 1);

--- a/t/50reverse-proxy-disconnected-keepalive.t
+++ b/t/50reverse-proxy-disconnected-keepalive.t
@@ -1,0 +1,77 @@
+use strict;
+use warnings;
+use File::Temp qw(tempfile);
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+subtest "tcp" => sub {
+    my $port = empty_port();
+    my $upstream = spawn_upstream($port);
+    doit("127.0.0.1:$port");
+};
+
+subtest "unix-socket" => sub {
+    plan skip_all => 'skipping unix-socket tests, requires Starlet >= 0.25'
+        if `perl -MStarlet -e 'print \$Starlet::VERSION'` < 0.25;
+
+    (undef, my $sockfn) = tempfile(UNLINK => 0);
+    unlink $sockfn;
+    my $guard = Scope::Guard->new(sub {
+        unlink $sockfn;
+    });
+
+    my $upstream = spawn_upstream($sockfn);
+    doit("[unix:$sockfn]");
+};
+
+done_testing;
+
+sub doit {
+    my $upaddr = shift;
+
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://$upaddr
+        proxy.timeout.io: 1000
+        proxy.timeout.keepalive: 10000
+EOT
+    my $port = $server->{port};
+
+    my $check_req = sub {
+        my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$port/index.txt 2>&1");
+        like $headers, qr{^HTTP/1\.1 200 }is;
+        is $body, "hello\n";
+    };
+    subtest "first-connect"  => $check_req;
+    subtest "redo-immediate" => $check_req;
+    sleep 2;
+    subtest "redo-after-upstream-disconnect" => $check_req;
+    sleep 2;
+    subtest "once-more" => $check_req;
+};
+
+sub spawn_upstream {
+    my $addr = shift;
+    spawn_server(
+        argv     => [
+            qw(plackup -s Starlet --max-keepalive-reqs 100 --keepalive-timeout 1 --access-log /dev/null --listen), $addr,
+            ASSETS_DIR . "/upstream.psgi"
+        ],
+        is_ready => sub {
+            if ($addr =~ /^\d+$/) {
+                check_port($addr);
+            } else {
+                !! -e $addr;
+            }
+        },
+    );
+}


### PR DESCRIPTION
If you are using persistent HTTP/1 connections to upstream servers, __it is very important to configure your upstream server to have a greater timeout value than H2O__ (configured via `proxy.timeout.keepalive`), as discussed in https://github.com/h2o/h2o/issues/281#issuecomment-92568622.

However, I have heard that Nginx occasionally closes downstream connections earlier than the configured timeout, and that the behavior is causing issues to the user.

This PR tries to remedy the issue by checking the health of a pooled connection just before being reused.  When H2O first encounters an unexpectedly-closed pooled connection, it will report an warning to give the users a chance to reconsider their configuration.

Note that __we cannot 100% fix the problem due to the restrictions of HTTP/1 (see the above link), I would always suggest to disable persistent connections to such servers__.