### PR TITLE
fix SIGBUS when temporary disk space is full

### DIFF
--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -31,6 +31,16 @@
 #include <unistd.h>
 #include "h2o/memory.h"
 
+#if defined(__linux__)
+#define USE_POSIX_FALLOCATE 1
+#elif __FreeBSD__ >= 9
+#define USE_POSIX_FALLOCATE 1
+#elif __NetBSD__ >= 7
+#define USE_POSIX_FALLOCATE 1
+#else
+#define USE_POSIX_FALLOCATE 0
+#endif
+
 struct st_h2o_mem_recycle_chunk_t {
     struct st_h2o_mem_recycle_chunk_t *next;
 };
@@ -241,7 +251,13 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
                 } else {
                     fd = inbuf->_fd;
                 }
-                if (ftruncate(fd, new_allocsize) != 0) {
+                int fallocate_ret;
+#if USE_POSIX_FALLOCATE
+                fallocate_ret = posix_fallocate(fd, 0, new_allocsize);
+#else
+                fallocate_ret = ftruncate(fd, new_allocsize);
+#endif
+                if (fallocate_ret != 0) {
                     perror("failed to resize temporary file");
                     goto MapError;
                 }


### PR DESCRIPTION
Use `posix_fallocate` for allocating file-backed storage (mmaped), instead of `ftruncate`.

`ftruncate` create a sparse file, and disk space allocation is delayed until data is actually being written.  In our case, we use memory access (though `mmap`) to write data.  That means that when the OS fails to allocate disk space, H2O receives SIGBUS.

This PR fixes the issue by replacing `ftruncate` with `posix_fallocate` on platforms that support it; the latter function allocates disk space eagerly, so there is no risk of getting SIGBUS.

fixes #909