### PR TITLE
support H2 push after delegation

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -945,9 +945,9 @@ size_t h2o_stringify_protocol_version(char *dst, int version);
 /**
  * extracts path to be pushed from `Link: rel=prelead` header, duplicating the chunk (or returns {NULL,0} if none)
  */
-h2o_iovec_t h2o_extract_push_path_from_link_header(h2o_mem_pool_t *pool, const char *value, size_t value_len,
-                                                   const h2o_url_scheme_t *base_scheme, h2o_iovec_t *base_authority,
-                                                   h2o_iovec_t *base_path);
+h2o_iovec_t h2o_extract_push_path_from_link_header(h2o_mem_pool_t *pool, const char *value, size_t value_len, h2o_iovec_t base_path,
+                                                   const h2o_url_scheme_t *input_scheme, h2o_iovec_t input_authority,
+                                                   const h2o_url_scheme_t *base_scheme, h2o_iovec_t *base_authority);
 /**
  * return a bitmap of compressible types, by parsing the `accept-encoding` header
  */

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -572,8 +572,9 @@ int h2o_puth_path_in_link_header(h2o_req_t *req, const char *value, size_t value
     if (req->conn->callbacks->push_path == NULL)
         return -1;
 
-    h2o_iovec_t path =
-        h2o_extract_push_path_from_link_header(&req->pool, value, value_len, req->input.scheme, &req->input.authority, &req->path);
+    h2o_iovec_t path = h2o_extract_push_path_from_link_header(&req->pool, value, value_len, req->path_normalized, req->input.scheme,
+                                                              req->input.authority, req->res_is_delegated ? req->scheme : NULL,
+                                                              req->res_is_delegated ? &req->authority : NULL);
     if (path.base == NULL)
         return -1;
 

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -569,7 +569,7 @@ h2o_iovec_t h2o_get_redirect_method(h2o_iovec_t method, int status)
 
 int h2o_puth_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
 {
-    if (req->conn->callbacks->push_path == NULL || req->res_is_delegated)
+    if (req->conn->callbacks->push_path == NULL)
         return -1;
 
     h2o_iovec_t path =

--- a/t/00unit/lib/core/util.c
+++ b/t/00unit/lib/core/util.c
@@ -72,36 +72,36 @@ static void test_extract_push_path_from_link_header(void)
 {
     h2o_mem_pool_t pool;
     h2o_iovec_t path;
-    h2o_iovec_t base_authority = {H2O_STRLIT("basehost")}, base_path = {H2O_STRLIT("/basepath/")};
-#define BASE &H2O_URL_SCHEME_HTTP, &base_authority, &base_path
+    h2o_iovec_t base_path = {H2O_STRLIT("/basepath/")}, input_authority = {H2O_STRLIT("basehost")};
+#define INPUT base_path, &H2O_URL_SCHEME_HTTP, input_authority
     h2o_mem_init_pool(&pool);
 
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http://basehost/otherpath>; rel=preload"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http://basehost/otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(h2o_memis(path.base, path.len, H2O_STRLIT("/otherpath")));
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("</otherpath>; rel=preload"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("</otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(h2o_memis(path.base, path.len, H2O_STRLIT("/otherpath")));
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<otherpath>; rel=preload"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(h2o_memis(path.base, path.len, H2O_STRLIT("/basepath/otherpath")));
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<../otherpath>; rel=preload"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<../otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(h2o_memis(path.base, path.len, H2O_STRLIT("/otherpath")));
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http:otherpath>; rel=preload"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http:otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(h2o_memis(path.base, path.len, H2O_STRLIT("/basepath/otherpath")));
 
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<../otherpath>; rel=author"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<../otherpath>; rel=author"), INPUT, NULL, NULL);
     ok(path.base == NULL);
     ok(path.len == 0);
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http://basehost:81/otherpath>; rel=preload"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http://basehost:81/otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(path.base == NULL);
     ok(path.len == 0);
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<https://basehost/otherpath>; rel=preload"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<https://basehost/otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(path.base == NULL);
     ok(path.len == 0);
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<https:otherpath>; rel=preload"), BASE);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<https:otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(path.base == NULL);
     ok(path.len == 0);
 
     h2o_mem_clear_pool(&pool);
-#undef BASE
+#undef INPUT
 }
 
 void test_build_destination(void)

--- a/t/00unit/lib/core/util.c
+++ b/t/00unit/lib/core/util.c
@@ -72,7 +72,8 @@ static void test_extract_push_path_from_link_header(void)
 {
     h2o_mem_pool_t pool;
     h2o_iovec_t path;
-    h2o_iovec_t base_path = {H2O_STRLIT("/basepath/")}, input_authority = {H2O_STRLIT("basehost")};
+    h2o_iovec_t base_path = {H2O_STRLIT("/basepath/")}, input_authority = {H2O_STRLIT("basehost")},
+                other_authority = {H2O_STRLIT("otherhost")};
 #define INPUT base_path, &H2O_URL_SCHEME_HTTP, input_authority
     h2o_mem_init_pool(&pool);
 
@@ -90,15 +91,32 @@ static void test_extract_push_path_from_link_header(void)
     path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<../otherpath>; rel=author"), INPUT, NULL, NULL);
     ok(path.base == NULL);
     ok(path.len == 0);
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http://basehost:81/otherpath>; rel=preload"), INPUT, NULL, NULL);
+    path =
+        h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http://basehost:81/otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(path.base == NULL);
     ok(path.len == 0);
-    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<https://basehost/otherpath>; rel=preload"), INPUT, NULL, NULL);
+    path =
+        h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<https://basehost/otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(path.base == NULL);
     ok(path.len == 0);
     path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<https:otherpath>; rel=preload"), INPUT, NULL, NULL);
     ok(path.base == NULL);
     ok(path.len == 0);
+
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("</otherpath>; rel=preload"), INPUT, &H2O_URL_SCHEME_HTTPS,
+                                                  &input_authority);
+    ok(path.base == NULL);
+    ok(path.len == 0);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("</otherpath>; rel=preload"), INPUT, &H2O_URL_SCHEME_HTTP,
+                                                  &input_authority);
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/otherpath")));
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("</otherpath>; rel=preload"), INPUT, &H2O_URL_SCHEME_HTTP,
+                                                  &other_authority);
+    ok(path.base == NULL);
+    ok(path.len == 0);
+    path = h2o_extract_push_path_from_link_header(&pool, H2O_STRLIT("<http://basehost/otherpath>; rel=preload"), INPUT,
+                                                  &H2O_URL_SCHEME_HTTP, &other_authority);
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/otherpath")));
 
     h2o_mem_clear_pool(&pool);
 #undef INPUT

