### PR TITLE
h2o_mem_swap only swaps the first 256 bytes at most

### DIFF
--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -358,6 +358,8 @@ void h2o_mem_swap(void *_x, void *_y, size_t len)
         memcpy(x, y, blocksz);
         memcpy(y, buf, blocksz);
         len -= blocksz;
+        x += blocksz;
+        y += blocksz;
     }
 }
 


### PR DESCRIPTION
Have the function increment `x` and `y` so that all the blocks are
swapped. This doesn't affect the current code as the only caller uses a
structure smaller than 256 bytes.

Reported by Tim Newsham