### PR TITLE
in-memory cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ SET(LIB_SOURCE_FILES
     deps/libyrmcds/text_mode.c
     deps/picohttpparser/picohttpparser.c
 
+    lib/common/cache.c
     lib/common/file.c
     lib/common/filecache.c
     lib/common/hostinfo.c
@@ -267,6 +268,7 @@ SET(UNIT_TEST_SOURCE_FILES
     ${BROTLI_SOURCE_FILES}
     deps/picotest/picotest.c
     t/00unit/test.c
+    t/00unit/lib/common/cache.c
     t/00unit/lib/common/hostinfo.c
     t/00unit/lib/common/multithread.c
     t/00unit/lib/common/serverutil.c
@@ -289,6 +291,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/src/ssl.c
     t/00unit/issues/293.c)
 LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
+    lib/common/cache.c
     lib/common/hostinfo.c
     lib/common/multithread.c
     lib/common/serverutil.c

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -199,6 +199,9 @@
 		10D0906C19F395FC0043D458 /* socket-client.c in Sources */ = {isa = PBXBuildFile; fileRef = 10D0905219F0CB130043D458 /* socket-client.c */; };
 		10D0907019F494CC0043D458 /* test.c in Sources */ = {isa = PBXBuildFile; fileRef = 10D0906E19F494CC0043D458 /* test.c */; };
 		10D0907319F633B00043D458 /* proxy.c in Sources */ = {isa = PBXBuildFile; fileRef = 10D0907219F633B00043D458 /* proxy.c */; };
+		10DA969C1CD2BF9000679165 /* cache.h in Headers */ = {isa = PBXBuildFile; fileRef = 10DA969B1CD2BF9000679165 /* cache.h */; };
+		10DA969E1CD2BFAC00679165 /* cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 10DA969D1CD2BFAC00679165 /* cache.c */; };
+		10DA96A01CD2BFEE00679165 /* cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 10DA969F1CD2BFEE00679165 /* cache.c */; };
 		10E299581A67E68500701AA6 /* scheduler.c in Sources */ = {isa = PBXBuildFile; fileRef = 10E299571A67E68500701AA6 /* scheduler.c */; };
 		10E2995A1A68D03100701AA6 /* scheduler.c in Sources */ = {isa = PBXBuildFile; fileRef = 10E299591A68D03100701AA6 /* scheduler.c */; };
 		10EC2A361A0B4D370083514F /* socketpool.h in Headers */ = {isa = PBXBuildFile; fileRef = 10EC2A351A0B4D370083514F /* socketpool.h */; };
