### PR TITLE
by default, run both http/1 and http/2 tests using curl

### DIFF
--- a/t/40pathconf-redirect.t
+++ b/t/40pathconf-redirect.t
@@ -13,14 +13,11 @@ hosts:
         file.dir: @{[ DOC_ROOT ]}
 EOT
 
-sub doit {
-    my ($proto, $port) = @_;
-    my ($stderr, $stdout) = run_prog("curl --silent --show-error --insecure --max-redirs 0 --dump-header /dev/stderr $proto://127.0.0.1:$port/abc");
+run_with_curl($server, sub {
+    my ($proto, $port, $curl) = @_;
+    my ($stderr, $stdout) = run_prog("$curl --silent --show-error --max-redirs 0 --dump-header /dev/stderr $proto://127.0.0.1:$port/abc");
     like $stderr, qr{^HTTP/[^ ]+ 301\s}s, "is 301";
     like $stderr, qr{^location: ?/abc/\r$}im, "location header";
-}
-
-subtest 'http' => sub { doit('http', $server->{port}); };
-subtest 'https' => sub { doit('https', $server->{tls_port}); };
+});
 
 done_testing;

--- a/t/40protocol.t
+++ b/t/40protocol.t
@@ -21,16 +21,14 @@ my $port = $server->{port};
 my $tls_port = $server->{tls_port};
 
 subtest 'curl' => sub {
-    plan skip_all => 'curl not found'
-        unless prog_exists('curl');
-    for my $file (sort keys %files) {
-        my $content = `curl --silent --show-error http://127.0.0.1:$port/$file`;
-        is length($content), $files{$file}->{size}, "http://127.0.0.1/$file (size)";
-        is md5_hex($content), $files{$file}->{md5}, "http://127.0.0.1/$file (md5)";
-        $content = `curl --silent --show-error --insecure https://127.0.0.1:$tls_port/$file`;
-        is length($content), $files{$file}->{size}, "http://127.0.0.1/$file (size)";
-        is md5_hex($content), $files{$file}->{md5}, "https://127.0.0.1/$file (md5)";
-    }
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        for my $file (sort keys %files) {
+            my $content = `$curl --silent --show-error $proto://127.0.0.1:$port/$file`;
+            is length($content), $files{$file}->{size}, "$file (size)";
+            is md5_hex($content), $files{$file}->{md5}, "$file (md5)";
+        }
+    });
 };
 
 subtest 'nghttp' => sub {

--- a/t/50errordoc.t
+++ b/t/50errordoc.t
@@ -3,26 +3,6 @@ use warnings;
 use Test::More;
 use t::Util;
 
-plan skip_all => 'curl not found'
-    unless prog_exists('curl');
-
-sub run_tests {
-    my ($server, $cb) = @_;
-    subtest 'HTTP/1.1' => sub {
-        subtest 'http' => sub {
-            $cb->('http', '', $server->{port});
-        };
-        subtest 'https' => sub {
-            $cb->('https', '--insecure', $server->{tls_port});
-        };
-    };
-    subtest 'HTTP/2' => sub {
-        plan skip_all => 'curl does not support HTTP/2'
-            unless curl_supports_http2();
-        $cb->('https', '--http2 --insecure', $server->{tls_port});
-    };
-}
-
 subtest 'basic' => sub {
     my $server = spawn_h2o(<< "EOT");
 hosts:
@@ -41,11 +21,11 @@ EOT
         local $/;
         <$fh>;
     };
-    run_tests($server, sub {
-        my ($proto, $opts, $port) = @_;
-        my $resp = `curl $opts --silent $proto://127.0.0.1:$port/nonexist`;
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my $resp = `$curl --silent $proto://127.0.0.1:$port/nonexist`;
         is $resp, $expected, "content";
-        $resp = `curl $opts --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
+        $resp = `$curl --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
         like $resp, qr{^HTTP/[^ ]+ 404\s}s, "status";
         like $resp, qr{\r\ncontent-type:\s*text/html.*\r\n}is, "content-type";
         like $resp, qr{\r\ncontent-length:\s*@{[length $expected]}\r\n}is, "content-length";
@@ -66,11 +46,11 @@ error-doc:
   url: /nonexist
 EOT
 
-    run_tests($server, sub {
-        my ($proto, $opts, $port) = @_;
-        my $resp = `curl $opts --silent $proto://127.0.0.1:$port/nonexist`;
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my $resp = `$curl --silent $proto://127.0.0.1:$port/nonexist`;
         is $resp, "not found", "content";
-        $resp = `curl $opts --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
+        $resp = `$curl --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
         like $resp, qr{^HTTP/[^ ]+ 404\s}s, "status";
         like $resp, qr{\r\ncontent-type:\s*text/plain.*\r\n}is, "content-type";
         like $resp, qr{\r\ncontent-length:\s*@{[length "not found"]}\r\n}is, "content-length";
@@ -97,11 +77,11 @@ EOT
         local $/;
         <$fh>;
     };
-    run_tests($server, sub {
-        my ($proto, $opts, $port) = @_;
-        my $resp = `curl $opts --silent $proto://127.0.0.1:$port/nonexist`;
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my $resp = `$curl --silent $proto://127.0.0.1:$port/nonexist`;
         is $resp, $expected, "content";
-        $resp = `curl $opts --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
+        $resp = `$curl --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
         like $resp, qr{^HTTP/[^ ]+ 404\s}s, "status";
         like $resp, qr{\r\ncontent-type:\s*text/plain.*\r\n}is, "content-type";
         like $resp, qr{\r\ncontent-length:\s*@{[length $expected]}\r\n}is, "content-length";
@@ -124,9 +104,9 @@ error-doc:
     url: /500.html
 EOT
 
-    run_tests($server, sub {
-        my ($proto, $opts, $port) = @_;
-        my $resp = `curl $opts --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my $resp = `$curl --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
         like $resp, qr{^HTTP/[^ ]+ 404\s}s, "status";
     });
 };

--- a/t/50fastcgi-cgi.t
+++ b/t/50fastcgi-cgi.t
@@ -24,16 +24,12 @@ hosts:
         file.dir: @{[ DOC_ROOT ]}
 EOT
 
-my $doit = sub {
-    my ($proto, $port) = @_;
-    subtest $proto => sub {
-        my $resp = `curl --insecure --silent $proto://127.0.0.1:$port/hello.cgi?name=world`;
-        is $resp, "Hello world", "GET";
-        $resp = `curl --insecure --silent -F name=world $proto://127.0.0.1:$port/hello.cgi`;
-        is $resp, "Hello world", "POST";
-    };
-};
-$doit->('http', $server->{port});
-$doit->('https', $server->{tls_port});
+run_with_curl($server, sub {
+    my ($proto, $port, $curl) = @_;
+    my $resp = `$curl --silent $proto://127.0.0.1:$port/hello.cgi?name=world`;
+    is $resp, "Hello world", "GET";
+    $resp = `$curl --silent -F name=world $proto://127.0.0.1:$port/hello.cgi`;
+    is $resp, "Hello world", "POST";
+});
 
 done_testing();

--- a/t/50file-range.t
+++ b/t/50file-range.t
@@ -21,9 +21,9 @@ hosts:
         file.dir: @{[ DOC_ROOT ]}
 EOT
 
-sub doit {
-    my ($proto, $port, $curl_opts) = @_;
-    my $curl_cmd = "curl --silent --show-error --insecure $curl_opts";
+run_with_curl($server, sub {
+    my ($proto, $port, $curl_cmd) = @_;
+    $curl_cmd .= " --silent --show-error";
     my $url = "$proto://127.0.0.1:$port/halfdome.jpg";
 
     subtest "non-ranged" => sub {
@@ -95,20 +95,6 @@ sub doit {
         my $headers = `$curl_cmd -r 100-199,1000-1099 --dump-header /dev/stderr $url 2>&1 > /dev/null`;
         like $headers, qr{^content-type:\s*multipart/byteranges; boundary=[0-9A-Za-z]{20}\r$}mi, "content-type";
     };
-}
-
-subtest "http1(http)" => sub {
-    doit("http", $server->{port}, "");
-};
-
-subtest "http1(https)" => sub {
-    doit("https", $server->{tls_port}, "");
-};
-
-subtest "http2" => sub {
-    plan skip_all => "curl does not support HTTP/2"
-        unless curl_supports_http2();
-    doit("https", $server->{tls_port}, "--http2");
-};
+});
 
 done_testing();

--- a/t/50gzip.t
+++ b/t/50gzip.t
@@ -27,6 +27,8 @@ EOT
 
 run_with_curl($server, sub {
     my ($proto, $port, $curl) = @_;
+    plan skip_all => 'curl issue #661'
+        if $curl =~ /--http2/;
     my $fetch_orig = sub {
         my ($path, $opts) = @_;
         run_prog("$curl --silent $opts $proto://127.0.0.1:$port$path/alice.txt");

--- a/t/50gzip.t
+++ b/t/50gzip.t
@@ -25,15 +25,15 @@ hosts:
             is_compressible: NO
 EOT
 
-my $doit = sub {
-    my ($proto, $port) = @_;
+run_with_curl($server, sub {
+    my ($proto, $port, $curl) = @_;
     my $fetch_orig = sub {
         my ($path, $opts) = @_;
-        run_prog("curl --silent --insecure $opts $proto://127.0.0.1:$port$path/alice.txt");
+        run_prog("$curl --silent $opts $proto://127.0.0.1:$port$path/alice.txt");
     };
     my $fetch_gunzip = sub {
         my ($path, $opts) = @_;
-        run_prog("curl --silent --insecure $opts $proto://127.0.0.1:$port$path/alice.txt | gzip -cd");
+        run_prog("$curl --silent $opts $proto://127.0.0.1:$port$path/alice.txt | gzip -cd");
     };
     my $expected = md5_file("@{[DOC_ROOT]}/alice.txt");
 
@@ -55,19 +55,12 @@ my $doit = sub {
     $resp = $fetch_orig->("/off-by-mime", "-H accept-encoding:gzip");
     is md5_hex($resp), $expected, "off due to is_compressible:NO";
 
-    $resp = run_prog("curl --silent --insecure -H accept-encoding:gzip $proto://127.0.0.1:$port/on/index.txt");
+    $resp = run_prog("$curl --silent -H accept-encoding:gzip $proto://127.0.0.1:$port/on/index.txt");
     is md5_hex($resp), md5_file("@{[DOC_ROOT]}/index.txt"), "tiny file not compressed";
 
-    $resp = run_prog("curl --silent --insecure -H accept-encoding:gzip $proto://127.0.0.1:$port/on/halfdome.jpg");
+    $resp = run_prog("$curl --silent -H accept-encoding:gzip $proto://127.0.0.1:$port/on/halfdome.jpg");
     is md5_hex($resp), md5_file("@{[DOC_ROOT]}/halfdome.jpg"), "image not compressed";
-};
-
-subtest 'http' => sub {
-    $doit->('http', $server->{port});
-};
-subtest 'https' => sub {
-    $doit->('https', $server->{tls_port});
-};
+});
 
 undef $server;
 

--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -135,9 +135,9 @@ hosts:
 EOT
 });
 
-sub doit {
-    my ($proto, $port) = @_;
-    my $curl_cmd = 'curl --insecure --silent --dump-header /dev/stderr';
+run_with_curl($server, sub {
+    my ($proto, $port, $curl_cmd) = @_;
+    $curl_cmd .= ' --silent --dump-header /dev/stderr';
     subtest "connection-error" => sub {
         my ($headers, $body) = run_prog("$curl_cmd $proto://127.0.0.1:$port/index.txt");
         like $headers, qr{HTTP/[^ ]+ 500\s}is;
@@ -221,20 +221,6 @@ sub doit {
             is $body, "delegated!";
         };
     };
-}
-
-subtest "http/1" => sub {
-    doit("http", $server->{port});
-};
-
-subtest "https/1" => sub {
-    doit("https", $server->{tls_port});
-};
-
-subtest "http2" => sub {
-    plan skip_all => "curl does not support HTTP/2"
-        unless curl_supports_http2();
-    doit("https", $server->{tls_port}, "--http2");
-};
+});
 
 done_testing();

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -298,18 +298,12 @@ hosts:
             [200, {}, [env["HTTP_COOKIE"]]]
           end
 EOT
-    subtest "http1" => sub {
-        my ($headers, $body) = run_prog("curl --silent -H 'cookie: a=b' -H 'cookie: c=d' --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
-        like $headers, qr{^HTTP/1\.1 200}is;
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($headers, $body) = run_prog("$curl --silent -H 'cookie: a=b' -H 'cookie: c=d' --dump-header /dev/stderr $proto://127.0.0.1:$port/");
+        like $headers, qr{^HTTP/\S+ 200}is;
         like $body, qr{^a=b;\s*c=d$}is;
-    };
-    subtest "http2" => sub {
-        plan skip_all => "curl does not support HTTP/2"
-            unless curl_supports_http2();
-        my ($headers, $body) = run_prog("curl --http2 --insecure --silent -H 'cookie: a=b' -H 'cookie: c=d' --dump-header /dev/stderr https://127.0.0.1:$server->{tls_port}/");
-        like $headers, qr{^HTTP/2\.0 200}is;
-        like $body, qr{^a=b;\s*c=d$}is;
-    };
+    });
 };
 
 subtest "close-called" => sub {

--- a/t/50post-size-limit.t
+++ b/t/50post-size-limit.t
@@ -21,8 +21,11 @@ subtest 'http1' => sub {
         my ($proto, $port, $chunked) = @_;
         my $url = "$proto://127.0.0.1:$port/";
         my $extra = "";
-        $extra .= " --insecure"
-            if $proto eq 'https';
+        if ($proto eq 'https') {
+            $extra .= " --insecure";
+            $extra .= " --http1.1"
+                if curl_supports_http2();
+        }
         $extra .= " --header 'Transfer-Encoding: chunked'"
             if $chunked;
         subtest "$proto, @{[ $chunked ? 'chunked' : 'content-length' ]}" => sub {

--- a/t/50redirect.t
+++ b/t/50redirect.t
@@ -6,6 +6,10 @@ use t::Util;
 plan skip_all => 'curl not found'
     unless prog_exists('curl');
 
+my $curl = "curl --insecure";
+$curl .= " --http1.1"
+    if curl_supports_http2();
+
 my $server = spawn_h2o(<< "EOT");
 hosts:
   default:
@@ -21,7 +25,7 @@ EOT
 sub doit {
     my ($url, $expected_status, $expected_location) = @_;
     subtest $url => sub {
-        my ($stderr, $stdout) = run_prog("curl --silent --show-error --insecure --max-redirs 0 --dump-header /dev/stderr $url");
+        my ($stderr, $stdout) = run_prog("$curl --silent --show-error --max-redirs 0 --dump-header /dev/stderr $url");
         like $stderr, qr{^HTTP/[^ ]+ $expected_status\s}s, "status";
         like $stderr, qr{^location: ?$expected_location\r$}im, "location";
     };

--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -173,6 +173,8 @@ run_with_curl($server, sub {
         like $resp, qr{^HTTP/[^ ]+ 200\s}m;
     };
     subtest 'gzip' => sub {
+        plan skip_all => 'curl issue #661'
+            if $curl =~ /--http2/;
         my $resp = `$curl --silent -H Accept-Encoding:gzip $proto://127.0.0.1:$port/gzip/alice.txt | gzip -cd`;
         is md5_hex($resp), md5_file("@{[DOC_ROOT]}/alice.txt");
     };

--- a/t/50server-starter.t
+++ b/t/50server-starter.t
@@ -82,10 +82,13 @@ sub fetch_test {
 
     plan skip_all => 'curl not found'
         unless prog_exists('curl');
+    my $curl = "curl --insecure";
+    $curl .= " --http1.1"
+        if curl_supports_http2();
 
     my $doit = sub {
         my ($proto, $port) = @_;
-        my $content = `curl --silent --show-error --insecure $proto://127.0.0.1:$port/`;
+        my $content = `$curl --silent --show-error $proto://127.0.0.1:$port/`;
         is md5_hex($content), md5_file(DOC_ROOT . "/index.txt"), $proto;
     };
     $doit->("http", $port);

--- a/t/80issues61.t
+++ b/t/80issues61.t
@@ -35,8 +35,11 @@ subtest 'http1' => sub {
     my $doit = sub {
         my ($proto, $port) = @_;
         my $extra = '';
-        $extra .= ' --insecure'
-            if $proto eq 'https';
+        if ($proto eq 'https') {
+            $extra .= ' --insecure';
+            $extra .= ' --http1.1'
+                if curl_supports_http2();
+        }
         subtest $proto => sub {
             my $resp = `curl --max-time 1 $extra $proto://127.0.0.1:$port/streaming-body 2>&1`;
             like $resp, qr/operation timed out/i, "operation should time out";


### PR DESCRIPTION
Until now, the test scripts have used curl for mostly HTTP/1 tests, while using nghttp2 for HTTP/2 tests.  When curl was intended to be used for HTTP/2 testing, `--http2` option was explicitely specified.

However, it seems that newer versions of Curl (with support for HTTP/2) seem to silently use HTTP/2 based on the result of ALPN, which is causing two troubles for us:
* some tests fail (due to HTTP/2 being used)
* HTTPS/1 tests are no longer executed (since curl would use HTTP/2)

This PR solves the issues by changing the test scripts to use curl for both HTTP/1 and HTTP/2 tests.

Still WIP.