### PR TITLE
fix build issue with poll backend: h2o_vector_reserve

### DIFF
--- a/lib/common/socket/evloop/poll.c.h
+++ b/lib/common/socket/evloop/poll.c.h
@@ -88,7 +88,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
             continue;
         assert(fd == sock->fd);
         if ((sock->_flags & (H2O_SOCKET_FLAG_IS_POLLED_FOR_READ | H2O_SOCKET_FLAG_IS_POLLED_FOR_WRITE)) != 0) {
-            h2o_vector_reserve(NULL, (void *)&pollfds, sizeof(pollfds.entries[0]), pollfds.size + 1);
+            h2o_vector_reserve(NULL, &pollfds, pollfds.size + 1);
             struct pollfd *slot = pollfds.entries + pollfds.size++;
             slot->fd = fd;
             slot->events = 0;
@@ -143,7 +143,7 @@ static void evloop_do_on_socket_create(struct st_h2o_evloop_socket_t *sock)
     struct st_h2o_evloop_poll_t *loop = (struct st_h2o_evloop_poll_t *)sock->loop;
 
     if (sock->fd >= loop->socks.size) {
-        h2o_vector_reserve(NULL, (void *)&loop->socks, sizeof(loop->socks.entries[0]), sock->fd + 1);
+        h2o_vector_reserve(NULL, &loop->socks, sock->fd + 1);
         memset(loop->socks.entries + loop->socks.size, 0, (sock->fd + 1 - loop->socks.size) * sizeof(loop->socks.entries[0]));
         loop->socks.size = sock->fd + 1;
     }


### PR DESCRIPTION
possible leftover from #735 ?

trying out h2o 1.7.0 today, and compiler complains:
```
[lib/common/socket/evloop/poll.c.h]:
error: macro "h2o_vector_reserve" passed 4 arguments, but takes just 3
```
...defined in https://github.com/h2o/h2o/blob/master/include/h2o/memory.h#L255
[am using the (fallback) poll interface since my platform doesn't support the others]

possibly an oversight from the above PR?
(alternatively also solved it by renaming `h2o_vector_reserve` back to `h2o_vector__reserve`)

anyway thanks kazuho for the 1.7.0 release, and mingodad for the initial PR
great work from both of you!