### PR TITLE
truncate body to the size specified with `content-length`

### DIFF
--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -657,8 +657,11 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
         h2o_start_response(generator->req, &generator->super);
         h2o_send(generator->req, NULL, 0, 1);
     } else {
-        if (content.len < generator->req->res.content_length)
+        if (content.len < generator->req->res.content_length) {
             generator->req->res.content_length = content.len;
+        } else {
+            content.len = generator->req->res.content_length;
+        }
         h2o_start_response(generator->req, &generator->super);
         h2o_send(generator->req, &content, 1, 1);
     }


### PR DESCRIPTION
Such code did not exist for the fast path (though it was implemented for the chunked sender).

This is a requirement by the HTTP/2 spec.:
> A request or response is also malformed if the value of a content-length header field does not equal the sum of the DATA frame payload lengths that form the body.
> [RFC 7540 Section 8.1.2.6](http://http2.github.io/http2-spec/index.html#malformed)

Fixes #778