### PR TITLE
Add an option to prevent emiting x-forwarded-* headers

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -373,6 +373,10 @@ struct st_h2o_globalconf_t {
          * a boolean flag if set to true, instructs the proxy to preserve the x-forwarded-proto header passed by the client
          */
         int preserve_x_forwarded_proto;
+        /**
+         * a boolean flag if set to true, instructs the proxy to emit x-forwarded-proto and x-forwarded-for headers
+         */
+        int emit_x_forwarded_headers;
     } proxy;
 
     /**

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -180,6 +180,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http1.callbacks = H2O_HTTP1_CALLBACKS;
     config->http2.idle_timeout = H2O_DEFAULT_HTTP2_IDLE_TIMEOUT;
     config->proxy.io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
+    config->proxy.emit_x_forwarded_headers = 1;
     config->http2.max_concurrent_requests_per_connection = H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams;
     config->http2.max_streams_for_priority = 16;
     config->http2.latency_optimization.min_rtt = UINT_MAX;

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -147,6 +147,15 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
     return 0;
 }
 
+static int on_config_emit_x_forwarded_headers(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    ctx->globalconf->proxy.emit_x_forwarded_headers = (int)ret;
+    return 0;
+}
+
 static int on_config_preserve_x_forwarded_proto(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
@@ -233,4 +242,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "proxy.preserve-x-forwarded-proto",
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_preserve_x_forwarded_proto);
+    h2o_configurator_define_command(&c->super, "proxy.emit-x-forwarded-headers",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_emit_x_forwarded_headers);
 }

--- a/srcdoc/configure/proxy_directives.mt
+++ b/srcdoc/configure/proxy_directives.mt
@@ -67,6 +67,20 @@ However in case H2O is run behind a trusted HTTPS proxy, such protection might n
 
 <?
 $ctx->{directive}->(
+    name    => "proxy.emit-x-forwarded-headers",
+    levels  => [ qw(global) ],
+    since   => "2.1",
+    default => q{proxy.emit-x-forwarded-headers: ON},
+    desc    => "A boolean flag(<code>ON</code> or <code>OFF</code>) indicating if the server will append or add the <code>x-forwarded-proto</code> and <code>x-forwarded-for</code> request headers.",
+)->(sub {
+?>
+<p>
+By default, when forwarding an HTTP request H2O sends its own <code>x-forwarded-proto</code> and <code>x-forwarded-for</code> request headers (or might append its value in the <code>x-forwarded-proto</code> case, see <code>proxy.preserve-x-forwarded-proto</code>). This might not be always desirable. Please keep in mind security implications when setting this of <code>OFF</code>, since it might allow an attacker to spoof the originator or the protocol of a request.
+</p>
+? })
+
+<?
+$ctx->{directive}->(
     name    => "proxy.ssl.cafile",
     levels  => [ qw(global host path) ],
     since   => "2.0",

--- a/t/50reverse-dont-add-x-forwarded-headers.t
+++ b/t/50reverse-dont-add-x-forwarded-headers.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $upstream_port = empty_port();
+
+my $guard = spawn_server(
+    argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+    is_ready =>  sub {
+        check_port($upstream_port);
+    },
+);
+
+sub test_xff {
+    my $emit_xff = shift;
+    my $emit_xff_str = $emit_xff ? "ON" : "OFF";
+    print $emit_xff;
+    my $server = spawn_h2o(<< "EOT");
+proxy.emit-x-forwarded-headers: $emit_xff_str
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1.XIP.IO:$upstream_port
+EOT
+
+    run_with_curl($server, sub {
+            my ($proto, $port, $curl) = @_;
+            my $resp = `$curl --silent $proto://127.0.0.1:$port/echo-headers`;
+            if ($emit_xff) {
+                like $resp, qr/^x-forwarded-for: ?127\.0\.0\.1$/mi, "x-forwarded-for";
+                like $resp, qr/^x-forwarded-proto: ?$proto$/mi, "x-forwarded-proto";
+            } else {
+                unlike $resp, qr/^x-forwarded-for: ?127\.0\.0\.1$/mi, "x-forwarded-for not present";
+                unlike $resp, qr/^x-forwarded-proto: ?$proto$/mi, "x-forwarded-proto not present";
+            }
+            like $resp, qr/^via: ?[^ ]+ 127\.0\.0\.1:$port$/mi, "via";
+            $resp = `$curl --silent --header 'X-Forwarded-For: 127.0.0.2' --header 'Via: 2 example.com' $proto://127.0.0.1:$port/echo-headers`;
+            if ($emit_xff) {
+                like $resp, qr/^x-forwarded-for: ?127\.0\.0\.2, 127\.0\.0\.1$/mi, "x-forwarded-for (append)";
+            } else {
+                like $resp, qr/^x-forwarded-for: ?127\.0\.0\.2$/mi, "x-forwarded-for only contains the original header";
+            }
+            like $resp, qr/^via: ?2 example.com, [^ ]+ 127\.0\.0\.1:$port$/mi, "via (append)";
+        });
+}
+
+test_xff(1);
+test_xff(0);
+
+done_testing();


### PR DESCRIPTION
There are setups where it might not be desirable to add the headers at
all (for example if H2O is not terminating the TLS connection, it will
set `x-forwarded-for:localhost`).

We add a `proxy.emit-x-forwarded-headers` global config option that
instructs H2O not to add or append `x-forwarded-for` and
`x-forwarded-proto`. This option is `OFF` by default.