### PR TITLE
Prepare some prerequisites for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
   - $CXX --version
   # for speed, pre-install deps installed in `before_script` section as ubuntu packages
-  - sudo apt-get install -qq cpanminus libipc-signal-perl liblist-moreutils-perl libplack-perl libtest-tcp-perl libscope-guard-perl libwww-perl libio-socket-ssl-perl zlib1g-dev
+  - sudo apt-get install -qq cpanminus libipc-signal-perl liblist-moreutils-perl libwww-perl libio-socket-ssl-perl zlib1g-dev
 
 before_script:
   # install libuv >= 1.0.0 (optionally required for building / testing libh2o)
@@ -22,6 +22,9 @@ before_script:
   - misc/install-perl-module.pl Digest::SHA1
   - misc/install-perl-module.pl Net::EmptyPort
   - misc/install-perl-module.pl Scope::Guard
+  - misc/install-perl-module.pl Plack
+  - misc/install-perl-module.pl FCGI
+  - misc/install-perl-module.pl FCGI::ProcManager
   - misc/install-perl-module.pl Starlet
   - misc/install-perl-module.pl JSON
   # install the `ab` command (a.k.a. ApacheBench; optionally required for running some of the tests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_script:
   - sudo apt-get install -qq libev-dev
   - curl -L https://github.com/tatsuhiro-t/nghttp2/releases/download/v1.4.0/nghttp2-1.4.0.tar.gz | tar xzf -
   - (cd nghttp2-1.4.0 && ./configure --prefix=/usr --disable-threads --enable-app && make && sudo make install)
+  - curl -L https://curl.haxx.se/download/curl-7.50.0.tar.gz | tar xzf -
+  - (cd curl-7.50.0 && ./configure --prefix=/usr --with-nghttp2 --disable-shared && make && sudo make install)
 
 script:
   - cmake -DWITH_MRUBY=ON .


### PR DESCRIPTION
This PR prepares some prerequisites for tests.

(1) 9894fc1
Currently, tests that need http2-enabled curl are skipped. So build curl.

(2) 43dd3c1
Currently, t/50fastcgi.t is skipped because
```
> perl -MPlack::Handler::FCGI -e1
Can't locate FCGI.pm in @INC (@INC contains: /etc/perl /usr/local/lib/perl/5.14.2 /usr/local/share/perl/5.14.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.14 /usr/share/perl/5.14 /usr/local/lib/site_perl .) at /usr/share/perl5/Plack/Handler/FCGI.pm line 8.
BEGIN failed--compilation aborted at /usr/share/perl5/Plack/Handler/FCGI.pm line 8.
Compilation failed in require.
BEGIN failed--compilation aborted.
```
To use Plack::Handler::FCGI, we need to install FCGI and FCGI::ProcManager.
Additionally we need to install latest Plack for allowing SERVER_PROTOCOL=HTTP/2.