@@ -573,6 +576,9 @@
 		10D0906F19F494CC0043D458 /* test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test.h; sourceTree = "<group>"; };
 		10D0907219F633B00043D458 /* proxy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = proxy.c; sourceTree = "<group>"; };
 		10DA969A1CCEF2C200679165 /* 50reverse-proxy-https.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-https.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		10DA969B1CD2BF9000679165 /* cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cache.h; sourceTree = "<group>"; };
+		10DA969D1CD2BFAC00679165 /* cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cache.c; sourceTree = "<group>"; };
+		10DA969F1CD2BFEE00679165 /* cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cache.c; sourceTree = "<group>"; };
 		10E299571A67E68500701AA6 /* scheduler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scheduler.c; sourceTree = "<group>"; };
 		10E299591A68D03100701AA6 /* scheduler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scheduler.c; sourceTree = "<group>"; };
 		10EC2A351A0B4D370083514F /* socketpool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socketpool.h; sourceTree = "<group>"; };
@@ -691,6 +697,7 @@
 		104B9A4A1A5FA7E5009EEE64 /* common */ = {
 			isa = PBXGroup;
 			children = (
+				10DA969D1CD2BFAC00679165 /* cache.c */,
 				107D4D541B5B30EE004A9B21 /* file.c */,
 				1044812F1BFD10450007863F /* filecache.c */,
 				1058C8891AA6E5E3008D6180 /* hostinfo.c */,
@@ -756,6 +763,7 @@
 		104B9A4D1A5FAA7B009EEE64 /* common */ = {
 			isa = PBXGroup;
 			children = (
+				10DA969F1CD2BFEE00679165 /* cache.c */,
 				10F9F2661AFC5F550056F26B /* hostinfo.c */,
 				10AA2EAD1A8E22DA004322AC /* multithread.c */,
 				104B9A271A4A5139009EEE64 /* serverutil.c */,
@@ -1063,6 +1071,7 @@
 		1079239F19A3215F00C52AD6 /* h2o */ = {
 			isa = PBXGroup;
 			children = (
+				10DA969B1CD2BF9000679165 /* cache.h */,
 				105534D71A3C785000627ECB /* configurator.h */,
 				107D4D521B5B2412004A9B21 /* file.h */,
 				1044812D1BFD0FBE0007863F /* filecache.h */,
@@ -1441,6 +1450,7 @@
 				10AA2E9F1A8807CF004322AC /* url.h in Headers */,
 				10B38A721B8D34BB007DC191 /* mruby_.h in Headers */,
 				10FCC13F1B2E4A4500F13674 /* cloexec.h in Headers */,
+				10DA969C1CD2BF9000679165 /* cache.h in Headers */,
 				1044812E1BFD0FBE0007863F /* filecache.h in Headers */,
 				107923A619A3215F00C52AD6 /* http2.h in Headers */,
 				107923A719A3215F00C52AD6 /* token.h in Headers */,
@@ -1642,6 +1652,7 @@
 				10A3D40A1B50DAB700327CF9 /* recv.c in Sources */,
 				101788B219B561AA0084C6D8 /* socket.c in Sources */,
 				10D0905519F102C70043D458 /* http1client.c in Sources */,
+				10DA969E1CD2BFAC00679165 /* cache.c in Sources */,
 				107923D219A3217300C52AD6 /* token.c in Sources */,
 				1058C88A1AA6E5E3008D6180 /* hostinfo.c in Sources */,
 				10AA2EBC1A9EEDF8004322AC /* proxy.c in Sources */,
@@ -1781,6 +1792,7 @@
 				107D4D4A1B5880BC004A9B21 /* reader.c in Sources */,
 				1079244819A3265C00C52AD6 /* connection.c in Sources */,
 				1079244119A3264300C52AD6 /* picohttpparser.c in Sources */,
+				10DA96A01CD2BFEE00679165 /* cache.c in Sources */,
 				1070E1631B4508B0001CCAFA /* util.c in Sources */,
 				107E341D1C7FEE1000AEF5F8 /* literal_cost.cc in Sources */,
 				1058C87D1AA41789008D6180 /* headers.c in Sources */,

--- a/include/h2o/cache.h
+++ b/include/h2o/cache.h
@@ -51,7 +51,16 @@ typedef struct st_h2o_cache_ref_t {
  */
 h2o_cache_hashcode_t h2o_cache_calchash(const char *s, size_t len);
 
-enum { H2O_CACHE_FLAG_MULTITHREADED = 0x1 };
+enum {
+    /**
+     * if set, the internals of the cache is protected by a mutex so that it can be accessed concurrently
+     */
+    H2O_CACHE_FLAG_MULTITHREADED = 0x1,
+    /**
+     * if set, the cache triggers an early update
+     */
+    H2O_CACHE_FLAG_EARLY_UPDATE = 0x2
+};
 
 /**
  * creates a new cache

--- a/include/h2o/cache.h
+++ b/include/h2o/cache.h
@@ -93,8 +93,9 @@ void h2o_cache_release(h2o_cache_t *cache, h2o_cache_ref_t *ref);
  * @param key
  * @param keyhash callers may optionally pass in the precalculated hash value (or should be set to 0)
  * @param value (when no longer needed, destroy_cb will be called)
+ * @return if the specified value already existed
  */
-void h2o_cache_set(h2o_cache_t *cache, uint64_t now, h2o_iovec_t key, h2o_cache_hashcode_t keyhash, h2o_iovec_t value);
+int h2o_cache_set(h2o_cache_t *cache, uint64_t now, h2o_iovec_t key, h2o_cache_hashcode_t keyhash, h2o_iovec_t value);
 /**
  * deletes a named value from the cache
  * @param cache

--- a/include/h2o/cache.h
+++ b/include/h2o/cache.h
@@ -51,9 +51,7 @@ typedef struct st_h2o_cache_ref_t {
  */
 h2o_cache_hashcode_t h2o_cache_calchash(const char *s, size_t len);
 
-enum {
-    H2O_CACHE_FLAG_MULTITHREADED = 0x1
-};
+enum { H2O_CACHE_FLAG_MULTITHREADED = 0x1 };
 
 /**
  * creates a new cache

--- a/include/h2o/cache.h
+++ b/include/h2o/cache.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2014-2016 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef h2o__cache_h
+#define h2o__cache_h
+
+#include <stdint.h>
+#include "h2o/linklist.h"
+#include "h2o/memory.h"
+
+typedef struct st_h2o_cache_t h2o_cache_t;
+
+typedef uint32_t /* eq. khint_t */ h2o_cache_hashcode_t;
+
+typedef struct st_h2o_cache_key_t {
+    h2o_iovec_t vec;
+    h2o_cache_hashcode_t hash;
+} h2o_cache_key_t;
+
+typedef struct st_h2o_cache_ref_t {
+    h2o_cache_key_t key;
+    h2o_iovec_t data;
+    uint64_t at;
+    int _requested_early_update;
+    h2o_linklist_t _lru_link;
+    h2o_linklist_t _age_link;
+    size_t _refcnt;
+} h2o_cache_ref_t;
+
+h2o_cache_t *h2o_cache_create(size_t capacity, uint64_t duration, void (*destroy_cb)(h2o_iovec_t value));
+void h2o_cache_destroy(h2o_cache_t *cache);
+
+void h2o_cache_clear(h2o_cache_t *cache, uint64_t now);
+
+h2o_cache_ref_t *h2o_cache_fetch(h2o_cache_t *cache, h2o_iovec_t key, uint64_t now);
+void h2o_cache_release(h2o_cache_t *cache, h2o_cache_ref_t *ref);
+void h2o_cache_update(h2o_cache_t *cache, h2o_cache_ref_t *ref, uint64_t now);
+
+#endif

--- a/include/h2o/cache.h
+++ b/include/h2o/cache.h
@@ -51,10 +51,14 @@ typedef struct st_h2o_cache_ref_t {
  */
 h2o_cache_hashcode_t h2o_cache_calchash(const char *s, size_t len);
 
+enum {
+    H2O_CACHE_FLAG_MULTITHREADED = 0x1
+};
+
 /**
  * creates a new cache
  */
-h2o_cache_t *h2o_cache_create(size_t capacity, uint64_t duration, void (*destroy_cb)(h2o_iovec_t value));
+h2o_cache_t *h2o_cache_create(int flags, size_t capacity, uint64_t duration, void (*destroy_cb)(h2o_iovec_t value));
 /**
  * destroys a cache
  */

--- a/lib/common/cache.c
+++ b/lib/common/cache.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2014-2016 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <assert.h>
+#include <pthread.h>
+#include "khash.h"
+#include "h2o/cache.h"
+#include "h2o/linklist.h"
+#include "h2o/memory.h"
+
+static h2o_cache_hashcode_t get_keyhash(h2o_cache_ref_t *ref);
+static int is_equal(h2o_cache_ref_t *x, h2o_cache_ref_t *y);
+
+KHASH_INIT(cache, h2o_cache_ref_t *, char, 0, get_keyhash, is_equal)
+
+struct st_h2o_cache_t {
+    pthread_mutex_t lock;
+    khash_t(cache) *table;
+    size_t size;
+    size_t capacity;
+    h2o_linklist_t lru;
+    h2o_linklist_t age;
+    uint64_t duration;
+    void (*destroy_cb)(h2o_iovec_t value);
+};
+
+static h2o_cache_hashcode_t calchash(const char *s, size_t l)
+{
+    h2o_cache_hashcode_t h = 0;
+    for (; l != 0; --l)
+        h = (h << 5) - h + *(unsigned char*)s;
+    return h;
+}
+
+static h2o_cache_hashcode_t get_keyhash(h2o_cache_ref_t *ref)
+{
+    return ref->key.hash;
+}
+
+static int is_equal(h2o_cache_ref_t *x, h2o_cache_ref_t *y)
+{
+    return x->key.vec.len == y->key.vec.len && memcmp(x->key.vec.base, y->key.vec.base, x->key.vec.len) == 0;
+}
+
+static void erase_ref(h2o_cache_t *cache, khiter_t iter, h2o_cache_ref_t *new_ref)
+{
+    h2o_cache_ref_t *ref = kh_key(cache->table, iter);
+
+    if (new_ref != NULL) {
+        kh_key(cache->table, iter) = new_ref;
+    } else {
+        kh_del(cache, cache->table, iter);
+    }
+    h2o_linklist_unlink(&ref->_lru_link);
+    h2o_linklist_unlink(&ref->_age_link);
+    cache->size -= ref->data.len;
+
+    h2o_cache_release(cache, ref);
+}
+
+static int64_t get_timeleft(h2o_cache_t *cache, h2o_cache_ref_t *ref, uint64_t now)
+{
+    return (int64_t)(ref->at + cache->duration) - now;
+}
+
+h2o_cache_t *h2o_cache_create(size_t capacity, uint64_t duration, void (*destroy_cb)(h2o_iovec_t value))
+{
+    h2o_cache_t *cache = h2o_mem_alloc(sizeof(*cache));
+
+    pthread_mutex_init(&cache->lock, NULL);
+    cache->table = kh_init(cache);
+    cache->size = 0;
+    cache->capacity = capacity;
+    h2o_linklist_init_anchor(&cache->lru);
+    h2o_linklist_init_anchor(&cache->age);
+    cache->duration = duration;
+    cache->destroy_cb = destroy_cb;
+
+    return cache;
+}
+
+void h2o_cache_destroy(h2o_cache_t *cache)
+{
+    h2o_cache_clear(cache, 0);
+
+    assert(kh_size(cache->table) == 0);
+
+    kh_destroy(cache, cache->table);
+    pthread_mutex_destroy(&cache->lock);
+    free(cache);
+}
+
+void h2o_cache_clear(h2o_cache_t *cache, uint64_t now)
+{
+    pthread_mutex_lock(&cache->lock);
+
+    while (! h2o_linklist_is_empty(&cache->age)) {
+        h2o_cache_ref_t *ref = H2O_STRUCT_FROM_MEMBER(h2o_cache_ref_t, _age_link, cache->age.next);
+        if (! (now == 0 || get_timeleft(cache, ref, now) < 0))
+            break;
+        erase_ref(cache, kh_get(cache, cache->table, ref), NULL);
+    }
+
+    pthread_mutex_unlock(&cache->lock);
+}
+
+h2o_cache_ref_t *h2o_cache_fetch(h2o_cache_t *cache, h2o_iovec_t key, uint64_t now)
+{
+    h2o_cache_key_t search_key = { key, calchash(key.base, key.len) };
+    khiter_t iter;
+    h2o_cache_ref_t *ref;
+    int64_t timeleft;
+
+    pthread_mutex_lock(&cache->lock);
+
+    if ((iter = kh_get(cache, cache->table, (void*)&search_key)) == kh_end(cache->table))
+        goto NotFound;
+
+    /* found */
+    ref = kh_key(cache->table, iter);
+    timeleft = get_timeleft(cache, ref, now);
+    if (timeleft < 0)
+        goto NotFound;
+    if (timeleft < 10 && ! ref->_requested_early_update) {
+        ref->_requested_early_update = 1;
+        goto NotFound;
+    }
+    /* move the entry to the top of LRU, and return */
+    h2o_linklist_unlink(&ref->_lru_link);
+    h2o_linklist_insert(&cache->lru, &ref->_lru_link);
+    __sync_fetch_and_add(&ref->_refcnt, 1);
+
+    /* unlock and return the found entry */
+    pthread_mutex_unlock(&cache->lock);
+    return ref;
+
+NotFound:
+    pthread_mutex_unlock(&cache->lock);
+
+    /* prepare new ref and return */
+    ref = h2o_mem_alloc(sizeof(*ref) + key.len);
+    ref->key.vec.base = (void*)(ref + 1);
+    ref->key.vec.len = key.len;
+    ref->key.hash = search_key.hash;
+    ref->data = (h2o_iovec_t){};
+    ref->at = 0;
+    ref->_requested_early_update = 0;
+    ref->_lru_link = (h2o_linklist_t){};
+    ref->_age_link = (h2o_linklist_t){};
+    ref->_refcnt = 1;
+    memcpy(ref->key.vec.base, key.base, key.len);
+
+    return ref;
+}
+
+void h2o_cache_release(h2o_cache_t *cache, h2o_cache_ref_t *ref)
+{
+    if (__sync_fetch_and_sub(&ref->_refcnt, 1) == 1) {
+        cache->destroy_cb(ref->data);
+        free(ref);
+    }
+}
+
+void h2o_cache_update(h2o_cache_t *cache, h2o_cache_ref_t *ref, uint64_t now)
+{
+    khiter_t iter;
+
+    assert(ref->_refcnt == 1);
+    assert(! h2o_linklist_is_linked(&ref->_lru_link));
+
+    pthread_mutex_lock(&cache->lock);
+
+    /* look for existing entry */
+    iter = kh_get(cache, cache->table, ref);
+
+    /* if delete is requested, doit, and return */
+    if (ref->data.base == NULL) {
+        if (iter != kh_end(cache->table)) {
+            erase_ref(cache, iter, NULL);
+        }
+        pthread_mutex_unlock(&cache->lock);
+        h2o_cache_release(cache, ref);
+        return;
+    }
+
+    /* update */
+    if (iter == kh_end(cache->table)) {
+        /* attach the entry to cache */
+        int unused;
+        kh_put(cache, cache->table, ref, &unused);
+    } else {
+        /* swap with the existing entry */
+        erase_ref(cache, iter, ref);
+    }
+    ref->at = now;
+    h2o_linklist_insert(&cache->lru, &ref->_lru_link);
+    h2o_linklist_insert(&cache->age, &ref->_age_link);
+    cache->size += ref->data.len;
+
+    /* purge if the cache has become too large */
+    while (cache->capacity < cache->size) {
+        h2o_cache_ref_t *oldest;
+        assert(! h2o_linklist_is_empty(&cache->age));
+        oldest = H2O_STRUCT_FROM_MEMBER(h2o_cache_ref_t, _age_link, cache->age.next);
+        if (get_timeleft(cache, oldest, now) >= 0)
+            break;
+        erase_ref(cache, kh_get(cache, cache->table, oldest), NULL);
+    }
+    while (cache->capacity < cache->size) {
+        h2o_cache_ref_t *last;
+        assert(! h2o_linklist_is_empty(&cache->lru));
+        last = H2O_STRUCT_FROM_MEMBER(h2o_cache_ref_t, _lru_link, cache->lru.next);
+        erase_ref(cache, kh_get(cache, cache->table, last), NULL);
+    }
+
+    pthread_mutex_unlock(&cache->lock);
+}

--- a/lib/common/cache.c
+++ b/lib/common/cache.c
@@ -34,7 +34,7 @@ KHASH_INIT(cache, h2o_cache_ref_t *, char, 0, get_keyhash, is_equal)
 
 struct st_h2o_cache_t {
     int flags;
-    khash_t(cache) *table;
+    khash_t(cache) * table;
     size_t size;
     size_t capacity;
     h2o_linklist_t lru;
@@ -106,7 +106,7 @@ h2o_cache_hashcode_t h2o_cache_calchash(const char *s, size_t l)
 {
     h2o_cache_hashcode_t h = 0;
     for (; l != 0; --l)
-        h = (h << 5) - h + *(unsigned char*)s;
+        h = (h << 5) - h + *(unsigned char *)s;
     return h;
 }
 
@@ -175,7 +175,7 @@ h2o_cache_ref_t *h2o_cache_fetch(h2o_cache_t *cache, uint64_t now, h2o_iovec_t k
     timeleft = get_timeleft(cache, ref, now);
     if (timeleft < 0)
         goto NotFound;
-    if (timeleft < 10 && ! ref->_requested_early_update) {
+    if (timeleft < 10 && !ref->_requested_early_update) {
         ref->_requested_early_update = 1;
         goto NotFound;
     }

--- a/lib/common/cache.c
+++ b/lib/common/cache.c
@@ -175,7 +175,7 @@ h2o_cache_ref_t *h2o_cache_fetch(h2o_cache_t *cache, uint64_t now, h2o_iovec_t k
     timeleft = get_timeleft(cache, ref, now);
     if (timeleft < 0)
         goto NotFound;
-    if (timeleft < 10 && !ref->_requested_early_update) {
+    if ((cache->flags & H2O_CACHE_FLAG_EARLY_UPDATE) != 0 && timeleft < 10 && !ref->_requested_early_update) {
         ref->_requested_early_update = 1;
         goto NotFound;
     }

--- a/t/00unit/lib/common/cache.c
+++ b/t/00unit/lib/common/cache.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014-2016 DeNA Co., Ltd., Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "../../test.h"
+#include "../../../../lib/common/cache.c"
+
+static size_t bytes_destroyed;
+
+static void on_destroy(h2o_iovec_t vec)
+{
+    bytes_destroyed += vec.len;
+}
+
+void test_lib__common__cache_c(void)
+{
+    h2o_cache_t *cache = h2o_cache_create(1024, 1000, on_destroy);
+    uint64_t now = 0;
+    h2o_iovec_t key = { H2O_STRLIT("key") };
+    h2o_cache_ref_t *ref, *ref2;
+
+    /* set "key" => "value" */
+    ref = h2o_cache_fetch(cache, key, now);
+    ok(ref->data.base == NULL);
+    ref->data = h2o_iovec_init(H2O_STRLIT("value"));
+    h2o_cache_update(cache, ref, now);
+
+    /* fetch "key" */
+    ref = h2o_cache_fetch(cache, key, now);
+    ok(h2o_memis(ref->data.base, ref->data.len, H2O_STRLIT("value")));
+    h2o_cache_release(cache, ref);
+
+    /* proceed 1001ms */
+    now += 999;
+
+    /* should fail to fetch "key" */
+    ref = h2o_cache_fetch(cache, key, now);
+    ok(ref->data.base == NULL);
+
+    /* refetch should succeed */
+    ref2 = h2o_cache_fetch(cache, key, now);
+    ok(h2o_memis(ref2->data.base, ref2->data.len, H2O_STRLIT("value")));
+    h2o_cache_release(cache, ref2);
+
+    /* set "key" to "value2" */
+    ref->data = h2o_iovec_init(H2O_STRLIT("value2"));
+    h2o_cache_update(cache, ref, now);
+
+    /* fetch */
+    ref = h2o_cache_fetch(cache, key, now);
+    ok(h2o_memis(ref->data.base, ref->data.len, H2O_STRLIT("value2")));
+    h2o_cache_release(cache, ref);
+
+    ok(bytes_destroyed == 5);
+
+    h2o_cache_destroy(cache);
+
+    ok(bytes_destroyed == 11);
+}

--- a/t/00unit/lib/common/cache.c
+++ b/t/00unit/lib/common/cache.c
@@ -31,7 +31,7 @@ static void on_destroy(h2o_iovec_t vec)
 
 void test_lib__common__cache_c(void)
 {
-    h2o_cache_t *cache = h2o_cache_create(1024, 1000, on_destroy);
+    h2o_cache_t *cache = h2o_cache_create(0, 1024, 1000, on_destroy);
     uint64_t now = 0;
     h2o_iovec_t key = { H2O_STRLIT("key") };
     h2o_cache_ref_t *ref;

--- a/t/00unit/lib/common/cache.c
+++ b/t/00unit/lib/common/cache.c
@@ -31,7 +31,7 @@ static void on_destroy(h2o_iovec_t vec)
 
 void test_lib__common__cache_c(void)
 {
-    h2o_cache_t *cache = h2o_cache_create(0, 1024, 1000, on_destroy);
+    h2o_cache_t *cache = h2o_cache_create(H2O_CACHE_FLAG_EARLY_UPDATE, 1024, 1000, on_destroy);
     uint64_t now = 0;
     h2o_iovec_t key = {H2O_STRLIT("key")};
     h2o_cache_ref_t *ref;

--- a/t/00unit/lib/common/cache.c
+++ b/t/00unit/lib/common/cache.c
@@ -33,7 +33,7 @@ void test_lib__common__cache_c(void)
 {
     h2o_cache_t *cache = h2o_cache_create(0, 1024, 1000, on_destroy);
     uint64_t now = 0;
-    h2o_iovec_t key = { H2O_STRLIT("key") };
+    h2o_iovec_t key = {H2O_STRLIT("key")};
     h2o_cache_ref_t *ref;
 
     /* fetch "key" */

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -151,6 +151,7 @@ int main(int argc, char **argv)
     init_openssl();
 
     { /* library tests */
+        subtest("lib/cache.c", test_lib__common__cache_c);
         subtest("lib/common/multithread.c", test_lib__common__multithread_c);
         subtest("lib/common/hostinfo.c", test_lib__common__hostinfo_c);
         subtest("lib/common/serverutil.c", test_lib__common__serverutil_c);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -48,6 +48,7 @@ extern h2o_loop_t *test_loop;
 
 char *sha1sum(const void *src, size_t len);
 
+void test_lib__common__cache_c(void);
 void test_lib__common__hostinfo_c(void);
 void test_lib__common__multithread_c(void);
 void test_lib__common__serverutil_c(void);


### PR DESCRIPTION
Implements in-memory cache for storing arbitrary types of data

* accessible from multiple threads
* support for early refetch

Will be useful for implementing things like caching proxy / client-side TLS session cache.