### PR TITLE
h2o_build_destination: don't escape ':' in the 'path' section of the url

### DIFF
--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -423,7 +423,7 @@ h2o_iovec_t h2o_build_destination(h2o_req_t *req, const char *prefix, size_t pre
 
     /* append suffix path and query */
     parts[num_parts++] = h2o_uri_escape(
-        &req->pool, req->path_normalized.base + req->pathconf->path.len, req->path_normalized.len - req->pathconf->path.len, "/@");
+        &req->pool, req->path_normalized.base + req->pathconf->path.len, req->path_normalized.len - req->pathconf->path.len, "/@:");
     if (req->query_at != SIZE_MAX)
         parts[num_parts++] = h2o_iovec_init(req->path.base + req->query_at, req->path.len - req->query_at);
 

--- a/t/50redirect.t
+++ b/t/50redirect.t
@@ -35,8 +35,9 @@ EOT
     $doit->("http://127.0.0.1:$server->{port}/foo", 302, "https://example.com/foo");
     $doit->("https://127.0.0.1:$server->{tls_port}/foo", 302, "https://example.com/foo");
     $doit->("http://127.0.0.1:$server->{port}/abc/foo/baz", 301, "http://example.net/bar/foo/baz");
+    $doit->("http://127.0.0.1:$server->{port}/abc/foo:baz", 301, "http://example.net/bar/foo:baz");
     $doit->("http://127.0.0.1:$server->{port}/foo?abc=def", 302, qr{https://example.com/foo\?abc=def});
-    $doit->("http://127.0.0.1:$server->{port}/foo%0D%0Aa:1", 302, "https://example\.com/foo\%0d\%0aa\%3a1");
+    $doit->("http://127.0.0.1:$server->{port}/foo%0D%0Aa:1", 302, "https://example\.com/foo\%0d\%0aa:1");
 };
 
 subtest "trailing-slash" => sub {


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc3986#section-3.3 'Path' :

      path-absolute = "/" [ segment-nz *( "/" segment ) ]
      segment       = *pchar
      segment-nz    = 1*pchar
      segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
                    ; non-zero-length segment without any colon ":"
      pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"

Since ':' is part of the allowed characters, The code should leave the
character as-is. Leaving the character as-is also matches the behavior
observed on Firefox, Chrome, Safari and IE.