### PR TITLE
Hpack parsing issue

### DIFF
--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -80,7 +80,7 @@ static int32_t decode_int(const uint8_t **src, const uint8_t *src_end, size_t pr
     int32_t value, mult;
     uint8_t prefix_max = (1 << prefix_bits) - 1;
 
-    if (*src == src_end)
+    if (*src >= src_end)
         return -1;
 
     value = (uint8_t) * (*src)++ & prefix_max;
@@ -94,7 +94,7 @@ static int32_t decode_int(const uint8_t **src, const uint8_t *src_end, size_t pr
 
     value = prefix_max;
     for (mult = 1;; mult *= 128) {
-        if (*src == src_end)
+        if (*src >= src_end)
             return -1;
         value += (**src & 127) * mult;
         if ((*(*src)++ & 128) == 0)
@@ -125,7 +125,7 @@ static h2o_iovec_t *decode_huffman(h2o_mem_pool_t *pool, const uint8_t *src, siz
     h2o_iovec_t *dst_buf = alloc_buf(pool, len * 2); /* max compression ratio is >= 0.5 */
 
     dst = dst_buf->base;
-    for (; src != src_end; src++) {
+    for (; src < src_end; src++) {
         if ((dst = huffdecode4(dst, *src >> 4, &state, &maybe_eos)) == NULL)
             return NULL;
         if ((dst = huffdecode4(dst, *src & 0xf, &state, &maybe_eos)) == NULL)
@@ -146,7 +146,7 @@ static h2o_iovec_t *decode_string(h2o_mem_pool_t *pool, const uint8_t **src, con
     int is_huffman;
     int32_t len;
 
-    if (*src == src_end)
+    if (*src >= src_end)
         return NULL;
 
     is_huffman = (**src & 0x80) != 0;
@@ -154,6 +154,8 @@ static h2o_iovec_t *decode_string(h2o_mem_pool_t *pool, const uint8_t **src, con
         return NULL;
 
     if (is_huffman) {
+        if (*src + len > src_end)
+            return NULL;
         if ((ret = decode_huffman(pool, *src, len)) == NULL)
             return NULL;
     } else {
@@ -241,7 +243,7 @@ static int decode_header(h2o_mem_pool_t *pool, struct st_h2o_decode_header_resul
     int value_is_indexed = 0, do_index = 0;
 
 Redo:
-    if (*src == src_end)
+    if (*src >= src_end)
         return H2O_HTTP2_ERROR_COMPRESSION;
 
     /* determine the mode and handle accordingly */

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -171,6 +171,19 @@ static void test_hpack(void)
     }
     h2o_mem_clear_pool(&pool);
 
+    note("decode_string_bogus");
+    {
+        char *str = "\x8c\xf1\xe3\xc2\xe5\xf2\x3a\x6b\xa0\xab\x90\xf4\xff";
+        const uint8_t *buf;
+        size_t len;
+        len = strlen(str);
+        buf = (const uint8_t *)str;
+        /* since we're only passing one byte, decode_string should fail */
+        h2o_iovec_t *decoded = decode_string(&pool, &buf, &buf[1]);
+        ok(decoded == NULL);
+    }
+    h2o_mem_clear_pool(&pool);
+
     note("decode_header (literal header field with indexing)");
     {
         struct st_h2o_decode_header_result_t result;


### PR DESCRIPTION
`decode_string` is missing a check that `src` hasn't gone over `src_end`
between the call to `decode_int` and `decode_huffman`.
As a result, we can:
- decode an int
- reach the end of the buffer
- then call `decode_huffman` having `src` greater than `src_end`, and
  thus read past the buffer

This patch fixes the issue by adding a check that `src` is smaller than
`src_end` before calling `decode_huffman`.

The patch also makes the code a bit more defensive by replacing `src ==
src_end` checks with `src <= src_end`, this will make the code more
robust to such mistakes should there be any in the future.

Finally, we add a test case in `t/00unit/lib/http2/hpack.c` that
reproduces the issue: without the patch, we read past the buffer and
`decode_string` doesn't fail.