### PR TITLE
implement server-status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/proxy.c
     lib/handler/redirect.c
     lib/handler/reproxy.c
+    lib/handler/status.c
     lib/handler/configurator/access_log.c
     lib/handler/configurator/compress.c
     lib/handler/configurator/errordoc.c
@@ -245,6 +246,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/configurator/proxy.c
     lib/handler/configurator/redirect.c
     lib/handler/configurator/reproxy.c
+    lib/handler/configurator/status.c
 
     lib/http1.c
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ SET(LIB_SOURCE_FILES
     lib/core/configurator.c
     lib/core/context.c
     lib/core/headers.c
+    lib/core/logconf.c
     lib/core/proxy.c
     lib/core/request.c
     lib/core/token.c

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		107E34201C7FEE1000AEF5F8 /* streams.cc in Sources */ = {isa = PBXBuildFile; fileRef = 107E34001C7EAF9300AEF5F8 /* streams.cc */; };
 		107E34211C7FEE1000AEF5F8 /* utf8_util.cc in Sources */ = {isa = PBXBuildFile; fileRef = 107E34011C7EAF9300AEF5F8 /* utf8_util.cc */; };
 		107E34221C7FEE2200AEF5F8 /* brotli.cc in Sources */ = {isa = PBXBuildFile; fileRef = 107E34111C7EE0D200AEF5F8 /* brotli.cc */; };
+		10835E011C9A6C2400197E59 /* logconf.c in Sources */ = {isa = PBXBuildFile; fileRef = 10835E001C9A6C2400197E59 /* logconf.c */; };
 		108867751AD9069900987967 /* defaults.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 108867741AD9069900987967 /* defaults.c.h */; };
 		108DD0861BA22E46004167DC /* mruby.c in Sources */ = {isa = PBXBuildFile; fileRef = 10B38A651B8D345D007DC191 /* mruby.c */; };
 		10A3D3D21B4CDBDC00327CF9 /* memcached.c in Sources */ = {isa = PBXBuildFile; fileRef = 10A3D3D11B4CDBDC00327CF9 /* memcached.c */; };
@@ -484,6 +485,7 @@
 		1082150C1AB26F4700D27E66 /* FindWslay.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = FindWslay.cmake; sourceTree = "<group>"; };
 		1082150D1AB26F4700D27E66 /* FindLibYAML.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = FindLibYAML.cmake; sourceTree = "<group>"; };
 		1082150E1AB26F4700D27E66 /* FindLibUV.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = FindLibUV.cmake; sourceTree = "<group>"; };
+		10835E001C9A6C2400197E59 /* logconf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = logconf.c; sourceTree = "<group>"; };
 		108867741AD9069900987967 /* defaults.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = defaults.c.h; sourceTree = "<group>"; };
 		1092E0011BEB1DDC001074BF /* 80issues579.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 80issues579.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10952D591C5082F7000D664C /* 80issues-from-proxy-reproxy-to-different-host.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "80issues-from-proxy-reproxy-to-different-host.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -722,6 +724,7 @@
 				10F4180419CA75C500B6E31A /* configurator.c */,
 				107923B919A3217300C52AD6 /* context.c */,
 				107923B019A3217300C52AD6 /* headers.c */,
+				10835E001C9A6C2400197E59 /* logconf.c */,
 				10AA2EBB1A9EEDF8004322AC /* proxy.c */,
 				107923BC19A3217300C52AD6 /* request.c */,
 				107923BF19A3217300C52AD6 /* token.c */,
@@ -1602,6 +1605,7 @@
 				107923CC19A3217300C52AD6 /* context.c in Sources */,
 				10A3D40C1B50DAB700327CF9 /* socket.c in Sources */,
 				10AA2EC21AA0402E004322AC /* reproxy.c in Sources */,
+				10835E011C9A6C2400197E59 /* logconf.c in Sources */,
 				107923C519A3217300C52AD6 /* http1.c in Sources */,
 				10AA2EA71A8DA93C004322AC /* redirect.c in Sources */,
 				10AA2EA11A88082E004322AC /* url.c in Sources */,

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		107E34211C7FEE1000AEF5F8 /* utf8_util.cc in Sources */ = {isa = PBXBuildFile; fileRef = 107E34011C7EAF9300AEF5F8 /* utf8_util.cc */; };
 		107E34221C7FEE2200AEF5F8 /* brotli.cc in Sources */ = {isa = PBXBuildFile; fileRef = 107E34111C7EE0D200AEF5F8 /* brotli.cc */; };
 		10835E011C9A6C2400197E59 /* logconf.c in Sources */ = {isa = PBXBuildFile; fileRef = 10835E001C9A6C2400197E59 /* logconf.c */; };
+		10835E031C9A860000197E59 /* status.c in Sources */ = {isa = PBXBuildFile; fileRef = 10835E021C9A860000197E59 /* status.c */; };
+		10835E051C9B3C6200197E59 /* status.c in Sources */ = {isa = PBXBuildFile; fileRef = 10835E041C9B3C6200197E59 /* status.c */; };
 		108867751AD9069900987967 /* defaults.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 108867741AD9069900987967 /* defaults.c.h */; };
 		108DD0861BA22E46004167DC /* mruby.c in Sources */ = {isa = PBXBuildFile; fileRef = 10B38A651B8D345D007DC191 /* mruby.c */; };
 		10A3D3D21B4CDBDC00327CF9 /* memcached.c in Sources */ = {isa = PBXBuildFile; fileRef = 10A3D3D11B4CDBDC00327CF9 /* memcached.c */; };
@@ -486,6 +488,8 @@
 		1082150D1AB26F4700D27E66 /* FindLibYAML.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = FindLibYAML.cmake; sourceTree = "<group>"; };
 		1082150E1AB26F4700D27E66 /* FindLibUV.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = FindLibUV.cmake; sourceTree = "<group>"; };
 		10835E001C9A6C2400197E59 /* logconf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = logconf.c; sourceTree = "<group>"; };
+		10835E021C9A860000197E59 /* status.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = status.c; sourceTree = "<group>"; };
+		10835E041C9B3C6200197E59 /* status.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = status.c; sourceTree = "<group>"; };
 		108867741AD9069900987967 /* defaults.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = defaults.c.h; sourceTree = "<group>"; };
 		1092E0011BEB1DDC001074BF /* 80issues579.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 80issues579.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10952D591C5082F7000D664C /* 80issues-from-proxy-reproxy-to-different-host.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "80issues-from-proxy-reproxy-to-different-host.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -713,6 +717,7 @@
 				10D0907219F633B00043D458 /* proxy.c */,
 				10AA2EA41A8D9999004322AC /* redirect.c */,
 				10AA2EC31AA0403A004322AC /* reproxy.c */,
+				10835E021C9A860000197E59 /* status.c */,
 			);
 			path = handler;
 			sourceTree = "<group>";
@@ -818,6 +823,7 @@
 				105534DE1A3C7B9800627ECB /* proxy.c */,
 				10AA2EA61A8DA93C004322AC /* redirect.c */,
 				10AA2EC11AA0402E004322AC /* reproxy.c */,
+				10835E041C9B3C6200197E59 /* status.c */,
 			);
 			path = configurator;
 			sourceTree = "<group>";
@@ -1596,7 +1602,9 @@
 				105534DB1A3C7A5400627ECB /* access_log.c in Sources */,
 				107923CE19A3217300C52AD6 /* mimemap.c in Sources */,
 				107923C619A3217300C52AD6 /* connection.c in Sources */,
+				10835E051C9B3C6200197E59 /* status.c in Sources */,
 				1058C87E1AA41A1F008D6180 /* headers.c in Sources */,
+				10835E031C9A860000197E59 /* status.c in Sources */,
 				10AA2E961A80A612004322AC /* time.c in Sources */,
 				107923C319A3217300C52AD6 /* file.c in Sources */,
 				106C22F81C040F6400405689 /* tunnel.c in Sources */,

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -490,6 +490,7 @@
 		10835E001C9A6C2400197E59 /* logconf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = logconf.c; sourceTree = "<group>"; };
 		10835E021C9A860000197E59 /* status.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = status.c; sourceTree = "<group>"; };
 		10835E041C9B3C6200197E59 /* status.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = status.c; sourceTree = "<group>"; };
+		10835E071C9B8EA700197E59 /* index.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
 		108867741AD9069900987967 /* defaults.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = defaults.c.h; sourceTree = "<group>"; };
 		1092E0011BEB1DDC001074BF /* 80issues579.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 80issues579.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10952D591C5082F7000D664C /* 80issues-from-proxy-reproxy-to-different-host.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "80issues-from-proxy-reproxy-to-different-host.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -667,6 +668,7 @@
 			isa = PBXGroup;
 			children = (
 				10F4EB881C195B5C003DA150 /* mruby */,
+				10835E061C9B8E8000197E59 /* status */,
 				10A60DE91B0D87FE006E38EC /* annotate-backtrace-symbols */,
 				104B9A401A5CD69B009EEE64 /* fetch-ocsp-response */,
 				10FCC1411B2FCC6B00F13674 /* kill-on-close */,
@@ -1194,6 +1196,14 @@
 				1082150E1AB26F4700D27E66 /* FindLibUV.cmake */,
 			);
 			path = cmake;
+			sourceTree = "<group>";
+		};
+		10835E061C9B8E8000197E59 /* status */ = {
+			isa = PBXGroup;
+			children = (
+				10835E071C9B8EA700197E59 /* index.html */,
+			);
+			path = status;
 			sourceTree = "<group>";
 		};
 		108867731AD9061100987967 /* mimemap */ = {

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -592,6 +592,9 @@ typedef struct st_h2o_conn_callbacks_t {
                 h2o_iovec_t (*priority_received_exclusive)(h2o_req_t *req);
                 h2o_iovec_t (*priority_received_parent)(h2o_req_t *req);
                 h2o_iovec_t (*priority_received_weight)(h2o_req_t *req);
+                h2o_iovec_t (*priority_actual)(h2o_req_t *req);
+                h2o_iovec_t (*priority_actual_parent)(h2o_req_t *req);
+                h2o_iovec_t (*priority_actual_weight)(h2o_req_t *req);
             } http2;
         };
         h2o_iovec_t (*callbacks[1])(h2o_req_t *req);

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1533,6 +1533,17 @@ void h2o_reproxy_register(h2o_pathconf_t *pathconf);
  */
 void h2o_reproxy_register_configurator(h2o_globalconf_t *conf);
 
+/* lib/handler/status.c */
+
+/**
+ * registers the status handler
+ */
+void h2o_status_register(h2o_pathconf_t *pathconf);
+/**
+ * registers the configurator
+ */
+void h2o_status_register_configurator(h2o_globalconf_t *conf);
+
 /* inline defs */
 
 inline h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval connected_at,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -94,6 +94,7 @@ typedef struct st_h2o_configurator_t h2o_configurator_t;
 typedef struct st_h2o_hostconf_t h2o_hostconf_t;
 typedef struct st_h2o_globalconf_t h2o_globalconf_t;
 typedef struct st_h2o_mimemap_t h2o_mimemap_t;
