### PR TITLE
Invalid write when incrementing http2 errors

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -278,17 +278,12 @@ int close_connection(h2o_http2_conn_t *conn)
     return 0;
 }
 
-static inline void h2o_context_http2_protocol_error_count(h2o_context_t *ctx, int errnum)
-{
-    ctx->http2.events.protocol_level_errors[-errnum]++;
-}
-
 void send_stream_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum)
 {
     assert(stream_id != 0);
     assert(conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING);
 
-    h2o_context_http2_protocol_error_count(conn->super.ctx, -errnum);
+    conn->super.ctx->http2.events.protocol_level_errors[-errnum]++;
 
     h2o_http2_encode_rst_stream_frame(&conn->_write.buf, stream_id, -errnum);
     h2o_http2_conn_request_write(conn);


### PR DESCRIPTION
The code ended up passing a negative value to the array index. Remove
the confusing double negative.