### PR TITLE
Fix for build without https

### DIFF
--- a/examples/libh2o/simple.c
+++ b/examples/libh2o/simple.c
@@ -205,10 +205,10 @@ static int setup_ssl(const char *cert_file, const char *key_file)
     }
 
 /* setup protocol negotiation methods */
-#if H2O_USE_NPN
+#if H2O_USE_NPN && USE_HTTPS
     h2o_ssl_register_npn_protocols(accept_ctx.ssl_ctx, h2o_http2_npn_protocols);
 #endif
-#if H2O_USE_ALPN
+#if H2O_USE_ALPN && USE_HTTPS
     h2o_ssl_register_alpn_protocols(accept_ctx.ssl_ctx, h2o_http2_alpn_protocols);
 #endif
 


### PR DESCRIPTION
Also if we try to build with https defining H2O_USE_EPOLL  we get an error because libh2o-evloop is not compiled with https:

```
undefined reference to `h2o_ssl_register_alpn_protocols(ssl_ctx_st*, h2o_iovec_t const*)'
```
