### PR TITLE
minimize HTTP/2 request latency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,12 @@ SET_TARGET_PROPERTIES(examples-websocket PROPERTIES
     EXCLUDE_FROM_ALL 1)
 TARGET_LINK_LIBRARIES(examples-websocket libh2o ${LIBUV_LIBRARIES} ${WSLAY_LIBRARIES} ${EXTRA_LIBS})
 
+ADD_EXECUTABLE(examples-latency-optimization examples/libh2o/latency-optimization.c)
+SET_TARGET_PROPERTIES(examples-latency-optimization PROPERTIES
+    COMPILE_FLAGS "-DH2O_USE_LIBUV=0"
+    EXCLUDE_FROM_ALL 1)
+TARGET_LINK_LIBRARIES(examples-latency-optimization libh2o-evloop ${EXTRA_LIBS})
+
 # standalone server directly links to libh2o using evloop
 SET(STANDALONE_SOURCE_FILES
     ${LIB_SOURCE_FILES}

--- a/examples/libh2o/latency-optimization.c
+++ b/examples/libh2o/latency-optimization.c
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2014 DeNA Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include "h2o/socket.h"
+#include "h2o/string_.h"
+
+/* configuration */
+static char *host, *port;
+static SSL_CTX *ssl_ctx;
+static int mode_server, server_flag_received;
+static h2o_socket_latency_optimization_conditions_t latopt_cond = {
+    .min_rtt              = 50,
+    .max_additional_delay = 10,
+    .max_cwnd             = 65535
+};
+size_t write_block_size = 65536;
+
+/* globals */
+static h2o_loop_t *loop;
+static h2o_socket_t *sock;
+static struct {
+    uint64_t ms;
+    uint64_t octets;
+} delay;
+
+static void server_write(h2o_socket_t *sock);
+
+static h2o_iovec_t prepare_write_buf(void)
+{
+    static h2o_iovec_t buf;
+    if (buf.base == NULL) {
+        buf.base = h2o_mem_alloc(write_block_size);
+        buf.len = write_block_size;
+        memset(buf.base, '0', buf.len);
+    }
+    return buf;
+}
+
+static void server_on_write_ready(h2o_socket_t *sock, const char *err)
+{
+    if (err != NULL) {
+        fprintf(stderr, "socket unexpected closed by peer:%s\n", err);
+        exit(1);
+        return;
+    }
+    server_write(sock);
+}
+
+static void server_on_write_complete(h2o_socket_t *sock, const char *err)
+{
+    if (err != NULL) {
+        fprintf(stderr, "write failed:%s\n", err);
+        exit(1);
+        return;
+    }
+    h2o_socket_notify_write(sock, server_on_write_ready);
+}
+
+void server_write(h2o_socket_t *sock)
+{
+    size_t sz = h2o_socket_prepare_for_latency_optimized_write(sock, &latopt_cond);
+    h2o_iovec_t buf = prepare_write_buf();
+
+    if (server_flag_received)
+        buf.base[0] = '1';
+    if (sz < buf.len)
+        buf.len = sz;
+
+    fprintf(stderr, "writing %zu bytes\n", buf.len);
+    h2o_socket_write(sock, &buf, 1, server_on_write_complete);
+}
+
+static void server_on_read_second(h2o_socket_t *sock, const char *err)
+{
+    if (err != NULL) {
+        fprintf(stderr, "connection closed unexpectedly:%s\n", err);
+        exit(1);
+        return;
+    }
+
+    fprintf(stderr, "received the flag\n");
+    server_flag_received = 1;
+}
+
+static void server_on_read_first(h2o_socket_t *sock, const char *err)
+{
+    if (err != NULL) {
+        fprintf(stderr, "connection closed unexpectedly:%s\n", err);
+        exit(1);
+        return;
+    }
+
+    server_write(sock);
+    h2o_socket_read_start(sock, server_on_read_second);
+}
+
+static void client_on_write_complete(h2o_socket_t *sock, const char *err)
+{
+    if (err == NULL)
+        return;
+    /* handle error */
+    fprintf(stderr, "write failed:%s\n", err);
+    h2o_socket_close(sock);
+    exit(1);
+}
+
+static void client_on_read_second(h2o_socket_t *sock, const char *err)
+{
+    size_t i;
+
+    if (err != NULL) {
+        fprintf(stderr, "connection closed unexpectedly:%s\n", err);
+        exit(1);
+        return;
+    }
+
+    for (i = 0; i != sock->input->size; ++i) {
+        if (sock->input->bytes[i] != '0')
+            goto FoundSig;
+        ++delay.octets;
+    }
+    h2o_buffer_consume(&sock->input, sock->input->size);
+    return;
+
+FoundSig:
+    delay.ms = h2o_now(h2o_socket_get_loop(sock)) - delay.ms;
+    printf("Delay: %" PRIu64 " ms, %" PRIu64 " octets\n", delay.ms, delay.octets);
+    exit(0);
+}
+
+static void client_on_read_first(h2o_socket_t *sock, const char *err)
+{
+    if (err != NULL) {
+        fprintf(stderr, "connection closed unexpectedly:%s\n", err);
+        exit(1);
+        return;
+    }
+
+    h2o_buffer_consume(&sock->input, sock->input->size);
+    delay.ms = h2o_now(h2o_socket_get_loop(sock));
+    h2o_iovec_t data = {H2O_STRLIT("!")};
+    h2o_socket_write(sock, &data, 1, client_on_write_complete);
+    h2o_socket_read_start(sock, client_on_read_second);
+}
+
+static void on_handshake_complete(h2o_socket_t *sock, const char *err)
+{
+    if (err != NULL && err != h2o_socket_error_ssl_cert_name_mismatch) {
+        /* TLS handshake failed */
+        fprintf(stderr, "TLS handshake failure:%s\n", err);
+        ERR_print_errors_fp(stderr);
+        h2o_socket_close(sock);
+        exit(1);
+        return;
+    }
+
+    if (mode_server) {
+        h2o_socket_read_start(sock, server_on_read_first);
+    } else {
+        h2o_iovec_t buf = {H2O_STRLIT("0")};
+        h2o_socket_write(sock, &buf, 1, client_on_write_complete);
+        h2o_socket_read_start(sock, client_on_read_first);
+    }
+}
+
+static void on_connect(h2o_socket_t *sock, const char *err)
+{
+    if (err != NULL) {
+        /* connection failed */
+        fprintf(stderr, "failed to connect to host:%s\n", err);
+        h2o_socket_close(sock);
+        exit(1);
+        return;
+    }
+
+    if (ssl_ctx != NULL) {
+        h2o_socket_ssl_handshake(sock, ssl_ctx, mode_server ? NULL : "blahblah", on_handshake_complete);
+    } else {
+        on_handshake_complete(sock, NULL);
+    }
+}
+
+static void on_accept(h2o_socket_t *listener, const char *err)
+{
+    if (err != NULL)
+        return;
+
+    if ((sock = h2o_evloop_socket_accept(listener)) != NULL) {
+        h2o_socket_close(listener);
+        if (ssl_ctx != NULL) {
+            h2o_socket_ssl_handshake(sock, ssl_ctx, mode_server ? NULL : "blahblah", on_handshake_complete);
+        } else {
+            on_handshake_complete(sock, NULL);
+        }
+    }
+}
+
+static void usage(const char *cmd)
+{
+    fprintf(stderr, "Usage: %s [opts] [<host>:]<port>\n"
+                    "Options: --listen             if set, waits for incoming connection. Otherwise,\n"
+                    "                              connects to the server running at given address\n"
+                    "         --reverse-role       if set, reverses the role bet. server and the\n"
+                    "                              client once the connection is established\n"
+                    "         --tls                use TLS\n"
+                    "         --block-size=octets  default write block size\n"
+                    "         --min-rtt=ms         minimum RTT to enable latency optimization\n"
+                    "         --max-cwnd=octets    maximum size of CWND to enable latency\n"
+                    "                              optimization\n", cmd);
+    exit(1);
+}
+
+int main(int argc, char **argv)
+{
+    static const struct option longopts[] = {
+        {"listen", no_argument, NULL, 'l'},
+        {"reverse-role", no_argument, NULL, 'r'},
+        {"tls", no_argument, NULL, 't'},
+        {"block-size", no_argument, NULL, 'b'},
+        {"min-rtt", required_argument, NULL, 'R'},
+        {"max-cwnd", required_argument, NULL, 'c'},
+        {}
+    };
+    int opt_ch, mode_listen = 0, mode_reverse_role = 0, mode_tls = 0;
+    struct addrinfo hints, *res = NULL;
+    int err;
+
+    while ((opt_ch = getopt_long(argc, argv, "lrtb:R:c:", longopts, NULL)) != -1) {
+        switch (opt_ch) {
+        case 'l':
+            mode_listen = 1;
+            break;
+        case 'r':
+            mode_reverse_role = 1;
+            break;
+        case 't':
+            mode_tls = 1;
+            break;
+        case 'b':
+            if (sscanf(optarg, "%zu", &write_block_size) != 1) {
+                fprintf(stderr, "write block size (-b) must be a non-negative number of octets\n");
+                exit(1);
+            }
+            break;
+        case 'R':
+            if (sscanf(optarg, "%u", &latopt_cond.min_rtt) != 1) {
+                fprintf(stderr, "min RTT (-m) must be a non-negative number in milliseconds\n");
+                exit(1);
+            }
+            break;
+        case 'c':
+            if (sscanf(optarg, "%u", &latopt_cond.max_cwnd) != 1) {
+                fprintf(stderr, "max CWND size must be a non-negative number of octets\n");
+                exit(1);
+            }
+            break;
+        default:
+            usage(argv[0]);
+            break;
+        }
+    }
+    mode_server = mode_listen;
+    if (mode_reverse_role)
+        mode_server = !mode_server;
+
+    if (argc == optind) {
+        usage(argv[0]);
+    } else {
+        char *hostport = argv[optind], *colon;
+        if ((colon = strchr(hostport, ':')) != NULL) {
+            hostport = argv[optind];
+            host = strdup(hostport);
+            host[colon - hostport] = '\0';
+            port = colon + 1;
+        } else {
+            host = "0.0.0.0";
+            port = argv[optind];
+            hostport = malloc(strlen(host) + strlen(port) + 2);
+            sprintf(hostport, "%s:%s", host, port);
+        }
+    }
+
+    if (mode_tls) {
+        SSL_load_error_strings();
+        SSL_library_init();
+        OpenSSL_add_all_algorithms();
+        if (mode_server) {
+            ssl_ctx = SSL_CTX_new(TLSv1_server_method());
+            SSL_CTX_use_certificate_file(ssl_ctx, "examples/h2o/server.crt", SSL_FILETYPE_PEM);
+            SSL_CTX_use_PrivateKey_file(ssl_ctx, "examples/h2o/server.key", SSL_FILETYPE_PEM);
+        } else {
+            ssl_ctx = SSL_CTX_new(TLSv1_client_method());
+        }
+    }
+
+#if H2O_USE_LIBUV
+    loop = uv_loop_new();
+#else
+    loop = h2o_evloop_create();
+#endif
+
+    /* resolve host:port (FIXME use the function supplied by the loop) */
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    hints.ai_flags = AI_ADDRCONFIG;
+    if ((err = getaddrinfo(host, port, &hints, &res)) != 0) {
+        fprintf(stderr, "failed to resolve %s:%s:%s\n", host, port, gai_strerror(err));
+        exit(1);
+    }
+
+    if (mode_listen) {
+        int fd, reuseaddr_flag = 1;
+        if ((fd = socket(AF_INET, SOCK_STREAM, 0)) == -1 ||
+            setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr_flag, sizeof(reuseaddr_flag)) != 0 ||
+            bind(fd, res->ai_addr, res->ai_addrlen) != 0 || listen(fd, SOMAXCONN) != 0) {
+            fprintf(stderr, "failed to listen to %s:%s:%s\n", host, port, strerror(errno));
+            exit(1);
+        }
+        h2o_socket_t *listen_sock = h2o_evloop_socket_create(loop, fd, H2O_SOCKET_FLAG_DONT_READ);
+        h2o_socket_read_start(listen_sock, on_accept);
+    } else {
+        if ((sock = h2o_socket_connect(loop, res->ai_addr, res->ai_addrlen, on_connect)) == NULL) {
+            fprintf(stderr, "failed to create socket:%s\n", strerror(errno));
+            exit(1);
+        }
+    }
+
+    while (1) {
+#if H2O_USE_LIBUV
+        uv_run(loop, UV_RUN_DEFAULT);
+#else
+        h2o_evloop_run(loop);
+#endif
+    }
+
+    return 0;
+}

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -209,6 +209,8 @@
 		10E299581A67E68500701AA6 /* scheduler.c in Sources */ = {isa = PBXBuildFile; fileRef = 10E299571A67E68500701AA6 /* scheduler.c */; };
 		10E2995A1A68D03100701AA6 /* scheduler.c in Sources */ = {isa = PBXBuildFile; fileRef = 10E299591A68D03100701AA6 /* scheduler.c */; };
 		10E598011CE1683A000D7B94 /* mruby.c in Sources */ = {isa = PBXBuildFile; fileRef = 10B38A731B8D3544007DC191 /* mruby.c */; };
