### PR TITLE
mark when hostinfo threads are idle

### DIFF
--- a/lib/common/hostinfo.c
+++ b/lib/common/hostinfo.c
@@ -72,6 +72,7 @@ static void *lookup_thread_main(void *_unused)
     pthread_mutex_lock(&queue.mutex);
 
     while (1) {
+        --queue.num_threads_idle;
         while (!h2o_linklist_is_empty(&queue.pending)) {
             h2o_hostinfo_getaddr_req_t *req = H2O_STRUCT_FROM_MEMBER(h2o_hostinfo_getaddr_req_t, _pending, queue.pending.next);
             h2o_linklist_unlink(&req->_pending);
@@ -79,6 +80,7 @@ static void *lookup_thread_main(void *_unused)
             lookup_and_respond(req);
             pthread_mutex_lock(&queue.mutex);
         }
+        ++queue.num_threads_idle;
         pthread_cond_wait(&queue.cond, &queue.mutex);
     }
 


### PR DESCRIPTION
After starting one lookup thread, `queue.num_threads_idle` will be `1` forever, and so the check for idle threads in `h2o__hostinfo_getaddr_dispatch` will always think there is an idle thread, and h2o will be stuck with 1 forever.

With this change, a thread is marked idle while it's waiting on the condvar, but marked busy while its blocked on `getaddrinfo`, so h2o will properly start to spawn more threads up to the configured maximum.