### PR TITLE
Support multiple links in a Link: header

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1045,9 +1045,9 @@ size_t h2o_stringify_protocol_version(char *dst, int version);
 /**
  * extracts path to be pushed from `Link: rel=prelead` header, duplicating the chunk (or returns {NULL,0} if none)
  */
-h2o_iovec_t h2o_extract_push_path_from_link_header(h2o_mem_pool_t *pool, const char *value, size_t value_len, h2o_iovec_t base_path,
-                                                   const h2o_url_scheme_t *input_scheme, h2o_iovec_t input_authority,
-                                                   const h2o_url_scheme_t *base_scheme, h2o_iovec_t *base_authority);
+h2o_iovec_vector_t h2o_extract_push_path_from_link_header(h2o_mem_pool_t *pool, const char *value, size_t value_len, h2o_iovec_t base_path,
+                                                          const h2o_url_scheme_t *input_scheme, h2o_iovec_t input_authority,
+                                                          const h2o_url_scheme_t *base_scheme, h2o_iovec_t *base_authority);
 /**
  * return a bitmap of compressible types, by parsing the `accept-encoding` header
  */

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -600,15 +600,18 @@ h2o_iovec_t h2o_get_redirect_method(h2o_iovec_t method, int status)
 
 int h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
 {
+    int i;
     if (req->conn->callbacks->push_path == NULL)
         return -1;
 
-    h2o_iovec_t path = h2o_extract_push_path_from_link_header(&req->pool, value, value_len, req->path_normalized, req->input.scheme,
-                                                              req->input.authority, req->res_is_delegated ? req->scheme : NULL,
-                                                              req->res_is_delegated ? &req->authority : NULL);
-    if (path.base == NULL)
+    h2o_iovec_vector_t paths = h2o_extract_push_path_from_link_header(&req->pool, value, value_len, req->path_normalized, req->input.scheme,
+                                                                      req->input.authority, req->res_is_delegated ? req->scheme : NULL,
+                                                                      req->res_is_delegated ? &req->authority : NULL);
+    if (paths.size == 0)
         return -1;
 
-    req->conn->callbacks->push_path(req, path.base, path.len);
+    for (i = 0; i < paths.size; i++) {
+        req->conn->callbacks->push_path(req, paths.entries[i].base, paths.entries[i].len);
+    }
     return 0;
 }

--- a/t/40server-push-multiple.t
+++ b/t/40server-push-multiple.t
@@ -1,0 +1,66 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+plan skip_all => 'nghttp not found'
+    unless prog_exists('nghttp');
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
+subtest "basic" => sub {
+    # spawn upstream
+    my $upstream_port = empty_port();
+    my $upstream = spawn_server(
+        argv     => [
+            qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
+        ],
+        is_ready => sub {
+            check_port($upstream_port);
+        },
+    );
+    # spawn server
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+      /mruby:
+        mruby.handler: |
+          Proc.new do |env|
+            [399, { "link" => "</index.txt.gz>; rel=preload, </index.txt.gz?1>; rel=preload, </index.txt.gz?nopush>; rel=preload; nopush" }, [] ]
+          end
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+      /assets:
+        file.dir: @{[DOC_ROOT]}
+EOT
+
+    my $doit = sub {
+        my ($proto, $opts, $port) = @_;
+        subtest 'push-prioritized' => sub {
+            my $resp = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/mruby'`;
+            like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\.gz}is, "index.txt.gz is pushed";
+            like $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\.gz\?1}is, "index.txt.gz?1 is pushed";
+            unlike $resp, qr{\nid\s*responseEnd\s.*\s/index\.txt\.gz\?nopush}is, "index.txt.gz?nopush isn't pushed";
+        };
+    };
+
+    subtest 'h2 direct' => sub {
+        $doit->('http', '', $server->{port});
+    };
+    subtest 'h2 upgrade' => sub {
+        $doit->('http', '-u', $server->{port});
+    };
+    subtest 'h2c' => sub {
+        $doit->('https', '', $server->{tls_port});
+    };
+};
+
+
+done_testing;


### PR DESCRIPTION
https://tools.ietf.org/html/rfc5988 appears to allow multiple links in the
'Link:' header. AFAIU, the grammar doesn't allow it explicitly, but the example
section does explicitly list such a link header:

```
   Link: </TheBook/chapter2>;
         rel="previous"; title*=UTF-8'de'letztes%20Kapitel,
         </TheBook/chapter4>;
         rel="next"; title*=UTF-8'de'n%c3%a4chstes%20Kapitel
```

This patch makes h2o_extract_push_path_from_link_header extract several
paths when found.