+		10EA45D81D0949BF00769A2B /* libh2o.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1079231519A320A700C52AD6 /* libh2o.a */; };
+		10EA45E11D094A1200769A2B /* latency-optimization.c in Sources */ = {isa = PBXBuildFile; fileRef = 10EA45E01D094A1200769A2B /* latency-optimization.c */; };
 		10EC2A361A0B4D370083514F /* socketpool.h in Headers */ = {isa = PBXBuildFile; fileRef = 10EC2A351A0B4D370083514F /* socketpool.h */; };
 		10EC2A381A0B4DC70083514F /* socketpool.c in Sources */ = {isa = PBXBuildFile; fileRef = 10EC2A371A0B4DC70083514F /* socketpool.c */; };
 		10F417CC19C1907B00B6E31A /* libh2o.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1079231519A320A700C52AD6 /* libh2o.a */; };
@@ -241,6 +243,13 @@
 			remoteInfo = h2o;
 		};
 		10D0905E19F38B2E0043D458 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1079230D19A320A700C52AD6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1079231419A320A700C52AD6;
+			remoteInfo = h2o;
+		};
+		10EA45D41D0949BF00769A2B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 1079230D19A320A700C52AD6 /* Project object */;
 			proxyType = 1;
@@ -294,6 +303,15 @@
 			runOnlyForDeploymentPostprocessing = 1;
 		};
 		10D0906319F38B2E0043D458 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		10EA45D91D0949BF00769A2B /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = /usr/share/man/man1/;
