### PR TITLE
don't append a header token already set

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -891,9 +891,9 @@ void h2o_set_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_toke
 void h2o_set_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len, int maybe_token,
                            const char *value, size_t value_len, int overwrite_if_exists);
 /**
- * adds a header token
+ * sets a header token
  */
-void h2o_add_header_token(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value,
+void h2o_set_header_token(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value,
                           size_t value_len);
 /**
  * deletes a header from list

--- a/lib/core/headers.c
+++ b/lib/core/headers.c
@@ -125,20 +125,20 @@ void h2o_set_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const c
     }
 }
 
-void h2o_add_header_token(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value,
+void h2o_set_header_token(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value,
                           size_t value_len)
 {
-    ssize_t cursor = h2o_find_header(headers, token, -1);
-    if (cursor != -1) {
-        h2o_iovec_t src = headers->entries[cursor].value, dst;
-        dst.len = src.len + value_len + 2;
-        dst.base = h2o_mem_alloc_pool(pool, dst.len + 1);
-        dst.base[dst.len] = '\0';
-        memcpy(dst.base, src.base, src.len);
-        dst.base[src.len] = ',';
-        dst.base[src.len + 1] = ' ';
-        memcpy(dst.base + src.len + 2, value, value_len);
-        headers->entries[cursor].value = dst;
+    h2o_header_t *dest = NULL;
+    size_t i;
+    for (i = 0; i != headers->size; ++i) {
+        if (headers->entries[i].name == &token->buf) {
+            if (h2o_contains_token(headers->entries[i].value.base, headers->entries[i].value.len, value, value_len, ','))
+                return;
+            dest = headers->entries + i;
+        }
+    }
+    if (dest != NULL) {
+        dest->value = h2o_concat(pool, dest->value, h2o_iovec_init(H2O_STRLIT(", ")), h2o_iovec_init(value, value_len));
     } else {
         h2o_add_header(pool, headers, token, value, value_len);
     }

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -100,7 +100,7 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     /* adjust the response headers */
     req->res.content_length = SIZE_MAX;
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_ENCODING, compressor->name.base, compressor->name.len);
-    h2o_add_header_token(&req->pool, &req->res.headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
+    h2o_set_header_token(&req->pool, &req->res.headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
     if (accept_ranges_header_index != -1) {
         req->res.headers.entries[accept_ranges_header_index].value = h2o_iovec_init(H2O_STRLIT("none"));
     } else {

--- a/lib/handler/expires.c
+++ b/lib/handler/expires.c
@@ -50,7 +50,7 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
             h2o_set_header(&req->pool, &req->res.headers, H2O_TOKEN_EXPIRES, self->value.base, self->value.len, 0);
             break;
         case H2O_EXPIRES_MODE_MAX_AGE:
-            h2o_add_header_token(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, self->value.base, self->value.len);
+            h2o_set_header_token(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, self->value.base, self->value.len);
             break;
         default:
             assert(0);

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -288,7 +288,7 @@ static void add_headers_unconditional(struct st_h2o_sendfile_generator_t *self, 
         h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ETAG, self->header_bufs.etag, etag_len);
     }
     if (self->send_vary)
-        h2o_add_header_token(&req->pool, &req->res.headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
+        h2o_set_header_token(&req->pool, &req->res.headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
 }
 
 static void do_send_file(struct st_h2o_sendfile_generator_t *self, h2o_req_t *req, int status, const char *reason,

--- a/t/00unit/lib/core/headers.c
+++ b/t/00unit/lib/core/headers.c
@@ -22,26 +22,32 @@
 #include "../../test.h"
 #include "../../../../lib/core/headers.c"
 
-static void test_add_header_token(void)
+static void test_set_header_token(void)
 {
     h2o_mem_pool_t pool;
     h2o_headers_t headers = {};
 
     h2o_mem_init_pool(&pool);
 
-    h2o_add_header_token(&pool, &headers, H2O_TOKEN_VARY, H2O_STRLIT("Cookie"));
+    h2o_set_header_token(&pool, &headers, H2O_TOKEN_VARY, H2O_STRLIT("cookie"));
     ok(headers.size == 1);
     ok(headers.entries[0].name == &H2O_TOKEN_VARY->buf);
-    ok(h2o_memis(headers.entries[0].value.base, headers.entries[0].value.len, H2O_STRLIT("Cookie")));
-    h2o_add_header_token(&pool, &headers, H2O_TOKEN_VARY, H2O_STRLIT("Accept-Encoding"));
+    ok(h2o_memis(headers.entries[0].value.base, headers.entries[0].value.len, H2O_STRLIT("cookie")));
+    h2o_set_header_token(&pool, &headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
     ok(headers.size == 1);
     ok(headers.entries[0].name == &H2O_TOKEN_VARY->buf);
-    ok(h2o_memis(headers.entries[0].value.base, headers.entries[0].value.len, H2O_STRLIT("Cookie, Accept-Encoding")));
+    ok(h2o_memis(headers.entries[0].value.base, headers.entries[0].value.len, H2O_STRLIT("cookie, accept-encoding")));
+
+    headers.entries[0].value.base[0] = 'C';
+    h2o_set_header_token(&pool, &headers, H2O_TOKEN_VARY, H2O_STRLIT("cookie"));
+    ok(headers.size == 1);
+    ok(headers.entries[0].name == &H2O_TOKEN_VARY->buf);
+    ok(h2o_memis(headers.entries[0].value.base, headers.entries[0].value.len, H2O_STRLIT("Cookie, accept-encoding")));
 
     h2o_mem_clear_pool(&pool);
 }
 
 void test_lib__core__headers_c(void)
 {
-    subtest("add_header_token", test_add_header_token);
+    subtest("set_header_token", test_set_header_token);
 }


### PR DESCRIPTION
Fixes https://github.com/h2o/h2o/issues/767#issuecomment-184016839.

While this is not strictly a bug, it is better not to have duplicate tokens in a header using 1# rule; e.g. `Vary: accept-encoding, accept-encoding`.