### PR TITLE
invalid format in Example of access_log document

### DIFF
--- a/doc/configure/access_log_directives.html
+++ b/doc/configure/access_log_directives.html
@@ -95,7 +95,7 @@ If the supplied argument is a mapping, its <code>path</code> property is conside
 <div class="caption">Example. Emit access log to file using Common Log Format</div>
 <pre><code>access-log:
     path: /path/to/access-log-file
-    format: &quot;%h %l %u %t \&quot;%r\&quot; %&gt;s %b&quot;
+    format: &quot;%h %l %u %t \&quot;%r\&quot; %s %b&quot;
 </code></pre>
 </div>
 


### PR DESCRIPTION
`failed to compile log format: unknown escape sequence: %>`