### PR TITLE
An API to access the underlying fd of a h2o_socket_t

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -607,7 +607,7 @@ typedef struct st_h2o_conn_callbacks_t {
     /**
      * Return the underlying socket struct
      */
-    h2o_socket_t *(*get_h2o_socket)(h2o_conn_t *_conn);
+    h2o_socket_t *(*get_socket)(h2o_conn_t *_conn);
     /**
      * logging callbacks (may be NULL)
      */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -605,6 +605,10 @@ typedef struct st_h2o_conn_callbacks_t {
      */
     void (*push_path)(h2o_req_t *req, const char *abspath, size_t abspath_len);
     /**
+     * Return the underlying socket struct
+     */
+    h2o_socket_t *(*get_h2o_socket)(h2o_conn_t *_conn);
+    /**
      * logging callbacks (may be NULL)
      */
     union {

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -132,7 +132,7 @@ void h2o_socket_close(h2o_socket_t *sock);
 /**
  * Obtain the underlying fd of a sock struct
  */
-int h2o_get_sock_fd(h2o_socket_t *sock);
+int h2o_socket_get_fd(h2o_socket_t *sock);
 /**
  * connects to peer
  */

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -130,6 +130,10 @@ void h2o_socket_dispose_export(h2o_socket_export_t *info);
  */
 void h2o_socket_close(h2o_socket_t *sock);
 /**
+ * Obtain the underlying fd of a sock struct
+ */
+int h2o_get_sock_fd(h2o_socket_t *sock);
+/**
  * connects to peer
  */
 h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, h2o_socket_cb cb);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -462,11 +462,6 @@ void h2o_socket_setpeername(h2o_socket_t *sock, struct sockaddr *sa, socklen_t l
     memcpy(&sock->_peername->addr, sa, len);
 }
 
-int h2o_get_sock_fd(h2o_socket_t *sock)
-{
-    return do_get_sock_fd(sock);
-}
-
 socklen_t h2o_socket_getpeername(h2o_socket_t *sock, struct sockaddr *sa)
 {
     /* return cached, if exists */

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -462,6 +462,11 @@ void h2o_socket_setpeername(h2o_socket_t *sock, struct sockaddr *sa, socklen_t l
     memcpy(&sock->_peername->addr, sa, len);
 }
 
+int h2o_get_sock_fd(h2o_socket_t *sock)
+{
+    return do_get_sock_fd(sock);
+}
+
 socklen_t h2o_socket_getpeername(h2o_socket_t *sock, struct sockaddr *sa)
 {
     /* return cached, if exists */

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -294,6 +294,12 @@ void do_write(h2o_socket_t *_sock, h2o_iovec_t *_bufs, size_t bufcnt, h2o_socket
     link_to_statechanged(sock);
 }
 
+int do_get_sock_fd(h2o_socket_t *_sock)
+{
+    struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;
+    return sock->fd;
+}
+
 void do_read_start(h2o_socket_t *_sock)
 {
     struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -294,7 +294,7 @@ void do_write(h2o_socket_t *_sock, h2o_iovec_t *_bufs, size_t bufcnt, h2o_socket
     link_to_statechanged(sock);
 }
 
-int do_get_sock_fd(h2o_socket_t *_sock)
+int h2o_socket_get_fd(h2o_socket_t *_sock)
 {
     struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;
     return sock->fd;

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -103,12 +103,12 @@ void do_dispose_socket(h2o_socket_t *_sock)
     uv_close((uv_handle_t *)sock->uv.stream, free_sock);
 }
 
-int do_get_sock_fd(h2o_socket_t *_sock)
+int h2o_socket_get_fd(h2o_socket_t *_sock)
 {
     int fd, ret;
     struct st_h2o_uv_socket_t *sock = (struct st_h2o_uv_socket_t *)_sock;
 
-    ret = uv_fileno(sock->uv.stream, (uv_os_fd_t*)&fd);
+    ret = uv_fileno((uv_handle_t *)sock->uv.stream, (uv_os_fd_t*)&fd);
     if (ret)
         return -1;
 

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -103,6 +103,18 @@ void do_dispose_socket(h2o_socket_t *_sock)
     uv_close((uv_handle_t *)sock->uv.stream, free_sock);
 }
 
+int do_get_sock_fd(h2o_socket_t *_sock)
+{
+    int fd, ret;
+    struct st_h2o_uv_socket_t *sock = (struct st_h2o_uv_socket_t *)_sock;
+
+    ret = uv_fileno(sock->uv.stream, (uv_os_fd_t*)&fd);
+    if (ret)
+        return -1;
+
+    return fd;
+}
+
 void do_read_start(h2o_socket_t *_sock)
 {
     struct st_h2o_uv_socket_t *sock = (struct st_h2o_uv_socket_t *)_sock;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -706,6 +706,12 @@ static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
     return h2o_socket_getpeername(conn->sock, sa);
 }
 
+static h2o_socket_t *get_h2o_socket(h2o_conn_t *_conn)
+{
+    struct st_h2o_http1_conn_t *conn = (void *)_conn;
+    return conn->sock;
+}
+
 #define DEFINE_TLS_LOGGER(name)                                                                                                    \
     static h2o_iovec_t log_##name(h2o_req_t *req)                                                                                  \
     {                                                                                                                              \
@@ -744,9 +750,10 @@ static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *c
 void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at)
 {
     static const h2o_conn_callbacks_t callbacks = {
-        get_sockname, /* stringify address */
-        get_peername, /* ditto */
-        NULL,         /* push */
+        get_sockname,   /* stringify address */
+        get_peername,   /* ditto */
+        NULL,           /* push */
+        get_h2o_socket, /* get underlying socket */
         {{
           {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits}, /* ssl */
           {log_request_index},                                                     /* http1 */

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -706,7 +706,7 @@ static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
     return h2o_socket_getpeername(conn->sock, sa);
 }
 
-static h2o_socket_t *get_h2o_socket(h2o_conn_t *_conn)
+static h2o_socket_t *get_socket(h2o_conn_t *_conn)
 {
     struct st_h2o_http1_conn_t *conn = (void *)_conn;
     return conn->sock;
@@ -753,7 +753,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
         get_sockname,   /* stringify address */
         get_peername,   /* ditto */
         NULL,           /* push */
-        get_h2o_socket, /* get underlying socket */
+        get_socket, /* get underlying socket */
         {{
           {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits}, /* ssl */
           {log_request_index},                                                     /* http1 */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1035,6 +1035,12 @@ static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
     return h2o_socket_getpeername(conn->sock, sa);
 }
 
+static h2o_socket_t *get_h2o_socket(h2o_conn_t *_conn)
+{
+    h2o_http2_conn_t *conn = (void *)_conn;
+    return conn->sock;
+}
+
 #define DEFINE_TLS_LOGGER(name)                                                                                                    \
     static h2o_iovec_t log_##name(h2o_req_t *req)                                                                                  \
     {                                                                                                                              \
@@ -1132,6 +1138,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
         get_sockname, /* stringify address */
         get_peername, /* ditto */
         push_path,    /* HTTP2 push */
+        get_h2o_socket, /* get underlying socket */
         {{
             {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits}, /* ssl */
             {}, /* http1 */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1035,7 +1035,7 @@ static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
     return h2o_socket_getpeername(conn->sock, sa);
 }
 
-static h2o_socket_t *get_h2o_socket(h2o_conn_t *_conn)
+static h2o_socket_t *get_socket(h2o_conn_t *_conn)
 {
     h2o_http2_conn_t *conn = (void *)_conn;
     return conn->sock;
@@ -1138,7 +1138,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
         get_sockname, /* stringify address */
         get_peername, /* ditto */
         push_path,    /* HTTP2 push */
-        get_h2o_socket, /* get underlying socket */
+        get_socket, /* get underlying socket */
         {{
             {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits}, /* ssl */
             {}, /* http1 */


### PR DESCRIPTION
Introduce `h2o_get_sock_fd()` that can be use to obtain the underlying
fd of a `h2o_socket_t` structure. This returns -1 if the socket isn't
valid anymore.