### PR TITLE
slow init crash on sigterm

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -134,6 +134,7 @@ static struct {
         h2o_multithread_receiver_t memcached;
     } *threads;
     volatile sig_atomic_t shutdown_requested;
+    volatile sig_atomic_t initialized_threads;
     struct {
         /* unused buffers exist to avoid false sharing of the cache line */
         char _unused1[32];
@@ -154,6 +155,7 @@ static struct {
     0,               /* initialized in main() */
     NULL,            /* thread_ids */
     0,               /* shutdown_requested */
+    0,               /* initialized_threads */
     {},              /* state */
 };
 
@@ -1115,6 +1117,10 @@ static void notify_all_threads(void)
 static void on_sigterm(int signo)
 {
     conf.shutdown_requested = 1;
+    if (conf.initialized_threads != conf.num_threads) {
+        /* initialization hasn't completed yet, exit right away */
+        exit(0);
+    }
     notify_all_threads();
 }
 
@@ -1296,6 +1302,7 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     /* and start listening */
     update_listener_state(listeners);
 
+    __sync_fetch_and_add(&conf.initialized_threads, 1);
     /* the main loop */
     while (1) {
         if (conf.shutdown_requested)


### PR DESCRIPTION
If `SIGTERM` is received by `h2o` before the initialization phase of
`run_loop` (in particular the h2o_multihread_register_receiver  calls),
we might end up calling `h2o_multithread_send_message` on uninitialized
structures, causing a crash (seen when running the tests suite on a
heavy loaded machine):
```
killing <path>/local/src/h2o-fastly/h2o... received fatal signal 11; backtrace follows
<path>/local/src/h2o-fastly/h2o[0x5019c2] on_sigfatal at <path>/local/src/h2o-fastly/src/main.c:1164
/lib/x86_64-linux-gnu/libpthread.so.0(+0xfcb0)[0x2b517dfffcb0] ??
/lib/x86_64-linux-gnu/libpthread.so.0(pthread_mutex_lock+0x4)[0x2b517dff9e84] ??
<path>/local/src/h2o-fastly/h2o(h2o_multithread_send_message+0x2a)[0x44e8e3] h2o_multithread_send_message at <path>/local/src/h2o-fastly/lib/common/multithread.c:162
<path>/local/src/h2o-fastly/h2o[0x501855] notify_all_threads at <path>/local/src/h2o-fastly/src/main.c:1115
<path>/local/src/h2o-fastly/h2o[0x501884] on_sigterm at <path>/local/src/h2o-fastly/src/main.c:1123
/lib/x86_64-linux-gnu/libpthread.so.0(+0xfcb0)[0x2b517dfffcb0] ??
/lib/x86_64-linux-gnu/libpthread.so.0(+0xe89c)[0x2b517dffe89c] ??
/lib/x86_64-linux-gnu/libpthread.so.0(+0xa065)[0x2b517dffa065] ??
/lib/x86_64-linux-gnu/libpthread.so.0(pthread_mutex_lock+0x3a)[0x2b517dff9eba] ??
<path>/local/src/h2o-fastly/h2o(h2o_context_init+0x2ba)[0x45bac8] h2o_context_init at <path>/local/src/h2o-fastly/lib/core/context.c:113
<path>/local/src/h2o-fastly/h2o[0x501d81] run_loop at <path>/local/src/h2o-fastly/src/main.c:1276
<path>/local/src/h2o-fastly/h2o(main+0x9d7)[0x503e65] main at <path>/local/src/h2o-fastly/src/main.c:1879
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xed)[0x2b517ea4076d] ??
<path>/local/src/h2o-fastly/h2o[0x443259] _start at ??:0
killed (got 11)
```

This patch adds a `initialized_threads` counter to `conf`, incremented
by each thread as it's done with the init phase. If we get a `SIGTERM`
and not all threads have been initialized, we simply call `exit()`
instead of signaling all threads for a graceful shutdown.