### PR TITLE
install share/h2o/mruby scripts to system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,9 @@ ENDIF ()
 
 INSTALL(PROGRAMS share/h2o/annotate-backtrace-symbols share/h2o/fastcgi-cgi share/h2o/fetch-ocsp-response share/h2o/kill-on-close share/h2o/setuidgid share/h2o/start_server DESTINATION share/h2o)
 INSTALL(DIRECTORY doc/ DESTINATION share/doc/h2o PATTERN "Makefile" EXCLUDE PATTERN "README.md" EXCLUDE)
+IF (WITH_MRUBY)
+    INSTALL(DIRECTORY share/h2o/mruby DESTINATION share/h2o)
+ENDIF (WITH_MRUBY)
 
 # tests
 ADD_EXECUTABLE(t-00unit-evloop.t ${UNIT_TEST_SOURCE_FILES})


### PR DESCRIPTION
Install `(path/to/src/)share/h2o/mruby/htpasswd.rb` (or other script files in the future) to the system (e.g. `/usr/share/h2o/mruby/*.rb`)