+typedef struct st_h2o_logconf_t h2o_logconf_t;
 
 /**
  * a predefined, read-only, fast variant of h2o_iovec_t, defined in h2o/token.h
@@ -1191,6 +1192,21 @@ int h2o_puth_path_in_link_header(h2o_req_t *req, const char *value, size_t value
  * logs an error
  */
 void h2o_req_log_error(h2o_req_t *req, const char *module, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+
+/* log */
+
+/**
+ * compiles a log configuration
+ */
+h2o_logconf_t *h2o_logconf_compile(const char *fmt, char *errbuf);
+/**
+ * disposes of a log configuration
+ */
+void h2o_logconf_dispose(h2o_logconf_t *logconf);
+/**
+ * logs a request
+ */
+char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char *buf);
 
 /* proxy */
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -427,6 +427,10 @@ struct st_h2o_context_t {
          * request timeout
          */
         h2o_timeout_t req_timeout;
+        /**
+         * link-list of h2o_http1_conn_t
+         */
+        h2o_linklist_t _conns;
     } http1;
 
     struct {

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -253,6 +253,7 @@ struct st_h2o_hostconf_t {
 
 typedef struct st_h2o_protocol_callbacks_t {
     void (*request_shutdown)(h2o_context_t *ctx);
+    int (*foreach_request)(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata);
 } h2o_protocol_callbacks_t;
 
 struct st_h2o_globalconf_t {

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -593,6 +593,9 @@ typedef struct st_h2o_conn_callbacks_t {
                 h2o_iovec_t (*cipher_bits)(h2o_req_t *req);
             } ssl;
             struct {
+                h2o_iovec_t (*request_index)(h2o_req_t *req);
+            } http1;
+            struct {
                 h2o_iovec_t (*stream_id)(h2o_req_t *req);
                 h2o_iovec_t (*priority_received)(h2o_req_t *req);
                 h2o_iovec_t (*priority_received_exclusive)(h2o_req_t *req);

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -343,6 +343,12 @@ struct st_h2o_globalconf_t {
         size_t capacity;
     } filecache;
 
+    /* status */
+    struct {
+        /* optional callback set by the user of libh2o to feed additional json to the status handler */
+        h2o_iovec_t (*extra_status)(h2o_globalconf_t *conf, h2o_mem_pool_t *pool);
+    } status;
+
     size_t _num_config_slots;
 };
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1196,10 +1196,15 @@ void h2o_req_log_error(h2o_req_t *req, const char *module, const char *fmt, ...)
 
 /* log */
 
+enum {
+    H2O_LOGCONF_ESCAPE_APACHE,
+    H2O_LOGCONF_ESCAPE_JSON
+};
+
 /**
  * compiles a log configuration
  */
-h2o_logconf_t *h2o_logconf_compile(const char *fmt, char *errbuf);
+h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf);
 /**
  * disposes of a log configuration
  */

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -97,6 +97,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
 
     h2o_timeout_init(ctx->loop, &ctx->handshake_timeout, config->handshake_timeout);
     h2o_timeout_init(ctx->loop, &ctx->http1.req_timeout, config->http1.req_timeout);
+    h2o_linklist_init_anchor(&ctx->http1._conns);
     h2o_timeout_init(ctx->loop, &ctx->http2.idle_timeout, config->http2.idle_timeout);
     h2o_linklist_init_anchor(&ctx->http2._conns);
     ctx->proxy.client_ctx.loop = loop;

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -171,6 +171,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_TYPE("process-time", ELEMENT_TYPE_PROCESS_TIME);
                     MAP_EXT_TO_TYPE("response-time", ELEMENT_TYPE_RESPONSE_TIME);
                     MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_DURATION);
+                    MAP_EXT_TO_PROTO("http1.request-index", http1.request_index);
                     MAP_EXT_TO_PROTO("http2.stream-id", http2.stream_id);
                     MAP_EXT_TO_PROTO("http2.priority.received", http2.priority_received);
                     MAP_EXT_TO_PROTO("http2.priority.received.exclusive", http2.priority_received_exclusive);

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -1,0 +1,594 @@
+/*
+ * Copyright (c) 2014-2016 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "h2o.h"
+
+enum {
+    ELEMENT_TYPE_EMPTY,                      /* empty element (with suffix only) */
+    ELEMENT_TYPE_LOCAL_ADDR,                 /* %A */
+    ELEMENT_TYPE_BYTES_SENT,                 /* %b */
+    ELEMENT_TYPE_PROTOCOL,                   /* %H */
+    ELEMENT_TYPE_REMOTE_ADDR,                /* %h */
+    ELEMENT_TYPE_LOGNAME,                    /* %l */
+    ELEMENT_TYPE_METHOD,                     /* %m */
+    ELEMENT_TYPE_LOCAL_PORT,                 /* %p */
+    ELEMENT_TYPE_QUERY,                      /* %q */
+    ELEMENT_TYPE_REQUEST_LINE,               /* %r */
+    ELEMENT_TYPE_STATUS,                     /* %s */
+    ELEMENT_TYPE_TIMESTAMP,                  /* %t */
+    ELEMENT_TYPE_TIMESTAMP_STRFTIME,         /* %{...}t */
+    ELEMENT_TYPE_TIMESTAMP_SEC_SINCE_EPOCH,  /* %{sec}t */
+    ELEMENT_TYPE_TIMESTAMP_MSEC_SINCE_EPOCH, /* %{msec}t */
+    ELEMENT_TYPE_TIMESTAMP_USEC_SINCE_EPOCH, /* %{usec}t */
+    ELEMENT_TYPE_TIMESTAMP_MSEC_FRAC,        /* %{msec_frac}t */
+    ELEMENT_TYPE_TIMESTAMP_USEC_FRAC,        /* %{usec_frac}t */
+    ELEMENT_TYPE_URL_PATH,                   /* %U */
+    ELEMENT_TYPE_REMOTE_USER,                /* %u */
+    ELEMENT_TYPE_AUTHORITY,                  /* %V */
+    ELEMENT_TYPE_HOSTCONF,                   /* %v */
+    ELEMENT_TYPE_IN_HEADER_TOKEN,            /* %{data.header_token}i */
+    ELEMENT_TYPE_IN_HEADER_STRING,           /* %{data.name}i */
+    ELEMENT_TYPE_OUT_HEADER_TOKEN,           /* %{data.header_token}o */
+    ELEMENT_TYPE_OUT_HEADER_STRING,          /* %{data.name}o */
+    ELEMENT_TYPE_EXTENDED_VAR,               /* %{data.name}x */
+    ELEMENT_TYPE_CONNECTION_ID,              /* %{connection-id}x */
+    ELEMENT_TYPE_CONNECT_TIME,               /* %{connect-time}x */
+    ELEMENT_TYPE_REQUEST_HEADER_TIME,        /* %{request-header-time}x */
+    ELEMENT_TYPE_REQUEST_BODY_TIME,          /* %{request-body-time}x */
+    ELEMENT_TYPE_REQUEST_TOTAL_TIME,         /* %{request-total-time}x */
+    ELEMENT_TYPE_PROCESS_TIME,               /* %{process-time}x */
+    ELEMENT_TYPE_RESPONSE_TIME,              /* %{response-total-time}x */
+    ELEMENT_TYPE_DURATION,                   /* %{duration}x */
+    ELEMENT_TYPE_PROTOCOL_SPECIFIC,          /* %{protocol-specific...}x */
+    NUM_ELEMENT_TYPES
+};
+
+struct log_element_t {
+    unsigned type;
+    h2o_iovec_t suffix;
+    union {
+        const h2o_token_t *header_token;
+        h2o_iovec_t name;
+        size_t protocol_specific_callback_index;
+    } data;
+};
+
+struct st_h2o_logconf_t {
+    H2O_VECTOR(struct log_element_t) elements;
+};
+
+static h2o_iovec_t strdup_lowercased(const char *s, size_t len)
+{
+    h2o_iovec_t v = h2o_strdup(NULL, s, len);
+    h2o_strtolower(v.base, v.len);
+    return v;
+}
+
+h2o_logconf_t *h2o_logconf_compile(const char *fmt, char *errbuf)
+{
+    h2o_logconf_t *logconf = h2o_mem_alloc(sizeof(*logconf));
+    const char *pt = fmt;
+    size_t fmt_len = strlen(fmt);
+
+    *logconf = (h2o_logconf_t){};
+
+#define LAST_ELEMENT() (logconf->elements.entries + logconf->elements.size - 1)
+/* suffix buffer is always guaranteed to be larger than the fmt + (sizeof('\n') - 1) (so that they would be no buffer overruns) */
+#define NEW_ELEMENT(ty)                                                                                                            \
+    do {                                                                                                                           \
+        h2o_vector_reserve(NULL, &logconf->elements, logconf->elements.size + 1);                                                  \
+        logconf->elements.size++;                                                                                                  \
+        *LAST_ELEMENT() = (struct log_element_t){};                                                                                \
+        LAST_ELEMENT()->type = ty;                                                                                                 \
+        LAST_ELEMENT()->suffix.base = h2o_mem_alloc(fmt_len + 1);                                                                  \
+    } while (0)
+
+    while (*pt != '\0') {
+        if (*pt == '%') {
+            ++pt;
+            if (*pt == '%') {
+                /* skip */
+            } else if (*pt == '{') {
+                const h2o_token_t *token;
+                const char *quote_end = strchr(++pt, '}');
+                if (quote_end == NULL) {
+                    sprintf(errbuf, "failed to compile log format: unterminated header name starting at: \"%16s\"", pt);
+                    goto Error;
+                }
+                const char modifier = quote_end[1];
+                switch (modifier) {
+                case 'i':
+                case 'o': {
+                    h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
+                    token = h2o_lookup_token(name.base, name.len);
+                    if (token != NULL) {
+                        free(name.base);
+                        NEW_ELEMENT(modifier == 'i' ? ELEMENT_TYPE_IN_HEADER_TOKEN : ELEMENT_TYPE_OUT_HEADER_TOKEN);
+                        LAST_ELEMENT()->data.header_token = token;
+                    } else {
+                        NEW_ELEMENT(modifier == 'i' ? ELEMENT_TYPE_IN_HEADER_STRING : ELEMENT_TYPE_OUT_HEADER_STRING);
+                        LAST_ELEMENT()->data.name = name;
+                    }
+                } break;
+                case 't':
+                    if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("sec"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_SEC_SINCE_EPOCH);
+                    } else if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("msec"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_MSEC_SINCE_EPOCH);
+                    } else if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("usec"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_USEC_SINCE_EPOCH);
+                    } else if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("msec_frac"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_MSEC_FRAC);
+                    } else if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("usec_frac"))) {
+                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_USEC_FRAC);
+                    } else {
+                        h2o_iovec_t name = h2o_strdup(NULL, pt, quote_end - pt);
+                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_STRFTIME);
+                        LAST_ELEMENT()->data.name = name;
+                    }
+                    break;
+                case 'x':
+#define MAP_EXT_TO_TYPE(name, id)                                                                                                  \
+    if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT(name))) {                                                                       \
+        NEW_ELEMENT(id);                                                                                                           \
+        goto MAP_EXT_Found;                                                                                                        \
+    }
+#define MAP_EXT_TO_PROTO(name, cb)                                                                                                 \
+    if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT(name))) {                                                                       \
+        NEW_ELEMENT(ELEMENT_TYPE_PROTOCOL_SPECIFIC);                                                                               \
+        LAST_ELEMENT()->data.protocol_specific_callback_index =                                                                    \
+            &((h2o_conn_callbacks_t *)NULL)->log_.cb - ((h2o_conn_callbacks_t *)NULL)->log_.callbacks;                             \
+        goto MAP_EXT_Found;                                                                                                        \
+    }
+                    MAP_EXT_TO_TYPE("connection-id", ELEMENT_TYPE_CONNECTION_ID);
+                    MAP_EXT_TO_TYPE("connect-time", ELEMENT_TYPE_CONNECT_TIME);
+                    MAP_EXT_TO_TYPE("request-total-time", ELEMENT_TYPE_REQUEST_TOTAL_TIME);
+                    MAP_EXT_TO_TYPE("request-header-time", ELEMENT_TYPE_REQUEST_HEADER_TIME);
+                    MAP_EXT_TO_TYPE("request-body-time", ELEMENT_TYPE_REQUEST_BODY_TIME);
+                    MAP_EXT_TO_TYPE("process-time", ELEMENT_TYPE_PROCESS_TIME);
+                    MAP_EXT_TO_TYPE("response-time", ELEMENT_TYPE_RESPONSE_TIME);
+                    MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_DURATION);
+                    MAP_EXT_TO_PROTO("http2.stream-id", http2.stream_id);
+                    MAP_EXT_TO_PROTO("http2.priority.received", http2.priority_received);
+                    MAP_EXT_TO_PROTO("http2.priority.received.exclusive", http2.priority_received_exclusive);
+                    MAP_EXT_TO_PROTO("http2.priority.received.parent", http2.priority_received_parent);
+                    MAP_EXT_TO_PROTO("http2.priority.received.weight", http2.priority_received_weight);
+                    MAP_EXT_TO_PROTO("ssl.protocol-version", ssl.protocol_version);
+                    MAP_EXT_TO_PROTO("ssl.session-reused", ssl.session_reused);
+                    MAP_EXT_TO_PROTO("ssl.cipher", ssl.cipher);
+                    MAP_EXT_TO_PROTO("ssl.cipher-bits", ssl.cipher_bits);
+                    { /* not found */
+                        h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
+                        NEW_ELEMENT(ELEMENT_TYPE_EXTENDED_VAR);
+                        LAST_ELEMENT()->data.name = name;
+                    }
+                MAP_EXT_Found:
+#undef MAP_EXT_TO_TYPE
+#undef MAP_EXT_TO_PROTO
+                    break;
+                default:
+                    sprintf(errbuf, "failed to compile log format: header name is not followed by either `i`, `o`, `x`");
+                    goto Error;
+                }
+                pt = quote_end + 2;
+                continue;
+            } else {
+                unsigned type = NUM_ELEMENT_TYPES;
+                switch (*pt++) {
+#define TYPE_MAP(ch, ty)                                                                                                           \
+    case ch:                                                                                                                       \
+        type = ty;                                                                                                                 \
+        break
+                    TYPE_MAP('A', ELEMENT_TYPE_LOCAL_ADDR);
+                    TYPE_MAP('b', ELEMENT_TYPE_BYTES_SENT);
+                    TYPE_MAP('H', ELEMENT_TYPE_PROTOCOL);
+                    TYPE_MAP('h', ELEMENT_TYPE_REMOTE_ADDR);
+                    TYPE_MAP('l', ELEMENT_TYPE_LOGNAME);
+                    TYPE_MAP('m', ELEMENT_TYPE_METHOD);
+                    TYPE_MAP('p', ELEMENT_TYPE_LOCAL_PORT);
+                    TYPE_MAP('q', ELEMENT_TYPE_QUERY);
+                    TYPE_MAP('r', ELEMENT_TYPE_REQUEST_LINE);
+                    TYPE_MAP('s', ELEMENT_TYPE_STATUS);
+                    TYPE_MAP('t', ELEMENT_TYPE_TIMESTAMP);
+                    TYPE_MAP('U', ELEMENT_TYPE_URL_PATH);
+                    TYPE_MAP('u', ELEMENT_TYPE_REMOTE_USER);
+                    TYPE_MAP('V', ELEMENT_TYPE_AUTHORITY);
+                    TYPE_MAP('v', ELEMENT_TYPE_HOSTCONF);
+#undef TYPE_MAP
+                default:
+                    sprintf(errbuf, "failed to compile log format: unknown escape sequence: %%%c", pt[-1]);
+                    goto Error;
+                }
+                NEW_ELEMENT(type);
+                continue;
+            }
+        }
+        /* emit current char */
+        if (logconf->elements.size == 0)
+            NEW_ELEMENT(ELEMENT_TYPE_EMPTY);
+        LAST_ELEMENT()->suffix.base[LAST_ELEMENT()->suffix.len++] = *pt++;
+    }
+
+    /* emit end-of-line */
+    if (logconf->elements.size == 0)
+        NEW_ELEMENT(ELEMENT_TYPE_EMPTY);
+    LAST_ELEMENT()->suffix.base[LAST_ELEMENT()->suffix.len++] = '\n';
+
+#undef NEW_ELEMENT
+
+    return logconf;
+
+Error:
+    h2o_logconf_dispose(logconf);
+    return NULL;
+}
+
+void h2o_logconf_dispose(h2o_logconf_t *logconf)
+{
+    size_t i;
+
+    for (i = 0; i != logconf->elements.size; ++i)
+        free(logconf->elements.entries[i].suffix.base);
+    free(logconf->elements.entries);
+    free(logconf);
+}
+
+static inline char *append_safe_string(char *pos, const char *src, size_t len)
+{
+    memcpy(pos, src, len);
+    return pos + len;
+}
+
+static char *append_unsafe_string(char *pos, const char *src, size_t len)
+{
+    const char *src_end = src + len;
+
+    for (; src != src_end; ++src) {
+        if (' ' <= *src && *src < 0x7d && *src != '"') {
+            *pos++ = *src;
+        } else {
+            *pos++ = '\\';
+            *pos++ = 'x';
+            *pos++ = ("0123456789abcdef")[(*src >> 4) & 0xf];
+            *pos++ = ("0123456789abcdef")[*src & 0xf];
+        }
+    }
+
+    return pos;
+}
+
+static char *append_addr(char *pos, socklen_t (*cb)(h2o_conn_t *conn, struct sockaddr *sa), h2o_conn_t *conn)
+{
+    struct sockaddr_storage ss;
+    socklen_t sslen;
+
+    if ((sslen = cb(conn, (void *)&ss)) == 0)
+        goto Fail;
+    size_t l = h2o_socket_getnumerichost((void *)&ss, sslen, pos);
+    if (l == SIZE_MAX)
+        goto Fail;
+    pos += l;
+    return pos;
+
+Fail:
+    *pos++ = '-';
+    return pos;
+}
+
+static char *append_port(char *pos, socklen_t (*cb)(h2o_conn_t *conn, struct sockaddr *sa), h2o_conn_t *conn)
+{
+    struct sockaddr_storage ss;
+    socklen_t sslen;
+
+    if ((sslen = cb(conn, (void *)&ss)) == 0)
+        goto Fail;
+    int32_t port = h2o_socket_getport((void *)&ss);
+    if (port == -1)
+        goto Fail;
+    pos += sprintf(pos, "%" PRIu16, (uint16_t)port);
+    return pos;
+
+Fail:
+    *pos++ = '-';
+    return pos;
+}
+
+static inline int timeval_is_null(struct timeval *tv)
+{
+    return tv->tv_sec == 0;
+}
+
+#define DURATION_MAX_LEN (sizeof(H2O_INT32_LONGEST_STR ".999999") - 1)
+
+static char *append_duration(char *pos, struct timeval *from, struct timeval *until)
+{
+    if (timeval_is_null(from) || timeval_is_null(until)) {
+        *pos++ = '-';
+    } else {
+        int32_t delta_sec = (int32_t)until->tv_sec - (int32_t)from->tv_sec;
+        int32_t delta_usec = (int32_t)until->tv_usec - (int32_t)from->tv_usec;
+        if (delta_usec < 0) {
+            delta_sec -= 1;
+            delta_usec += 1000000;
+        }
+        pos += sprintf(pos, "%" PRId32, delta_sec);
+        if (delta_usec != 0) {
+            int i;
+            *pos++ = '.';
+            for (i = 5; i >= 0; --i) {
+                pos[i] = '0' + delta_usec % 10;
+                delta_usec /= 10;
+            }
+            pos += 6;
+        }
+    }
+    return pos;
+}
+
+static char *expand_line_buf(char *line, size_t cur_size, size_t required, int should_realloc)
+{
+    size_t new_size = cur_size;
+
+    /* determine the new size */
+    do {
+        new_size *= 2;
+    } while (new_size < required);
+
+    /* reallocate */
+    if (!should_realloc) {
+        char *newpt = h2o_mem_alloc(new_size);
+        memcpy(newpt, line, cur_size);
+        line = newpt;
+    } else {
+        line = h2o_mem_realloc(line, new_size);
+    }
+
+    return line;
+}
+
+char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char *buf)
+{
+    char *line = buf, *pos = line, *line_end = line + *len;
+    size_t element_index;
+    struct tm localt = {};
+    int should_realloc_on_expand = 0;
+
+    for (element_index = 0; element_index != logconf->elements.size; ++element_index) {
+        struct log_element_t *element = logconf->elements.entries + element_index;
+
+/* reserve capacity + suffix.len */
+#define RESERVE(capacity)                                                                                                          \
+    do {                                                                                                                           \
+        if ((capacity) + element->suffix.len > line_end - pos) {                                                                   \
+            size_t off = pos - line;                                                                                               \
+            line = expand_line_buf(line, line_end - line, off + (capacity) + element->suffix.len, should_realloc_on_expand);       \
+            pos = line + off;                                                                                                      \
+            should_realloc_on_expand = 1;                                                                                          \
+        }                                                                                                                          \
+    } while (0)
+
+        switch (element->type) {
+        case ELEMENT_TYPE_EMPTY:
+            RESERVE(0);
+            break;
+        case ELEMENT_TYPE_LOCAL_ADDR: /* %A */
+            RESERVE(NI_MAXHOST);
+            pos = append_addr(pos, req->conn->callbacks->get_sockname, req->conn);
+            break;
+        case ELEMENT_TYPE_BYTES_SENT: /* %b */
+            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
+            pos += sprintf(pos, "%" PRIu64, (uint64_t)req->bytes_sent);
+            break;
+        case ELEMENT_TYPE_PROTOCOL: /* %H */
+            RESERVE(sizeof("HTTP/1.1"));
+            pos += h2o_stringify_protocol_version(pos, req->version);
+            break;
+        case ELEMENT_TYPE_REMOTE_ADDR: /* %h */
+            RESERVE(NI_MAXHOST);
+            pos = append_addr(pos, req->conn->callbacks->get_peername, req->conn);
+            break;
+        case ELEMENT_TYPE_METHOD: /* %m */
+            RESERVE(req->input.method.len * 4);
+            pos = append_unsafe_string(pos, req->input.method.base, req->input.method.len);
+            break;
+        case ELEMENT_TYPE_LOCAL_PORT: /* %p */
+            RESERVE(sizeof(H2O_UINT16_LONGEST_STR) - 1);
+            pos = append_port(pos, req->conn->callbacks->get_sockname, req->conn);
+            break;
+        case ELEMENT_TYPE_QUERY: /* %q */
+            if (req->input.query_at != SIZE_MAX) {
+                size_t len = req->input.path.len - req->input.query_at;
+                RESERVE(len * 4);
+                pos = append_unsafe_string(pos, req->input.path.base + req->input.query_at, len);
+            }
+            break;
+        case ELEMENT_TYPE_REQUEST_LINE: /* %r */
+            RESERVE((req->input.method.len + req->input.path.len) * 4 + sizeof("  HTTP/1.1"));
+            pos = append_unsafe_string(pos, req->input.method.base, req->input.method.len);
+            *pos++ = ' ';
+            pos = append_unsafe_string(pos, req->input.path.base, req->input.path.len);
+            *pos++ = ' ';
+            pos += h2o_stringify_protocol_version(pos, req->version);
+            break;
+        case ELEMENT_TYPE_STATUS: /* %s */
+            RESERVE(sizeof(H2O_INT32_LONGEST_STR) - 1);
+            pos += sprintf(pos, "%" PRId32, (int32_t)req->res.status);
+            break;
+        case ELEMENT_TYPE_TIMESTAMP: /* %t */
+            RESERVE(H2O_TIMESTR_LOG_LEN + 2);
+            *pos++ = '[';
+            pos = append_safe_string(pos, req->processed_at.str->log, H2O_TIMESTR_LOG_LEN);
+            *pos++ = ']';
+            break;
+        case ELEMENT_TYPE_TIMESTAMP_STRFTIME: /* %{...}t */ {
+            size_t bufsz, len;
+            if (localt.tm_year == 0)
+                localtime_r(&req->processed_at.at.tv_sec, &localt);
+            for (bufsz = 128;; bufsz *= 2) {
+                RESERVE(bufsz);
+                if ((len = strftime(pos, bufsz, element->data.name.base, &localt)) != 0)
+                    break;
+            }
+            pos += len;
+        } break;
+        case ELEMENT_TYPE_TIMESTAMP_SEC_SINCE_EPOCH: /* %{sec}t */
+            RESERVE(sizeof(H2O_UINT32_LONGEST_STR) - 1);
+            pos += sprintf(pos, "%" PRIu32, (uint32_t)req->processed_at.at.tv_sec);
+            break;
+        case ELEMENT_TYPE_TIMESTAMP_MSEC_SINCE_EPOCH: /* %{msec}t */
+            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
+            pos += sprintf(pos, "%" PRIu64,
+                           (uint64_t)req->processed_at.at.tv_sec * 1000 + (uint64_t)req->processed_at.at.tv_usec / 1000);
+            break;
+        case ELEMENT_TYPE_TIMESTAMP_USEC_SINCE_EPOCH: /* %{usec}t */
+            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
+            pos +=
+                sprintf(pos, "%" PRIu64, (uint64_t)req->processed_at.at.tv_sec * 1000000 + (uint64_t)req->processed_at.at.tv_usec);
+            break;
+        case ELEMENT_TYPE_TIMESTAMP_MSEC_FRAC: /* %{msec_frac}t */
+            RESERVE(3);
+            pos += sprintf(pos, "%03u", (unsigned)(req->processed_at.at.tv_usec / 1000));
+            break;
+        case ELEMENT_TYPE_TIMESTAMP_USEC_FRAC: /* %{usec_frac}t */
+            RESERVE(6);
+            pos += sprintf(pos, "%06u", (unsigned)req->processed_at.at.tv_usec);
+            break;
+        case ELEMENT_TYPE_URL_PATH: /* %U */ {
+            size_t path_len = req->input.query_at == SIZE_MAX ? req->input.path.len : req->input.query_at;
+            RESERVE(path_len * 4);
+            pos = append_unsafe_string(pos, req->input.path.base, path_len);
+        } break;
+        case ELEMENT_TYPE_REMOTE_USER: /* %u */
+            if (req->remote_user.base == NULL)
+                goto EmitDash;
+            RESERVE(req->remote_user.len * 4);
+            pos = append_unsafe_string(pos, req->remote_user.base, req->remote_user.len);
+            break;
+        case ELEMENT_TYPE_AUTHORITY: /* %V */
+            RESERVE(req->input.authority.len * 4);
+            pos = append_unsafe_string(pos, req->input.authority.base, req->input.authority.len);
+            break;
+        case ELEMENT_TYPE_HOSTCONF: /* %v */
+            RESERVE(req->hostconf->authority.hostport.len * 4);
+            pos = append_unsafe_string(pos, req->hostconf->authority.hostport.base, req->hostconf->authority.hostport.len);
+            break;
+
+#define EMIT_HEADER(headers, _index)                                                                                               \
+    do {                                                                                                                           \
+        ssize_t index = (_index);                                                                                                  \
+        if (index == -1)                                                                                                           \
+            goto EmitDash;                                                                                                         \
+        const h2o_header_t *header = (headers)->entries + index;                                                                   \
+        RESERVE(header->value.len * 4);                                                                                            \
+        pos = append_unsafe_string(pos, header->value.base, header->value.len);                                                    \
+    } while (0)
+        case ELEMENT_TYPE_IN_HEADER_TOKEN:
+            EMIT_HEADER(&req->headers, h2o_find_header(&req->headers, element->data.header_token, SIZE_MAX));
+            break;
+        case ELEMENT_TYPE_IN_HEADER_STRING:
+            EMIT_HEADER(&req->headers,
+                        h2o_find_header_by_str(&req->headers, element->data.name.base, element->data.name.len, SIZE_MAX));
+            break;
+        case ELEMENT_TYPE_OUT_HEADER_TOKEN:
+            EMIT_HEADER(&req->res.headers, h2o_find_header(&req->res.headers, element->data.header_token, SIZE_MAX));
+            break;
+        case ELEMENT_TYPE_OUT_HEADER_STRING:
+            EMIT_HEADER(&req->res.headers,
+                        h2o_find_header_by_str(&req->res.headers, element->data.name.base, element->data.name.len, SIZE_MAX));
+            break;
+#undef EMIT_HEADER
+
+        case ELEMENT_TYPE_CONNECTION_ID:
+            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
+            pos += sprintf(pos, "%" PRIu64, req->conn->id);
+            break;
+
+        case ELEMENT_TYPE_CONNECT_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->conn->connected_at, &req->timestamps.request_begin_at);
+            break;
+
+        case ELEMENT_TYPE_REQUEST_HEADER_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.request_begin_at, timeval_is_null(&req->timestamps.request_body_begin_at)
+                                                                              ? &req->processed_at.at
+                                                                              : &req->timestamps.request_body_begin_at);
+            break;
+
+        case ELEMENT_TYPE_REQUEST_BODY_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.request_body_begin_at, &req->processed_at.at);
+            break;
+
+        case ELEMENT_TYPE_REQUEST_TOTAL_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.request_begin_at, &req->processed_at.at);
+            break;
+
+        case ELEMENT_TYPE_PROCESS_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->processed_at.at, &req->timestamps.response_start_at);
+            break;
+
+        case ELEMENT_TYPE_RESPONSE_TIME:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
+            break;
+
+        case ELEMENT_TYPE_DURATION:
+            RESERVE(DURATION_MAX_LEN);
+            pos = append_duration(pos, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
+            break;
+
+        case ELEMENT_TYPE_PROTOCOL_SPECIFIC: {
+            h2o_iovec_t (*cb)(h2o_req_t *) = req->conn->callbacks->log_.callbacks[element->data.protocol_specific_callback_index];
+            if (cb != NULL) {
+                h2o_iovec_t s = cb(req);
+                RESERVE(s.len);
+                pos = append_safe_string(pos, s.base, s.len);
+            } else {
+                goto EmitDash;
+            }
+        } break;
+
+        case ELEMENT_TYPE_LOGNAME:      /* %l */
+        case ELEMENT_TYPE_EXTENDED_VAR: /* %{...}x */
+        EmitDash:
+            RESERVE(1);
+            *pos++ = '-';
+            break;
+
+        default:
+            assert(!"unknown type");
+            break;
+        }
+
+#undef RESERVE
+
+        pos = append_safe_string(pos, element->suffix.base, element->suffix.len);
+    }
+
+    *len = pos - line;
+    return line;
+}

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -176,6 +176,9 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_PROTO("http2.priority.received.exclusive", http2.priority_received_exclusive);
                     MAP_EXT_TO_PROTO("http2.priority.received.parent", http2.priority_received_parent);
                     MAP_EXT_TO_PROTO("http2.priority.received.weight", http2.priority_received_weight);