@@ -593,6 +611,8 @@
 		10DA969F1CD2BFEE00679165 /* cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cache.c; sourceTree = "<group>"; };
 		10E299571A67E68500701AA6 /* scheduler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scheduler.c; sourceTree = "<group>"; };
 		10E299591A68D03100701AA6 /* scheduler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scheduler.c; sourceTree = "<group>"; };
+		10EA45DF1D0949BF00769A2B /* examples-latency-optimization */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "examples-latency-optimization"; sourceTree = BUILT_PRODUCTS_DIR; };
+		10EA45E01D094A1200769A2B /* latency-optimization.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "latency-optimization.c"; sourceTree = "<group>"; };
 		10EC2A351A0B4D370083514F /* socketpool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socketpool.h; sourceTree = "<group>"; };
 		10EC2A371A0B4DC70083514F /* socketpool.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = socketpool.c; sourceTree = "<group>"; };
 		10F417D319C1907B00B6E31A /* h2o */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = h2o; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -663,6 +683,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				10D0906219F38B2E0043D458 /* libh2o.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		10EA45D71D0949BF00769A2B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				10EA45D81D0949BF00769A2B /* libh2o.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1035,6 +1063,7 @@
 				10F417D319C1907B00B6E31A /* h2o */,
 				10D0905119F0CA9C0043D458 /* examples-socket-server */,
 				10D0906919F38B2E0043D458 /* examples-http1client */,
+				10EA45DF1D0949BF00769A2B /* examples-latency-optimization */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1304,6 +1333,7 @@
 				10D0905219F0CB130043D458 /* socket-client.c */,
 				107923FC19A3238500C52AD6 /* simple.c */,
 				1079241319A324B400C52AD6 /* websocket.c */,
+				10EA45E01D094A1200769A2B /* latency-optimization.c */,
 			);
 			path = libh2o;
 			sourceTree = "<group>";
@@ -1620,6 +1650,24 @@
 			productReference = 10D0906919F38B2E0043D458 /* examples-http1client */;
 			productType = "com.apple.product-type.tool";
 		};
+		10EA45D21D0949BF00769A2B /* examples-latency-optimization */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 10EA45DA1D0949BF00769A2B /* Build configuration list for PBXNativeTarget "examples-latency-optimization" */;
+			buildPhases = (
+				10EA45D51D0949BF00769A2B /* Sources */,
+				10EA45D71D0949BF00769A2B /* Frameworks */,
+				10EA45D91D0949BF00769A2B /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				10EA45D31D0949BF00769A2B /* PBXTargetDependency */,
+			);
+			name = "examples-latency-optimization";
+			productName = simple;
+			productReference = 10EA45DF1D0949BF00769A2B /* examples-latency-optimization */;
+			productType = "com.apple.product-type.tool";
+		};
 		10F417C619C1907B00B6E31A /* server */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 10F417CE19C1907B00B6E31A /* Build configuration list for PBXNativeTarget "server" */;
@@ -1666,6 +1714,7 @@
 				1079240219A3247A00C52AD6 /* examples-websocket */,
 				10D0904419F0CA9C0043D458 /* examples-socket-client */,
 				10D0905C19F38B2E0043D458 /* examples-http1client */,
+				10EA45D21D0949BF00769A2B /* examples-latency-optimization */,
 			);
 		};
 /* End PBXProject section */
@@ -1848,6 +1897,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		10EA45D51D0949BF00769A2B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				10EA45E11D094A1200769A2B /* latency-optimization.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		10F417C919C1907B00B6E31A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1902,6 +1959,11 @@
 			isa = PBXTargetDependency;
 			target = 1079231419A320A700C52AD6 /* h2o */;
 			targetProxy = 10D0905E19F38B2E0043D458 /* PBXContainerItemProxy */;
