### PR TITLE
fix error "Undefined subroutine &main::die called at fetch-ocsp-response line 139."

### DIFF
--- a/share/h2o/fetch-ocsp-response
+++ b/share/h2o/fetch-ocsp-response
@@ -138,7 +138,7 @@ sub run_openssl {
         or die "failed to invoke $openssl_cmd:$!";
     my $resp = do { local $/; <$fh> };
     close $fh
-        or ($tempfail ? \&tempfail : \&die)->("OpenSSL exitted abnormally: $openssl_cmd $args:$!");
+        or ($tempfail ? \&tempfail : \&CORE::die)->("OpenSSL exitted abnormally: $openssl_cmd $args:$!");
     $resp;
 }
 


### PR DESCRIPTION
Fixed in my error log.

## Before

```
Undefined subroutine &main::die called at /usr/local/share/h2o/fetch-ocsp-response line 139.
```

## After

```
OpenSSL exitted abnormally: openssl x509 -in /path/to/fullchain.pem -noout -ocsp_uri: at /usr/local/share/h2o/fetch-ocsp-response line 139.