### PR TITLE
on_connection_upgrade asserts if extra bytes are sent after the first request

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -880,9 +880,14 @@ static void on_upgrade_complete(void *_conn, h2o_socket_t *sock, size_t reqsize)
     /* handle the request */
     execute_or_enqueue_request(conn, h2o_http2_conn_get_stream(conn, 1));
 
-    if (conn->_http1_req_input->size != reqsize) {
-        /* FIXME copy the remaining data to conn->_input and call handle_input */
-        assert(0);
+    if (conn->_http1_req_input->size > reqsize) {
+        size_t remaining_bytes;
+
+        remaining_bytes = conn->_http1_req_input->size - reqsize;
+        h2o_buffer_reserve(&sock->input, remaining_bytes);
+        memcpy(sock->input->bytes, conn->_http1_req_input->bytes + reqsize, remaining_bytes);
+        sock->input->size += remaining_bytes;
+        on_read(conn->sock, NULL);
     }
 }
 


### PR DESCRIPTION


As suggested in the FIXME comment, copy the remaining bytes for
and continue processing.

Reported by Tim Newsham