+		};
+		10EA45D31D0949BF00769A2B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1079231419A320A700C52AD6 /* h2o */;
+			targetProxy = 10EA45D41D0949BF00769A2B /* PBXContainerItemProxy */;
 		};
 		10F417C719C1907B00B6E31A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2676,6 +2738,112 @@
 			};
 			name = "libuv-release";
 		};
+		10EA45DB1D0949BF00769A2B /* evloop-debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"/usr/local/openssl-1.0.2/include",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					/usr/local/include,
+					include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"/usr/local/openssl-1.0.2/lib",
+					/usr/local/lib,
+				);
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = (
+					"-lssl",
+					"-lcrypto",
+					"-lz",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "evloop-debug";
+		};
+		10EA45DC1D0949BF00769A2B /* libuv-debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"/usr/local/openssl-1.0.2/include",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					/usr/local/include,
+					include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"/usr/local/openssl-1.0.2/lib",
+					/usr/local/lib,
+				);
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = (
+					"-lssl",
+					"-lcrypto",
+					"-luv",
+					"-lz",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "libuv-debug";
+		};
+		10EA45DD1D0949BF00769A2B /* evloop-release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"/usr/local/openssl-1.0.2/include",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					/usr/local/include,
+					include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"/usr/local/openssl-1.0.2/lib",
+					/usr/local/lib,
+				);
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = (
+					"-lssl",
+					"-lcrypto",
+					"-lz",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "evloop-release";
+		};
+		10EA45DE1D0949BF00769A2B /* libuv-release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"/usr/local/openssl-1.0.2/include",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					/usr/local/include,
+					include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"/usr/local/openssl-1.0.2/lib",
+					/usr/local/lib,
+				);
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = (
+					"-lssl",
+					"-lcrypto",
+					"-luv",
+					"-lz",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "libuv-release";
+		};
 		10F417CF19C1907B00B6E31A /* evloop-debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2876,6 +3044,17 @@
 				10D0906619F38B2E0043D458 /* libuv-debug */,
 				10D0906719F38B2E0043D458 /* evloop-release */,
 				10D0906819F38B2E0043D458 /* libuv-release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "evloop-release";
+		};
+		10EA45DA1D0949BF00769A2B /* Build configuration list for PBXNativeTarget "examples-latency-optimization" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				10EA45DB1D0949BF00769A2B /* evloop-debug */,
+				10EA45DC1D0949BF00769A2B /* libuv-debug */,
+				10EA45DD1D0949BF00769A2B /* evloop-release */,
+				10EA45DE1D0949BF00769A2B /* libuv-release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "evloop-release";

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -351,6 +351,10 @@ struct st_h2o_globalconf_t {
          */
         size_t max_streams_for_priority;
         /**
+         * conditions for latency optimization
+         */
+        h2o_socket_latency_optimization_conditions_t latency_optimization;
+        /**
          * list of callbacks
          */
         h2o_protocol_callbacks_t callbacks;

--- a/include/h2o/http2_scheduler.h
+++ b/include/h2o/http2_scheduler.h
@@ -109,6 +109,10 @@ void h2o_http2_scheduler_activate(h2o_http2_scheduler_openref_t *ref);
  * weight.
  */
 int h2o_http2_scheduler_run(h2o_http2_scheduler_node_t *root, h2o_http2_scheduler_run_cb cb, void *cb_arg);
+/**
+ * returns if there are any active entries nodes in the scheduler (may have false positives, but no false negatives)
+ */
+int h2o_http2_scheduler_is_active(h2o_http2_scheduler_node_t *root);
 
 /* inline definitions */
 

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -51,6 +51,22 @@ extern "C" {
 #define H2O_USE_NPN 0
 #endif
 
+typedef struct st_h2o_sliding_counter_t {
+    uint64_t average;
+    struct {
+        uint64_t sum;
+        uint64_t slots[8];
+        size_t index;
+    } prev;
+    struct {
+        uint64_t start_at;
+    } cur;
+} h2o_sliding_counter_t;
+
+static int h2o_sliding_counter_is_running(h2o_sliding_counter_t *counter);
+static void h2o_sliding_counter_start(h2o_sliding_counter_t *counter, uint64_t now);
+void h2o_sliding_counter_stop(h2o_sliding_counter_t *counter, uint64_t now);
+
 #define H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE 4096
 
 typedef struct st_h2o_socket_t h2o_socket_t;
@@ -66,6 +82,13 @@ typedef void (*h2o_socket_cb)(h2o_socket_t *sock, const char *err);
 struct st_h2o_socket_peername_t {
     socklen_t len;
     struct sockaddr addr;
+};
+
+enum {
+    H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_TBD = 0,
+    H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_NEEDS_UPDATE,
+    H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DISABLED,
+    H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DETERMINED
 };
 
 /**
@@ -85,6 +108,11 @@ struct st_h2o_socket_t {
         h2o_socket_cb write;
     } _cb;
     struct st_h2o_socket_peername_t *_peername;
+    struct {
+        uint8_t state; /* one of H2O_SOCKET_LATENCY_STATE_* */
+        uint16_t suggested_tls_payload_size;
+        size_t suggested_write_size; /* SIZE_MAX if no need to optimize for latency */
+    } _latency_optimization;
 };
 
 typedef struct st_h2o_socket_export_t {
@@ -92,6 +120,24 @@ typedef struct st_h2o_socket_export_t {
     struct st_h2o_socket_ssl_t *ssl;
     h2o_buffer_t *input;
 } h2o_socket_export_t;
+
+/**
+ * sets the conditions to enable the optimization
+ */
+typedef struct st_h2o_socket_latency_optimization_conditions_t {
+    /**
+     * in milliseconds
+     */
+    unsigned min_rtt;
+    /**
+     * percent ratio
+     */
+    unsigned max_additional_delay;
+    /**
+     * in number of octets
+     */
+    unsigned max_cwnd;
+} h2o_socket_latency_optimization_conditions_t;
 
 typedef void (*h2o_socket_ssl_resumption_get_async_cb)(h2o_socket_t *sock, h2o_iovec_t session_id);
 typedef void (*h2o_socket_ssl_resumption_new_cb)(h2o_iovec_t session_id, h2o_iovec_t session_data);
@@ -147,6 +193,13 @@ void h2o_socket_dont_read(h2o_socket_t *sock, int dont_read);
  * connects to peer
  */
 h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, h2o_socket_cb cb);
