### PR TITLE
configuration directive to disable H2 push

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -262,7 +262,11 @@ struct st_h2o_hostconf_t {
          * whether if blocking assets being pulled should be given highest priority in case of clients that do not implement
          * dependency-based prioritization
          */
-        int reprioritize_blocking_assets;
+        int reprioritize_blocking_assets : 1;
+        /**
+         * if server push should be used
+         */
+        int push_preload : 1;
         /**
          * casper settings
          */

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -33,6 +33,7 @@ static h2o_hostconf_t *create_hostconf(h2o_globalconf_t *globalconf)
 {
     h2o_hostconf_t *hostconf = h2o_mem_alloc(sizeof(*hostconf));
     *hostconf = (h2o_hostconf_t){globalconf};
+    hostconf->http2.push_preload = 1; /* enabled by default */
     h2o_config_init_pathconf(&hostconf->fallback_path, globalconf, NULL, globalconf->mimemap);
     hostconf->mimemap = globalconf->mimemap;
     h2o_mem_addref_shared(hostconf->mimemap);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1188,7 +1188,8 @@ static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_le
     if (h2o_http2_stream_is_push(src_stream->stream_id))
         return;
 
-    if (!conn->peer_settings.enable_push || conn->num_streams.push.open >= conn->peer_settings.max_concurrent_streams)
+    if (!src_stream->req.hostconf->http2.push_preload || !conn->peer_settings.enable_push ||
+        conn->num_streams.push.open >= conn->peer_settings.max_concurrent_streams)
         return;
 
     if (conn->push_stream_ids.max_open >= 0x7ffffff0)


### PR DESCRIPTION
Some users may want to just send `link: rel=preload` headers without H2 push.