### PR TITLE
avoid using malloc in signal handler

### DIFF
--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -68,7 +68,7 @@ void h2o_multithread_register_receiver(h2o_multithread_queue_t *queue, h2o_multi
  */
 void h2o_multithread_unregister_receiver(h2o_multithread_queue_t *queue, h2o_multithread_receiver_t *receiver);
 /**
- * sends a message
+ * sends a message (or set message to NULL to just wake up the receiving thread)
  */
 void h2o_multithread_send_message(h2o_multithread_receiver_t *receiver, h2o_multithread_message_t *message);
 /**

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -158,15 +158,19 @@ void h2o_multithread_send_message(h2o_multithread_receiver_t *receiver, h2o_mult
 {
     int do_send = 0;
 
-    assert(!h2o_linklist_is_linked(&message->link));
-
     pthread_mutex_lock(&receiver->queue->mutex);
-    if (h2o_linklist_is_empty(&receiver->_messages)) {
-        h2o_linklist_unlink(&receiver->_link);
-        h2o_linklist_insert(&receiver->queue->receivers.active, &receiver->_link);
-        do_send = 1;
+    if (message != NULL) {
+        assert(!h2o_linklist_is_linked(&message->link));
+        if (h2o_linklist_is_empty(&receiver->_messages)) {
+            h2o_linklist_unlink(&receiver->_link);
+            h2o_linklist_insert(&receiver->queue->receivers.active, &receiver->_link);
+            do_send = 1;
+        }
+        h2o_linklist_insert(&receiver->_messages, &message->link);
+    } else {
+        if (h2o_linklist_is_empty(&receiver->_messages))
+            do_send = 1;
     }
-    h2o_linklist_insert(&receiver->_messages, &message->link);
     pthread_mutex_unlock(&receiver->queue->mutex);
 
     if (do_send) {

--- a/src/main.c
+++ b/src/main.c
@@ -1103,11 +1103,8 @@ static yoml_t *load_config(const char *fn)
 static void notify_all_threads(void)
 {
     unsigned i;
-    for (i = 0; i != conf.num_threads; ++i) {
-        h2o_multithread_message_t *message = h2o_mem_alloc(sizeof(*message));
-        *message = (h2o_multithread_message_t){};
-        h2o_multithread_send_message(&conf.threads[i].server_notifications, message);
-    }
+    for (i = 0; i != conf.num_threads; ++i)
+        h2o_multithread_send_message(&conf.threads[i].server_notifications, NULL);
 }
 
 static void on_sigterm(int signo)


### PR DESCRIPTION
`notify_all_threads` must be async-signal-safe (thus should not call `malloc`), since it is invoked by `on_sigterm`.