### PR TITLE
Fix mruby directives initialization time leak

### DIFF
--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -137,7 +137,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
     struct mruby_configurator_t *self = (void *)_self;
 
     /* free if the to-be-exitted frame level contains a different source */
-    if (self->vars[-1].source.base != self->vars[-1].source.base)
+    if (self->vars[-1].source.base != self->vars[0].source.base)
         free(self->vars->source.base);
 
     --self->vars;


### PR DESCRIPTION
A typo in `mruby.c:on_config_exit()` prevented releasing the memory
allocated in previous mruby directives.