### PR TITLE
Fixed a bug that returns 403 when the trailing slash in the URI

### DIFF
--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -629,7 +629,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     } else {
         if (h2o_mimemap_has_dynamic_type(self->mimemap) && try_dynamic_request(self, req, rpath, rpath_len) == 0)
             return 0;
-        if (errno == ENOENT) {
+        if (errno == ENOENT || errno == ENOTDIR) {
             return -1;
         } else {
             h2o_send_error(req, 403, "Access Forbidden", "access forbidden", 0);

--- a/t/50file.t
+++ b/t/50file.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+subtest 'trailing-slash' => sub {
+  my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[DOC_ROOT]}
+EOT
+
+  my $resp = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/index.txt/ 2>&1 > /dev/null`;
+  like $resp, qr{^HTTP/1.1 404 File Not Found}s, "status";
+};
+
+done_testing;


### PR DESCRIPTION
```
    # Subtest: trailing-slash
spawning /home/ykzts/work/h2o/build/h2o... [INFO] raised RLIMIT_NOFILE to 65536
h2o server (pid:20172) is ready to serve requests
done
    not ok 1 - status

    #   Failed test 'status'
    #   at t/50file.t line 19.
    #                   'HTTP/1.1 403 Access Forbidden
    # Date: Fri, 08 Jan 2016 09:13:52 GMT
    # Server: h2o/1.7.0-beta1
    # Connection: keep-alive
    # Content-Length: 16
    # content-type: text/plain; charset=utf-8
    #   
    # ' 
    #     doesn't match '(?^s:^HTTP/1.1 404 File Not Found)'
killing /home/ykzts/work/h2o/build/h2o... received SIGTERM, gracefully shutting down
fetch-ocsp-response (using OpenSSL 1.0.1k 8 Jan 2015)
failed to extract ocsp URI from examples/h2o/server.crt
    1..1
not ok 1 - trailing-slash
```