### PR TITLE
Fix crash on connect timeout

### DIFF
--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -197,6 +197,8 @@ h2o_socket_t *h2o_uv_socket_create(uv_stream_t *stream, uv_close_cb close_cb)
 
 static void on_connect(uv_connect_t *conn, int status)
 {
+    if (status == UV_ECANCELED)
+        return;
     struct st_h2o_uv_socket_t *sock = H2O_STRUCT_FROM_MEMBER(struct st_h2o_uv_socket_t, _creq, conn);
     h2o_socket_cb cb = sock->super._cb.write;
     sock->super._cb.write = NULL;


### PR DESCRIPTION
libuv will call connect callback after uv_close, so the callback should ignore when status == UV_ECANCELED