### PR TITLE
add dos_detector mruby handler

### DIFF
--- a/share/h2o/mruby/dos_detector.rb
+++ b/share/h2o/mruby/dos_detector.rb
@@ -44,7 +44,7 @@ class DoSDetector
       @cache.set(ip, client)
     end
 
-    detected, vars = @strategy.detect(client, now, env)
+    detected, vars = @strategy.detect?(client, now, env)
     if detected
       vars = { :ip => client[:ip] }.merge(vars || {})
       return @callback.call(vars)
@@ -68,7 +68,7 @@ class DoSDetector
       raise "ban_period must not be negative" if @ban_period < 0
     end
 
-    def detect(client, now, env)
+    def detect?(client, now, env)
       count = countup(client, now)
 
       banned_until = client[:banned_until] || 0

--- a/share/h2o/mruby/dos_detector.rb
+++ b/share/h2o/mruby/dos_detector.rb
@@ -1,0 +1,109 @@
+require "lru_cache.rb"
+
+class DoSDetector
+
+  def initialize(config={})
+    config = {
+      :strategy   => CountingStrategy.new,
+      :callback   => self.class.default_callback,
+      :forwarded  => true,
+      :cache_size => 128,
+    }.merge(config)
+
+    @strategy = config[:strategy]
+    @callback = config[:callback]
+    @forwarded = !!(config[:forwarded])
+    @cache = LRUCache.new(config[:cache_size])
+    raise "strategy must not be nil" if @strategy.nil?
+    raise "callback must not be nil" if @callback.nil?
+  end
+
+  def self.default_callback
+    Proc.new do |vars|
+      [ 403, { "Content-Type" => "text/plain" }, [ "Forbidden" ] ]
+    end
+  end
+
+  def self.fallthrough_callback
+    Proc.new do |vars|
+      env_headers = vars.map { |k, v| [ "x-fallthru-set-dos-#{k}", v.to_s ] }.to_h
+      [ 399, env_headers, [] ]
+    end
+  end
+
+  def call(env)
+    now = Time.now.to_i
+
+    ip = env['REMOTE_ADDR']
+    if @forwarded && (xff = env['HTTP_X_FORWARDED_FOR'])
+      ip = xff.split(",")[0]
+    end
+
+    unless client = @cache.get(ip)
+      client = { :ip => ip }
+      @cache.set(ip, client)
+    end
+
+    detected, vars = @strategy.detect(client, now, env)
+    if detected
+      vars = { :ip => client[:ip] }.merge(vars || {})
+      return @callback.call(vars)
+    end
+    return [ 399, {}, [] ]
+  end
+
+  class CountingStrategy
+
+    def initialize(config={})
+      config = {
+        :period     => 10,
+        :threshold  => 100,
+        :ban_period => 300,
+      }.merge(config)
+      @period = config[:period]
+      @threshold = config[:threshold]
+      @ban_period = config[:ban_period]
+      raise "period must be greater than zero" if @period <= 0
+      raise "threshold must be greater than zero" if @threshold <= 0
+      raise "ban_period must not be negative" if @ban_period < 0
+    end
+
+    def detect(client, now, env)
+      count = countup(client, now)
+
+      banned_until = client[:banned_until] || 0
+      if banned_until >= now
+        detected = true
+      else
+        detected = count >= @threshold 
+        if detected
+          banned_until = now + @ban_period
+          client[:banned_until] = banned_until
+        end
+      end
+
+      return detected, { :count => count, :banned_until => banned_until }
+    end
+
+    private
+
+    def countup(client, now)
+      count = client[:count] || 0
+      period_index = client[:period_index] || 0
+
+      current_period_index = (now / @period).floor
+      if current_period_index > period_index
+        count -= (current_period_index - period_index) * @threshold
+        count = 0 if count < 0
+        client[:period_index] = current_period_index
+      end
+
+      count += 1
+      client[:count] = count
+
+      return count
+    end
+
+  end
+
+end

--- a/share/h2o/mruby/dos_detector.rb
+++ b/share/h2o/mruby/dos_detector.rb
@@ -39,7 +39,7 @@ class DoSDetector
   end
 
   def self.default_callback
-    Proc.new do |detected, ip|
+    Proc.new do |env, detected, ip|
       if detected
         [ 403, { "Content-Type" => "text/plain" }, [ "Forbidden" ] ]
       else
@@ -49,7 +49,7 @@ class DoSDetector
   end
 
   def self.fallthrough_callback
-    Proc.new do |detected, ip, vars|
+    Proc.new do |env, detected, ip, vars|
       if detected
         vars ||= {}
         env_headers = vars.merge({:ip => ip}).map { |k, v| [ "x-fallthru-set-dos-#{k}", v.to_s ] }.to_h
@@ -74,7 +74,7 @@ class DoSDetector
     end
 
     detected, *args = @strategy.detect?(client, now, env)
-    return @callback.call(detected, ip, *args)
+    return @callback.call(env, detected, ip, *args)
   end
 
   class CountingStrategy

--- a/share/h2o/mruby/lru_cache.rb
+++ b/share/h2o/mruby/lru_cache.rb
@@ -1,3 +1,23 @@
+# Copyright (c) 2016 DeNA Co., Ltd., Ichito Nagata
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
 class LRUCache
 
   def initialize(capacity)

