### PR TITLE
don't use etag for calculating casper cookie

### DIFF
--- a/include/h2o/http2_casper.h
+++ b/include/h2o/http2_casper.h
@@ -43,8 +43,7 @@ size_t h2o_http2_casper_num_entries(h2o_http2_casper_t *casper);
 /**
  * checks if a key is (was) marked as cached at the moment the fuction is invoked
  */
-int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len,
-                            int set);
+int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, int set);
 /**
  * consumes the `Cookie` headers in requests and updates the structure
  */

--- a/lib/http2/casper.c
+++ b/lib/http2/casper.c
@@ -34,12 +34,11 @@ struct st_h2o_http2_casper_t {
     h2o_iovec_t cookie_cache;
 };
 
-static unsigned calc_key(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len)
+static unsigned calc_key(h2o_http2_casper_t *casper, const char *path, size_t path_len)
 {
     SHA_CTX ctx;
     SHA1_Init(&ctx);
     SHA1_Update(&ctx, path, path_len);
-    SHA1_Update(&ctx, etag, etag_len);
 
     union {
         unsigned key;
@@ -74,10 +73,9 @@ size_t h2o_http2_casper_num_entries(h2o_http2_casper_t *casper)
     return casper->keys.size;
 }
 
-int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, const char *etag, size_t etag_len,
-                            int set)
+int h2o_http2_casper_lookup(h2o_http2_casper_t *casper, const char *path, size_t path_len, int set)
 {
-    unsigned key = calc_key(casper, path, path_len, etag, etag_len);
+    unsigned key = calc_key(casper, path, path_len);
     size_t i;
 
     /* FIXME use binary search */

--- a/t/00unit/lib/http2/casper.c
+++ b/t/00unit/lib/http2/casper.c
@@ -36,8 +36,8 @@ static void test_calc_key(void)
 {
     h2o_http2_casper_t *casper = h2o_http2_casper_create(13, 6);
 
-    unsigned key = calc_key(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0")), expected;
-    memcpy(&expected, "\x1a\xa6\xfc\x81", 4);
+    unsigned key = calc_key(casper, H2O_STRLIT("/index.html")), expected;
+    memcpy(&expected, "\x14\xfe\x45\x59", 4);
     expected &= (1 << 13) - 1;
     ok(key == expected);
 
@@ -49,11 +49,11 @@ static void test_lookup(void)
     h2o_http2_casper_t *casper;
     casper = h2o_http2_casper_create(13, 6);
 
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 0);
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1) == 0);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 0) == 0);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 1) == 0);
     ok(casper->keys.size == 1);
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1) == 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 0) == 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 1) == 1);
     ok(casper->keys.size == 1);
 
     h2o_http2_casper_destroy(casper);
@@ -69,7 +69,7 @@ static void test_cookie(void)
     ok(cookie.base == NULL);
     ok(cookie.len == 0);
 
-    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
+    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 1);
     cookie = h2o_http2_casper_get_cookie(casper);
     ok(cookie.len != 0);
     cookie = h2o_strdup(NULL, cookie.base, cookie.len);
@@ -77,11 +77,11 @@ static void test_cookie(void)
     casper = h2o_http2_casper_create(13, 6);
 
     h2o_http2_casper_consume_cookie(casper, cookie.base, get_end_of_cookie_value(cookie.base, cookie.len));
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 0) == 0);
-    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 0) == 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), 0) == 0);
+    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), 1);
 
-    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
+    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 1);
     cookie = h2o_http2_casper_get_cookie(casper);
     ok(cookie.len != 0);
     cookie = h2o_strdup(NULL, cookie.base, cookie.len);
@@ -90,8 +90,8 @@ static void test_cookie(void)
     casper = h2o_http2_casper_create(13, 6);
 
     h2o_http2_casper_consume_cookie(casper, cookie.base, get_end_of_cookie_value(cookie.base, cookie.len));
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 0) == 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 0) == 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), 0) == 1);
 
     h2o_http2_casper_destroy(casper);
 }
@@ -101,13 +101,13 @@ static void test_cookie_merge(void)
     h2o_http2_casper_t *casper;
 
     casper = h2o_http2_casper_create(13, 6);
-    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 1);
+    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 1);
     h2o_iovec_t cookie1 = h2o_http2_casper_get_cookie(casper);
     cookie1 = h2o_strdup(NULL, cookie1.base, cookie1.len);
     h2o_http2_casper_destroy(casper);
 
     casper = h2o_http2_casper_create(13, 6);
-    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 1);
+    h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), 1);
     h2o_iovec_t cookie2 = h2o_http2_casper_get_cookie(casper);
     cookie2 = h2o_strdup(NULL, cookie2.base, cookie2.len);
     h2o_http2_casper_destroy(casper);
@@ -116,11 +116,11 @@ static void test_cookie_merge(void)
     h2o_http2_casper_consume_cookie(casper, cookie1.base, get_end_of_cookie_value(cookie1.base, cookie1.len));
     h2o_http2_casper_consume_cookie(casper, cookie1.base, get_end_of_cookie_value(cookie1.base, cookie1.len));
     ok(casper->keys.size == 1);
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 0) == 1);
     h2o_http2_casper_consume_cookie(casper, cookie2.base, get_end_of_cookie_value(cookie2.base, cookie2.len));
     ok(casper->keys.size == 2);
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), H2O_STRLIT("0-0"), 0) == 1);
-    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), H2O_STRLIT("0-0"), 0) == 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.html"), 0) == 1);
+    ok(h2o_http2_casper_lookup(casper, H2O_STRLIT("/index.php"), 0) == 1);
     h2o_http2_casper_destroy(casper);
 }
 


### PR DESCRIPTION
Change of etag value should not cause an HTTP response to be pushed, since the client would ignore the push in case it already has the response freshly-cached.