### PR TITLE
support `<<` in h2o.conf

### DIFF
--- a/deps/yoml/.gitmodules
+++ b/deps/yoml/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/picotest"]
+	path = deps/picotest
+	url = https://github.com/h2o/picotest.git

--- a/deps/yoml/test-yoml.c
+++ b/deps/yoml/test-yoml.c
@@ -32,22 +32,33 @@ static yoml_t *parse(const char *fn, const char *s)
 
     yaml_parser_initialize(&parser);
     yaml_parser_set_input_string(&parser, (yaml_char_t*)s, strlen(s));
-    doc = yoml_parse_document(&parser, NULL, fn);
+    doc = yoml_parse_document(&parser, NULL, NULL, fn);
     yaml_parser_delete(&parser);
 
     return doc;
 }
 
+static yoml_t *get_value(yoml_t *mapping, const char *key)
+{
+    size_t i;
+    for (i = 0; i != mapping->data.mapping.size; ++i)
+        if (mapping->data.mapping.elements[i].key->type == YOML_TYPE_SCALAR &&
+            strcmp(mapping->data.mapping.elements[i].key->data.scalar, key) == 0)
+            return mapping->data.mapping.elements[i].value;
+    return NULL;
+}
+
 int main(int argc, char **argv)
 {
     yoml_t *doc, *t;
+    size_t i;
 
     doc = parse("foo.yaml", "abc");
     ok(doc != NULL);
     ok(strcmp(doc->filename, "foo.yaml") == 0);
     ok(doc->type == YOML_TYPE_SCALAR);
     ok(strcmp(doc->data.scalar, "abc") == 0);
-    yoml_free(doc);
+    yoml_free(doc, NULL);
 
     doc = parse(
        "foo.yaml",
@@ -76,7 +87,7 @@ int main(int argc, char **argv)
     ok(strcmp(t->filename, "foo.yaml") == 0);
     ok(t->type == YOML_TYPE_SCALAR);
     ok(strcmp(t->data.scalar, "d") == 0);
-    yoml_free(doc);
+    yoml_free(doc, NULL);
 
     doc = parse(
             "bar.yaml",
@@ -111,7 +122,7 @@ int main(int argc, char **argv)
     ok(strcmp(doc->filename, "bar.yaml") == 0);
     ok(t->type == YOML_TYPE_SCALAR);
     ok(strcmp(t->data.scalar, "e") == 0);
-    yoml_free(doc);
+    yoml_free(doc, NULL);
 
     doc = parse(
         "baz.yaml",
@@ -137,6 +148,107 @@ int main(int argc, char **argv)
     ok(strcmp(t->filename, "baz.yaml") == 0);
     ok(t->type == YOML_TYPE_SCALAR);
     ok(strcmp(t->data.scalar, "2") == 0);
+
+    doc = parse(
+        "foo.yaml",
+        "- &link\n"
+        "  x: 1\n"
+        "  y: 2\n"
+        "- <<: *link\n"
+        "  y: 3\n");
+    ok(doc != NULL);
+    ok(doc->type == YOML_TYPE_SEQUENCE);
+    ok(doc->data.sequence.size == 2);
+    ok(doc->data.sequence.elements[0]->type == YOML_TYPE_MAPPING);
+    ok(doc->data.sequence.elements[0]->data.mapping.size == 2);
+    ok(doc->data.sequence.elements[0]->data.mapping.elements[0].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[0]->data.mapping.elements[0].key->data.scalar, "x") == 0);
+    ok(doc->data.sequence.elements[0]->data.mapping.elements[0].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[0]->data.mapping.elements[0].value->data.scalar, "1") == 0);
+    ok(doc->data.sequence.elements[0]->data.mapping.elements[1].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[0]->data.mapping.elements[1].key->data.scalar, "y") == 0);
+    ok(doc->data.sequence.elements[0]->data.mapping.elements[1].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[0]->data.mapping.elements[1].value->data.scalar, "2") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[0].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[0].key->data.scalar, "x") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[0].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[0].value->data.scalar, "1") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[1].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[1].key->data.scalar, "y") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[1].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[1].value->data.scalar, "3") == 0);
+
+    doc = parse(
+        "foo.yaml",
+        "- &CENTER { x: 1, y: 2 }\n"
+        "- &LEFT { x: 0, y: 2 }\n"
+        "- &BIG { r: 10 }\n"
+        "- &SMALL { r: 1 }\n"
+        "- # Explicit keys\n"
+        "  x: 1\n"
+        "  y: 2\n"
+        "  r: 10\n"
+        "- # Merge one map\n"
+        "  << : *CENTER\n"
+        "  r: 10\n"
+        "- # Merge multiple maps\n"
+        "  << : [ *CENTER, *BIG ]\n"
+        "- # Override\n"
+        "  << : [ *BIG, *LEFT, *SMALL ]\n"
+        "  x: 1\n");
+    ok(doc != NULL);
+    ok(doc->type == YOML_TYPE_SEQUENCE);
+    for (i = 4; i <= 7; ++i) {
+        ok(doc->data.sequence.elements[i]->type == YOML_TYPE_MAPPING);
+        ok(doc->data.sequence.elements[i]->data.mapping.size == 3);
+        t = get_value(doc->data.sequence.elements[i], "x");
+        ok(t != NULL);
+        ok(t->type == YOML_TYPE_SCALAR);
+        ok(strcmp(t->data.scalar, "1") == 0);
+        t = get_value(doc->data.sequence.elements[i], "y");
+        ok(t != NULL);
+        ok(t->type == YOML_TYPE_SCALAR);
+        ok(strcmp(t->data.scalar, "2") == 0);
+        t = get_value(doc->data.sequence.elements[i], "r");
+        ok(t != NULL);
+        ok(t->type == YOML_TYPE_SCALAR);
+        ok(strcmp(t->data.scalar, "10") == 0);
+    }
+
+    doc = parse(
+        "foo.yaml",
+        "- &link\n"
+        "  x: 1\n"
+        "  x: 2\n"
+        "-\n"
+        "  x: 3\n"
+        "  <<: *link\n");
+    ok(doc != NULL);
+    ok(doc->type == YOML_TYPE_SEQUENCE);
+    ok(doc->data.sequence.size == 2);
+    ok(doc->data.sequence.elements[0]->type == YOML_TYPE_MAPPING);
+    ok(doc->data.sequence.elements[0]->data.mapping.size == 2);
+    ok(doc->data.sequence.elements[0]->data.mapping.elements[0].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[0]->data.mapping.elements[0].key->data.scalar, "x") == 0);
+    ok(doc->data.sequence.elements[0]->data.mapping.elements[0].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[0]->data.mapping.elements[0].value->data.scalar, "1") == 0);
+    ok(doc->data.sequence.elements[0]->data.mapping.elements[1].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[0]->data.mapping.elements[1].key->data.scalar, "x") == 0);
+    ok(doc->data.sequence.elements[0]->data.mapping.elements[1].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[0]->data.mapping.elements[1].value->data.scalar, "2") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.size == 3);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[0].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[0].key->data.scalar, "x") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[0].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[0].value->data.scalar, "3") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[1].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[1].key->data.scalar, "x") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[1].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[1].value->data.scalar, "1") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[2].key->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[2].key->data.scalar, "x") == 0);
+    ok(doc->data.sequence.elements[1]->data.mapping.elements[2].value->type == YOML_TYPE_SCALAR);
+    ok(strcmp(doc->data.sequence.elements[1]->data.mapping.elements[2].value->data.scalar, "2") == 0);
 
     return done_testing();
 }

