### PR TITLE
h2 -> http/1.1 proxy: don't forward two 'host:' headers

### DIFF
--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -174,6 +174,8 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive, int is_websocket
                 const h2o_token_t *token = (void *)h->name;
                 if (token->proxy_should_drop) {
                     continue;
+                } else if (token == H2O_TOKEN_HOST) {
+                    continue;
                 } else if (token == H2O_TOKEN_COOKIE) {
                     /* merge the cookie headers; see HTTP/2 8.1.2.5 and HTTP/1 (RFC6265 5.4) */
                     /* FIXME current algorithm is O(n^2) against the number of cookie headers */

--- a/t/80dup-host-headers.t
+++ b/t/80dup-host-headers.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'nghttp not found'
+    unless prog_exists('nghttp');
+
+my $upstream_port = empty_port();
+$| = 1;
+my $socket = new IO::Socket::INET (
+    LocalHost => '127.0.0.1',
+    LocalPort => $upstream_port,
+    Proto => 'tcp',
+    Listen => 1,
+    Reuse => 1
+);
+die "cannot create socket $!\n" unless $socket;
+
+check_port($upstream_port) or die "can't connect to server socket";
+# accent and close check_port's connection
+my $client_socket = $socket->accept();
+close($client_socket);
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+system("nghttp http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' &");
+
+my $req;
+$client_socket = $socket->accept();
+$client_socket->recv($req, 1024);
+$client_socket->send("HTTP/1.1 200 Ok\r\nConnection:close\r\n\r\nBody\r\n");
+close($client_socket);
+$socket->close();
+
+my $host_headers = 0;
+foreach (split(/\r\n/, $req)) {
+    if (/^host:/i) {
+        $host_headers++
+    }
+}
+
+ok($host_headers == 1, "Only saw one host: header");
+done_testing();


### PR DESCRIPTION
When h2o acts as a proxy between an h2 client and an http/1.1 server, it
will generate the http/1.1 Host header by using the `:authority:` h2
pseudo header. Unfortunately, if a h2 `host:` header is already present,
the http/1.1 request will have two Host headers, which will make the
request invalid.

AFAIU, RFC7540 language doesn't explicitely state what to do in the
case where `:authority:` and `host:` are present, but preferring
`:authority:` intuitively makes more sense since both in h2 and http/1.1
the http authority should be the same. See also another discussion on
the subject (with the same conclusion) here:
https://github.com/nghttp2/nghttp2/issues/317