+                    MAP_EXT_TO_PROTO("http2.priority.actual", http2.priority_actual);
+                    MAP_EXT_TO_PROTO("http2.priority.actual.parent", http2.priority_actual_parent);
+                    MAP_EXT_TO_PROTO("http2.priority.actual.weight", http2.priority_actual_weight);
                     MAP_EXT_TO_PROTO("ssl.protocol-version", ssl.protocol_version);
                     MAP_EXT_TO_PROTO("ssl.session-reused", ssl.session_reused);
                     MAP_EXT_TO_PROTO("ssl.cipher", ssl.cipher);

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -32,61 +32,8 @@
 #include "h2o.h"
 #include "h2o/serverutil.h"
 
-#define LOG_ALLOCA_SIZE 4096
-
-enum {
-    ELEMENT_TYPE_EMPTY,                      /* empty element (with suffix only) */
-    ELEMENT_TYPE_LOCAL_ADDR,                 /* %A */
-    ELEMENT_TYPE_BYTES_SENT,                 /* %b */
-    ELEMENT_TYPE_PROTOCOL,                   /* %H */
-    ELEMENT_TYPE_REMOTE_ADDR,                /* %h */
-    ELEMENT_TYPE_LOGNAME,                    /* %l */
-    ELEMENT_TYPE_METHOD,                     /* %m */
-    ELEMENT_TYPE_LOCAL_PORT,                 /* %p */
-    ELEMENT_TYPE_QUERY,                      /* %q */
-    ELEMENT_TYPE_REQUEST_LINE,               /* %r */
-    ELEMENT_TYPE_STATUS,                     /* %s */
-    ELEMENT_TYPE_TIMESTAMP,                  /* %t */
-    ELEMENT_TYPE_TIMESTAMP_STRFTIME,         /* %{...}t */
-    ELEMENT_TYPE_TIMESTAMP_SEC_SINCE_EPOCH,  /* %{sec}t */
-    ELEMENT_TYPE_TIMESTAMP_MSEC_SINCE_EPOCH, /* %{msec}t */
-    ELEMENT_TYPE_TIMESTAMP_USEC_SINCE_EPOCH, /* %{usec}t */
-    ELEMENT_TYPE_TIMESTAMP_MSEC_FRAC,        /* %{msec_frac}t */
-    ELEMENT_TYPE_TIMESTAMP_USEC_FRAC,        /* %{usec_frac}t */
-    ELEMENT_TYPE_URL_PATH,                   /* %U */
-    ELEMENT_TYPE_REMOTE_USER,                /* %u */
-    ELEMENT_TYPE_AUTHORITY,                  /* %V */
-    ELEMENT_TYPE_HOSTCONF,                   /* %v */
-    ELEMENT_TYPE_IN_HEADER_TOKEN,            /* %{data.header_token}i */
-    ELEMENT_TYPE_IN_HEADER_STRING,           /* %{data.name}i */
-    ELEMENT_TYPE_OUT_HEADER_TOKEN,           /* %{data.header_token}o */
-    ELEMENT_TYPE_OUT_HEADER_STRING,          /* %{data.name}o */
-    ELEMENT_TYPE_EXTENDED_VAR,               /* %{data.name}x */
-    ELEMENT_TYPE_CONNECTION_ID,              /* %{connection-id}x */
-    ELEMENT_TYPE_CONNECT_TIME,               /* %{connect-time}x */
-    ELEMENT_TYPE_REQUEST_HEADER_TIME,        /* %{request-header-time}x */
-    ELEMENT_TYPE_REQUEST_BODY_TIME,          /* %{request-body-time}x */
-    ELEMENT_TYPE_REQUEST_TOTAL_TIME,         /* %{request-total-time}x */
-    ELEMENT_TYPE_PROCESS_TIME,               /* %{process-time}x */
-    ELEMENT_TYPE_RESPONSE_TIME,              /* %{response-total-time}x */
-    ELEMENT_TYPE_DURATION,                   /* %{duration}x */
-    ELEMENT_TYPE_PROTOCOL_SPECIFIC,          /* %{protocol-specific...}x */
-    NUM_ELEMENT_TYPES
-};
-
-struct log_element_t {
-    unsigned type;
-    h2o_iovec_t suffix;
-    union {
-        const h2o_token_t *header_token;
-        h2o_iovec_t name;
-        size_t protocol_specific_callback_index;
-    } data;
-};
-
 struct st_h2o_access_log_filehandle_t {
-    struct log_element_t *elements;
-    size_t num_elements;
+    h2o_logconf_t *logconf;
     int fd;
 };
 
