### PR TITLE
truncate the 3rd argument of `read` below `INT_MAX` to avoid FreeBSD / OS X limitation

### DIFF
--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -120,7 +120,7 @@ static int on_read_core(int fd, h2o_buffer_t **input)
             /* memory allocation failed */
             return -1;
         }
-        while ((rret = read(fd, buf.base, buf.len)) == -1 && errno == EINTR)
+        while ((rret = read(fd, buf.base, buf.len <= INT_MAX / 2 ? buf.len : INT_MAX / 2 + 1)) == -1 && errno == EINTR)
             ;
         if (rret == -1) {
             if (errno == EAGAIN)


### PR DESCRIPTION
This PR caps the maximum size of the buffer passed to read(2) to 1GB.

Note: [`man 2 read` of FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=read&sektion=2) has a following statement
```
[EINVAL]		The value nbytes is greater than INT_MAX.
```
in contrast to POSIX that state as follows:
```
If the value of nbyte is greater than {SSIZE_MAX}, the result is implementation-defined.
```
http://pubs.opengroup.org/onlinepubs/9699919799/functions/pread.html

The man page of OS X does not state such limitation exists, but seem to behave the same way as FreeBSD does.

Fixes #821