### PR TITLE
preserve link header

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1252,7 +1252,7 @@ h2o_iovec_t h2o_get_redirect_method(h2o_iovec_t method, int status);
 /**
  * registers push path (if necessary) by parsing a Link header
  */
-int h2o_puth_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len);
+int h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len);
 /**
  * logs an error
  */

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -375,7 +375,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                 }
                 goto AddHeaderDuped;
             } else if (token == H2O_TOKEN_LINK) {
-                h2o_puth_path_in_link_header(req, headers[i].value, headers[i].value_len);
+                h2o_push_path_in_link_header(req, headers[i].value, headers[i].value_len);
             }
         /* default behaviour, transfer the header downstream */
         AddHeaderDuped:

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -592,7 +592,7 @@ h2o_iovec_t h2o_get_redirect_method(h2o_iovec_t method, int status)
     return method;
 }
 
-int h2o_puth_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
+int h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
 {
     if (req->conn->callbacks->push_path == NULL)
         return -1;

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -506,7 +506,7 @@ static int fill_headers(h2o_req_t *req, struct phr_header *headers, size_t num_h
                 h2o_add_header(&req->pool, &req->res.headers, token,
                                h2o_strdup(&req->pool, headers[i].value, headers[i].value_len).base, headers[i].value_len);
                 if (token == H2O_TOKEN_LINK)
-                    h2o_puth_path_in_link_header(req, headers[i].value, headers[i].value_len);
+                    h2o_push_path_in_link_header(req, headers[i].value, headers[i].value_len);
             }
         } else if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("status"))) {
             h2o_iovec_t value = h2o_iovec_init(headers[i].value, headers[i].value_len);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -535,9 +535,9 @@ static int handle_response_header(h2o_mruby_context_t *handler_ctx, h2o_iovec_t 
             /* skip */
         } else if (token == H2O_TOKEN_CONTENT_LENGTH) {
             req->res.content_length = h2o_strtosize(value.base, value.len);
-        } else if (token == H2O_TOKEN_LINK && h2o_push_path_in_link_header(req, value.base, value.len)) {
-            /* do not send the link header that is going to be pushed */
         } else {
+            if (token == H2O_TOKEN_LINK)
+                h2o_push_path_in_link_header(req, value.base, value.len);
             value = h2o_strdup(&req->pool, value.base, value.len);
             h2o_add_header(&req->pool, &req->res.headers, token, value.base, value.len);
         }

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -535,7 +535,7 @@ static int handle_response_header(h2o_mruby_context_t *handler_ctx, h2o_iovec_t 
             /* skip */
         } else if (token == H2O_TOKEN_CONTENT_LENGTH) {
             req->res.content_length = h2o_strtosize(value.base, value.len);
-        } else if (token == H2O_TOKEN_LINK && h2o_puth_path_in_link_header(req, value.base, value.len)) {
+        } else if (token == H2O_TOKEN_LINK && h2o_push_path_in_link_header(req, value.base, value.len)) {
             /* do not send the link header that is going to be pushed */
         } else {
             value = h2o_strdup(&req->pool, value.base, value.len);


### PR DESCRIPTION
mruby handler is currently dropping all the link headers _except_ those that were successfully pushed.

This PR changes the behavior to always send downstream the header being set, which aligns with the behavior to the other handlers (fastcgi, proxy).