### PR TITLE
fix response getting truncated when neither content-length nor transfer-encoding is used

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -108,7 +108,6 @@ static void on_body_until_close(h2o_socket_t *sock, int status)
             close_client(client);
             return;
         }
-        h2o_buffer_consume(&sock->input, sock->input->size);
     }
 
     h2o_timeout_link(client->super.ctx->loop, client->super.ctx->io_timeout, &client->_timeout);


### PR DESCRIPTION
When upstream sends a response that neither has `content-length` nor `transfer-encoding` is used, the response that could not be sent immediately gets truncated within the http1 client.

This PR fixes the issue.