### PR TITLE
Fix `h2o_cache_calchash` to take into account the whole key value when

### DIFF
--- a/lib/common/cache.c
+++ b/lib/common/cache.c
@@ -106,7 +106,7 @@ h2o_cache_hashcode_t h2o_cache_calchash(const char *s, size_t l)
 {
     h2o_cache_hashcode_t h = 0;
     for (; l != 0; --l)
-        h = (h << 5) - h + *(unsigned char *)s;
+        h = (h << 5) - h + ((unsigned char *)s)[l - 1];
     return h;
 }
 


### PR DESCRIPTION
computing the hash value.