### PR TITLE
change signature of `h2o_config_register_path`

### DIFF
--- a/examples/libh2o/simple.c
+++ b/examples/libh2o/simple.c
@@ -37,7 +37,7 @@
 
 static h2o_pathconf_t *register_handler(h2o_hostconf_t *hostconf, const char *path, int (*on_req)(h2o_handler_t *, h2o_req_t *))
 {
-    h2o_pathconf_t *pathconf = h2o_config_register_path(hostconf, path);
+    h2o_pathconf_t *pathconf = h2o_config_register_path(hostconf, path, 0);
     h2o_handler_t *handler = h2o_create_handler(pathconf, sizeof(*handler));
     handler->on_req = on_req;
     return pathconf;
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
     register_handler(hostconf, "/post-test", post_test);
     register_handler(hostconf, "/chunked-test", chunked_test);
     h2o_reproxy_register(register_handler(hostconf, "/reproxy-test", reproxy_test));
-    h2o_file_register(h2o_config_register_path(hostconf, "/"), "examples/doc_root", NULL, NULL, 0);
+    h2o_file_register(h2o_config_register_path(hostconf, "/", 0), "examples/doc_root", NULL, NULL, 0);
 
 #if H2O_USE_LIBUV
     uv_loop_t loop;

--- a/examples/libh2o/websocket.c
+++ b/examples/libh2o/websocket.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
 
     h2o_config_init(&config);
     hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT("default")), 65535);
-    pathconf = h2o_config_register_path(hostconf, "/");
+    pathconf = h2o_config_register_path(hostconf, "/", 0);
     h2o_create_handler(pathconf, sizeof(h2o_handler_t))->on_req = on_req;
 
     h2o_context_init(&ctx, loop, &config);

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1060,8 +1060,23 @@ void h2o_config_init(h2o_globalconf_t *config);
 h2o_hostconf_t *h2o_config_register_host(h2o_globalconf_t *config, h2o_iovec_t host, uint16_t port);
 /**
  * registers a path context
+ * @param hostconf host-level configuration that the path-level configuration belongs to
+ * @param path path
+ * @param flags unused and must be set to zero
+ *
+ * Handling of the path argument has changed in version 2.0 (of the standard server).
+ * 
+ * Before 2.0, the function implicitely added a trailing `/` to the supplied path (if it did not end with a `/`), and when receiving
+ * a HTTP request for a matching path without the trailing `/`, libh2o sent a 301 response redirecting the client to a URI with a
+ * trailing `/`.
+ * 
+ * Since 2.0, the function retains the exact path given as the argument, and the handlers of the pathconf is invoked if one of the
+ * following conditions are met:
+ *
+ * * request path is an exact match to the configuration path
+ * * configuration path does not end with a `/`, and the request path begins with the configuration path followed by a `/`
  */
-h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *pathname);
+h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *path, int flags);
 /**
  * disposes of the resources allocated for the global configuration
  */

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -114,14 +114,14 @@ void h2o_config_init(h2o_globalconf_t *config)
     h2o_configurator__init_core(config);
 }
 
-h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *pathname)
+h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *path, int flags)
 {
     h2o_pathconf_t *pathconf;
 
     h2o_vector_reserve(NULL, &hostconf->paths, hostconf->paths.size + 1);
     pathconf = hostconf->paths.entries + hostconf->paths.size++;
 
-    h2o_config_init_pathconf(pathconf, hostconf->global, pathname, hostconf->mimemap);
+    h2o_config_init_pathconf(pathconf, hostconf->global, path, hostconf->mimemap);
 
     return pathconf;
 }

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -232,7 +232,7 @@ static int on_config_paths(h2o_configurator_command_t *cmd, h2o_configurator_con
         yoml_t *key = node->data.mapping.elements[i].key;
         yoml_t *value = node->data.mapping.elements[i].value;
         h2o_configurator_context_t path_ctx = *ctx;
-        path_ctx.pathconf = h2o_config_register_path(path_ctx.hostconf, key->data.scalar);
+        path_ctx.pathconf = h2o_config_register_path(path_ctx.hostconf, key->data.scalar, 0);
         path_ctx.mimemap = &path_ctx.pathconf->mimemap;
         path_ctx.parent = ctx;
         if (h2o_configurator_apply_commands(&path_ctx, value, H2O_CONFIGURATOR_FLAG_PATH, NULL) != 0)

--- a/t/00unit/issues/293.c
+++ b/t/00unit/issues/293.c
@@ -30,7 +30,7 @@ static void register_authority(h2o_globalconf_t *globalconf, h2o_iovec_t host, u
     static h2o_iovec_t x_authority = {H2O_STRLIT("x-authority")};
 
     h2o_hostconf_t *hostconf = h2o_config_register_host(globalconf, host, port);
-    h2o_pathconf_t *pathconf = h2o_config_register_path(hostconf, "/");
+    h2o_pathconf_t *pathconf = h2o_config_register_path(hostconf, "/", 0);
     h2o_file_register(pathconf, "t/00unit/assets", NULL, NULL, 0);
 
     char *authority = h2o_mem_alloc(host.len + sizeof(":" H2O_UINT16_LONGEST_STR));

--- a/t/00unit/lib/handler/fastcgi.c
+++ b/t/00unit/lib/handler/fastcgi.c
@@ -172,7 +172,7 @@ void test_lib__handler__fastcgi_c()
     h2o_config_init(&globalconf);
     globalconf.server_name = h2o_iovec_init(H2O_STRLIT("h2o/1.2.1-alpha1"));
     hostconf = h2o_config_register_host(&globalconf, h2o_iovec_init(H2O_STRLIT("default")), 65535);
-    pathconf = h2o_config_register_path(hostconf, "/");
+    pathconf = h2o_config_register_path(hostconf, "/", 0);
 
     h2o_context_init(&ctx, test_loop, &globalconf);
 

--- a/t/00unit/lib/handler/file.c
+++ b/t/00unit/lib/handler/file.c
@@ -599,7 +599,7 @@ void test_lib__handler__file_c()
 
     h2o_config_init(&globalconf);
     hostconf = h2o_config_register_host(&globalconf, h2o_iovec_init(H2O_STRLIT("default")), 65535);
-    pathconf = h2o_config_register_path(hostconf, "/");
+    pathconf = h2o_config_register_path(hostconf, "/", 0);
     h2o_file_register(pathconf, "t/00unit/assets", NULL, NULL, 0);
 
     h2o_context_init(&ctx, test_loop, &globalconf);

--- a/t/00unit/lib/handler/redirect.c
+++ b/t/00unit/lib/handler/redirect.c
@@ -41,7 +41,7 @@ void test_lib__handler__redirect_c()
 
     h2o_config_init(&globalconf);
     hostconf = h2o_config_register_host(&globalconf, h2o_iovec_init(H2O_STRLIT("default")), 65535);
-    pathconf = h2o_config_register_path(hostconf, "/");
+    pathconf = h2o_config_register_path(hostconf, "/", 0);
     h2o_redirect_register(pathconf, 0, 301, "https://example.com/bar/");
 
     h2o_context_init(&ctx, test_loop, &globalconf);


### PR DESCRIPTION
We have changed the interpretation of `path` in #820.  We need to give users of libh2o the chance to learn that it has been changed and to update their code.

Therefore, we intentionally change the number of arguments accepted by the function.