### PR TITLE
fix PUSH_PROMISE sent in wrong order when under high pressure

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1070,7 +1070,7 @@ static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_le
         return;
     if (conn->push_stream_ids.max_open >= 0x7ffffff0)
         return;
-    if (!can_run_requests(conn))
+    if (!(h2o_linklist_is_empty(&conn->_pending_reqs) && can_run_requests(conn)))
         return;
 
     /* casper-related code */


### PR DESCRIPTION
`PUSH_PROMISE` frames must be sent in the ascending order of the stream id.

However, when the number of in-flight requests exceeds the limit imposed by `http2-max-concurrent-requests-per-connection` (default: 100), there is a chance that they get sent in a wrong order.

This PR changes the code so that contents would get pushed only if there is no pending requests within the internal queue (that implements the aforementioned limit).

fixes #726