### PR TITLE
support relative URI in x-reproxy-url header

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 		1082150E1AB26F4700D27E66 /* FindLibUV.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = FindLibUV.cmake; sourceTree = "<group>"; };
 		108867741AD9069900987967 /* defaults.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = defaults.c.h; sourceTree = "<group>"; };
 		1092E0011BEB1DDC001074BF /* 80issues579.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 80issues579.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		10952D591C5082F7000D664C /* 80issues-from-proxy-reproxy-to-different-host.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "80issues-from-proxy-reproxy-to-different-host.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10A3D3D01B4CDBC700327CF9 /* memcached.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memcached.h; sourceTree = "<group>"; };
 		10A3D3D11B4CDBDC00327CF9 /* memcached.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = memcached.c; sourceTree = "<group>"; };
 		10A3D3D61B4F1E3200327CF9 /* 50mruby.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 50mruby.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -1188,6 +1189,7 @@
 				105534FE1A46134A00627ECB /* 80issues61.t */,
 				1092E0011BEB1DDC001074BF /* 80issues579.t */,
 				104481271BFC05FC0007863F /* 80issues595.t */,
+				10952D591C5082F7000D664C /* 80issues-from-proxy-reproxy-to-different-host.t */,
 				104B9A451A5D1004009EEE64 /* 90live-fetch-ocsp-response.t */,
 				10C2117C1B8164B1005A9D02 /* 90root-fastcgi-php.t */,
 				10AA2EC51AA0557A004322AC /* assets */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1106,13 +1106,17 @@ void h2o_send_inline(h2o_req_t *req, const char *body, size_t len);
  */
 void h2o_send_error(h2o_req_t *req, int status, const char *reason, const char *body, int flags);
 /**
+ * sends error response using zero timeout; can be called by output filters while processing the headers
+ */
+void h2o_send_error_deferred(h2o_req_t *req, int status, const char *reason, const char *body, int flags);
+/**
  * sends a redirect response
  */
 void h2o_send_redirect(h2o_req_t *req, int status, const char *reason, const char *url, size_t url_len);
 /**
  * handles redirect internally
  */
-void h2o_send_redirect_internal(h2o_req_t *req, h2o_iovec_t method, const char *url_str, size_t url_len);
+void h2o_send_redirect_internal(h2o_req_t *req, h2o_iovec_t method, const char *url_str, size_t url_len, int preserve_overrides);
 /**
  * returns method to be used after redirection
  */

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -357,7 +357,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                 if (req->res_is_delegated && (300 <= status && status <= 399) && status != 304) {
                     self->client = NULL;
                     h2o_iovec_t method = h2o_get_redirect_method(req->method, status);
-                    h2o_send_redirect_internal(req, method, headers[i].value, headers[i].value_len);
+                    h2o_send_redirect_internal(req, method, headers[i].value, headers[i].value_len, 1);
                     return NULL;
                 }
                 if (req->overrides != NULL && req->overrides->location_rewrite.match != NULL) {

--- a/lib/handler/errordoc.c
+++ b/lib/handler/errordoc.c
@@ -122,7 +122,7 @@ Found:
         method = h2o_iovec_init(H2O_STRLIT("GET"));
     req->headers = (h2o_headers_t){};
     req->res.headers = (h2o_headers_t){};
-    h2o_send_redirect_internal(req, method, errordoc->url.base, errordoc->url.len);
+    h2o_send_redirect_internal(req, method, errordoc->url.base, errordoc->url.len, 0);
     /* create fake ostream that swallows the contents emitted by the generator */
     ostream = h2o_add_ostream(req, sizeof(*ostream), slot);
     ostream->do_send = on_ostream_send;

--- a/t/80issues-from-proxy-reproxy-to-different-host.t
+++ b/t/80issues-from-proxy-reproxy-to-different-host.t
@@ -1,0 +1,79 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+# start upstream
+my $upstream = empty_port();
+my $upstream_guard = spawn_server(
+    argv     => [
+        qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), "127.0.0.1:$upstream",
+        ASSETS_DIR . "/upstream.psgi",
+    ],
+    is_ready =>  sub {
+        check_port($upstream);
+    },
+);
+
+my $error_upstream = empty_port();
+my $error_upstream_guard = spawn_server(
+    argv     => [
+        qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), "127.0.0.1:$error_upstream",
+        "-e", 'sub { [200, [], [123]] }',
+    ],
+    is_ready =>  sub {
+        check_port($upstream);
+    },
+);
+
+subtest "internal-redirect-from-proxy" => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream/
+        error-doc:
+          status: 404
+          url: http://127.0.0.1:$error_upstream/
+EOT
+    my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/index.txt");
+    like $headers, qr{^HTTP/1\.1 200 }is;
+    is $body, "hello\n";
+
+    ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/notfound");
+    like $headers, qr{^HTTP/1\.1 404 }is;
+    is $body, "123";
+};
+
+subtest "internal-redirect-within-proxy" => sub {
+    plan skip_all => 'mruby support is off'
+        unless server_features()->{mruby};
+    my $server = spawn_h2o(<< "EOT");
+reproxy: ON
+hosts:
+  default:
+    paths:
+      "/":
+        mruby.handler: |
+          Proc.new do |env|
+            [200, { "x-reproxy-url" => "/proxy?resp:status=302&resp:location=/index.txt" }, ["from mruby"]]
+          end
+      "/proxy":
+        proxy.reverse.url: http://127.0.0.1:$upstream/
+EOT
+    my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+    like $headers, qr{^HTTP/1\.1 200 }is;
+    is $body, "hello\n";
+};
+
+done_testing;


### PR DESCRIPTION
implements #704

Also fixes an issue that leads to a wrong response being sent when an internal redirect is triggered (e.g. error-doc, reproxy) after proxy is used, and if the authority of the source and destination of the redirect differ.