### PR TITLE
Introduce a 'proxy.per_socket_pool' option.

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1556,6 +1556,7 @@ void h2o_headers_register_configurator(h2o_globalconf_t *conf);
 typedef struct st_h2o_proxy_config_vars_t {
     uint64_t io_timeout;
     int preserve_host;
+    int per_client_pool;
     uint64_t keepalive_timeout; /* in milliseconds; set to zero to disable keepalive */
     struct {
         int enabled;

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -71,6 +71,7 @@ struct st_h2o_socket_peername_t {
 /**
  * abstraction layer for sockets (SSL vs. TCP)
  */
+struct st_h2o_socketpool_t;
 struct st_h2o_socket_t {
     void *data;
     struct st_h2o_socket_ssl_t *ssl;
@@ -85,6 +86,9 @@ struct st_h2o_socket_t {
         h2o_socket_cb write;
     } _cb;
     struct st_h2o_socket_peername_t *_peername;
+    /* when proxy.per_socket_pool is 'ON' each client socket will have a dedicated
+     * socket pool, and this will be non-NULL */
+    struct st_h2o_socketpool_t *per_socket_pool;
 };
 
 typedef struct st_h2o_socket_export_t {

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <openssl/err.h>
 #include "h2o/socket.h"
+#include "h2o/socketpool.h"
 #include "h2o/timeout.h"
 
 #if defined(__APPLE__) && defined(__clang__)
@@ -280,6 +281,12 @@ static void dispose_socket(h2o_socket_t *sock, const char *err)
 
     close_cb = sock->on_close.cb;
     close_cb_data = sock->on_close.data;
+
+    if (sock->per_socket_pool) {
+        h2o_socketpool_dispose(sock->per_socket_pool);
+        free(sock->per_socket_pool);
+        sock->per_socket_pool = NULL;
+    }
 
     do_dispose_socket(sock);
 

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -46,6 +46,16 @@ static int on_config_timeout_keepalive(h2o_configurator_command_t *cmd, h2o_conf
     return h2o_configurator_scanf(cmd, node, "%" PRIu64, &self->vars->keepalive_timeout);
 }
 
+static int on_config_per_client_socket_pool(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct proxy_configurator_t *self = (void *)cmd->configurator;
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    self->vars->per_client_pool = (int)ret;
+    return 0;
+}
+
 static int on_config_preserve_host(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
@@ -215,6 +225,9 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "proxy.preserve-host",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_preserve_host);
+    h2o_configurator_define_command(&c->super, "proxy.per_client_socket_pool",
+                                    H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_per_client_socket_pool);
     h2o_configurator_define_command(&c->super, "proxy.timeout.io",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_timeout_io);
     h2o_configurator_define_command(&c->super, "proxy.timeout.keepalive",

--- a/srcdoc/configure/proxy_directives.mt
+++ b/srcdoc/configure/proxy_directives.mt
@@ -123,6 +123,24 @@ The value should be set to something smaller than that being set at the upstream
 
 <?
 $ctx->{directive}->(
+    name    => "proxy.per_client_socket_pool",
+    levels  => [ qw(global host path) ],
+    default => q{proxy.per_client_socket_pool: 0},
+    desc    => 'Connection pooling is only done on a per-client socket basis.',
+)->(sub {
+?>
+<p>
+This option can be used to make sure that unrelated frontend h2 connections
+are not sharing the same backend http1 connection. It provides greater
+separation at the cost of less effective connection re-use.
+If the option is <code>ON</code>, each frontend connection will have
+it's own socket pool.
+</p>
+? })
+
+
+<?
+$ctx->{directive}->(
     name    => "proxy.websocket",
     levels  => [ qw(global host path) ],
     default => q{proxy.websocket: OFF},

--- a/t/50reverse-proxy-per-socket-pool.t
+++ b/t/50reverse-proxy-per-socket-pool.t
@@ -1,0 +1,100 @@
+use strict;
+use warnings;
+use File::Temp qw(tempfile);
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'nghttp not found'
+    unless prog_exists('nghttp');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+subtest "tcp" => sub {
+    my $port = empty_port();
+    my $upstream = spawn_upstream($port);
+    doit("127.0.0.1:$port", 1);
+};
+
+subtest "unix-socket" => sub {
+    plan skip_all => 'skipping unix-socket tests, requires Starlet >= 0.25'
+        if `perl -MStarlet -e 'print \$Starlet::VERSION'` < 0.25;
+
+    (undef, my $sockfn) = tempfile(UNLINK => 0);
+    unlink $sockfn;
+    my $guard = Scope::Guard->new(sub {
+        unlink $sockfn;
+    });
+
+    my $upstream = spawn_upstream($sockfn);
+    doit("[unix:$sockfn]", 0);
+};
+
+done_testing;
+
+sub doit {
+    my $upaddr = shift;
+    my $tcp = shift;
+
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://$upaddr
+        proxy.timeout.io: 1000
+        proxy.timeout.keepalive: 10000
+        proxy.per_client_socket_pool: ON
+EOT
+    my $port = $server->{port};
+
+    sub issue_req {
+        sub uniq {
+            my %seen;
+            return grep { !$seen{$_}++ } @_;
+        }
+        my $port = shift;
+        my ($ignore, $resp) = run_prog("nghttp -v -a -n http://127.0.0.1:$port/echo-port");
+        my @ports = map { /x-remote-port: (\d+)$/; $1; } grep(/x-remote-port/, split(/\n/, $resp));
+        is @ports, 2, "Found two requests as expected";
+        my @unic = uniq(@ports);
+        is @unic, 1, "All ports used by h2o are the same";
+        return $unic[0];
+    };
+    my $first_port = issue_req($port);
+    if (!$tcp) {
+        # return early if it's not tcp: we can't really verify
+        # that we're re-using the same port. Let's just very that the
+        # query works as expected.
+        return;
+    }
+    my $second_port = issue_req($port);
+
+    sleep 2;
+    my $third_port = issue_req($port);
+    sleep 2;
+    my $fourth_port = issue_req($port);
+    my $fifth_port = issue_req($port);
+
+    isnt $first_port, $second_port, "first and second frontend connections used a different backend connection";
+    isnt $second_port, $third_port, "second and third frontend connections used a different backend connection";
+    isnt $third_port, $fourth_port, "third and fourth frontend connections used a different backend connection";
+    isnt $fourth_port, $fifth_port, "fourth and fifth frontend connections used a different backend connection";
+};
+
+sub spawn_upstream {
+    my $addr = shift;
+    spawn_server(
+        argv     => [
+            qw(plackup -s Starlet --max-keepalive-reqs 100 --keepalive-timeout 1 --access-log /dev/null --listen), $addr,
+            ASSETS_DIR . "/upstream.psgi"
+        ],
+        is_ready => sub {
+            if ($addr =~ /^\d+$/) {
+                check_port($addr);
+            } else {
+                !! -e $addr;
+            }
+        },
+    );
+}

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -81,6 +81,19 @@ builder {
             $content->rewind(),
         ];
     };
+    mount "/echo-port" => sub {
+        my $env = shift;
+        return [
+            200,
+            [
+                'content-type' => 'text/' . $env->{QUERY_STRING} ? $env->{QUERY_STRING} : 'html',
+                'x-remote-port' => $env->{REMOTE_PORT},
+            ],
+            [
+                '<html><head><link rel="stylesheet" type="text/css" href="/echo-port?css"><title>ok</title></head></html>',
+            ]
+        ];
+    };
     mount "/echo-headers" => sub {
         my $env = shift;
         return [


### PR DESCRIPTION
When this option is 'ON', socket pooling is done at the frontend
connection level, so that backend connections are only re-used for a
given frontend connection.
We achieve this by adding a `per_socket_pool` member to `h2o_socket_t`.
If the option is set, pooled sockets will be added there and the pool
will be destroyed at the same time as the socket.

This also adds a test that checks that tcp connections are re-using the
same port, there's also a part of the test that checks that connections
over unix sockets are still functional.

Question: we currently lower case `struct rp_handler_t->upstream` in order to be able to match it afterwards. In order to keep that functionality _and_ be able to re-use `upstream` in the pool creation, I've added a `lcupstream` lowercase version to use for matching. Is that the right thing to do? Another possibility would be to special case the unix socket case, but that requires an intrusive change, as far as I understand.