### PR TITLE
[minor cleanup] Make needlessly global functions static

### DIFF
--- a/include/h2o/serverutil.h
+++ b/include/h2o/serverutil.h
@@ -76,6 +76,6 @@ int h2o_read_command(const char *cmd, char **argv, h2o_buffer_t **resp, int *chi
 /**
  * Gets the number of processor cores
  */
-size_t h2o_numproc();
+size_t h2o_numproc(void);
 
 #endif

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -295,7 +295,7 @@ Exit:
     return ret;
 }
 
-size_t h2o_numproc()
+size_t h2o_numproc(void)
 {
 #if defined(_SC_NPROCESSORS_ONLN)
     return (size_t)sysconf(_SC_NPROCESSORS_ONLN);

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -367,7 +367,7 @@ socklen_t get_peername_uncached(h2o_socket_t *_sock, struct sockaddr *sa)
     return len;
 }
 
-struct st_h2o_evloop_socket_t *create_socket(h2o_evloop_t *loop, int fd, int flags)
+static struct st_h2o_evloop_socket_t *create_socket(h2o_evloop_t *loop, int fd, int flags)
 {
     struct st_h2o_evloop_socket_t *sock;
 

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -61,7 +61,7 @@ static void log_access(h2o_logger_t *_self, h2o_req_t *req)
         free(logline);
 }
 
-void on_dispose_handle(void *_fh)
+static void on_dispose_handle(void *_fh)
 {
     h2o_access_log_filehandle_t *fh = _fh;
 

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -213,7 +213,7 @@ Error:
     return -1;
 }
 
-void spawnproc_on_dispose(h2o_fastcgi_handler_t *handler, void *data)
+static void spawnproc_on_dispose(h2o_fastcgi_handler_t *handler, void *data)
 {
     int pipe_fd = (int)((char *)data - (char *)NULL);
     close(pipe_fd);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -400,7 +400,7 @@ static void on_rack_input_free(mrb_state *mrb, const char *base, mrb_int len, vo
     *input_stream = mrb_nil_value();
 }
 
-int build_env_sort_header_cb(const void *_x, const void *_y)
+static int build_env_sort_header_cb(const void *_x, const void *_y)
 {
     const h2o_header_t *x = (const h2o_header_t *)_x, *y = (const h2o_header_t *)_y;
     if (x->name->len < y->name->len)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -169,7 +169,7 @@ static struct {
     {} /* tickets */
 };
 
-struct st_session_ticket_t *new_ticket(const EVP_CIPHER *cipher, const EVP_MD *md, uint64_t not_before, uint64_t not_after,
+static struct st_session_ticket_t *new_ticket(const EVP_CIPHER *cipher, const EVP_MD *md, uint64_t not_before, uint64_t not_after,
                                        int fill_in)
 {
     struct st_session_ticket_t *ticket = h2o_mem_alloc(sizeof(*ticket) + cipher->key_len + md->block_size);


### PR DESCRIPTION
This patch makes needlessly global function static. The functions were
reported by `-Wmissing-prototypes`. There's also a minor cleanup to add an
explicit list of arguments for `h2o_numproc`