### PR TITLE
fix build error when an older version of H2O is installed aside with an optional external dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,18 @@ ELSE (WITH_BUNDLED_SSL)
     ENDIF (OPENSSL_VERSION VERSION_LESS "1.0.2")
 ENDIF (WITH_BUNDLED_SSL)
 
+INCLUDE_DIRECTORIES(
+    include
+    deps/cloexec
+    deps/golombset
+    deps/libyrmcds
+    deps/klib
+    deps/neverbleed
+    deps/picohttpparser
+    deps/picotest
+    deps/yaml/include
+    deps/yoml)
+
 IF (PKG_CONFIG_FOUND)
     PKG_CHECK_MODULES(LIBUV libuv>=1.0.0)
     IF (LIBUV_FOUND)
@@ -138,18 +150,6 @@ IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 ENDIF ()
 
 SET(CMAKE_C_FLAGS "-O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS} -DH2O_ROOT=\"${CMAKE_INSTALL_PREFIX}\"")
-
-INCLUDE_DIRECTORIES(
-    include
-    deps/cloexec
-    deps/golombset
-    deps/libyrmcds
-    deps/klib
-    deps/neverbleed
-    deps/picohttpparser
-    deps/picotest
-    deps/yaml/include
-    deps/yoml)
 
 SET(LIBYAML_SOURCE_FILES
     deps/yaml/src/api.c


### PR DESCRIPTION
The build configuration script (i.e. CMakeLists.txt) searches for optional dependencies (e.g. libuv) and sets the include path to the library before setting include paths for the files provided by H2O.

It means that if an older version of H2O is installed next to libuv (or other dependencies), the compiler will use the files in the installed directory instead of the ones in the source directory (for example, if libuv and an older version of H2O is installed under `/usr/local`, GCC option will be `-I /usr/local/include -I /path/to/h2o/include`).

This PR fixes the issue by moving the `INCLUDE_DIRECTORIES` command that specifies project-level search paths above the commands that specify the include paths for external dependencies.