--- a/share/h2o/mruby/lru_cache.rb
+++ b/share/h2o/mruby/lru_cache.rb
@@ -1,0 +1,61 @@
+class LRUCache
+
+  def initialize(capacity)
+    @capacity = capacity
+    @head = nil
+    @tail = nil
+    @nodes = {}
+    raise "capacity must not be negative" if @capacity < 0
+  end
+
+  def set(key, value)
+    if ! @head
+      @nodes[key] = @head = @tail = [ nil, nil, key, value ]
+    elsif node = @nodes[key]
+      move_to_head(node)
+      node[3] = value
+    else
+      node = [ nil, @head, key, value ]
+      @head[0] = node
+      @nodes[key] = @head = node
+    end
+
+    while @nodes.size > @capacity do
+      @nodes.delete(@tail[2])
+      @tail = @tail[0]
+      if @tail
+        @tail[1] = nil
+      else
+        @head = nil
+        break
+      end
+    end
+
+    return value
+  end
+
+  def get(key)
+    node = @nodes[key]
+    return nil unless node
+    move_to_head(node)
+    return node[3]
+  end
+
+  private
+
+  def move_to_head(node)
+    if node == @head
+      return
+    elsif node == @tail
+      @tail = @tail[0]
+      @tail[1] = nil
+    end
+    node[0][1] = node[1]
+    node[1][0] = node[0] if node[1]
+    node[0] = nil
+    node[1] = @head
+    @head[0] = node
+    @head = node
+  end
+
+end

--- a/t/50mruby-dos-detector.t
+++ b/t/50mruby-dos-detector.t
@@ -1,0 +1,107 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+subtest "default callback" => sub {
+    my $server = spawn_h2o(<< 'EOT');
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          require "share/h2o/mruby/dos_detector.rb"
+          DoSDetector.new({
+            :strategy => DoSDetector::CountingStrategy.new({ :period => 1000, :threshold => 2, :ban_period => 1 << 32 }),
+          })
+        mruby.handler:
+          Proc.new do |env|
+            [200, {}, []]
+          end
+EOT
+    subtest "forbidden" => sub {
+        {
+            my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+            like $headers, qr{^HTTP/1\.1 200 }s, "status";
+        }
+        {
+            my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+            like $headers, qr{^HTTP/1\.1 403 }s, "status";
+            is $body, "Forbidden", "content";
+        }
+    };
+};
+
+subtest "fallthrough callback" => sub {
+    my $server = spawn_h2o(<< 'EOT');
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          require "share/h2o/mruby/dos_detector.rb"
+          DoSDetector.new({
+            :strategy => DoSDetector::CountingStrategy.new({ :period => 1000, :threshold => 2, :ban_period => 1 << 32 }),
+            :callback => DoSDetector.fallthrough_callback,
+          })
+        mruby.handler:
+          Proc.new do |env|
+            [200, {}, ["DOS_COUNT is ", env["DOS_COUNT"], ", DOS_IP is ", env["DOS_IP"]]]
+          end
+EOT
+    subtest "success" => sub {
+        {
+            my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+            like $headers, qr{^HTTP/1\.1 200 }s, "status";
+        }
+        {
+            my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+            like $headers, qr{^HTTP/1\.1 200 }s, "status";
+            is $body, "DOS_COUNT is 2, DOS_IP is 127.0.0.1", "content";
+        }
+    };
+};
+
+subtest "customized callback" => sub {
+    my $server = spawn_h2o(<< 'EOT');
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          require "share/h2o/mruby/dos_detector.rb"
+          DoSDetector.new({
+            :strategy => DoSDetector::CountingStrategy.new({ :period => 1000, :threshold => 2, :ban_period => 1 << 32 }),
+            :callback => Proc.new do |vars|
+              [503, {}, ["Service Unavailable"]]
+            end
+          })
+        mruby.handler:
+          Proc.new do |env|
+            [200, {}, []]
+          end
+EOT
+    subtest "success" => sub {
+        {
+            my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+            like $headers, qr{^HTTP/1\.1 200 }s, "status";
+        }
+        {
+            my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+            like $headers, qr{^HTTP/1\.1 503 }s, "status";
+            is $body, "Service Unavailable", "content";
+        }
+    };
+};
+
+done_testing();

--- a/t/50mruby-dos-detector.t
+++ b/t/50mruby-dos-detector.t
@@ -82,7 +82,7 @@ hosts:
           require "share/h2o/mruby/dos_detector.rb"
           DoSDetector.new({
             :strategy => DoSDetector::CountingStrategy.new({ :period => 1000, :threshold => 2, :ban_period => 1 << 32 }),
-            :callback => Proc.new do |detected, ip|
+            :callback => Proc.new do |env, detected, ip|
               if detected
                 [503, {}, ["Service Unavailable"]]
               else

--- a/t/50mruby-dos-detector.t
+++ b/t/50mruby-dos-detector.t
@@ -82,8 +82,12 @@ hosts:
           require "share/h2o/mruby/dos_detector.rb"
           DoSDetector.new({
             :strategy => DoSDetector::CountingStrategy.new({ :period => 1000, :threshold => 2, :ban_period => 1 << 32 }),
-            :callback => Proc.new do |vars|
-              [503, {}, ["Service Unavailable"]]
+            :callback => Proc.new do |detected, ip|
+              if detected
+                [503, {}, ["Service Unavailable"]]
+              else
+                [399, {}, []]
+              end
             end
           })
         mruby.handler:


### PR DESCRIPTION
This adds a mruby handler for DoS attack detection.

The default detecting strategy is simply counting requests, based on the following:
* https://github.com/stanaka/mod_dosdetector
* https://github.com/matsumoto-r/http-dos-detector

but the behavior can be changed by setting parameters, or creating new strategies.