### PR TITLE
Add a custom crash handler directive

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -143,22 +143,24 @@ static struct {
         int _num_connections; /* should use atomic functions to update the value */
         char _unused2[32];
     } state;
+    char *crash_handler;
 } conf = {
-    {},              /* globalconf */
-    RUN_MODE_WORKER, /* dry-run */
-    {},              /* server_starter */
-    NULL,            /* listeners */
-    0,               /* num_listeners */
-    NULL,            /* pid_file */
-    NULL,            /* error_log */
-    1024,            /* max_connections */
-    0,               /* initialized in main() */
-    0,               /* initialized in main() */
-    0,               /* initialized in main() */
-    NULL,            /* thread_ids */
-    0,               /* shutdown_requested */
-    0,               /* initialized_threads */
-    {},              /* state */
+    {},                                     /* globalconf */
+    RUN_MODE_WORKER,                        /* dry-run */
+    {},                                     /* server_starter */
+    NULL,                                   /* listeners */
+    0,                                      /* num_listeners */
+    NULL,                                   /* pid_file */
+    NULL,                                   /* error_log */
+    1024,                                   /* max_connections */
+    0,                                      /* initialized in main() */
+    0,                                      /* initialized in main() */
+    0,                                      /* initialized in main() */
+    NULL,                                   /* thread_ids */
+    0,                                      /* shutdown_requested */
+    0,                                      /* initialized_threads */
+    {},                                     /* state */
+    "share/h2o/annotate-backtrace-symbols", /* crash_handler */
 };
 
 static neverbleed_t *neverbleed = NULL;
@@ -1115,6 +1117,12 @@ static int on_config_temp_buffer_path(h2o_configurator_command_t *cmd, h2o_confi
     return 0;
 }
 
+static int on_config_crash_handler(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    conf.crash_handler = h2o_strdup(NULL, node->data.scalar, SIZE_MAX).base;
+    return 0;
+}
+
 static yoml_t *load_config(const char *fn)
 {
     FILE *fp;
@@ -1159,9 +1167,9 @@ static void on_sigterm(int signo)
 }
 
 #ifdef __GLIBC__
-static int popen_annotate_backtrace_symbols(void)
+static int popen_crash_handler(void)
 {
-    char *cmd_fullpath = h2o_configurator_get_cmd_path("share/h2o/annotate-backtrace-symbols"), *argv[] = {cmd_fullpath, NULL};
+    char *cmd_fullpath = h2o_configurator_get_cmd_path(conf.crash_handler), *argv[] = {cmd_fullpath, NULL};
     int pipefds[2];
 
     /* create pipe */
@@ -1188,17 +1196,17 @@ static int popen_annotate_backtrace_symbols(void)
     return pipefds[1];
 }
 
-static int backtrace_symbols_to_fd = -1;
+static int crash_handler_fd = -1;
 
 static void on_sigfatal(int signo)
 {
-    fprintf(stderr, "received fatal signal %d; backtrace follows\n", signo);
+    fprintf(stderr, "received fatal signal %d\n", signo);
 
     h2o_set_signal_handler(signo, SIG_DFL);
 
     void *frames[128];
     int framecnt = backtrace(frames, sizeof(frames) / sizeof(frames[0]));
-    backtrace_symbols_fd(frames, framecnt, backtrace_symbols_to_fd);
+    backtrace_symbols_fd(frames, framecnt, crash_handler_fd);
 
     raise(signo);
 }
@@ -1209,8 +1217,8 @@ static void setup_signal_handlers(void)
     h2o_set_signal_handler(SIGTERM, on_sigterm);
     h2o_set_signal_handler(SIGPIPE, SIG_IGN);
 #ifdef __GLIBC__
-    if ((backtrace_symbols_to_fd = popen_annotate_backtrace_symbols()) == -1)
-        backtrace_symbols_to_fd = 2;
+    if ((crash_handler_fd = popen_crash_handler()) == -1)
+        crash_handler_fd = 2;
     h2o_set_signal_handler(SIGABRT, on_sigfatal);
     h2o_set_signal_handler(SIGBUS, on_sigfatal);
     h2o_set_signal_handler(SIGFPE, on_sigfatal);
@@ -1512,6 +1520,8 @@ static void setup_configurators(void)
                                         on_config_num_ocsp_updaters);
         h2o_configurator_define_command(c, "temp-buffer-path", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_temp_buffer_path);
+        h2o_configurator_define_command(c, "crash-handler", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_crash_handler);
     }
 
     h2o_access_log_register_configurator(&conf.globalconf);

--- a/srcdoc/configure/base_directives.mt
+++ b/srcdoc/configure/base_directives.mt
@@ -601,4 +601,26 @@ If the directive is omitted and if the server is started under root privileges, 
 </p>
 ? })
 
+<?
+$ctx->{directive}->(
+    name   => "crash-handler",
+    levels => [ qw(global) ],
+    desc   => q{Script to invoke if <code>h2o</code> receives a fatal signal.},
+    default  => q{crash-handler: "${H2O_ROOT}/share/h2o/annotate-backtrace-symbols"},
+    since    => "2.1",
+)->(sub {
+?>
+<p>Note: this feature is only available when linking to the GNU libc.</p>
+
+<p>The script is invoked if one of the <code>SIGABRT</code>,
+<code>SIGBUS</code>, <code>SIGFPE</code>, <code>SIGILL</code> or
+<code>SIGSEGV</code> signals is received by <code>h2o</code>.</p>
+
+<p><code>h2o</code> writes the backtrace as provided by
+<code>backtrace()</code> and <code>backtrace_symbols_fd</code> to the
+standard input of the program.</p>
+
+<p>If the path is not absolute, it is prefixed with <code>${H2O_ROOT}/</code>.</p>
+? })
+
 ? })


### PR DESCRIPTION
This adds a two new top level config options to the `h2o` daemon:
- `crash-handler`: takes a path to a script to execute if `h2o` receives
  a fatal signal.
- `crash-handler-args`: takes arguments to pass to the crash handler

The default behavior to invoke 'share/h2o/annotate-backtrace-symbols' is
preserved.