### PR TITLE
define `h2o_http1client_header_t` which is a copy of `phr_header`

### DIFF
--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -34,14 +34,22 @@ extern "C" {
 struct phr_header;
 typedef struct st_h2o_http1client_t h2o_http1client_t;
 
+/* the definition MUST match that of `struct phr_header` */
+typedef struct st_h2o_http1client_header_t {
+  const char* name;
+  size_t name_len;
+  const char* value;
+  size_t value_len;
+} h2o_http1client_header_t;
+
 typedef int (*h2o_http1client_body_cb)(h2o_http1client_t *client, const char *errstr);
 typedef h2o_http1client_body_cb (*h2o_http1client_head_cb)(h2o_http1client_t *client, const char *errstr, int minor_version,
-                                                           int status, h2o_iovec_t msg, struct phr_header *headers,
+                                                           int status, h2o_iovec_t msg, h2o_http1client_header_t *headers,
                                                            size_t num_headers);
 typedef h2o_http1client_head_cb (*h2o_http1client_connect_cb)(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs,
                                                               size_t *reqbufcnt, int *method_is_head);
 typedef int (*h2o_http1client_informational_cb)(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg,
-                                                struct phr_header *headers, size_t num_headers);
+                                                h2o_http1client_header_t *headers, size_t num_headers);
 
 typedef struct st_h2o_http1client_ctx_t {
     h2o_loop_t *loop;

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -246,8 +246,8 @@ static void on_head(h2o_socket_t *sock, const char *err)
     /* handle 1xx response (except 101, which is handled by on_head callback) */
     if (100 <= http_status && http_status <= 199 && http_status != 101) {
         if (client->super.informational_cb != NULL &&
-            client->super.informational_cb(&client->super, minor_version, http_status, h2o_iovec_init(msg, msg_len), headers,
-                                           num_headers) != 0) {
+            client->super.informational_cb(&client->super, minor_version, http_status, h2o_iovec_init(msg, msg_len),
+                                           (void *)headers, num_headers) != 0) {
             close_client(client);
             return;
         }

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -327,7 +327,7 @@ static int on_body(h2o_http1client_t *client, const char *errstr)
 }
 
 static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
-                                       h2o_iovec_t msg, struct phr_header *headers, size_t num_headers)
+                                       h2o_iovec_t msg, h2o_http1client_header_t *headers, size_t num_headers)
 {
     struct rp_generator_t *self = client->data;
     h2o_req_t *req = self->src_req;
@@ -411,7 +411,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
     return on_body;
 }
 
-static int on_1xx(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg, struct phr_header *headers,
+static int on_1xx(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg, h2o_http1client_header_t *headers,
                   size_t num_headers)
 {
     struct rp_generator_t *self = client->data;


### PR DESCRIPTION
Instead of relying on an incomplete definition of `struct phr_header`.

Fixes #942