### PR TITLE
add option to send proxy header to upstream

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -641,6 +641,7 @@
 		10FCC1411B2FCC6B00F13674 /* kill-on-close */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.perl; path = "kill-on-close"; sourceTree = "<group>"; };
 		10FCC1421B300A6800F13674 /* 50fastcgi-php.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50fastcgi-php.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10FCC1431B31408B00F13674 /* fastcgi_directives.mt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = fastcgi_directives.mt; sourceTree = "<group>"; };
+		10FEF2441D6444E900E11B1D /* 50reverse-proxy-proxy-protocol.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-proxy-protocol.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10FFEE081BB23A8C0087AD75 /* neverbleed.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = neverbleed.c; sourceTree = "<group>"; };
 		10FFEE091BB23A8C0087AD75 /* neverbleed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neverbleed.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1408,6 +1409,7 @@
 				108214FE1AAD34DD00D27E66 /* 50reverse-proxy-0.t */,
 				108102151C3DB05100C024CD /* 50reverse-proxy-disconnected-keepalive.t */,
 				104C65021A6DF36B000AC190 /* 50reverse-proxy-config.t */,
+				10FEF2441D6444E900E11B1D /* 50reverse-proxy-proxy-protocol.t */,
 				10AA2EB21A9479B4004322AC /* 50reverse-proxy-upstream-down.t */,
 				10DA969A1CCEF2C200679165 /* 50reverse-proxy-https.t */,
 				104B9A2B1A4BBDA4009EEE64 /* 50server-starter.t */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -782,6 +782,10 @@ typedef struct st_h2o_req_overrides_t {
          */
         h2o_iovec_t path_prefix;
     } location_rewrite;
+    /**
+     * whether if the PROXY header should be sent
+     */
+    unsigned use_proxy_protocol : 1;
 } h2o_req_overrides_t;
 
 /**
@@ -1056,6 +1060,12 @@ void h2o_accept_setup_async_ssl_resumption(h2o_memcached_context_t *ctx, unsigne
  * returns the protocol version (e.g. "HTTP/1.1", "HTTP/2")
  */
 size_t h2o_stringify_protocol_version(char *dst, int version);
+/**
+ * builds the proxy header defined by the PROXY PROTOCOL
+ */
+size_t h2o_stringify_proxy_header(h2o_conn_t *conn, char *buf);
+#define H2O_PROXY_HEADER_MAX_LENGTH                                                                                                \
+    (sizeof("PROXY TCP6 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n") - 1)
 /**
  * extracts path to be pushed from `Link: rel=prelead` header, duplicating the chunk (or returns {NULL,0} if none)
  */
@@ -1663,7 +1673,8 @@ void h2o_headers_register_configurator(h2o_globalconf_t *conf);
 
 typedef struct st_h2o_proxy_config_vars_t {
     uint64_t io_timeout;
-    int preserve_host;
+    unsigned preserve_host : 1;
+    unsigned use_proxy_protocol : 1;
     uint64_t keepalive_timeout; /* in milliseconds; set to zero to disable keepalive */
     struct {
         int enabled;

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -47,6 +47,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     }
     overrides->location_rewrite.match = &self->upstream;
     overrides->location_rewrite.path_prefix = req->pathconf->path;
+    overrides->use_proxy_protocol = self->config.use_proxy_protocol;
     overrides->client_ctx = h2o_context_get_handler_context(req->conn->ctx, &self->super);
 
     /* determine the scheme and authority */

--- a/t/50reverse-proxy-proxy-protocol.t
+++ b/t/50reverse-proxy-proxy-protocol.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use IO::Socket::INET;
+use Test::TCP;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use Scope::Guard qw(guard);
+use t::Util;
+
+my $upstream_port = empty_port();
+
+my $listen = IO::Socket::INET->new(
+    LocalAddr => '127.0.0.1',
+    LocalPort => $upstream_port,
+    Listen => 5,
+) or die "failed to listen to 127.0.0.1:$upstream_port:$!";
+
+my $upstream_guard = do {
+    my $pid = fork;
+    die "fork failed:$!"
+        unless defined $pid;
+    if ($pid == 0) {
+        # server process
+        while (1) {
+            if (my $conn = $listen->accept) {
+                sysread $conn, my $buf, 4096;
+print STDERR "**** $buf";
+                syswrite $conn, "HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n$buf";
+print STDERR "**** yeoh";
+                $conn->close;
+            }
+        }
+    }
+    guard {
+        kill 'TERM', $pid;
+    };
+};
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port/
+        proxy.proxy-protocol: ON
+        proxy.timeout.keepalive: 0
+EOT
+
+run_with_curl($server, sub {
+    my ($proto, $port, $curl_cmd) = @_;
+    my $resp = `$curl_cmd --silent $proto://127.0.0.1:$port/hello`;
+    like $resp, qr{^PROXY TCP4 127\.0\.0\.1 127\.0\.0\.1 [0-9]{1,5} $port\r\nGET /hello HTTP/1\.}is;
+});
+
+done_testing;


### PR DESCRIPTION
Implements #602.

Note that this feature can be used only when `proxy.timeout.keepalive` is set to zero, since otherwise we would need to implement a per-connection socket pool (relates to #919).

ToDo:
* [x] add test