### PR TITLE
handlers must not `free` pointers returned by `h2o_create_handler`

### DIFF
--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -792,7 +792,6 @@ static void on_handler_dispose(h2o_handler_t *_handler)
 
     h2o_socketpool_dispose(&handler->sockpool);
     free(handler->config.document_root.base);
-    free(handler);
 }
 
 static h2o_fastcgi_handler_t *register_common(h2o_pathconf_t *pathconf, h2o_fastcgi_config_vars_t *vars)

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -128,8 +128,6 @@ static void on_handler_dispose(h2o_handler_t *_self)
         h2o_socketpool_dispose(self->sockpool);
         free(self->sockpool);
     }
-
-    free(self);
 }
 
 void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstream, h2o_proxy_config_vars_t *config)


### PR DESCRIPTION
fixes a double-free bug in configuration phase; reported in https://github.com/h2o/h2o/issues/717#issuecomment-173837892.