+/**
+ * prepares for latency-optimized write and returns the number of octets that should be written, or SIZE_MAX if failed to prepare
+ */
+static size_t h2o_socket_prepare_for_latency_optimized_write(h2o_socket_t *sock,
+                                                             const h2o_socket_latency_optimization_conditions_t *conditions);
+size_t h2o_socket_do_prepare_for_latency_optimized_write(h2o_socket_t *sock,
+                                                         const h2o_socket_latency_optimization_conditions_t *conditions);
 /**
  * writes given data to socket
  * @param sock the socket
@@ -264,6 +317,18 @@ inline int h2o_socket_is_reading(h2o_socket_t *sock)
     return sock->_cb.read != NULL;
 }
 
+inline size_t h2o_socket_prepare_for_latency_optimized_write(h2o_socket_t *sock,
+                                                             const h2o_socket_latency_optimization_conditions_t *conditions)
+{
+    switch (sock->_latency_optimization.state) {
+    case H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_TBD:
+    case H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_NEEDS_UPDATE:
+        return h2o_socket_do_prepare_for_latency_optimized_write(sock, conditions);
+    default:
+        return sock->_latency_optimization.suggested_write_size;
+    }
+}
+
 inline h2o_iovec_t h2o_socket_log_ssl_protocol_version(h2o_socket_t *sock, h2o_mem_pool_t *pool)
 {
     const char *s = h2o_socket_get_ssl_protocol_version(sock);
@@ -286,6 +351,16 @@ inline h2o_iovec_t h2o_socket_log_ssl_cipher(h2o_socket_t *sock, h2o_mem_pool_t 
 {
     const char *s = h2o_socket_get_ssl_cipher(sock);
     return s != NULL ? h2o_iovec_init(s, strlen(s)) : h2o_iovec_init(H2O_STRLIT("-"));
+}
+
+inline int h2o_sliding_counter_is_running(h2o_sliding_counter_t *counter)
+{
+    return counter->cur.start_at != 0;
+}
+
+inline void h2o_sliding_counter_start(h2o_sliding_counter_t *counter, uint64_t now)
+{
+    counter->cur.start_at = now;
 }
 
 #ifdef __cplusplus

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -98,7 +98,14 @@ struct st_h2o_socket_t {
     void *data;
     struct st_h2o_socket_ssl_t *ssl;
     h2o_buffer_t *input;
+    /**
+     * total bytes read (above the TLS layer)
+     */
     size_t bytes_read;
+    /**
+     * total bytes written (above the TLS layer)
+     */
+    size_t bytes_written;
     struct {
         void (*cb)(void *data);
         void *data;

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -110,6 +110,7 @@ struct st_h2o_socket_t {
     struct st_h2o_socket_peername_t *_peername;
     struct {
         uint8_t state; /* one of H2O_SOCKET_LATENCY_STATE_* */
+        uint8_t notsent_is_minimized : 1;
         uint16_t suggested_tls_payload_size;
         size_t suggested_write_size; /* SIZE_MAX if no need to optimize for latency */
     } _latency_optimization;

--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -43,6 +43,7 @@ typedef struct st_h2o_evloop_t {
     } _statechanged;
     uint64_t _now;
     h2o_linklist_t _timeouts; /* list of h2o_timeout_t */
+    h2o_sliding_counter_t exec_time_counter;
 } h2o_evloop_t;
 
 typedef h2o_evloop_t h2o_loop_t;
@@ -58,9 +59,16 @@ h2o_evloop_t *h2o_evloop_create(void);
 void h2o_evloop_destroy(h2o_evloop_t *loop);
 int h2o_evloop_run(h2o_evloop_t *loop);
 
+/* inline definitions */
+
 static inline uint64_t h2o_now(h2o_evloop_t *loop)
 {
     return loop->_now;
+}
+
+static inline uint64_t h2o_evloop_get_execution_time(h2o_evloop_t *loop)
+{
+    return loop->exec_time_counter.average;
 }
 
 #endif

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -407,7 +407,7 @@ static void disable_latency_optimized_write(h2o_socket_t *sock, int (*adjust_not
     }
 #endif
     sock->_latency_optimization.state = H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DISABLED;
-    sock->_latency_optimization.suggested_tls_payload_size = calc_suggested_tls_payload_size(sock, 16384);
+    sock->_latency_optimization.suggested_tls_payload_size = 16384;
     sock->_latency_optimization.suggested_write_size = SIZE_MAX;
 }
 
@@ -444,7 +444,7 @@ static inline void prepare_for_latency_optimized_write(h2o_socket_t *sock,
                 goto Disable;
             sock->_latency_optimization.notsent_is_minimized = 0;
         }
-        sock->_latency_optimization.suggested_tls_payload_size = calc_suggested_tls_payload_size(sock, 16384);
+        sock->_latency_optimization.suggested_tls_payload_size = 16384;
         sock->_latency_optimization.suggested_write_size = SIZE_MAX;
     }
     return;

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -577,6 +577,9 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
         case H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_TBD:
             ssl_record_size = 1400;
             break;
