### PR TITLE
Make the minimum size for compression configurable

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1386,6 +1386,7 @@ typedef struct st_h2o_compress_context_t {
 } h2o_compress_context_t;
 
 typedef struct st_h2o_compress_args_t {
+    size_t min_size;
     struct {
         int quality; /* -1 if disabled */
     } gzip;

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -65,8 +65,7 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
         h2o_req_fill_mime_attributes(req);
     if (!req->res.mime_attr->is_compressible)
         goto Next;
-    /* 100 is a rough estimate */
-    if (req->res.content_length <= self->args.min_size)
+    if (req->res.content_length < self->args.min_size)
         goto Next;
     /* skip if failed to gather the list of compressible types */
     if ((compressible_types = h2o_get_compressible_types(&req->headers)) == 0)

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -66,7 +66,7 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     if (!req->res.mime_attr->is_compressible)
         goto Next;
     /* 100 is a rough estimate */
-    if (req->res.content_length <= 100)
+    if (req->res.content_length <= self->args.min_size)
         goto Next;
     /* skip if failed to gather the list of compressible types */
     if ((compressible_types = h2o_get_compressible_types(&req->headers)) == 0)

--- a/lib/handler/configurator/compress.c
+++ b/lib/handler/configurator/compress.c
@@ -161,7 +161,7 @@ void h2o_compress_register_configurator(h2o_globalconf_t *conf)
     c->super.enter = on_config_enter;
     c->super.exit = on_config_exit;
     h2o_configurator_define_command(&c->super, "compress", H2O_CONFIGURATOR_FLAG_ALL_LEVELS, on_config_compress);
-    h2o_configurator_define_command(&c->super, "compress-min-size",
+    h2o_configurator_define_command(&c->super, "compress-minimum-size",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_compress_min_size);
     h2o_configurator_define_command(&c->super, "gzip", H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,

--- a/srcdoc/configure/compress_directives.mt
+++ b/srcdoc/configure/compress_directives.mt
@@ -51,6 +51,18 @@ EOT
 
 <?
 $ctx->{directive}->(
+    name     => "compress-min-size",
+    levels   => [ qw(global host path extension) ],
+    default  => "compress-min-size: 100",
+    since    => '2.0',
+    desc     => <<'EOT',
+Defines the minimum size a files needs to have in order for H2O to compress the request.
+EOT
+)->(sub {});
+?>
+
+<?
+$ctx->{directive}->(
     name     => "gzip",
     levels   => [ qw(global host path extension) ],
     default  => "gzip: OFF",

--- a/srcdoc/configure/compress_directives.mt
+++ b/srcdoc/configure/compress_directives.mt
@@ -51,9 +51,9 @@ EOT
 
 <?
 $ctx->{directive}->(
-    name     => "compress-min-size",
+    name     => "compress-minimum-size",
     levels   => [ qw(global host path extension) ],
-    default  => "compress-min-size: 100",
+    default  => "compress-minimum-size: 100",
     since    => '2.0',
     desc     => <<'EOT',
 Defines the minimum size a files needs to have in order for H2O to compress the request.


### PR DESCRIPTION
Add a `compress-min-size` configuration parameter that controls the
minimum size that an object needs to have for us to compress it.