### PR TITLE
append --mruby option to standalone h2o for debugging mruby handler

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1135,6 +1135,7 @@ static int eval_mruby(const char *fn)
         abort();
     }
     h2o_mruby_compile_code(mrb, &config, errbuf);
+    mrb_close(mrb);
     if (errbuf[0]) {
         fprintf(stderr, "%s\n", errbuf);
         goto Exit;

--- a/src/main.c
+++ b/src/main.c
@@ -1546,12 +1546,13 @@ int main(int argc, char **argv)
     setup_configurators();
 
     { /* parse options */
+#define LONG_OPT_MRUBY 1001
         int ch;
         static struct option longopts[] = {{"conf", required_argument, NULL, 'c'},
                                            {"mode", required_argument, NULL, 'm'},
                                            {"test", no_argument, NULL, 't'},
 #if H2O_USE_MRUBY
-                                           {"mruby", required_argument, NULL, 1001},
+                                           {"mruby", required_argument, NULL, LONG_OPT_MRUBY},
 #endif
                                            {"version", no_argument, NULL, 'v'},
                                            {"help", no_argument, NULL, 'h'},
@@ -1590,7 +1591,7 @@ int main(int argc, char **argv)
                 conf.run_mode = RUN_MODE_TEST;
                 break;
 #if H2O_USE_MRUBY
-            case 1001:
+            case LONG_OPT_MRUBY:
                 if (conf.run_mode != RUN_MODE_TEST) {
                     printf("--mruby requires --mode=test\n");
                     exit(1);
@@ -1627,6 +1628,10 @@ int main(int argc, char **argv)
                        "                               process to reconfigure or upgrade the server.\n"
                        "                     - test:   tests the configuration and exits\n"
                        "  -t, --test         synonym of `--mode=test`\n"
+#if H2O_USE_MRUBY
+                       "  --mruby FILE       eval specified file as mruby under h2o context.\n"
+                       "                     only works with `--mode=test`\n"
+#endif
                        "  -v, --version      prints the version number\n"
                        "  -h, --help         print this help\n"
                        "\n"
@@ -1645,6 +1650,7 @@ int main(int argc, char **argv)
         }
         argc -= optind;
         argv += optind;
+#undef LONG_OPT_MRUBY
     }
 
     /* setup conf.server_starter */

--- a/src/main.c
+++ b/src/main.c
@@ -1134,7 +1134,7 @@ static int eval_mruby(const char *fn)
         fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
         abort();
     }
-    mrb_value result = h2o_mruby_compile_code(mrb, &config, errbuf);
+    h2o_mruby_compile_code(mrb, &config, errbuf);
     if (errbuf[0]) {
         fprintf(stderr, "%s\n", errbuf);
         goto Exit;

--- a/t/90standalone.t
+++ b/t/90standalone.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use File::Temp qw(tempfile);
+use Test::More;
+use t::Util;
+use Capture::Tiny qw(capture);
+
+subtest "--mruby" => sub {
+	plan skip_all => "mruby is not enabled" unless server_features->{mruby};
+
+	my $run = sub {
+		my ($code) = @_;
+		my ($fh, $fn) = tempfile(UNLINK => 1);
+		print $fh $code;
+		close $fh;
+
+		return capture {
+			system(bindir() . "/h2o", "--mode=test", "--mruby=$fn");
+		};
+	};
+
+	subtest "stdout / stderr" => sub {
+		my ($stdout, $stderr) = $run->(q{
+			puts "puts stdout"
+			raise "warn stderr"
+		});
+
+		like $stdout, qr/puts stdout\n/;
+		like $stderr, qr/warn stderr \(RuntimeError\)/;
+	};
+
+	subtest "mruby context" => sub {
+		local $ENV{H2O_ROOT} = '.';
+		my ($stdout, $stderr) = $run->(q{
+			p $LOAD_PATH
+		});
+		like $stdout, qr{\[".", "./share/h2o/mruby"\]};
+		is $stderr, '';
+	};
+};
+
+# avoid no tests run
+ok 1;
+done_testing;


### PR DESCRIPTION
This is useful for debugging/testing mruby.handler (eval mruby code under h2o context with same functions).

Usage

```
H2O_ROOT=. ./h2o --mode=test --mruby ./test.rb 
```

```rb:test.rb
## in h2o mruby context
p $LOAD_PATH

require 'htpasswd.rb'
p Htpasswd

## example
handler = instance_eval do
	lambda do |env|
		case env['PATH_INFO']
		when "/"
			return [307, {"x-reproxy-url" => "/index.ja.html" }, []]
		end
		return [399, {}, []]
	end
end

p handler.call({ 'PATH_INFO' => '/' })
p handler.call({ 'PATH_INFO' => '/index.ja.html' })
```