+        case H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DETERMINED:
+            sock->_latency_optimization.state = H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_NEEDS_UPDATE;
+            /* fallthru */
         default:
             ssl_record_size = sock->_latency_optimization.suggested_tls_payload_size;
             break;

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -472,7 +472,7 @@ static int obtain_tcp_info(int fd, uint32_t *rtt, uint32_t *mss, uint32_t *cwnd_
     *cwnd_avail = tcpi.tcpi_snd_cwnd > tcpi.tcpi_unacked ? tcpi.tcpi_snd_cwnd - tcpi.tcpi_unacked + 1 : 1;
     return 0;
 
-#elif defined(__FreeBSD__) && defined(TCP_INFO)
+#elif defined(__FreeBSD__) && defined(TCP_INFO) && 0 /* disabled since we wouldn't use it anyways; the OS lacks TCP_NOTSENT_LOWAT */
 
     struct tcp_info tcpi;
     socklen_t tcpisz = sizeof(tcpi);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -557,21 +557,16 @@ size_t h2o_socket_do_prepare_for_latency_optimized_write(h2o_socket_t *sock,
 
 void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb)
 {
+    size_t i, prev_bytes_written = sock->bytes_written;
+
+    for (i = 0; i != bufcnt; ++i) {
+        sock->bytes_written = bufs[i].len;
 #if H2O_SOCKET_DUMP_WRITE
-    {
-        size_t i;
-        for (i = 0; i != bufcnt; ++i) {
-            fprintf(stderr, "writing %zu bytes to fd:%d\n", bufs[i].len,
-#if H2O_USE_LIBUV
-                    ((struct st_h2o_uv_socket_t *)sock)->uv.stream->io_watcher.fd
-#else
-                    ((struct st_h2o_evloop_socket_t *)sock)->fd
+        fprintf(stderr, "writing %zu bytes to fd:%d\n", bufs[i].len, h2o_socket_get_fd(sock));
+        h2o_dump_memory(stderr, bufs[i].base, bufs[i].len);
 #endif
-                    );
-            h2o_dump_memory(stderr, bufs[i].base, bufs[i].len);
-        }
     }
-#endif
+
     if (sock->ssl == NULL) {
         do_write(sock, bufs, bufcnt, cb);
     } else {
@@ -580,7 +575,8 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
         size_t ssl_record_size;
         switch (sock->_latency_optimization.state) {
         case H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_TBD:
-            ssl_record_size = 1400;
+        case H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DISABLED:
+            ssl_record_size = prev_bytes_written < 200 * 1024 ? calc_suggested_tls_payload_size(sock, 1400) : 16384;
             break;
         case H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DETERMINED:
             sock->_latency_optimization.state = H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_NEEDS_UPDATE;

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -462,7 +462,7 @@ static int obtain_tcp_info(int fd, uint32_t *rtt, uint32_t *mss, uint32_t *cwnd_
 {
 #define CALC_CWND_PAIR_FROM_BYTE_UNITS(cwnd_bytes, inflight_bytes) do { \
     *cwnd_size = (cwnd_bytes + *mss / 2) / *mss; \
-    *cwnd_avail = cwnd_bytes > inflight_bytes ? (cwnd_bytes - inflight_bytes) / *mss + 1 : 1; \
+    *cwnd_avail = cwnd_bytes > inflight_bytes ? (cwnd_bytes - inflight_bytes) / *mss + 2 : 2; \
 } while (0)
 
 #if defined(__linux__) && defined(TCP_INFO)
@@ -474,7 +474,7 @@ static int obtain_tcp_info(int fd, uint32_t *rtt, uint32_t *mss, uint32_t *cwnd_
     *rtt = tcpi.tcpi_rtt;
     *mss = tcpi.tcpi_snd_mss;
     *cwnd_size = tcpi.tcpi_snd_cwnd;
-    *cwnd_avail = tcpi.tcpi_snd_cwnd > tcpi.tcpi_unacked ? tcpi.tcpi_snd_cwnd - tcpi.tcpi_unacked + 1 : 1;
+    *cwnd_avail = tcpi.tcpi_snd_cwnd > tcpi.tcpi_unacked ? tcpi.tcpi_snd_cwnd - tcpi.tcpi_unacked + 2 : 2;
     return 0;
 
 #elif defined(__FreeBSD__) && defined(TCP_INFO) && 0 /* disabled since we wouldn't use it anyways; the OS lacks TCP_NOTSENT_LOWAT */

--- a/lib/common/socket/evloop/epoll.c.h
+++ b/lib/common/socket/evloop/epoll.c.h
@@ -117,6 +117,9 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
     if (nevents == -1)
         return -1;
 
+    if (nevents != 0)
+        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now);
+
     /* update readable flags, perform writes */
     for (i = 0; i != nevents; ++i) {
         struct st_h2o_evloop_socket_t *sock = events[i].data.ptr;

--- a/lib/common/socket/evloop/kqueue.c.h
+++ b/lib/common/socket/evloop/kqueue.c.h
@@ -128,6 +128,9 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
     if (nevents == -1)
         return -1;
 
+    if (nevents != 0)
+        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now);
+
     /* update readable flags, perform writes */
     for (i = 0; i != nevents; ++i) {
         struct st_h2o_evloop_socket_t *sock = (void *)events[i].udata;

--- a/lib/common/socket/evloop/poll.c.h
+++ b/lib/common/socket/evloop/poll.c.h
@@ -110,6 +110,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
     /* update readable flags, perform writes */
     if (ret > 0) {
         size_t i;
+        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now);
         for (i = 0; i != pollfds.size; ++i) {
             /* set read_ready flag before calling the write cb, since app. code invoked by the latter may close the socket, clearing
              * the former flag */

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -20,6 +20,7 @@
  * IN THE SOFTWARE.
  */
 #include <inttypes.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -181,6 +182,9 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->proxy.io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
     config->http2.max_concurrent_requests_per_connection = H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams;
     config->http2.max_streams_for_priority = 16;
+    config->http2.latency_optimization.min_rtt = UINT_MAX;
+    config->http2.latency_optimization.max_additional_delay = 10;
+    config->http2.latency_optimization.max_cwnd = 65535;
     config->http2.callbacks = H2O_HTTP2_CALLBACKS;
     config->mimemap = h2o_mimemap_create();
 

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -359,6 +359,32 @@ static int on_config_http2_max_concurrent_requests_per_connection(h2o_configurat
     return h2o_configurator_scanf(cmd, node, "%zu", &ctx->globalconf->http2.max_concurrent_requests_per_connection);
 }
 
+static int on_config_http2_latency_optimization_min_rtt(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx,
+                                                        yoml_t *node)
+{
+    return h2o_configurator_scanf(cmd, node, "%u", &ctx->globalconf->http2.latency_optimization.min_rtt);
+}
+
+static int on_config_http2_latency_optimization_max_additional_delay(h2o_configurator_command_t *cmd,
+                                                                     h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    double ratio;
+    if (h2o_configurator_scanf(cmd, node, "%lf", &ratio) != 0)
+        return -1;
+    if (!(0.0 < ratio)) {
+        h2o_configurator_errprintf(cmd, node, "ratio must be a positive number");
+        return -1;
+    }
+    ctx->globalconf->http2.latency_optimization.max_additional_delay = 100 * ratio;
+    return 0;
+}
+
+static int on_config_http2_latency_optimization_max_cwnd(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx,
+                                                         yoml_t *node)
+{
+    return h2o_configurator_scanf(cmd, node, "%u", &ctx->globalconf->http2.latency_optimization.max_cwnd);
+}
+
 static int on_config_http2_reprioritize_blocking_assets(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx,
                                                         yoml_t *node)
 {
@@ -774,6 +800,15 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(&c->super, "http2-max-concurrent-requests-per-connection",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_max_concurrent_requests_per_connection);
+        h2o_configurator_define_command(&c->super, "http2-latency-optimization-min-rtt",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http2_latency_optimization_min_rtt);
+        h2o_configurator_define_command(&c->super, "http2-latency-optimization-max-additional-delay",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http2_latency_optimization_max_additional_delay);
+        h2o_configurator_define_command(&c->super, "http2-latency-optimization-max-cwnd",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http2_latency_optimization_max_cwnd);
         h2o_configurator_define_command(&c->super, "http2-reprioritize-blocking-assets",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -292,10 +292,8 @@ void send_stream_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum)
 static void request_gathered_write(h2o_http2_conn_t *conn)
 {
     assert(conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING);
-    if (conn->_write.buf_in_flight == NULL) {
-        if (!h2o_timeout_is_linked(&conn->_write.timeout_entry))
-            h2o_timeout_link(conn->super.ctx->loop, &conn->super.ctx->zero_timeout, &conn->_write.timeout_entry);
-    }
+    if (conn->sock->_cb.write == NULL && !h2o_timeout_is_linked(&conn->_write.timeout_entry))
+        h2o_timeout_link(conn->super.ctx->loop, &conn->super.ctx->zero_timeout, &conn->_write.timeout_entry);
 }
 
 static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta)
@@ -913,6 +911,17 @@ void h2o_http2_conn_register_for_proceed_callback(h2o_http2_conn_t *conn, h2o_ht
     }
 }
 
+static void on_notify_write(h2o_socket_t *sock, const char *err)
+{
+    h2o_http2_conn_t *conn = sock->data;
+
+    if (err != NULL) {
+        close_connection_now(conn);
+        return;
+    }
+    do_emit_writereq(conn);
+}
+
 static void on_write_complete(h2o_socket_t *sock, const char *err)
 {
     h2o_http2_conn_t *conn = sock->data;
@@ -931,7 +940,7 @@ static void on_write_complete(h2o_socket_t *sock, const char *err)
     assert(conn->_write.buf_in_flight == NULL);
 
     /* call the proceed callback of the streams that have been flushed (while unlinking them from the list) */
-    if (err == NULL && conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING) {
+    if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING) {
         while (!h2o_linklist_is_empty(&conn->_write.streams_to_proceed)) {
             h2o_http2_stream_t *stream =
                 H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _refs.link, conn->_write.streams_to_proceed.next);
@@ -944,6 +953,14 @@ static void on_write_complete(h2o_socket_t *sock, const char *err)
     /* cancel the write callback if scheduled (as the generator may have scheduled a write just before this function gets called) */
     if (h2o_timeout_is_linked(&conn->_write.timeout_entry))
         h2o_timeout_unlink(&conn->_write.timeout_entry);
+
+#if !H2O_USE_LIBUV
+    if (conn->state == H2O_HTTP2_CONN_STATE_OPEN) {
+        if (conn->_write.buf->size != 0 || h2o_http2_scheduler_is_active(&conn->scheduler))
+            h2o_socket_notify_write(sock, on_notify_write);
+        return;
+    }
+#endif
 
     /* write more, if possible */
     if (do_emit_writereq(conn))

--- a/lib/http2/scheduler.c
+++ b/lib/http2/scheduler.c
@@ -357,3 +357,10 @@ int h2o_http2_scheduler_run(h2o_http2_scheduler_node_t *root, h2o_http2_schedule
     }
     return 0;
 }
+
+int h2o_http2_scheduler_is_active(h2o_http2_scheduler_node_t *root)
+{
+    return root->_queue != NULL && root->_queue->bits != 0;
+}
+
+

--- a/t/00unit/lib/common/socket.c
+++ b/t/00unit/lib/common/socket.c
@@ -46,7 +46,119 @@ static void test_on_alpn_select(void)
     ok(h2o_memis(out, outlen, H2O_STRLIT("h2-16")));
 }
 
+static void test_sliding_counter(void)
+{
+    h2o_sliding_counter_t counter = {};
+    size_t i;
+
+    h2o_sliding_counter_start(&counter, 100);
+    h2o_sliding_counter_stop(&counter, 80 + 100);
+    ok(counter.average == 10);
+
+    for (i = 0; i != 7; ++i) {
+        h2o_sliding_counter_start(&counter, 1);
+        h2o_sliding_counter_stop(&counter, 81);
+    }
+    ok(counter.average == 80);
+
+    h2o_sliding_counter_start(&counter, 1000);
+    h2o_sliding_counter_stop(&counter, 1000 + 1000 * 8 - 80 * 7);
+    ok(counter.average == 1000);
+
+    for (i = 0; i != 8; ++i) {
+        h2o_sliding_counter_start(&counter, 1);
+        h2o_sliding_counter_stop(&counter, 11);
+    }
+    ok(counter.average == 10);
+}
+
+static struct {
+    struct {
+        int ret;
+    } fetch_tcp_info;
+    struct {
+        int ret;
+        size_t call_cnt;
+    } minimize_notsent_lowat;
+    struct {
+        unsigned long ret;
+    } get_cipher;
+} cb_ret_vars;
+
+static int test_adjust_notsent_lowat(h2o_socket_t *sock, unsigned notsent_lowat)
+{
+    ++cb_ret_vars.minimize_notsent_lowat.call_cnt;
+    return cb_ret_vars.minimize_notsent_lowat.ret;
+}
+
+static void test_prepare_for_latency_optimization(void)
+{
+    struct st_h2o_socket_ssl_t sock_ssl = {NULL, NULL, 5 + 8 + 16 /* GCM overhead */};
+    h2o_socket_t sock = {NULL, &sock_ssl};
+    h2o_socket_latency_optimization_conditions_t cond = {UINT_MAX, 10, 65535};
+
+    /* option disabled, or if rtt is too small */
+    memset(&sock._latency_optimization, 0, sizeof(sock._latency_optimization));
+    memset(&cb_ret_vars, 0, sizeof(cb_ret_vars));
+    cb_ret_vars.fetch_tcp_info.ret = 0;
+    cb_ret_vars.get_cipher.ret = TLS1_CK_RSA_WITH_AES_128_GCM_SHA256;
+    prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, 10 /* cwnd_size */, 6 /* cwnd_avail */, 4,
+                                        test_adjust_notsent_lowat);
+    ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DISABLED);
+    ok(sock._latency_optimization.suggested_tls_payload_size == (16384 - (5 + 8 + 16)));
+    ok(sock._latency_optimization.suggested_write_size == SIZE_MAX);
+    ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 0);
+
+    /* trigger optimiziation */
+    memset(&sock._latency_optimization, 0, sizeof(sock._latency_optimization));
+    cond.min_rtt = 25; /* 25 ms */
+    prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, 10 /* cwnd_size */, 6 /* cwnd_avail */, 4,
+                                        test_adjust_notsent_lowat);
+    ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DETERMINED);
+    ok(sock._latency_optimization.suggested_tls_payload_size == 1400 - (5 + 8 + 16));
+    ok(sock._latency_optimization.suggested_write_size == (1400 - (5 + 8 + 16)) * (10 - 5 + 1));
+    ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 1);
+
+    /* recalculate with an updated cwnd,unacked */
+    sock._latency_optimization.state = H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_NEEDS_UPDATE;
+    prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, 14 /* cwnd_size */, 12 /* cwnd_avail */, 4,
+                                        test_adjust_notsent_lowat);
+    ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DETERMINED);
+    ok(sock._latency_optimization.suggested_tls_payload_size == 1400 - (5 + 8 + 16));
+    ok(sock._latency_optimization.suggested_write_size == (1400 - (5 + 8 + 16)) * (14 - 3 + 1));
+    ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 1);
+
+    /* switches to B/W optimization when CWND becomes greater */
+    sock._latency_optimization.state = H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_NEEDS_UPDATE;
+    prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, (65535 / 1400) + 1 /* cwnd_size */,
+                                        (65535 / 1400) + 1 /* cwnd_avail */, 4, test_adjust_notsent_lowat);
+    ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DETERMINED);
+    ok(sock._latency_optimization.suggested_tls_payload_size == 16384 - (5 + 8 + 16));
+    ok(sock._latency_optimization.suggested_write_size == SIZE_MAX);
+    ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 1);
+
+    /* switches back to latency optimization when CWND becomes small */
+    sock._latency_optimization.state = H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_NEEDS_UPDATE;
+    prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, 8 /* cwnd_size */, 6 /* cwnd_avail */, 4,
+                                        test_adjust_notsent_lowat);
+    ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DETERMINED);
+    ok(sock._latency_optimization.suggested_tls_payload_size == 1400 - (5 + 8 + 16));
+    ok(sock._latency_optimization.suggested_write_size == (1400 - (5 + 8 + 16)) * (8 - 3 + 1));
+    ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 1);
+
+    /* switches back to latency optimization when CWND becomes small */
+    sock._latency_optimization.state = H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_NEEDS_UPDATE;
+    prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, 8 /* cwnd_size */, 6 /* cwnd_avail */, 6,
+                                        test_adjust_notsent_lowat);
+    ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DISABLED);
+    ok(sock._latency_optimization.suggested_tls_payload_size == 16384 - (5 + 8 + 16));
+    ok(sock._latency_optimization.suggested_write_size == SIZE_MAX);
+    ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 2);
+}
+
 void test_lib__common__socket_c(void)
 {
     subtest("on_alpn_select", test_on_alpn_select);
+    subtest("sliding_counter", test_sliding_counter);
+    subtest("prepare_for_latency_optimization", test_prepare_for_latency_optimization);
 }

