### PR TITLE
user-configurable option for preserving `x-forwarded-proto`

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -351,6 +351,10 @@ struct st_h2o_globalconf_t {
          * SSL context for connections initiated by the proxy (optional, governed by the application)
          */
         SSL_CTX *ssl_ctx;
+        /**
+         * a boolean flag if set to true, instructs the proxy to preserve the x-forwarded-proto header passed by the client
+         */
+        int preserve_x_forwarded_proto;
     } proxy;
 
     /**

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -147,6 +147,15 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
     return 0;
 }
 
+static int on_config_preserve_x_forwarded_proto(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    ctx->globalconf->proxy.preserve_x_forwarded_proto = (int)ret;
+    return 0;
+}
+
 static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)_self;
@@ -221,4 +230,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
                                     on_config_ssl_verify_peer);
     h2o_configurator_define_command(&c->super, "proxy.ssl.cafile",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_ssl_cafile);
+    h2o_configurator_define_command(&c->super, "proxy.preserve-x-forwarded-proto",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_preserve_x_forwarded_proto);
 }


### PR DESCRIPTION
adds a global configuration directive named `proxy.preserve-x-forwarded-proto` which, if set to `ON`, instructs the reverse proxy to preserve the value of the `x-forwarded-proto` header passed from downstream.

Note that users should not set this variable to `ON` in case H2O is directly accepting connections from a third party, since, an attacker connecting over HTTP may try to spoof oneself to be using HTTPS by using the header.

implements #883