--- a/deps/yoml/yoml-parser.h
+++ b/deps/yoml/yoml-parser.h
@@ -161,30 +161,106 @@ static yoml_t *yoml__parse_node(yaml_parser_t *parser, yaml_event_type_t *unhand
     return node;
 }
 
-static inline int yoml__resolve_alias(yoml_t **target, yoml_t *doc, void *(*mem_set)(void *, int, size_t))
+static inline int yoml__merge(yoml_t **dest, size_t offset, yoml_t *src)
 {
-    size_t i;
+    yoml_t *key, *value;
+    size_t i, j;
+
+    if (src->type != YOML_TYPE_MAPPING)
+        return -1;
+
+    for (i = 0; i != src->data.mapping.size; ++i) {
+        key = src->data.mapping.elements[i].key;
+        value = src->data.mapping.elements[i].value;
+        if (key->type == YOML_TYPE_SCALAR) {
+            for (j = offset; j != (*dest)->data.mapping.size; ++j) {
+                if ((*dest)->data.mapping.elements[j].key->type == YOML_TYPE_SCALAR &&
+                    strcmp((*dest)->data.mapping.elements[j].key->data.scalar, key->data.scalar) == 0)
+                    goto Skip;
+            }
+        }
+        *dest = realloc(*dest, offsetof(yoml_t, data.mapping.elements) +
+                                   ((*dest)->data.mapping.size + 1) * sizeof((*dest)->data.mapping.elements[0]));
+        memmove((*dest)->data.mapping.elements + offset + 1, (*dest)->data.mapping.elements + offset,
+                ((*dest)->data.mapping.size - offset) * sizeof((*dest)->data.mapping.elements[0]));
+        (*dest)->data.mapping.elements[offset].key = key;
+        ++key->_refcnt;
+        (*dest)->data.mapping.elements[offset].value = value;
+        ++value->_refcnt;
+        ++(*dest)->data.mapping.size;
+        ++offset;
+    Skip:
+        ;
+    }
+
+    return 0;
+}
+
+static inline int yoml__resolve_alias(yoml_t **target, yoml_t *doc, yaml_parser_t *parser, void *(*mem_set)(void *, int, size_t))
+{
+    size_t i, j;
 
     switch ((*target)->type) {
     case YOML_TYPE_SCALAR:
         break;
     case YOML_TYPE_SEQUENCE:
         for (i = 0; i != (*target)->data.sequence.size; ++i) {
-            if (yoml__resolve_alias((*target)->data.sequence.elements + i, doc, mem_set) != 0)
+            if (yoml__resolve_alias((*target)->data.sequence.elements + i, doc, parser, mem_set) != 0)
                 return -1;
         }
         break;
     case YOML_TYPE_MAPPING:
-        for (i = 0; i != (*target)->data.mapping.size; ++i) {
-            if (yoml__resolve_alias(&(*target)->data.mapping.elements[i].key, doc, mem_set) != 0 ||
-                yoml__resolve_alias(&(*target)->data.mapping.elements[i].value, doc, mem_set) != 0)
-                return -1;
+        /* traverse in descending order (for ease of merge) */
+        if ((*target)->data.mapping.size != 0) {
+            i = (*target)->data.mapping.size;
+            do {
+                --i;
+                /* merge the value */
+                if (yoml__resolve_alias(&(*target)->data.mapping.elements[i].value, doc, parser, mem_set) != 0)
+                    return -1;
+                /* merge the keys or resolve the alias */
+                if ((*target)->data.mapping.elements[i].key->type == YOML_TYPE_SCALAR &&
+                    strcmp((*target)->data.mapping.elements[i].key->data.scalar, "<<") == 0) {
+                    /* erase the slot (as well as preserving the values) */
+                    yoml_mapping_element_t src = (*target)->data.mapping.elements[i];
+                    memmove((*target)->data.mapping.elements + i, (*target)->data.mapping.elements + i + 1,
+                            ((*target)->data.mapping.size - i - 1) * sizeof((*target)->data.mapping.elements[0]));
+                    --(*target)->data.mapping.size;
+                    /* merge */
+                    if (src.value->type == YOML_TYPE_SEQUENCE) {
+                        for (j = 0; j != src.value->data.sequence.size; ++j)
+                            if (yoml__merge(target, i, src.value->data.sequence.elements[j]) != 0) {
+                            MergeError:
+                                if (parser != NULL) {
+                                    parser->problem = "value of the merge key MUST be a mapping or a sequence of mappings";
+                                    parser->problem_mark.line = src.key->line;
+                                    parser->problem_mark.column = src.key->column;
+                                }
+                                return -1;
+                            }
+                    } else {
+                        if (yoml__merge(target, i, src.value) != 0)
+                            goto MergeError;
+                    }
+                    /* cleanup */
+                    yoml_free(src.key, mem_set);
+                    yoml_free(src.value, mem_set);
+                } else if (yoml__resolve_alias(&(*target)->data.mapping.elements[i].key, doc, parser, mem_set) != 0) {
+                    return -1;
+                }
+            } while (i != 0);
         }
         break;
     case YOML__TYPE_UNRESOLVED_ALIAS: {
         yoml_t *node = yoml_find_anchor(doc, (*target)->data.alias);
-        if (node == NULL)
+        if (node == NULL) {
+            if (parser != NULL) {
+                parser->problem = "could not resolve the alias";
+                parser->problem_mark.line = (*target)->line;
+                parser->problem_mark.column = (*target)->column;
+            }
             return -1;
+        }
         yoml_free(*target, mem_set);
         *target = node;
         ++node->_refcnt;
@@ -207,7 +283,7 @@ static inline yoml_t *yoml_parse_document(yaml_parser_t *parser, yaml_event_type
         *unhandled = YAML_NO_EVENT;
 
     /* resolve aliases */
-    if (yoml__resolve_alias(&doc, doc, mem_set) != 0) {
+    if (yoml__resolve_alias(&doc, doc, parser, mem_set) != 0) {
         yoml_free(doc, mem_set);
         doc = NULL;
     }

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -483,6 +483,7 @@
 		10B38A651B8D345D007DC191 /* mruby.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mruby.c; sourceTree = "<group>"; };
 		10B38A711B8D34BB007DC191 /* mruby_.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mruby_.h; sourceTree = "<group>"; };
 		10B38A731B8D3544007DC191 /* mruby.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mruby.c; sourceTree = "<group>"; };
+		10B6D4501C727315005F0CF8 /* 80yaml-merge.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "80yaml-merge.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10BA72A919AAD6300059392A /* stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stream.c; sourceTree = "<group>"; };
 		10BCF2FC1B168CAE0076939D /* fastcgi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fastcgi.c; sourceTree = "<group>"; };
 		10BCF2FE1B1A892F0076939D /* fastcgi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fastcgi.c; sourceTree = "<group>"; };
@@ -1196,6 +1197,7 @@
 				1092E0011BEB1DDC001074BF /* 80issues579.t */,
 				104481271BFC05FC0007863F /* 80issues595.t */,
 				10952D591C5082F7000D664C /* 80issues-from-proxy-reproxy-to-different-host.t */,
+				10B6D4501C727315005F0CF8 /* 80yaml-merge.t */,
 				104B9A451A5D1004009EEE64 /* 90live-fetch-ocsp-response.t */,
 				10C2117C1B8164B1005A9D02 /* 90root-fastcgi-php.t */,
 				10AA2EC51AA0557A004322AC /* assets */,

--- a/t/80yaml-merge.t
+++ b/t/80yaml-merge.t
@@ -1,0 +1,82 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use File::Temp qw(tempdir);
+use Net::EmptyPort qw(check_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
+plan skip_all => 'nc not found'
+    unless prog_exists('nc');
+
+my @ports = empty_ports(3);
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+{ # create configuration file
+    open my $fh, ">", "$tempdir/h2o.conf"
+        or die "failed to create file:$tempdir/h2o.conf:$!";
+    print $fh <<"EOT";
+hosts:
+  host1: \&default
+    listen: $ports[0]
+    paths:
+      /:
+        mruby.handler: |
+          Proc.new do |env|
+            [200, {}, [env["SERVER_NAME"]]]
+          end
+  host2:
+    listen: $ports[1]
+    <<: *default
+  host3:
+    <<: *default
+    listen: $ports[2]
+EOT
+};
+
+my $guard = spawn_server(
+    argv     => [ bindir() . "/h2o", "-c", "$tempdir/h2o.conf" ],
+    is_ready => sub {
+        for (@ports) {
+            return unless check_port($_);
+        }
+        return 1;
+    },
+);
+
+subtest "port1" => sub {
+    subtest "no-host" => sub {
+        my $resp = `(echo "GET / HTTP/1.0"; echo) | nc 127.0.0.1 $ports[0] 2>&1`;
+        like $resp, qr{^HTTP/1\.[0-9]+ 200 OK\r\n}s;
+        like $resp, qr{\r\n\r\nhost1$}s;
+    };
+    subtest "host=host2" => sub {
+        my $resp = `(echo "GET / HTTP/1.0"; echo "Host: host2"; echo) | nc 127.0.0.1 $ports[0] 2>&1`;
+        like $resp, qr{^HTTP/1\.[0-9]+ 200 OK\r\n}s;
+        like $resp, qr{\r\n\r\nhost2$}s;
+    };
+    subtest "host=host3" => sub {
+        # host3 is not listening on the default port
+        my $resp = `(echo "GET / HTTP/1.0"; echo) | nc 127.0.0.1 $ports[0] 2>&1`;
+        like $resp, qr{^HTTP/1\.[0-9]+ 200 OK\r\n}s;
+        like $resp, qr{\r\n\r\nhost1$}s;
+    };
+};
+
+subtest "port2" => sub {
+    my $resp = `(echo "GET / HTTP/1.0"; echo) | nc 127.0.0.1 $ports[1] 2>&1`;
+    like $resp, qr{^HTTP/1\.[0-9]+ 200 OK\r\n}s;
+    like $resp, qr{\r\n\r\nhost2$}s;
+};
+
+subtest "port3" => sub {
+    my $resp = `(echo "GET / HTTP/1.0"; echo) | nc 127.0.0.1 $ports[2] 2>&1`;
+    like $resp, qr{^HTTP/1\.[0-9]+ 200 OK\r\n}s;
+    like $resp, qr{\r\n\r\nhost3$}s;
+};
+
+done_testing;


### PR DESCRIPTION
Implements [Merge Key Language-Independent Type for YAML™ Version 1.1](http://yaml.org/type/merge.html) for h2o.conf.

With this PR, it is possible to _inherit_ a YAML node and overrwrite some of the properties.
As an example, the snippet below reuses the SSL attributes defined for `host1.example.com` in `host2example.com`.
```yaml
hosts:
  host1.example.com:
    listen:
      port: 443
      ssl: &ssl_base
        key-file: /path/to/host1.key
        certificate-file: /path/to/host1.crt
        minimum-version: TLSv1.1
        cipher-suite: ...
        cipher-preference: server
    ...
  host2.example.com:
    listen:
      port: 443
      ssl:
        <<: *ssl_base
        key-file: /path/to/host2.key
        certificate-file: /path/to/host2.crt
    ...
```
see also: https://github.com/h2o/yoml/pull/2, relates to: #758 #764 #772