### PR TITLE
refuse to start when a duplicate host entry has been found

### DIFF
--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -271,7 +271,10 @@ static int on_config_hosts(h2o_configurator_command_t *cmd, h2o_configurator_con
             return -1;
         }
         h2o_configurator_context_t host_ctx = *ctx;
-        host_ctx.hostconf = h2o_config_register_host(host_ctx.globalconf, hostname, port);
+        if ((host_ctx.hostconf = h2o_config_register_host(host_ctx.globalconf, hostname, port)) == NULL) {
+            h2o_configurator_errprintf(cmd, key, "duplicate host entry");
+            return -1;
+        }
         host_ctx.mimemap = &host_ctx.hostconf->mimemap;
         host_ctx.parent = ctx;
         if (h2o_configurator_apply_commands(&host_ctx, value, H2O_CONFIGURATOR_FLAG_HOST, NULL) != 0)


### PR DESCRIPTION
Every key of the `hosts` mapping MUST be unique; however there were no checks that assert the requirement.

relates to https://github.com/h2o/h2o/issues/704#issuecomment-172453334