### PR TITLE
Configurable Server: header

### DIFF
--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -693,6 +693,26 @@ static int on_config_unsetenv(h2o_configurator_command_t *cmd, h2o_configurator_
     return 0;
 }
 
+static int on_config_server_name(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ctx->globalconf->server_name = h2o_strdup(NULL, node->data.scalar, SIZE_MAX);
+    return 0;
+}
+
+static int on_config_send_server_name(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ssize_t on;
+
+    if ((on = h2o_configurator_get_one_of(cmd, node, "OFF,ON")) == -1)
+        return -1;
+
+    if (!on) {
+        ctx->globalconf->server_name = h2o_iovec_init(H2O_STRLIT(""));
+    }
+
+    return 0;
+}
+
 void h2o_configurator__init_core(h2o_globalconf_t *conf)
 {
     /* check if already initialized */
@@ -765,6 +785,11 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(&c->super, "setenv",
                                         H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING, on_config_setenv);
         h2o_configurator_define_command(&c->super, "unsetenv", H2O_CONFIGURATOR_FLAG_ALL_LEVELS, on_config_unsetenv);
+        h2o_configurator_define_command(&c->super, "server-name",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_server_name);
+        h2o_configurator_define_command(&c->super, "send-server-name",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR |
+                                        H2O_CONFIGURATOR_FLAG_DEFERRED , on_config_send_server_name);
     }
 }
 

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -576,11 +576,14 @@ static size_t flatten_headers(char *buf, h2o_req_t *req, const char *connection)
     /* send essential headers with the first chars uppercased for max. interoperability (#72) */
     if (req->res.content_length != SIZE_MAX) {
         dst +=
-            sprintf(dst, "HTTP/1.1 %d %s\r\nDate: %s\r\nServer: %s\r\nConnection: %s\r\nContent-Length: %zu\r\n", req->res.status,
-                    req->res.reason, ts.str->rfc1123, ctx->globalconf->server_name.base, connection, req->res.content_length);
+            sprintf(dst, "HTTP/1.1 %d %s\r\nDate: %s\r\nConnection: %s\r\nContent-Length: %zu\r\n", req->res.status,
+                    req->res.reason, ts.str->rfc1123, connection, req->res.content_length);
     } else {
-        dst += sprintf(dst, "HTTP/1.1 %d %s\r\nDate: %s\r\nServer: %s\r\nConnection: %s\r\n", req->res.status, req->res.reason,
-                       ts.str->rfc1123, ctx->globalconf->server_name.base, connection);
+        dst += sprintf(dst, "HTTP/1.1 %d %s\r\nDate: %s\r\nConnection: %s\r\n", req->res.status, req->res.reason,
+                       ts.str->rfc1123, connection);
+    }
+    if (ctx->globalconf->server_name.len) {
+        dst += sprintf(dst, "Server: %s\r\n", ctx->globalconf->server_name.base);
     }
 
     { /* flatten the normal headers */

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -773,7 +773,9 @@ void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *he
     capacity += STATUS_HEADER_MAX_SIZE;      /* for :status: */
 #ifndef H2O_UNITTEST
     capacity += 2 + H2O_TIMESTR_RFC1123_LEN; /* for Date: */
-    capacity += 5 + server_name->len;        /* for Server: */
+    if (server_name->len) {
+        capacity += 5 + server_name->len;        /* for Server: */
+    }
 #endif
     if (content_length != SIZE_MAX)
         capacity += CONTENT_LENGTH_HEADER_MAX_SIZE; /* for content-length: UINT64_MAX (with huffman compression applied) */
@@ -785,7 +787,9 @@ void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *he
     dst = encode_status(dst, res->status);
 #ifndef H2O_UNITTEST
     /* TODO keep some kind of reference to the indexed headers of Server and Date, and reuse them */
-    dst = encode_header(header_table, dst, &H2O_TOKEN_SERVER->buf, server_name);
+    if (server_name->len) {
+        dst = encode_header(header_table, dst, &H2O_TOKEN_SERVER->buf, server_name);
+    }
     h2o_iovec_t date_value = {ts->str->rfc1123, H2O_TIMESTR_RFC1123_LEN};
     dst = encode_header(header_table, dst, &H2O_TOKEN_DATE->buf, &date_value);
 #endif

--- a/t/50servername.t
+++ b/t/50servername.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+subtest "default server header" => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[ DOC_ROOT ]}
+EOT
+
+    my $resp = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/index.txt 2>&1 > /dev/null`;
+    like $resp, qr{^HTTP/1\.1 200 }s, "200 response";
+    like $resp, qr{^server: h2o/.*\r$}im, "h2o default Server: header found";
+    is +(() = $resp =~ m{^server}img), 1, "header added only once";
+};
+
+subtest "alternate server header" => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[ DOC_ROOT ]}
+server-name: h2oalternate
+EOT
+
+    my $resp = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/index.txt 2>&1 > /dev/null`;
+    like $resp, qr{^HTTP/1\.1 200 }s, "200 response";
+    like $resp, qr{^server: h2oalternate\r$}im, "alternate h2o Server: header found";
+    is +(() = $resp =~ m{^server}img), 1, "header added only once";
+};
+
+subtest "no server header" => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[ DOC_ROOT ]}
+server-name: h2oalternate
+send-server-name: OFF
+EOT
+    my $resp = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/index.txt 2>&1 > /dev/null`;
+    like $resp, qr{^HTTP/1\.1 200 }s, "200 response";
+    unlike $resp, qr{^server}, "server unset";
+};
+
+done_testing();


### PR DESCRIPTION
Add two configuration options that allow to control what h2o displays in
the 'Server:' http header:
- server-name: this will allow to specify the contents of the 'Server:'
  header.
- display-server-name: defaults to "ON". When set to "OFF", h2o won't
  emit the header in the responses it generates.