--- a/t/00unit/lib/common/socket.c
+++ b/t/00unit/lib/common/socket.c
@@ -107,7 +107,7 @@ static void test_prepare_for_latency_optimization(void)
     prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, 10 /* cwnd_size */, 6 /* cwnd_avail */, 4,
                                         test_adjust_notsent_lowat);
     ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DISABLED);
-    ok(sock._latency_optimization.suggested_tls_payload_size == (16384 - (5 + 8 + 16)));
+    ok(sock._latency_optimization.suggested_tls_payload_size == 16384);
     ok(sock._latency_optimization.suggested_write_size == SIZE_MAX);
     ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 0);
 
@@ -137,7 +137,7 @@ static void test_prepare_for_latency_optimization(void)
     prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, (65535 / 1400) + 1 /* cwnd_size */,
                                         (65535 / 1400) + 1 /* cwnd_avail */, 4, test_adjust_notsent_lowat);
     ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DETERMINED);
-    ok(sock._latency_optimization.suggested_tls_payload_size == 16384 - (5 + 8 + 16));
+    ok(sock._latency_optimization.suggested_tls_payload_size == 16384);
     ok(sock._latency_optimization.suggested_write_size == SIZE_MAX);
     ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 2);
     ok(cb_ret_vars.minimize_notsent_lowat.cur == 0);
@@ -157,7 +157,7 @@ static void test_prepare_for_latency_optimization(void)
     prepare_for_latency_optimized_write(&sock, &cond, 50000 /* rtt */, 1400 /* mss */, 8 /* cwnd_size */, 6 /* cwnd_avail */, 6,
                                         test_adjust_notsent_lowat);
     ok(sock._latency_optimization.state == H2O_SOCKET_LATENCY_OPTIMIZATION_STATE_DISABLED);
-    ok(sock._latency_optimization.suggested_tls_payload_size == 16384 - (5 + 8 + 16));
+    ok(sock._latency_optimization.suggested_tls_payload_size == 16384);
     ok(sock._latency_optimization.suggested_write_size == SIZE_MAX);
     ok(cb_ret_vars.minimize_notsent_lowat.call_cnt == 4);
     ok(cb_ret_vars.minimize_notsent_lowat.cur == 0);


### PR DESCRIPTION
WIP.

The basic idea is to only write(2) data that can be immediately sent by the TCP/IP stack, by using TCP_NOTSENT_LOWAT and TCP_INFO.