--- a/t/40server-push.t
+++ b/t/40server-push.t
@@ -11,19 +11,19 @@ plan skip_all => 'Starlet not found'
 plan skip_all => 'nghttp not found'
     unless prog_exists('nghttp');
 
-# spawn upstream
-my $upstream_port = empty_port();
-my $upstream = spawn_server(
-    argv     => [
-        qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
-    ],
-    is_ready => sub {
-        check_port($upstream_port);
-    },
-);
-
-# spawn server
-my $server = spawn_h2o(<< "EOT");
+subtest "basic" => sub {
+    # spawn upstream
+    my $upstream_port = empty_port();
+    my $upstream = spawn_server(
+        argv     => [
+            qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
+        ],
+        is_ready => sub {
+            check_port($upstream_port);
+        },
+    );
+    # spawn server
+    my $server = spawn_h2o(<< "EOT");
 hosts:
   default:
     paths:
@@ -39,35 +39,62 @@ hosts:
         file.dir: @{[DOC_ROOT]}
 EOT
 
-sub doit {
-    my ($proto, $opts, $port) = @_;
-
-    subtest 'push-prioritized' => sub {
-        my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.js>\%3b\%20rel=preload'`;
-        like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.js\n.*\s/index\.txt\?}is;
+    my $doit = sub {
+        my ($proto, $opts, $port) = @_;
+        subtest 'push-prioritized' => sub {
+            my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</assets/index.js>\%3b\%20rel=preload'`;
+            like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.js\n.*\s/index\.txt\?}is;
+        };
+        subtest 'push-unprioritized' => sub {
+            my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</index.txt.gz>\%3b\%20rel=preload'`;
+            like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\?.*\s/index\.txt.gz\n}is;
+        };
+        subtest 'push-while-sleep' => sub {
+            plan skip_all => 'mruby support is off'
+                unless server_features()->{mruby};
+            my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/mruby/sleep-and-respond?sleep=1'`;
+            like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\.gz\n.*\s/mruby/sleep-and-respond}is;
+        };
     };
 
-    subtest 'push-unprioritized' => sub {
-        my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/index.txt?resp:link=</index.txt.gz>\%3b\%20rel=preload'`;
-        like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\?.*\s/index\.txt.gz\n}is;
+    subtest 'h2 direct' => sub {
+        $doit->('http', '', $server->{port});
     };
-
-    subtest 'push-while-sleep' => sub {
-        plan skip_all => 'mruby support is off'
-            unless server_features()->{mruby};
-        my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/mruby/sleep-and-respond?sleep=1'`;
-        like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\.gz\n.*\s/mruby/sleep-and-respond}is;
+    subtest 'h2 upgrade' => sub {
+        $doit->('http', '-u', $server->{port});
     };
-}
-
-subtest 'h2 direct' => sub {
-    doit('http', '', $server->{port});
+    subtest 'h2c' => sub {
+        $doit->('https', '', $server->{tls_port});
+    };
 };
-subtest 'h2 upgrade' => sub {
-    doit('http', '-u', $server->{port});
-};
-subtest 'h2c' => sub {
-    doit('https', '', $server->{tls_port});
+
+subtest "reproxy and server-push" => sub {
+    my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        return << "EOT";
+hosts:
+  "127.0.0.1:$tls_port":
+    paths:
+      /:
+        reproxy: ON
+        mruby.handler: |
+          Proc.new do |env|
+            case env["PATH_INFO"]
+            when "/reproxy"
+              [307, {"x-reproxy-url" => "/index.txt"}, ["should never see this"]]
+            when "/index.txt"
+              push_paths = []
+              push_paths << "/index.js"
+              [399, push_paths.empty? ? {} : {"link" => push_paths.map{|p| "<#{p}>; rel=preload"}.join()}, []]
+            else
+              [399, {}, []]
+            end
+          end
+        file.dir: t/assets/doc_root
+EOT
+    });
+    my $resp = `nghttp -n --stat https://127.0.0.1:$server->{tls_port}/reproxy`;
+    like $resp, qr{\nid\s*responseEnd\s.*\s/index\.js\n.*\s/reproxy}is, "receives index.js then /reproxy";
 };
 
 done_testing;


### PR DESCRIPTION
Until now, H2 push (with the `link` header) has intentionally been disabled after delegation (i.e. internal redirect).

This is because a delegation might include a change in the orgin of the HTTP request, while H2 only allows requests to be pushed from the same origin as the main request.

This PR address the issue.  It adds a code that compares the origin of the delegated request against that sent by the client; and if the two match, pushes the resources specified by the `link` header.

fixes #860 