### PR TITLE
fix and reduce the risk of GC-arena related leaks

### DIFF
--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -143,7 +143,7 @@ void h2o_mruby_define_callback(mrb_state *mrb, const char *name, int id);
 mrb_value h2o_mruby_create_data_instance(mrb_state *mrb, mrb_value class_obj, void *ptr, const mrb_data_type *type);
 mrb_value h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config, char *errbuf);
 h2o_mruby_handler_t *h2o_mruby_register(h2o_pathconf_t *pathconf, h2o_mruby_config_vars_t *config);
-void h2o_mruby_run_fiber(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value input, int gc_arena, int *is_delegate);
+void h2o_mruby_run_fiber(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value input, int *is_delegate);
 mrb_value h2o_mruby_each_to_array(h2o_mruby_context_t *handler_ctx, mrb_value src);
 int h2o_mruby_iterate_headers(h2o_mruby_context_t *handler_ctx, mrb_value headers,
                               int (*cb)(h2o_mruby_context_t *, h2o_iovec_t, h2o_iovec_t, void *), void *cb_data);


### PR DESCRIPTION
Current design pushes down the arena value to callees so that they could restore the arena when operation is complete.  The positive side of the design is that it would help us restore the arena earlier, and that there is more chance of callees getting tail-call optimized.  The downside is that we need to assert that the arena is restored in more code paths.

As has been reported in #699, we have failed to assert that the arena is always being restored.  I have found that such code is also missing [here](https://github.com/h2o/h2o/blob/f0e3af1/lib/handler/mruby/http_request.c#L153).

Now that we have found multiple occurrences of such failures we should switch to a more conservative design: maintain GC arena at the highest level; i.e. restore the GC state within the functions that collect the GC state.  With the change, the code paths involved to handling the GC arena decreases, thereby it becomes easier for us to audit the code.