@@ -95,523 +42,30 @@ struct st_h2o_access_logger_t {
     h2o_access_log_filehandle_t *fh;
 };
 
-static h2o_iovec_t strdup_lowercased(const char *s, size_t len)
-{
-    h2o_iovec_t v = h2o_strdup(NULL, s, len);
-    h2o_strtolower(v.base, v.len);
-    return v;
-}
-
-static struct log_element_t *compile_log_format(const char *fmt, size_t *_num_elements)
-{
-    struct log_element_t *elements = NULL;
-    size_t fmt_len = strlen(fmt), num_elements = 0;
-    const char *pt = fmt;
-
-/* suffix buffer is always guaranteed to be larger than the fmt + (sizeof('\n') - 1) (so that they would be no buffer overruns) */
-#define NEW_ELEMENT(ty)                                                                                                            \
-    do {                                                                                                                           \
-        elements = h2o_mem_realloc(elements, sizeof(*elements) * (num_elements + 1));                                              \
-        elements[num_elements].type = ty;                                                                                          \
-        elements[num_elements].suffix = h2o_iovec_init(h2o_mem_alloc(fmt_len + 1), 0);                                             \
-        ++num_elements;                                                                                                            \
-    } while (0)
-
-    while (*pt != '\0') {
-        if (*pt == '%') {
-            ++pt;
-            if (*pt == '%') {
-                /* skip */
-            } else if (*pt == '{') {
-                const h2o_token_t *token;
-                const char *quote_end = strchr(++pt, '}');
-                if (quote_end == NULL) {
-                    fprintf(stderr, "failed to compile log format: unterminated header name starting at: \"%16s\"\n", pt);
-                    goto Error;
-                }
-                const char modifier = quote_end[1];
-                switch (modifier) {
-                case 'i':
-                case 'o': {
-                    h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
-                    token = h2o_lookup_token(name.base, name.len);
-                    if (token != NULL) {
-                        free(name.base);
-                        NEW_ELEMENT(modifier == 'i' ? ELEMENT_TYPE_IN_HEADER_TOKEN : ELEMENT_TYPE_OUT_HEADER_TOKEN);
-                        elements[num_elements - 1].data.header_token = token;
-                    } else {
-                        NEW_ELEMENT(modifier == 'i' ? ELEMENT_TYPE_IN_HEADER_STRING : ELEMENT_TYPE_OUT_HEADER_STRING);
-                        elements[num_elements - 1].data.name = name;
-                    }
-                } break;
-                case 't':
-                    if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("sec"))) {
-                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_SEC_SINCE_EPOCH);
-                    } else if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("msec"))) {
-                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_MSEC_SINCE_EPOCH);
-                    } else if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("usec"))) {
-                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_USEC_SINCE_EPOCH);
-                    } else if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("msec_frac"))) {
-                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_MSEC_FRAC);
-                    } else if (h2o_memis(pt, quote_end - pt, H2O_STRLIT("usec_frac"))) {
-                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_USEC_FRAC);
-                    } else {
-                        h2o_iovec_t name = h2o_strdup(NULL, pt, quote_end - pt);
-                        NEW_ELEMENT(ELEMENT_TYPE_TIMESTAMP_STRFTIME);
-                        elements[num_elements - 1].data.name = name;
-                    }
-                    break;
-                case 'x':
-#define MAP_EXT_TO_TYPE(name, id)                                                                                                  \
-    if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT(name))) {                                                                       \
-        NEW_ELEMENT(id);                                                                                                           \
-        goto MAP_EXT_Found;                                                                                                        \
-    }
-#define MAP_EXT_TO_PROTO(name, cb)                                                                                                 \
-    if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT(name))) {                                                                       \
-        NEW_ELEMENT(ELEMENT_TYPE_PROTOCOL_SPECIFIC);                                                                               \
-        elements[num_elements - 1].data.protocol_specific_callback_index =                                                         \
-            &((h2o_conn_callbacks_t *)NULL)->log_.cb - ((h2o_conn_callbacks_t *)NULL)->log_.callbacks;                             \
-        goto MAP_EXT_Found;                                                                                                        \
-    }
-                    MAP_EXT_TO_TYPE("connection-id", ELEMENT_TYPE_CONNECTION_ID);
-                    MAP_EXT_TO_TYPE("connect-time", ELEMENT_TYPE_CONNECT_TIME);
-                    MAP_EXT_TO_TYPE("request-total-time", ELEMENT_TYPE_REQUEST_TOTAL_TIME);
-                    MAP_EXT_TO_TYPE("request-header-time", ELEMENT_TYPE_REQUEST_HEADER_TIME);
-                    MAP_EXT_TO_TYPE("request-body-time", ELEMENT_TYPE_REQUEST_BODY_TIME);
-                    MAP_EXT_TO_TYPE("process-time", ELEMENT_TYPE_PROCESS_TIME);
-                    MAP_EXT_TO_TYPE("response-time", ELEMENT_TYPE_RESPONSE_TIME);
-                    MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_DURATION);
-                    MAP_EXT_TO_PROTO("http2.stream-id", http2.stream_id);
-                    MAP_EXT_TO_PROTO("http2.priority.received", http2.priority_received);
-                    MAP_EXT_TO_PROTO("http2.priority.received.exclusive", http2.priority_received_exclusive);
-                    MAP_EXT_TO_PROTO("http2.priority.received.parent", http2.priority_received_parent);
-                    MAP_EXT_TO_PROTO("http2.priority.received.weight", http2.priority_received_weight);
-                    MAP_EXT_TO_PROTO("ssl.protocol-version", ssl.protocol_version);
-                    MAP_EXT_TO_PROTO("ssl.session-reused", ssl.session_reused);
-                    MAP_EXT_TO_PROTO("ssl.cipher", ssl.cipher);
-                    MAP_EXT_TO_PROTO("ssl.cipher-bits", ssl.cipher_bits);
-                    { /* not found */
-                        h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
-                        NEW_ELEMENT(ELEMENT_TYPE_EXTENDED_VAR);
-                        elements[num_elements - 1].data.name = name;
-                    }
-                MAP_EXT_Found:
-#undef MAP_EXT_TO_TYPE
-#undef MAP_EXT_TO_PROTO
-                    break;
-                default:
-                    fprintf(stderr, "failed to compile log format: header name is not followed by either `i`, `o`, `x`\n");
-                    goto Error;
-                }
-                pt = quote_end + 2;
-                continue;
-            } else {
-                unsigned type = NUM_ELEMENT_TYPES;
-                switch (*pt++) {
-#define TYPE_MAP(ch, ty)                                                                                                           \
-    case ch:                                                                                                                       \
-        type = ty;                                                                                                                 \
-        break
-                    TYPE_MAP('A', ELEMENT_TYPE_LOCAL_ADDR);
-                    TYPE_MAP('b', ELEMENT_TYPE_BYTES_SENT);
-                    TYPE_MAP('H', ELEMENT_TYPE_PROTOCOL);
-                    TYPE_MAP('h', ELEMENT_TYPE_REMOTE_ADDR);
-                    TYPE_MAP('l', ELEMENT_TYPE_LOGNAME);
-                    TYPE_MAP('m', ELEMENT_TYPE_METHOD);
-                    TYPE_MAP('p', ELEMENT_TYPE_LOCAL_PORT);
-                    TYPE_MAP('q', ELEMENT_TYPE_QUERY);
-                    TYPE_MAP('r', ELEMENT_TYPE_REQUEST_LINE);
-                    TYPE_MAP('s', ELEMENT_TYPE_STATUS);
-                    TYPE_MAP('t', ELEMENT_TYPE_TIMESTAMP);
-                    TYPE_MAP('U', ELEMENT_TYPE_URL_PATH);
-                    TYPE_MAP('u', ELEMENT_TYPE_REMOTE_USER);
-                    TYPE_MAP('V', ELEMENT_TYPE_AUTHORITY);
-                    TYPE_MAP('v', ELEMENT_TYPE_HOSTCONF);
-#undef TYPE_MAP
-                default:
-                    fprintf(stderr, "failed to compile log format: unknown escape sequence: %%%c\n", pt[-1]);
-                    goto Error;
-                }
-                NEW_ELEMENT(type);
-                continue;
-            }
-        }
-        /* emit current char */
-        if (elements == NULL)
-            NEW_ELEMENT(ELEMENT_TYPE_EMPTY);
-        elements[num_elements - 1].suffix.base[elements[num_elements - 1].suffix.len++] = *pt++;
-    }
-
-    /* emit end-of-line */
-    if (elements == NULL)
-        NEW_ELEMENT(ELEMENT_TYPE_EMPTY);
-    elements[num_elements - 1].suffix.base[elements[num_elements - 1].suffix.len++] = '\n';
-
-#undef NEW_ELEMENT
-
-    *_num_elements = num_elements;
-    return elements;
-
-Error:
-    free(elements);
-    return NULL;
-}
-
-static inline char *append_safe_string(char *pos, const char *src, size_t len)
-{
-    memcpy(pos, src, len);
-    return pos + len;
-}
-
-static char *append_unsafe_string(char *pos, const char *src, size_t len)
-{
-    const char *src_end = src + len;
-
-    for (; src != src_end; ++src) {
-        if (' ' <= *src && *src < 0x7d && *src != '"') {
-            *pos++ = *src;
-        } else {
-            *pos++ = '\\';
-            *pos++ = 'x';
-            *pos++ = ("0123456789abcdef")[(*src >> 4) & 0xf];
-            *pos++ = ("0123456789abcdef")[*src & 0xf];
-        }
-    }
-
-    return pos;
-}
-
-static char *append_addr(char *pos, socklen_t (*cb)(h2o_conn_t *conn, struct sockaddr *sa), h2o_conn_t *conn)
-{
-    struct sockaddr_storage ss;
-    socklen_t sslen;
-
-    if ((sslen = cb(conn, (void *)&ss)) == 0)
-        goto Fail;
-    size_t l = h2o_socket_getnumerichost((void *)&ss, sslen, pos);
-    if (l == SIZE_MAX)
-        goto Fail;
-    pos += l;
-    return pos;
-
-Fail:
-    *pos++ = '-';
-    return pos;
-}
-
-static char *append_port(char *pos, socklen_t (*cb)(h2o_conn_t *conn, struct sockaddr *sa), h2o_conn_t *conn)
-{
-    struct sockaddr_storage ss;
-    socklen_t sslen;
-
-    if ((sslen = cb(conn, (void *)&ss)) == 0)
-        goto Fail;
-    int32_t port = h2o_socket_getport((void *)&ss);
-    if (port == -1)
-        goto Fail;
-    pos += sprintf(pos, "%" PRIu16, (uint16_t)port);
-    return pos;
-
-Fail:
-    *pos++ = '-';
-    return pos;
-}
-
-static inline int timeval_is_null(struct timeval *tv)
-{
-    return tv->tv_sec == 0;
-}
-
-#define DURATION_MAX_LEN (sizeof(H2O_INT32_LONGEST_STR ".999999") - 1)
-
-static char *append_duration(char *pos, struct timeval *from, struct timeval *until)
-{
-    if (timeval_is_null(from) || timeval_is_null(until)) {
-        *pos++ = '-';
-    } else {
-        int32_t delta_sec = (int32_t)until->tv_sec - (int32_t)from->tv_sec;
-        int32_t delta_usec = (int32_t)until->tv_usec - (int32_t)from->tv_usec;
-        if (delta_usec < 0) {
-            delta_sec -= 1;
-            delta_usec += 1000000;
-        }
-        pos += sprintf(pos, "%" PRId32, delta_sec);
-        if (delta_usec != 0) {
-            int i;
-            *pos++ = '.';
-            for (i = 5; i >= 0; --i) {
-                pos[i] = '0' + delta_usec % 10;
-                delta_usec /= 10;
-            }
-            pos += 6;
-        }
-    }
-    return pos;
-}
-
-static char *expand_line_buf(char *line, size_t cur_size, size_t required)
-{
-    size_t new_size = cur_size;
-
-    /* determine the new size */
-    do {
-        new_size *= 2;
-    } while (new_size < required);
-
-    /* reallocate */
-    if (cur_size == LOG_ALLOCA_SIZE) {
-        char *newpt = h2o_mem_alloc(new_size);
-        memcpy(newpt, line, cur_size);
-        line = newpt;
-    } else {
-        line = h2o_mem_realloc(line, new_size);
-    }
-
-    return line;
-}
-
 static void log_access(h2o_logger_t *_self, h2o_req_t *req)
 {
     struct st_h2o_access_logger_t *self = (struct st_h2o_access_logger_t *)_self;
     h2o_access_log_filehandle_t *fh = self->fh;
-    char *line, *pos, *line_end;
-    size_t element_index;
-    struct tm localt = {};
+    char *logline, buf[4096];
+    size_t len;
 
-    /* note: LOG_ALLOCA_SIZE should be much greater than NI_MAXHOST to avoid unnecessary reallocations */
-    line = alloca(LOG_ALLOCA_SIZE);
-    pos = line;
-    line_end = line + LOG_ALLOCA_SIZE;
+    /* stringify */
+    len = sizeof(buf);
+    logline = h2o_log_request(fh->logconf, req, &len, buf);
 
-    for (element_index = 0; element_index != fh->num_elements; ++element_index) {
-        struct log_element_t *element = fh->elements + element_index;
+    /* emit */
+    write(fh->fd, logline, len);
 
-/* reserve capacity + suffix.len */
-#define RESERVE(capacity)                                                                                                          \
-    do {                                                                                                                           \
-        if ((capacity) + element->suffix.len > line_end - pos) {                                                                   \
-            size_t off = pos - line;                                                                                               \
-            line = expand_line_buf(line, line_end - line, off + (capacity) + element->suffix.len);                                 \
-            pos = line + off;                                                                                                      \
-        }                                                                                                                          \
-    } while (0)
-
-        switch (element->type) {
-        case ELEMENT_TYPE_EMPTY:
-            RESERVE(0);
-            break;
-        case ELEMENT_TYPE_LOCAL_ADDR: /* %A */
-            RESERVE(NI_MAXHOST);
-            pos = append_addr(pos, req->conn->callbacks->get_sockname, req->conn);
-            break;
-        case ELEMENT_TYPE_BYTES_SENT: /* %b */
-            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
-            pos += sprintf(pos, "%" PRIu64, (uint64_t)req->bytes_sent);
-            break;
-        case ELEMENT_TYPE_PROTOCOL: /* %H */
-            RESERVE(sizeof("HTTP/1.1"));
-            pos += h2o_stringify_protocol_version(pos, req->version);
-            break;
-        case ELEMENT_TYPE_REMOTE_ADDR: /* %h */
-            RESERVE(NI_MAXHOST);
-            pos = append_addr(pos, req->conn->callbacks->get_peername, req->conn);
-            break;
-        case ELEMENT_TYPE_METHOD: /* %m */
-            RESERVE(req->input.method.len * 4);
-            pos = append_unsafe_string(pos, req->input.method.base, req->input.method.len);
-            break;
-        case ELEMENT_TYPE_LOCAL_PORT: /* %p */
-            RESERVE(sizeof(H2O_UINT16_LONGEST_STR) - 1);
-            pos = append_port(pos, req->conn->callbacks->get_sockname, req->conn);
-            break;
-        case ELEMENT_TYPE_QUERY: /* %q */
-            if (req->input.query_at != SIZE_MAX) {
-                size_t len = req->input.path.len - req->input.query_at;
-                RESERVE(len * 4);
-                pos = append_unsafe_string(pos, req->input.path.base + req->input.query_at, len);
-            }
-            break;
-        case ELEMENT_TYPE_REQUEST_LINE: /* %r */
-            RESERVE((req->input.method.len + req->input.path.len) * 4 + sizeof("  HTTP/1.1"));
-            pos = append_unsafe_string(pos, req->input.method.base, req->input.method.len);
-            *pos++ = ' ';
-            pos = append_unsafe_string(pos, req->input.path.base, req->input.path.len);
-            *pos++ = ' ';
-            pos += h2o_stringify_protocol_version(pos, req->version);
-            break;
-        case ELEMENT_TYPE_STATUS: /* %s */
-            RESERVE(sizeof(H2O_INT32_LONGEST_STR) - 1);
-            pos += sprintf(pos, "%" PRId32, (int32_t)req->res.status);
-            break;
-        case ELEMENT_TYPE_TIMESTAMP: /* %t */
-            RESERVE(H2O_TIMESTR_LOG_LEN + 2);
-            *pos++ = '[';
-            pos = append_safe_string(pos, req->processed_at.str->log, H2O_TIMESTR_LOG_LEN);
-            *pos++ = ']';
-            break;
-        case ELEMENT_TYPE_TIMESTAMP_STRFTIME: /* %{...}t */ {
-            size_t bufsz, len;
-            if (localt.tm_year == 0)
-                localtime_r(&req->processed_at.at.tv_sec, &localt);
-            for (bufsz = 128;; bufsz *= 2) {
-                RESERVE(bufsz);
-                if ((len = strftime(pos, bufsz, element->data.name.base, &localt)) != 0)
-                    break;
-            }
-            pos += len;
-        } break;
-        case ELEMENT_TYPE_TIMESTAMP_SEC_SINCE_EPOCH: /* %{sec}t */
-            RESERVE(sizeof(H2O_UINT32_LONGEST_STR) - 1);
-            pos += sprintf(pos, "%" PRIu32, (uint32_t)req->processed_at.at.tv_sec);
-            break;
-        case ELEMENT_TYPE_TIMESTAMP_MSEC_SINCE_EPOCH: /* %{msec}t */
-            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
-            pos += sprintf(pos, "%" PRIu64,
-                           (uint64_t)req->processed_at.at.tv_sec * 1000 + (uint64_t)req->processed_at.at.tv_usec / 1000);
-            break;
-        case ELEMENT_TYPE_TIMESTAMP_USEC_SINCE_EPOCH: /* %{usec}t */
-            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
-            pos +=
-                sprintf(pos, "%" PRIu64, (uint64_t)req->processed_at.at.tv_sec * 1000000 + (uint64_t)req->processed_at.at.tv_usec);
-            break;
-        case ELEMENT_TYPE_TIMESTAMP_MSEC_FRAC: /* %{msec_frac}t */
-            RESERVE(3);
-            pos += sprintf(pos, "%03u", (unsigned)(req->processed_at.at.tv_usec / 1000));
-            break;
-        case ELEMENT_TYPE_TIMESTAMP_USEC_FRAC: /* %{usec_frac}t */
-            RESERVE(6);
-            pos += sprintf(pos, "%06u", (unsigned)req->processed_at.at.tv_usec);
-            break;
-        case ELEMENT_TYPE_URL_PATH: /* %U */ {
-            size_t path_len = req->input.query_at == SIZE_MAX ? req->input.path.len : req->input.query_at;
-            RESERVE(path_len * 4);
-            pos = append_unsafe_string(pos, req->input.path.base, path_len);
-        } break;
-        case ELEMENT_TYPE_REMOTE_USER: /* %u */
-            if (req->remote_user.base == NULL)
-                goto EmitDash;
-            RESERVE(req->remote_user.len * 4);
-            pos = append_unsafe_string(pos, req->remote_user.base, req->remote_user.len);
-            break;
-        case ELEMENT_TYPE_AUTHORITY: /* %V */
-            RESERVE(req->input.authority.len * 4);
-            pos = append_unsafe_string(pos, req->input.authority.base, req->input.authority.len);
-            break;
-        case ELEMENT_TYPE_HOSTCONF: /* %v */
-            RESERVE(req->hostconf->authority.hostport.len * 4);
-            pos = append_unsafe_string(pos, req->hostconf->authority.hostport.base, req->hostconf->authority.hostport.len);
-            break;
-
-#define EMIT_HEADER(headers, _index)                                                                                               \
-    do {                                                                                                                           \
-        ssize_t index = (_index);                                                                                                  \
-        if (index == -1)                                                                                                           \
-            goto EmitDash;                                                                                                         \
-        const h2o_header_t *header = (headers)->entries + index;                                                                   \
-        RESERVE(header->value.len * 4);                                                                                            \
-        pos = append_unsafe_string(pos, header->value.base, header->value.len);                                                    \
-    } while (0)
-        case ELEMENT_TYPE_IN_HEADER_TOKEN:
-            EMIT_HEADER(&req->headers, h2o_find_header(&req->headers, element->data.header_token, SIZE_MAX));
-            break;
-        case ELEMENT_TYPE_IN_HEADER_STRING:
-            EMIT_HEADER(&req->headers,
-                        h2o_find_header_by_str(&req->headers, element->data.name.base, element->data.name.len, SIZE_MAX));
-            break;
-        case ELEMENT_TYPE_OUT_HEADER_TOKEN:
-            EMIT_HEADER(&req->res.headers, h2o_find_header(&req->res.headers, element->data.header_token, SIZE_MAX));
-            break;
-        case ELEMENT_TYPE_OUT_HEADER_STRING:
-            EMIT_HEADER(&req->res.headers,
-                        h2o_find_header_by_str(&req->res.headers, element->data.name.base, element->data.name.len, SIZE_MAX));
-            break;
-#undef EMIT_HEADER
-
-        case ELEMENT_TYPE_CONNECTION_ID:
-            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
-            pos += sprintf(pos, "%" PRIu64, req->conn->id);
-            break;
-
-        case ELEMENT_TYPE_CONNECT_TIME:
-            RESERVE(DURATION_MAX_LEN);
-            pos = append_duration(pos, &req->conn->connected_at, &req->timestamps.request_begin_at);
-            break;
-
-        case ELEMENT_TYPE_REQUEST_HEADER_TIME:
-            RESERVE(DURATION_MAX_LEN);
-            pos = append_duration(pos, &req->timestamps.request_begin_at, timeval_is_null(&req->timestamps.request_body_begin_at)
-                                                                              ? &req->processed_at.at
-                                                                              : &req->timestamps.request_body_begin_at);
-            break;
-
-        case ELEMENT_TYPE_REQUEST_BODY_TIME:
-            RESERVE(DURATION_MAX_LEN);
-            pos = append_duration(pos, &req->timestamps.request_body_begin_at, &req->processed_at.at);
-            break;
-
-        case ELEMENT_TYPE_REQUEST_TOTAL_TIME:
-            RESERVE(DURATION_MAX_LEN);
-            pos = append_duration(pos, &req->timestamps.request_begin_at, &req->processed_at.at);
-            break;
-
-        case ELEMENT_TYPE_PROCESS_TIME:
-            RESERVE(DURATION_MAX_LEN);
-            pos = append_duration(pos, &req->processed_at.at, &req->timestamps.response_start_at);
-            break;
-
-        case ELEMENT_TYPE_RESPONSE_TIME:
-            RESERVE(DURATION_MAX_LEN);
-            pos = append_duration(pos, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
-            break;
-
-        case ELEMENT_TYPE_DURATION:
-            RESERVE(DURATION_MAX_LEN);
-            pos = append_duration(pos, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
-            break;
-
-        case ELEMENT_TYPE_PROTOCOL_SPECIFIC: {
-            h2o_iovec_t (*cb)(h2o_req_t *) = req->conn->callbacks->log_.callbacks[element->data.protocol_specific_callback_index];
-            if (cb != NULL) {
-                h2o_iovec_t s = cb(req);
-                RESERVE(s.len);
-                pos = append_safe_string(pos, s.base, s.len);
-            } else {
-                goto EmitDash;
-            }
-        } break;
-
-        case ELEMENT_TYPE_LOGNAME:      /* %l */
-        case ELEMENT_TYPE_EXTENDED_VAR: /* %{...}x */
-        EmitDash:
-            RESERVE(1);
-            *pos++ = '-';
-            break;
-
-        default:
-            assert(!"unknown type");
-            break;
-        }
-
-#undef RESERVE
-
-        pos = append_safe_string(pos, element->suffix.base, element->suffix.len);
-    }
-
-    write(fh->fd, line, pos - line);
-
-    if (line_end - line != LOG_ALLOCA_SIZE)
-        free(line);
+    /* free memory */
+    if (logline != buf)
+        free(logline);
 }
 
 void on_dispose_handle(void *_fh)
 {
     h2o_access_log_filehandle_t *fh = _fh;
-    size_t i;
 
-    for (i = 0; i != fh->num_elements; ++i)
-        free(fh->elements[i].suffix.base);
-    free(fh->elements);
+    h2o_logconf_dispose(fh->logconf);
     close(fh->fd);
 }
 
@@ -654,26 +108,28 @@ int h2o_access_log_open_log(const char *path)
 
 h2o_access_log_filehandle_t *h2o_access_log_open_handle(const char *path, const char *fmt)
 {
-    struct log_element_t *elements;
-    size_t num_elements;
+    h2o_logconf_t *logconf;
     int fd;
     h2o_access_log_filehandle_t *fh;
+    char errbuf[256];
 
     /* default to combined log format */
     if (fmt == NULL)
         fmt = "%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"";
-    if ((elements = compile_log_format(fmt, &num_elements)) == NULL)
+    if ((logconf = h2o_logconf_compile(fmt, errbuf)) == NULL) {
+        fprintf(stderr, "%s\n", errbuf);
         return NULL;
+    }
 
     /* open log file */
-    if ((fd = h2o_access_log_open_log(path)) == -1)
+    if ((fd = h2o_access_log_open_log(path)) == -1) {
+        h2o_logconf_dispose(logconf);
         return NULL;
+    }
 
     fh = h2o_mem_alloc_shared(NULL, sizeof(*fh), on_dispose_handle);
-    fh->elements = elements;
-    fh->num_elements = num_elements;
+    fh->logconf = logconf;
     fh->fd = fd;
-
     return fh;
 }
 

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -116,7 +116,7 @@ h2o_access_log_filehandle_t *h2o_access_log_open_handle(const char *path, const 
     /* default to combined log format */
     if (fmt == NULL)
         fmt = "%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"";
-    if ((logconf = h2o_logconf_compile(fmt, errbuf)) == NULL) {
+    if ((logconf = h2o_logconf_compile(fmt, H2O_LOGCONF_ESCAPE_APACHE, errbuf)) == NULL) {
         fprintf(stderr, "%s\n", errbuf);
         return NULL;
     }

--- a/lib/handler/configurator/status.c
+++ b/lib/handler/configurator/status.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "h2o.h"
+#include "h2o/configurator.h"
+
+static int on_config_status(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    if (strcasecmp(node->data.scalar, "default") != 0) {
+        h2o_configurator_errprintf(cmd, node, "unknown mode");
+        return -1;
+    }
+
+    h2o_status_register(ctx->pathconf);
+    return 0;
+}
+
+void h2o_status_register_configurator(h2o_globalconf_t *conf)
+{
+    h2o_configurator_t *c = h2o_configurator_create(conf, sizeof(*c));
+
+    h2o_configurator_define_command(c, "status", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_status);
+}

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -83,6 +83,7 @@ static void collect_reqs_of_context(struct st_h2o_status_collector_t *collector,
     int was_last_thread;
 
     h2o_buffer_init(&cbdata.buffer, &h2o_socket_buffer_prototype);
+    ctx->globalconf->http1.callbacks.foreach_request(ctx, collect_req_status, &cbdata);
     ctx->globalconf->http2.callbacks.foreach_request(ctx, collect_req_status, &cbdata);
 
     pthread_mutex_lock(&collector->mutex);

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -23,12 +23,11 @@
 
 struct st_h2o_status_handler_t {
     h2o_handler_t super;
-    h2o_logconf_t *logconf;
 };
 
 struct st_status_context_t {
-    struct st_h2o_status_handler_t *handler;
     h2o_buffer_t *buffer;
+    h2o_logconf_t *logconf;
 };
 
 static int collect_req_status(h2o_req_t *req, void *cbdata)
@@ -38,10 +37,15 @@ static int collect_req_status(h2o_req_t *req, void *cbdata)
     /* collect log */
     char buf[4096];
     size_t len = sizeof(buf);
-    char *logline = h2o_log_request(ctx->handler->logconf, req, &len, buf);
+    char *logline = h2o_log_request(ctx->logconf, req, &len, buf);
 
     /* append to buffer */
-    h2o_buffer_reserve(&ctx->buffer, len);
+    assert(len != 0);
+    --len; /* omit trailing LF */
+    h2o_buffer_reserve(&ctx->buffer, len + 3);
+    ctx->buffer->bytes[ctx->buffer->size++] = ',';
+    ctx->buffer->bytes[ctx->buffer->size++] = '\n';
+    ctx->buffer->bytes[ctx->buffer->size++] = ' ';
     memcpy(ctx->buffer->bytes + ctx->buffer->size, logline, len);
     ctx->buffer->size += len;
 
@@ -51,16 +55,56 @@ static int collect_req_status(h2o_req_t *req, void *cbdata)
     return 0;
 }
 
-static int on_req(h2o_handler_t *_self, h2o_req_t *req)
+static int on_req_json(struct st_h2o_status_handler_t *self, h2o_req_t *req)
 {
-    struct st_h2o_status_handler_t *self = (void *)_self;
-    struct st_status_context_t ctx = {self};
     static h2o_generator_t generator = {NULL, NULL};
+    struct st_status_context_t ctx = {};
+    char errbuf[256];
+
+#define ELEMENT(key, expr) "\"" key "\": \"" expr "\""
+#define X_ELEMENT(id) ELEMENT(id, "%{" id "}x")
+#define SEPARATOR ", "
+    const char *fmt = "{"
+        /* combined_log */
+        ELEMENT("host", "%h") SEPARATOR ELEMENT("user", "%u") SEPARATOR ELEMENT("at", "%{%Y%m%dT%H%M%S}t.%{usec_frac}t%{%z}t")
+            SEPARATOR ELEMENT("method", "%m") SEPARATOR ELEMENT("path", "%U") SEPARATOR ELEMENT("query", "%q")
+                SEPARATOR ELEMENT("protocol", "%H") SEPARATOR ELEMENT("referer", "%{Referer}i")
+                    SEPARATOR ELEMENT("user-agent", "%{User-agent}i") SEPARATOR
+        /* time */
+        X_ELEMENT("connect-time") SEPARATOR X_ELEMENT("request-header-time") SEPARATOR X_ELEMENT("request-body-time")
+            SEPARATOR X_ELEMENT("request-total-time") SEPARATOR X_ELEMENT("process-time") SEPARATOR X_ELEMENT("response-time")
+                SEPARATOR
+        /* connection */
+        X_ELEMENT("connection-id") SEPARATOR X_ELEMENT("ssl.protocol-version") SEPARATOR X_ELEMENT("ssl.session-reused")
+            SEPARATOR X_ELEMENT("ssl.cipher") SEPARATOR X_ELEMENT("ssl.cipher-bits") SEPARATOR
+        /* http2 */
+        X_ELEMENT("http2.stream-id") SEPARATOR X_ELEMENT("http2.priority.received.exclusive")
+            SEPARATOR X_ELEMENT("http2.priority.received.parent") SEPARATOR X_ELEMENT("http2.priority.received.weight")
+        /* end */
+        "}";
+#undef ELEMENT
+#undef X_ELEMENT
+#undef SEPARATOR
+
+    if ((ctx.logconf = h2o_logconf_compile(fmt, H2O_LOGCONF_ESCAPE_JSON, errbuf)) == NULL) {
+        h2o_iovec_t resp = h2o_concat(&req->pool, h2o_iovec_init(H2O_STRLIT("failed to compile log format:")),
+                                      h2o_iovec_init(errbuf, strlen(errbuf)));
+        h2o_send_error(req, 400, "Invalid Request", resp.base, 0);
+        return 0;
+    }
 
     h2o_buffer_init(&ctx.buffer, &h2o_socket_buffer_prototype);
+
+    /* collect the in-flight log as a JSON array */
     req->conn->ctx->globalconf->http2.callbacks.foreach_request(req->conn->ctx, collect_req_status, &ctx);
+    ctx.buffer->bytes[0] = '[';
+    h2o_buffer_reserve(&ctx.buffer, ctx.buffer->size + 3);
+    ctx.buffer->bytes[ctx.buffer->size++] = '\n';
+    ctx.buffer->bytes[ctx.buffer->size++] = ']';
+    ctx.buffer->bytes[ctx.buffer->size++] = '\n';
 
     h2o_buffer_link_to_pool(ctx.buffer, &req->pool);
+    h2o_logconf_dispose(ctx.logconf);
 
     req->res.status = 200;
     req->res.content_length = ctx.buffer->size;
@@ -77,22 +121,30 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     return 0;
 }
 
-void on_dispose(h2o_handler_t *_self)
+static int on_req(h2o_handler_t *_self, h2o_req_t *req)
 {
     struct st_h2o_status_handler_t *self = (void *)_self;
-    h2o_logconf_dispose(self->logconf);
+    size_t prefix_len = req->pathconf->path.len - (req->pathconf->path.base[req->pathconf->path.len - 1] == '/');
+    h2o_iovec_t local_path = h2o_iovec_init(req->path_normalized.base + prefix_len, req->path_normalized.len - prefix_len);
+
+    if (local_path.len == 0 || h2o_memis(local_path.base, local_path.len, H2O_STRLIT("/"))) {
+        /* root of the handler returns HTML that renders the status */
+        h2o_iovec_t fn;
+        const char *root = getenv("H2O_ROOT");
+        if (root == NULL)
+            root = H2O_TO_STR(H2O_ROOT);
+        fn = h2o_concat(&req->pool, h2o_iovec_init(root, strlen(root)), h2o_iovec_init(H2O_STRLIT("/share/h2o/status/index.html")));
+        return h2o_file_send(req, 200, "OK", fn.base, h2o_iovec_init(H2O_STRLIT("text/html; charset=utf-8")), 0);
+    } else if (h2o_memis(local_path.base, local_path.len, H2O_STRLIT("/json"))) {
+        /* "/json" maps to the JSON API */
+        return on_req_json(self, req);
+    }
+
+    return -1;
 }
 
 void h2o_status_register(h2o_pathconf_t *pathconf)
 {
     struct st_h2o_status_handler_t *self = (void *)h2o_create_handler(pathconf, sizeof(*self));
-    char errbuf[256];
-
     self->super.on_req = on_req;
-    self->super.dispose = on_dispose;
-    if ((self->logconf = h2o_logconf_compile("%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"", H2O_LOGCONF_ESCAPE_JSON,
-                                             errbuf)) == NULL) {
-        fprintf(stderr, "%s\n", errbuf);
-        h2o_fatal("[status] failed to compile log format:%s\n");
-    }
 }

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -187,7 +187,9 @@ static int on_req_json(struct st_h2o_status_handler_t *self, h2o_req_t *req)
             SEPARATOR X_ELEMENT("ssl.cipher") SEPARATOR X_ELEMENT("ssl.cipher-bits") SEPARATOR
         /* http2 */
         X_ELEMENT("http2.stream-id") SEPARATOR X_ELEMENT("http2.priority.received.exclusive")
-            SEPARATOR X_ELEMENT("http2.priority.received.parent") SEPARATOR X_ELEMENT("http2.priority.received.weight")
+            SEPARATOR X_ELEMENT("http2.priority.received.parent") SEPARATOR X_ELEMENT("http2.priority.received.weight") SEPARATOR
+        /* misc */
+        ELEMENT("authority", "%V")
         /* end */
         "}";
 #undef ELEMENT

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -186,6 +186,8 @@ static int on_req_json(struct st_h2o_status_handler_t *self, h2o_req_t *req)
         /* connection */
         X_ELEMENT("connection-id") SEPARATOR X_ELEMENT("ssl.protocol-version") SEPARATOR X_ELEMENT("ssl.session-reused")
             SEPARATOR X_ELEMENT("ssl.cipher") SEPARATOR X_ELEMENT("ssl.cipher-bits") SEPARATOR
+        /* http1 */
+        X_ELEMENT("http1.request-index") SEPARATOR
         /* http2 */
         X_ELEMENT("http2.stream-id") SEPARATOR X_ELEMENT("http2.priority.received.exclusive")
             SEPARATOR X_ELEMENT("http2.priority.received.parent") SEPARATOR X_ELEMENT("http2.priority.received.weight")

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "h2o.h"
+
+struct st_h2o_status_handler_t {
+    h2o_handler_t super;
+    h2o_logconf_t *logconf;
+};
+
+struct st_status_context_t {
+    struct st_h2o_status_handler_t *handler;
+    h2o_buffer_t *buffer;
+};
+
+static int collect_req_status(h2o_req_t *req, void *cbdata)
+{
+    struct st_status_context_t *ctx = cbdata;
+
+    /* collect log */
+    char buf[4096];
+    size_t len = sizeof(buf);
+    char *logline = h2o_log_request(ctx->handler->logconf, req, &len, buf);
+
+    /* append to buffer */
+    h2o_buffer_reserve(&ctx->buffer, len);
+    memcpy(ctx->buffer->bytes + ctx->buffer->size, logline, len);
+    ctx->buffer->size += len;
+
+    if (logline != buf)
+        free(logline);
+
+    return 0;
+}
+
+static int on_req(h2o_handler_t *_self, h2o_req_t *req)
+{
+    struct st_h2o_status_handler_t *self = (void *)_self;
+    struct st_status_context_t ctx = {self};
+    static h2o_generator_t generator = {NULL, NULL};
+
+    h2o_buffer_init(&ctx.buffer, &h2o_socket_buffer_prototype);
+    req->conn->ctx->globalconf->http2.callbacks.foreach_request(req->conn->ctx, collect_req_status, &ctx);
+
+    h2o_buffer_link_to_pool(ctx.buffer, &req->pool);
+
+    req->res.status = 200;
+    req->res.content_length = ctx.buffer->size;
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain; charset=utf-8"));
+
+    h2o_start_response(req, &generator);
+    if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD"))) {
+        h2o_send(req, NULL, 0, 1);
+    } else {
+        h2o_iovec_t resp = h2o_iovec_init(ctx.buffer->bytes, ctx.buffer->size);
+        h2o_send(req, &resp, 1, 1);
+    }
+
+    return 0;
+}
+
+void on_dispose(h2o_handler_t *_self)
+{
+    struct st_h2o_status_handler_t *self = (void *)_self;
+    h2o_logconf_dispose(self->logconf);
+}
+
+void h2o_status_register(h2o_pathconf_t *pathconf)
+{
+    struct st_h2o_status_handler_t *self = (void *)h2o_create_handler(pathconf, sizeof(*self));
+    char errbuf[256];
+
+    self->super.on_req = on_req;
+    self->super.dispose = on_dispose;
+    if ((self->logconf = h2o_logconf_compile("%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"", errbuf)) == NULL) {
+        fprintf(stderr, "%s\n", errbuf);
+        h2o_fatal("[status] failed to compile log format:%s\n");
+    }
+}

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -90,7 +90,8 @@ void h2o_status_register(h2o_pathconf_t *pathconf)
 
     self->super.on_req = on_req;
     self->super.dispose = on_dispose;
-    if ((self->logconf = h2o_logconf_compile("%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"", errbuf)) == NULL) {
+    if ((self->logconf = h2o_logconf_compile("%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"", H2O_LOGCONF_ESCAPE_JSON,
+                                             errbuf)) == NULL) {
         fprintf(stderr, "%s\n", errbuf);
         h2o_fatal("[status] failed to compile log format:%s\n");
     }

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -187,7 +187,8 @@ static int on_req_json(struct st_h2o_status_handler_t *self, h2o_req_t *req)
             SEPARATOR X_ELEMENT("ssl.cipher") SEPARATOR X_ELEMENT("ssl.cipher-bits") SEPARATOR
         /* http2 */
         X_ELEMENT("http2.stream-id") SEPARATOR X_ELEMENT("http2.priority.received.exclusive")
-            SEPARATOR X_ELEMENT("http2.priority.received.parent") SEPARATOR X_ELEMENT("http2.priority.received.weight") SEPARATOR
+            SEPARATOR X_ELEMENT("http2.priority.received.parent") SEPARATOR X_ELEMENT("http2.priority.received.weight")
+                SEPARATOR X_ELEMENT("http2.priority.actual.parent") SEPARATOR X_ELEMENT("http2.priority.actual.weight") SEPARATOR
         /* misc */
         ELEMENT("authority", "%V")
         /* end */

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -116,6 +116,7 @@ static void send_response(struct st_h2o_status_collector_t *collector)
             resp[3] = req->conn->ctx->globalconf->status.extra_status(req->conn->ctx->globalconf, &req->pool);
         req->res.status = 200;
         h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain; charset=utf-8"));
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("no-cache, no-store"));
         h2o_start_response(req, &generator);
         h2o_send(req, resp,
                  h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : sizeof(resp) / sizeof(resp[0]),
@@ -246,6 +247,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
         if (root == NULL)
             root = H2O_TO_STR(H2O_ROOT);
         fn = h2o_concat(&req->pool, h2o_iovec_init(root, strlen(root)), h2o_iovec_init(H2O_STRLIT("/share/h2o/status/index.html")));
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("no-cache"));
         return h2o_file_send(req, 200, "OK", fn.base, h2o_iovec_init(H2O_STRLIT("text/html; charset=utf-8")), 0);
     } else if (h2o_memis(local_path.base, local_path.len, H2O_STRLIT("/json"))) {
         /* "/json" maps to the JSON API */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1134,6 +1134,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
         push_path,    /* HTTP2 push */
         {{
             {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits}, /* ssl */
+            {}, /* http1 */
             {log_stream_id, log_priority_received, log_priority_received_exclusive, log_priority_received_parent,
              log_priority_received_weight, log_priority_actual, log_priority_actual_parent, log_priority_actual_weight} /* http2 */
         }} /* loggers */

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -56,6 +56,8 @@ function update(cb) {
           s += "-" + req["http2.stream-id"];
         return s;
       } else if (field.match(/^HTTP\/2/)) {
+        if (req["http2.priority.actual.parent"] == "-")
+          return "-";
         return ["actual.parent", "actual.weight", "received.parent", "received.weight", "received.exclusive"].map(function (n) {
           return req["http2.priority." + n];
         }).join("/");

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -76,6 +76,10 @@ function update(cb) {
         return ["actual.parent", "actual.weight", "received.parent", "received.weight", "received.exclusive"].map(function (n) {
           return req["http2.priority." + n];
         }).join("/");
+      } else if (field.match(/^SSL/)) {
+        if (req["ssl.protocol-version"] == "-")
+          return "-";
+        return req["ssl.protocol-version"] + "/" + req["ssl.cipher"] + "/" + (req["ssl.session-reused"] == "1" ? "Y" : "N");
       } else if (field == "client") {
         return req.host;
       } else if (field == "URI") {
@@ -153,6 +157,7 @@ Worker threads: <span id="value:worker-threads">-</span>
 <tr>
 <th>id</th>
 <th>HTTP/2<span style="font-weight: normal; font-size: 80%"><br>Pa/Wa/Pr/Wr/X</span></th>
+<th>SSL<span style="font-weight: normal; font-size: 80%"><br>Ver/Cipher/Resume</th>
 <th>client</th>
 <th>method</th>
 <th>URI</th>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -34,7 +34,34 @@ function fetchJson(url, cb) {
   xhr.send();
 }
 
-function update(cb) {
+var update = function () {
+  var inFlight = false;
+  var timerId = null;
+  return function (force) {
+    if (timerId != null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+    if (!inFlight && (force || $("refresh").checked)) {
+      inFlight = true;
+      update.doUpdate(function (result) {
+        inFlight = false;
+        if (result) {
+          if ($("refresh").checked) {
+            timerId = setTimeout(function () {
+              timerId = null;
+              update(false);
+            }.bind(this), 1000);
+          }
+        } else {
+          $("refresh").checked = false;
+        }
+      }.bind(this));
+    }
+  }
+}();
+
+update.doUpdate = function update(cb) {
   var json_uri = (location.pathname + "/json").replace(/\/{2,}/g, "/");
   fetchJson(json_uri, function (json) {
     if (json == null) {
@@ -115,8 +142,10 @@ function update(cb) {
 }
 
 window.addEventListener("load", function () {
-  update(function (success) {
+  $("refresh").addEventListener("click", function () {
+    update(false);
   });
+  update(true);
 });
 </script>
 <style type="text/css">
@@ -171,6 +200,7 @@ body {
 <tr><th>Generation: <td id="value:generation">-
 <tr><th>Connections: <td><span id="value:connections">-</span> / <span id="value:max-connections"></span>
 <tr><th>Worker threads: <td id="value:worker-threads">-
+<tr><th>Refresh:<td><input id="refresh" type="checkbox">
 </table>
 <table id="reqs-in-flight">
 <caption>Requests In-flight</caption>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -49,6 +49,21 @@ function update(cb) {
         slot.innerHTML = json[k] != null ? json[k] : "-";
     }
 
+    $("value:uptime").innerHTML = (function () {
+      var d = json["uptime"];
+      if (isNaN(d))
+        return "-";
+      var s = "";
+      if (d >= 86400)
+        s += Math.floor(d / 86400) + "d";
+      if (d >= 3600)
+        s += Math.floor(d / 3600 % 24) + "h";
+      if (d >= 60)
+        s += Math.floor(d / 60 % 60) + "m";
+      s += (d % 60) + "s";
+      return s;
+    })();
+
     function stringifyColumn(req, field) {
       if (field == "id") {
         var s = req["connection-id"];
@@ -127,9 +142,12 @@ window.addEventListener("load", function () {
 <body>
 <h1>H2O Server Status</h1>
 <p>
+Current Time: <span id="value:current-time">-</span><br>
+Restart Time: <span id="value:restart-time">-</span><br>
+Uptime: <span id="value:uptime">-</span><br>
 Generation: <span id="value:generation">-</span><br>
 Connections: <span id="value:connections">-</span> / <span id="value:max-connections">-</span><br>
-Worker-threads: <span id="value:worker-threads">-</span>
+Worker threads: <span id="value:worker-threads">-</span>
 </p>
 <table id="reqs-in-flight">
 <caption>Requests In-flight</caption>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -120,6 +120,9 @@ window.addEventListener("load", function () {
 });
 </script>
 <style type="text/css">
+body {
+  font-family: sans-serif;
+}
 #summary {
   border: 0;
   margin: 1em 0;

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -43,6 +43,12 @@ function update(cb) {
       return;
     }
 
+    for (var k in json) {
+      var slot = $("value:" + k);
+      if (slot != null)
+        slot.innerHTML = json[k] != null ? json[k] : "-";
+    }
+
     function stringifyColumn(req, field) {
       if (field == "id") {
         var s = req["connection-id"];
@@ -61,11 +67,11 @@ function update(cb) {
       return req[field];
     }
 
-    var table = $("in-flight");
+    var table = $("reqs-in-flight");
     var columns = toArray(table.getElementsByTagName("th"));
     var oldRows = toArray(table.getElementsByTagName("tr"));
     oldRows.shift(); // first tr is a list of headers
-    json.map(function (req) {
+    json.requests.map(function (req) {
       if (!req.method)
         return;
       var row = document.createElement("tr");
@@ -92,31 +98,37 @@ window.addEventListener("load", function () {
 });
 </script>
 <style type="text/css">
-table {
+#reqs-in-flight {
   border: 1px solid gray;
   border-collapse: collapse;
   width: 100%;
 }
-table caption {
+#reqs-in-flight caption {
   font-weight: bold;
   margin: 1em auto 0.5em auto;
 }
-table td,th {
+#reqs-in-flight td,th {
   border: 1px solid gray;
   line-height: 1.2em;
   padding: 0.3em 0.5em;
 }
-table th {
+#reqs-in-flight th {
   text-align: center;
   background: #ddd;
 }
-table td {
+#reqs-in-flight td {
   vertical-align: top;
 }
 </style>
 </head>
 <body>
-<table id="in-flight">
+<h1>H2O Server Status</h1>
+<p>
+Generation: <span id="value:generation">-</span><br>
+Connections: <span id="value:connections">-</span> / <span id="value:max-connections">-</span><br>
+Worker-threads: <span id="value:worker-threads">-</span>
+</p>
+<table id="reqs-in-flight">
 <caption>Requests In-flight</caption>
 <tr>
 <th>id</th>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -140,8 +140,6 @@ window.addEventListener("load", function () {
 </style>
 </head>
 <body>
-<h1>H2O Server Status</h1>
-<p>
 Server Version: <span id="value:server-version">-</span><br>
 OpenSSL Version: <span id="value:openssl-version">-</span><br>
 Current Time: <span id="value:current-time">-</span><br>
@@ -150,7 +148,6 @@ Uptime: <span id="value:uptime">-</span><br>
 Generation: <span id="value:generation">-</span><br>
 Connections: <span id="value:connections">-</span> / <span id="value:max-connections">-</span><br>
 Worker threads: <span id="value:worker-threads">-</span>
-</p>
 <table id="reqs-in-flight">
 <caption>Requests In-flight</caption>
 <tr>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -120,9 +120,24 @@ window.addEventListener("load", function () {
 });
 </script>
 <style type="text/css">
+#summary {
+  border: 0;
+  margin: 1em 0;
+}
+#summary th,td {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+#summary th {
+  font-weight: normal;
+  text-align: right;
+  padding-right: 0.5em;
+}
 #reqs-in-flight {
   border: 1px solid gray;
   border-collapse: collapse;
+  margin: 1em 0;
   width: 100%;
 }
 #reqs-in-flight caption {
@@ -144,14 +159,16 @@ window.addEventListener("load", function () {
 </style>
 </head>
 <body>
-Server Version: <span id="value:server-version">-</span><br>
-OpenSSL Version: <span id="value:openssl-version">-</span><br>
-Current Time: <span id="value:current-time">-</span><br>
-Restart Time: <span id="value:restart-time">-</span><br>
-Uptime: <span id="value:uptime">-</span><br>
-Generation: <span id="value:generation">-</span><br>
-Connections: <span id="value:connections">-</span> / <span id="value:max-connections">-</span><br>
-Worker threads: <span id="value:worker-threads">-</span>
+<table id="summary">
+<tr><th>Server Version:<td id="value:server-version">-
+<tr><th>OpenSSL Version: <td id="value:openssl-version">-
+<tr><th>Current Time: <td id="value:current-time">-
+<tr><th>Restart Time: <td id="value:restart-time">-
+<tr><th>Uptime: <td id="value:uptime">-
+<tr><th>Generation: <td id="value:generation">-
+<tr><th>Connections: <td><span id="value:connections">-</span> / <span id="value:max-connections"></span>
+<tr><th>Worker threads: <td id="value:worker-threads">-
+</table>
 <table id="reqs-in-flight">
 <caption>Requests In-flight</caption>
 <tr>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -59,7 +59,7 @@ function update(cb) {
         return ["actual.parent", "actual.weight", "received.parent", "received.weight", "received.exclusive"].map(function (n) {
           return req["http2.priority." + n];
         }).join("/");
-      } else if (field == "address") {
+      } else if (field == "client") {
         return req.host;
       } else if (field == "path") {
         return req.path + req.query;
@@ -133,7 +133,7 @@ Worker-threads: <span id="value:worker-threads">-</span>
 <tr>
 <th>id</th>
 <th>HTTP/2<span style="font-weight: normal; font-size: 80%"><br>Pa/Wa/Pr/Wr/X</span></th>
-<th>host</th>
+<th>client</th>
 <th>method</th>
 <th>path</th>
 <th>protocol</th>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -52,7 +52,7 @@ function update(cb) {
     function stringifyColumn(req, field) {
       if (field == "id") {
         var s = req["connection-id"];
-        if (req["http2.stream-id"])
+        if (req["http2.stream-id"] != "-")
           s += "-" + req["http2.stream-id"];
         return s;
       } else if (field.match(/^HTTP\/2/)) {

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -94,8 +94,11 @@ update.doUpdate = function update(cb) {
     function stringifyColumn(req, field) {
       if (field == "id") {
         var s = req["connection-id"];
-        if (req["http2.stream-id"] != "-")
+        if (req["http1.request-index"] != "-") {
+          s += "-" + req["http1.request-index"];
+        } else if (req["http2.stream-id"] != "-") {
           s += "-" + req["http2.stream-id"];
+        }
         return s;
       } else if (field.match(/^HTTP\/2/)) {
         if (req["http2.priority.actual.parent"] == "-")

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -63,8 +63,9 @@ function update(cb) {
         }).join("/");
       } else if (field == "client") {
         return req.host;
-      } else if (field == "path") {
-        return req.path + req.query;
+      } else if (field == "URI") {
+        var scheme = req["ssl.cipher-bits"] != "-" ? "https:" : "http";
+        return scheme + "://" + req.authority + req.path + req.query;
       }
       return req[field];
     }
@@ -137,7 +138,7 @@ Worker-threads: <span id="value:worker-threads">-</span>
 <th>HTTP/2<span style="font-weight: normal; font-size: 80%"><br>Pa/Wa/Pr/Wr/X</span></th>
 <th>client</th>
 <th>method</th>
-<th>path</th>
+<th>URI</th>
 <th>protocol</th>
 <th>referer</th>
 <th>user-agent</th>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -49,6 +49,10 @@ function update(cb) {
         if (req["http2.stream-id"])
           s += "-" + req["http2.stream-id"];
         return s;
+      } else if (field.match(/^HTTP\/2/)) {
+        return ["actual.parent", "actual.weight", "received.parent", "received.weight", "received.exclusive"].map(function (n) {
+          return req["http2.priority." + n];
+        }).join("/");
       } else if (field == "address") {
         return req.host;
       } else if (field == "path") {
@@ -99,7 +103,8 @@ table caption {
 }
 table td,th {
   border: 1px solid gray;
-  padding: 0 0.5em;
+  line-height: 1.2em;
+  padding: 0.3em 0.5em;
 }
 table th {
   text-align: center;
@@ -113,7 +118,16 @@ table td {
 <body>
 <table id="in-flight">
 <caption>Requests In-flight</caption>
-<tr><th>id</th><th>host</th><th>method</th><th>path</th><th>protocol</th><th>referer</th><th>user-agent</th></tr>
+<tr>
+<th>id</th>
+<th>HTTP/2<span style="font-weight: normal; font-size: 80%"><br>Pa/Wa/Pr/Wr/X</span></th>
+<th>host</th>
+<th>method</th>
+<th>path</th>
+<th>protocol</th>
+<th>referer</th>
+<th>user-agent</th>
+</tr>
 </table>
 </body>
 </html>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>H2O status</title>
+<script type="text/javascript">
+
+function $(id) {
+  return document.getElementById(id);
+}
+
+function toArray(list) {
+  return Array.prototype.map.call(list, function (e) {
+    return e;
+  });
+}
+
+function fetchJson(url, cb) {
+  var xhr = new XMLHttpRequest();
+  xhr.open("GET", url, true);
+  xhr.onreadystatechange = function () {
+    if (xhr.readyState != 4)
+      return;
+    if (xhr.status == 200) {
+      try {
+         cb(JSON.parse(xhr.responseText));
+      } catch (e) {
+         console.log(e);
+         cb(null);
+      }
+    } else {
+      cb(null);
+    }
+  }
+  xhr.send();
+}
+
+function update(cb) {
+  var json_uri = (location.pathname + "/json").replace(/\/{2,}/g, "/");
+  fetchJson(json_uri, function (json) {
+    if (json == null) {
+      alert("an error occurred while trying to receive the status");
+      cb(false);
+      return;
+    }
+
+    function stringifyColumn(req, field) {
+      if (field == "id") {
+        var s = req["connection-id"];
+        if (req["http2.stream-id"])
+          s += "-" + req["http2.stream-id"];
+        return s;
+      } else if (field == "address") {
+        return req.host;
+      } else if (field == "path") {
+        return req.path + req.query;
+      }
+      return req[field];
+    }
+
+    var table = $("in-flight");
+    var columns = toArray(table.getElementsByTagName("th"));
+    var oldRows = toArray(table.getElementsByTagName("tr"));
+    oldRows.shift(); // first tr is a list of headers
+    json.map(function (req) {
+      if (!req.method)
+        return;
+      var row = document.createElement("tr");
+      columns.map(function (column) {
+        var text = stringifyColumn(req, column.innerHTML);
+        row.insertBefore((function () {
+          var node = document.createElement("td");
+          node.insertBefore(document.createTextNode(text), null);
+          return node;
+        })(), null);
+        table.insertBefore(row, oldRows.length != 0 ? oldRows[0] : null);
+      });
+    });
+    while (oldRows.length != 0)
+      table.removeChild(oldRows.shift());
+
+    cb(true);
+  });
+}
+
+window.addEventListener("load", function () {
+  update(function (success) {
+  });
+});
+</script>
+<style type="text/css">
+table {
+  border: 1px solid gray;
+  border-collapse: collapse;
+  width: 100%;
+}
+table caption {
+  font-weight: bold;
+  margin: 1em auto 0.5em auto;
+}
+table td,th {
+  border: 1px solid gray;
+  padding: 0 0.5em;
+}
+table th {
+  text-align: center;
+  background: #ddd;
+}
+table td {
+  vertical-align: top;
+}
+</style>
+</head>
+<body>
+<table id="in-flight">
+<caption>Requests In-flight</caption>
+<tr><th>id</th><th>host</th><th>method</th><th>path</th><th>protocol</th><th>referer</th><th>user-agent</th></tr>
+</table>
+</body>
+</html>

--- a/share/h2o/status/index.html
+++ b/share/h2o/status/index.html
@@ -142,6 +142,8 @@ window.addEventListener("load", function () {
 <body>
 <h1>H2O Server Status</h1>
 <p>
+Server Version: <span id="value:server-version">-</span><br>
+OpenSSL Version: <span id="value:openssl-version">-</span><br>
 Current Time: <span id="value:current-time">-</span><br>
 Restart Time: <span id="value:restart-time">-</span><br>
 Uptime: <span id="value:uptime">-</span><br>

--- a/src/main.c
+++ b/src/main.c
@@ -1443,6 +1443,7 @@ static void setup_configurators(void)
     h2o_proxy_register_configurator(&conf.globalconf);
     h2o_reproxy_register_configurator(&conf.globalconf);
     h2o_redirect_register_configurator(&conf.globalconf);
+    h2o_status_register_configurator(&conf.globalconf);
 #if H2O_USE_MRUBY
     h2o_mruby_register_configurator(&conf.globalconf);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -1417,6 +1417,8 @@ static h2o_iovec_t on_extra_status(h2o_globalconf_t *_conf, h2o_mem_pool_t *pool
 
     ret.base = h2o_mem_alloc_pool(pool, BUFSIZE);
     ret.len = snprintf(ret.base, BUFSIZE, ",\n"
+                                          " \"server-version\": \"" H2O_VERSION "\",\n"
+                                          " \"openssl-version\": \"%s\",\n"
                                           " \"current-time\": \"%s\",\n"
                                           " \"restart-time\": \"%s\",\n"
                                           " \"uptime\": %" PRIu64 ",\n"
@@ -1425,8 +1427,8 @@ static h2o_iovec_t on_extra_status(h2o_globalconf_t *_conf, h2o_mem_pool_t *pool
                                           " \"max-connections\": %d,\n"
                                           " \"listeners\": %zu,\n"
                                           " \"worker-threads\": %zu",
-                       current_time, restart_time, (uint64_t)(now - conf.launch_time), generation, num_connections(0),
-                       conf.max_connections, conf.num_listeners, conf.num_threads);
+                       SSLeay_version(SSLEAY_VERSION), current_time, restart_time, (uint64_t)(now - conf.launch_time), generation,
+                       num_connections(0), conf.max_connections, conf.num_listeners, conf.num_threads);
     assert(ret.len < BUFSIZE);
 
     return ret;


### PR DESCRIPTION
Still WIP. The strategy is:
* use the core of access-log to stringify the requests in-flight
* provide web I/F that emits the in-flight requests in JSON
* provide HTML that obtains the JSON using XHR and renders it

implements #430 