### PR TITLE
Possible use-after-free in memcached.c::writer_main()

### DIFF
--- a/lib/common/memcached.c
+++ b/lib/common/memcached.c
@@ -196,6 +196,7 @@ static void *writer_main(void *_conn)
                 discard_req(req);
                 if (err != YRMCDS_OK)
                     goto Error;
+                break;
             default:
                 fprintf(stderr, "[lib/common/memcached.c] unknown type:%d\n", (int)req->type);
                 err = YRMCDS_NOT_IMPLEMENTED;


### PR DESCRIPTION
The `REQ_TYPE_DELETE` case is missing a break, causing it to fallthrough
to the following case, which dereferences `req`, which we just freed.

Reported by Tim Newsham