### PR TITLE
crash after upgrading request to websocket when access log is enabled

### DIFF
--- a/t/40websocket.t
+++ b/t/40websocket.t
@@ -21,8 +21,8 @@ my $upstream = spawn_server(
     },
 );
 
-# spawn server
-my $server = spawn_h2o(<< "EOT");
+sub silent_server {
+    return spawn_h2o(<< "EOT");
 hosts:
   default:
     paths:
@@ -31,8 +31,10 @@ hosts:
         proxy.websocket: ON
         proxy.websocket.timeout: 1000
 EOT
+}
 
 subtest "http/1.1" => sub {
+    my $server = silent_server();
     plan skip_all => "curl not found"
         unless prog_exists("curl");
     my $resp = `curl --silent --insecure 'http://127.0.0.1:$server->{port}/index.txt'`;
@@ -68,6 +70,7 @@ sub doit {
 }
 
 subtest "ws" => sub {
+    my $server = silent_server();
     my $conn = IO::Socket::INET->new(
         PeerHost => '127.0.0.1',
         PeerPort => $server->{port},
@@ -77,12 +80,33 @@ subtest "ws" => sub {
 };
 
 subtest "wss" => sub {
+    my $server = silent_server();
     eval q{use IO::Socket::SSL; 1}
         or plan skip_all => "IO::Socket::SSL not found";
     my $conn = IO::Socket::SSL->new(
         PeerAddr        => "127.0.0.1:$server->{tls_port}",
         SSL_verify_mode => 0,
     ) or die "failed to connect via TLS to 127.0.0.1:$server->{tls_port}:". IO::Socket::SSL::errstr();
+    doit($conn);
+};
+
+subtest "logged-ws" => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port/
+        proxy.websocket: ON
+        proxy.websocket.timeout: 1000
+access-log: /dev/null # enable logging
+EOT
+
+    my $conn = IO::Socket::INET->new(
+        PeerHost => '127.0.0.1',
+        PeerPort => $server->{port},
+        Proto    => 'tcp',
+    ) or die "failed to connect to 127.0.0.1:$server->{port}:$!";
     doit($conn);
 };
 


### PR DESCRIPTION
attached failing test.

On logging websocket upgraded request, SEGV occurs when `log_access` tries to get peername. Because `http1.c`:`on_upgrade_complete` detaches `req->conn->sock`.

I tried to write a patch, but I thought this can't be fixed with simple patch, so submitting issue earlier.

IMO remote address should be logged, but detaching socket makes it impossible. So I guess we have to add new member for keeping peername in `h2o_conn_t`? There are several ways to achieve this, but I can't determine which is the best.

```
(lldb) bt
* thread #2: tid = 0x1a835b7, 0x000000010000afd5 h2o`h2o_socket_getpeername(sock=0x0000000000000000, sa=0x000070000030e440) + 21 at socket.c:435, stop reason = EXC_BAD_ACCESS (code=1, address=0x40)
  * frame #0: 0x000000010000afd5 h2o`h2o_socket_getpeername(sock=0x0000000000000000, sa=0x000070000030e440) + 21 at socket.c:435
    frame #1: 0x0000000100019ddd h2o`log_access [inlined] append_addr(pos=<unavailable>, cb=<unavailable>, conn=<unavailable>) + 2 at access_log.c:269
    frame #2: 0x0000000100019ddb h2o`log_access(_self=<unavailable>, req=0x00000001014007a8) + 4235 at access_log.c:385
    frame #3: 0x0000000100014d19 h2o`h2o_dispose_request(req=0x00000001014007a8) + 169 at request.c:221
    frame #4: 0x00000001000270a1 h2o`on_upgrade_complete [inlined] close_connection(conn=0x00000001014006f0) + 21 at http1.c:110
    frame #5: 0x000000010002708c h2o`on_upgrade_complete(socket=<unavailable>, status=<unavailable>) + 60 at http1.c:543
    frame #6: 0x000000010000bcc5 h2o`run_socket [inlined] on_write_complete(status=0) + 181 at socket.c:408
    frame #7: 0x000000010000bc88 h2o`run_socket(sock=0x0000000101500a00) + 120 at evloop.c.h:479
    frame #8: 0x000000010000a25a h2o`h2o_evloop_run [inlined] run_pending(loop=0x0000000100601d70) + 36 at evloop.c.h:501
    frame #9: 0x000000010000a236 h2o`h2o_evloop_run(loop=0x0000000100601d70) + 1654 at evloop.c.h:515
    frame #10: 0x0000000100051e23 h2o`run_loop(_thread_index=0x0000000000000005) + 803 at main.c:1270
    frame #11: 0x00007fff93e6c9b1 libsystem_pthread.dylib`_pthread_body + 131
    frame #12: 0x00007fff93e6c92e libsystem_pthread.dylib`_pthread_start + 168
    frame #13: 0x00007fff93e6a385 libsystem_pthread.dylib`thread_start + 13
```