### PR TITLE
fix crash in h2o_url_stringify

### DIFF
--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -304,9 +304,9 @@ h2o_iovec_t h2o_url_resolve(h2o_mem_pool_t *pool, const h2o_url_t *base, const h
 
     if (relative == NULL) {
         /* build URL using base copied to dest */
-        static const h2o_url_t fake_relative = {};
-        relative = &fake_relative;
         *dest = *base;
+        base_path = base->path;
+        relative_path = h2o_iovec_init(NULL, 0);
         goto Build;
     }
 

--- a/t/00unit/lib/common/url.c
+++ b/t/00unit/lib/common/url.c
@@ -392,6 +392,9 @@ static void test_resolve(void)
     ok(h2o_url_get_port(&resolved) == 81);
     ok(h2o_memis(resolved.path.base, resolved.path.len, H2O_STRLIT("/icon.ico")));
 
+    final = h2o_url_stringify(&pool, &base);
+    ok(h2o_memis(final.base, final.len, H2O_STRLIT("http://example.com/dir/index.html")));
+
     h2o_mem_clear_pool(&pool);
 }
 


### PR DESCRIPTION
h2o_url_stringify typically ends up crashing due to an uninitialized pointer access.

Note: the function is never called by the standalone server.