### PR TITLE
mark `application/*script` and `application/json` as compressible by default

### DIFF
--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -389,7 +389,9 @@ void h2o_mimemap_get_default_attributes(const char *_mime, h2o_mime_attributes_t
 
     *attr = (h2o_mime_attributes_t){};
 
-    if (strncmp(mime, "text/", 5) == 0 || h2o_strstr(mime, type_end_at - mime, H2O_STRLIT("+xml")) != SIZE_MAX)
+    if (strncmp(mime, "text/", 5) == 0 || h2o_strstr(mime, type_end_at - mime, H2O_STRLIT("+xml")) != SIZE_MAX ||
+        (strncmp(mime, "application/", sizeof("application/") - 1) == 0 && memcmp(type_end_at - 6, "script", 6) == 0) ||
+        strcmp(mime, "application/json") == 0)
         attr->is_compressible = 1;
     if (h2o_memis(mime, type_end_at - mime, H2O_STRLIT("text/css")) ||
         h2o_memis(mime, type_end_at - mime, H2O_STRLIT("application/ecmascript")) ||


### PR DESCRIPTION
implements https://github.com/h2o/h2o/pull/802#issuecomment-188454626
