### PR TITLE
Additional stats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ INCLUDE_DIRECTORIES(
     deps/cloexec
     deps/brotli/enc
     deps/golombset
+    deps/libgkc
     deps/libyrmcds
     deps/klib
     deps/neverbleed
@@ -195,6 +196,7 @@ SET(BROTLI_SOURCE_FILES
 
 SET(LIB_SOURCE_FILES
     deps/cloexec/cloexec.c
+    deps/libgkc/gkc.c
     deps/libyrmcds/close.c
     deps/libyrmcds/connect.c
     deps/libyrmcds/recv.c
@@ -250,6 +252,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/status/events.c
     lib/handler/status/requests.c
     lib/handler/http2_debug_state.c
+    lib/handler/status/durations.c
     lib/handler/configurator/access_log.c
     lib/handler/configurator/compress.c
     lib/handler/configurator/errordoc.c

--- a/deps/libgkc/gkc.c
+++ b/deps/libgkc/gkc.c
@@ -1,0 +1,440 @@
+/*
+ * Copyright (c) 2016 Fastly, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/*
+ * A streaming quantile library.
+ *
+ *
+ * A `gkc_summary` structure is used to summarize observations
+ * within a given error range. Observations are inserted using
+ * `gkc_insert_value`, quantile queries can then be performed with
+ * `gkc_query` against the summary.
+ * Provided two summaries are using the same epsilon, they can be merged
+ * by calling `gkc_combine`.
+ *
+ * The algorithm guaranties a bounded memory usage to:
+ * (11/(2 x epsilon))*log(2 * epsilon * N)
+ *
+ * For epsilon = 0.01 and N = 2^64, this is only 10k max in the
+ * theoritical worse case. In practice, it's reliably using less:
+ * inserting random data gets us * ~100 max insertions for > 50 millions
+ * of entries.
+ *
+ * See www.cis.upenn.edu/~sanjeev/papers/sigmod01_quantiles.pdf for
+ * the paper describing this algorithm and data structure.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+struct list {
+    struct list *prev, *next;
+};
+
+struct gkc_summary {
+    size_t nr_elems;
+    double epsilon;
+    unsigned long alloced;
+    unsigned long max_alloced;
+    struct list head;
+    struct freelist *fl;
+};
+
+
+static inline int list_empty(struct list *l)
+{
+    return l->next == l;
+}
+static inline void list_init(struct list *n)
+{
+    n->next = n;
+    n->prev = n;
+}
+
+static inline void list_del(struct list *n)
+{
+    n->next->prev = n->prev;
+    n->prev->next = n->next;
+}
+
+static inline void list_add(struct list *l, struct list *n)
+{
+    n->next = l->next;
+    n->next->prev = n;
+    l->next = n;
+    n->prev = l;
+}
+
+static inline void list_add_tail(struct list *l, struct list *n)
+{
+    list_add(l->prev, n);
+}
+
+#undef offsetof
+#ifdef __compiler_offsetof
+#define offsetof(TYPE,MEMBER) __compiler_offsetof(TYPE,MEMBER)
+#else
+#define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#endif
+
+#define container_of(ptr, type, member) ({          \
+        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
+        (type *)( (char *)__mptr - offsetof(type,member) );})
+
+struct freelist {
+    struct freelist *next;
+};
+
+static unsigned long ullog2(unsigned long x)
+{
+    static const unsigned long debruijn_magic = 0x022fdd63cc95386d;
+
+    static const unsigned long magic_table[] = {
+        0, 1, 2, 53, 3, 7, 54, 27, 4, 38, 41, 8, 34, 55, 48, 28,
+        62, 5, 39, 46, 44, 42, 22, 9, 24, 35, 59, 56, 49, 18, 29, 11,
+        63, 52, 6, 26, 37, 40, 33, 47, 61, 45, 43, 21, 23, 58, 17, 10,
+        51, 25, 36, 32, 60, 20, 57, 16, 50, 31, 19, 15, 30, 14, 13, 12,
+    };
+
+    x |= (x >> 1);
+    x |= (x >> 2);
+    x |= (x >> 4);
+    x |= (x >> 8);
+    x |= (x >> 16);
+    x |= (x >> 32);
+    return (magic_table[((x & ~(x>>1))*debruijn_magic)>>58]);
+}
+
+struct gkc_tuple {
+    unsigned long value;
+    double g;
+    unsigned long delta;
+    struct list node;
+};
+#define list_to_tuple(ln) (container_of((ln), struct gkc_tuple, node))
+
+
+void gkc_summary_init(struct gkc_summary *s, double epsilon)
+{
+    list_init(&s->head);
+    s->epsilon = epsilon;
+}
+
+struct gkc_summary *gkc_summary_alloc(double epsilon)
+{
+    struct gkc_summary *s;
+    s = calloc(1, sizeof(*s));
+    gkc_summary_init(s, epsilon);
+    return s;
+}
+
+#include <assert.h>
+/* debug only, checks a number of properties that s must satisfy at all times */
+void gkc_sanity_check(struct gkc_summary *s)
+{
+    unsigned long nr_elems, nr_alloced;
+    struct list *cur;
+    struct gkc_tuple *tcur;
+
+    nr_elems = 0;
+    nr_alloced = 0;
+    cur = s->head.next;
+    while (cur != &s->head) {
+        tcur = list_to_tuple(cur);
+        cur = cur->next;
+        nr_elems += tcur->g;
+        nr_alloced++;
+        if (s->nr_elems > (1/s->epsilon)) {
+            /* there must be enough observations for this to become true */
+            assert(tcur->g + tcur->delta <= (s->nr_elems * s->epsilon * 2));
+        }
+        assert(nr_alloced <= s->alloced);
+    }
+    assert(nr_elems == s->nr_elems);
+    assert(nr_alloced == s->alloced);
+}
+
+static struct gkc_tuple *gkc_alloc(struct gkc_summary *s)
+{
+    s->alloced++;
+    if (s->alloced > s->max_alloced) {
+        s->max_alloced = s->alloced;
+    }
+
+    if (s->fl) {
+        void *ret;
+        ret = s->fl;
+        s->fl = s->fl->next;
+        return ret;
+    }
+    return malloc(sizeof(struct gkc_tuple));
+}
+
+static void gkc_free(struct gkc_summary *s, struct gkc_tuple *p)
+{
+    struct freelist *flp = (void *)p;
+    s->alloced--;
+
+    flp->next = s->fl;
+    s->fl = flp;
+}
+
+void gkc_summary_free(struct gkc_summary *s)
+{
+    struct freelist *fl;
+    struct list *cur;
+
+    cur = s->head.next;
+    while (cur != &s->head) {
+        struct list *next;
+        next = cur->next;
+        gkc_free(s, list_to_tuple(cur));
+        cur = next;
+    }
+    fl = s->fl;
+    while (fl) {
+        void *p;
+        p = fl;
+        fl = fl->next;
+        free(p);
+    }
+    free(s);
+}
+
+unsigned long gkc_query(struct gkc_summary *s, double q)
+{
+    struct list *cur, *next;
+    int rank;
+    double gi;
+    double ne;
+
+    rank = 0.5 + q * s->nr_elems;
+    ne = s->nr_elems * s->epsilon;
+    gi = 0;
+    if (list_empty(&s->head)) {
+        return 0;
+    }
+
+    cur = s->head.next;
+
+    while (1) {
+        struct gkc_tuple *tcur, *tnext;
+
+        tcur = list_to_tuple(cur);
+        next = cur->next;
+        if (next == &s->head) {
+            return tcur->value;
+        }
+        tnext = list_to_tuple(next);
+
+        gi += tcur->g;
+        if ((rank + ne) < (gi + tnext->g + tnext->delta)) {
+            if ((rank + ne) < (gi + tnext->g)) {
+                return tcur->value;
+            }
+            return tnext->value;
+        }
+        cur = next;
+    }
+}
+
+static unsigned long band(struct gkc_summary *s, unsigned long delta)
+{
+    unsigned long diff;
+
+    diff = 1 + (s->epsilon * s->nr_elems * 2) - delta;
+
+    if (diff == 1) {
+        return 0;
+    } else {
+        return ullog2(diff)/ullog2(2);
+    }
+}
+
+static void gkc_compress(struct gkc_summary *s)
+{
+    int max_compress;
+    struct list *cur, *prev;
+    struct gkc_tuple *tcur, *tprev;
+    unsigned long bi, b_plus_1;
+
+    max_compress = 2 * s->epsilon * s->nr_elems;
+    if (s->nr_elems < 2) {
+        return;
+    }
+
+    prev = s->head.prev;
+    cur = prev->prev;
+
+    while (cur != &s->head) {
+        tcur = list_to_tuple(cur);
+        tprev = list_to_tuple(prev);
+
+        b_plus_1 = band(s, tprev->delta);
+        bi = band(s, tcur->delta);
+
+        if (bi <= b_plus_1 && ((tcur->g + tprev->g + tprev->delta) <= max_compress)) {
+            tprev->g += tcur->g;
+            list_del(cur);
+            gkc_free(s, tcur);
+            cur = prev->prev;
+            continue;
+        }
+        prev = cur;
+        cur = cur->prev;
+    }
+}
+
+void gkc_insert_value(struct gkc_summary *s, double value)
+{
+    struct list *cur = NULL;
+    struct gkc_tuple *new, *tcur, *tnext = NULL;
+
+    new = gkc_alloc(s);
+    memset(new, 0, sizeof(*new));
+    new->value = value;
+    new->g = 1;
+    list_init(&new->node);
+
+
+    s->nr_elems++;
+
+
+    /* first insert */
+    if (list_empty(&s->head)) {
+        list_add(&s->head, &new->node);
+        return;
+    }
+
+    cur = s->head.next;
+    tcur = list_to_tuple(cur);
+    /* v < v0, new min */
+    if (tcur->value > new->value) {
+        list_add(&s->head, &new->node);
+        goto out;
+    }
+
+    double gi = 0;
+    while (cur->next != &s->head) {
+        tnext = list_to_tuple(cur->next);
+        tcur = list_to_tuple(cur);
+
+        gi += tcur->g;
+        if (tcur->value <= new->value && new->value < tnext->value) {
+            /*     INSERT "(v, 1, Δ)" into S between vi and vi+1; */
+            new->delta = tcur->g + tcur->delta - 1;
+            list_add(cur, &new->node);
+            goto out;
+        }
+        cur = cur->next;
+    }
+    /* v > vs-1, new max */
+    list_add_tail(&s->head, &new->node);
+out:
+    if (s->nr_elems % (int)(1/(2*s->epsilon))) {
+        gkc_compress(s);
+    }
+}
+
+void gkc_print_summary(struct gkc_summary *s)
+{
+    struct gkc_tuple *tcur;
+    struct list *cur;
+
+    fprintf(stderr, "nr_elems: %lu, epsilon: %.02f, alloced: %lu, overfilled: %.02f, max_alloced: %lu\n",
+            s->nr_elems, s->epsilon, s->alloced, 2 * s->epsilon * s->nr_elems, s->max_alloced);
+    if (list_empty(&s->head)) {
+        fprintf(stderr, "Empty summary\n");
+        return;
+    }
+
+    cur = s->head.next;
+    while (cur != &s->head) {
+        tcur = list_to_tuple(cur);
+        fprintf(stderr, "(v: %lu, g: %.02f, d: %lu) ", tcur->value, tcur->g, tcur->delta);
+        cur = cur->next;
+    }
+    fprintf(stderr, "\n");
+}
+
+struct gkc_summary *gkc_combine(struct gkc_summary *s1, struct gkc_summary *s2)
+{
+    struct gkc_summary *snew;
+    struct list *cur1, *cur2;
+    struct gkc_tuple *tcur1, *tcur2, *tnew;
+
+    if (s1->epsilon != s2->epsilon) {
+        return NULL;
+    }
+    snew = gkc_summary_alloc(s1->epsilon);
+
+    cur1 = s1->head.next;
+    cur2 = s2->head.next;
+    while (cur1 != &s1->head && cur2 != &s2->head) {
+        tcur1 = list_to_tuple(cur1);
+        tcur2 = list_to_tuple(cur2);
+
+        tnew = gkc_alloc(snew);
+        if (tcur1->value < tcur2->value) {
+            tnew->value = tcur1->value;
+            tnew->g = tcur1->g;
+            tnew->delta = tcur1->delta;
+            cur1 = cur1->next;
+        } else {
+            tnew->value = tcur2->value;
+            tnew->g = tcur2->g;
+            tnew->delta = tcur2->delta;
+            cur2 = cur2->next;
+        }
+        list_add_tail(&snew->head, &tnew->node);
+        snew->nr_elems += tnew->g;
+    }
+    while (cur1 != &s1->head) {
+        tcur1 = list_to_tuple(cur1);
+
+        tnew = gkc_alloc(snew);
+        tnew->value = tcur1->value;
+        tnew->g = tcur1->g;
+        tnew->delta = tcur1->delta;
+        list_add_tail(&snew->head, &tnew->node);
+        snew->nr_elems += tnew->g;
+        cur1 = cur1->next;
+    }
+    while (cur2 != &s2->head) {
+        tcur2 = list_to_tuple(cur2);
+
+        tnew = gkc_alloc(snew);
+        tnew->value = tcur2->value;
+        tnew->g = tcur2->g;
+        tnew->delta = tcur2->delta;
+        list_add_tail(&snew->head, &tnew->node);
+        snew->nr_elems += tnew->g;
+        cur2 = cur2->next;
+    }
+    snew->max_alloced = snew->alloced;
+    gkc_compress(snew);
+
+    return snew;
+}

--- a/deps/libgkc/gkc.h
+++ b/deps/libgkc/gkc.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016 Fastly, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef __GKC_H__
+#define __GKC_H__
+
+struct gkc_summary;
+
+void gkc_print_summary(struct gkc_summary *s);
+void gkc_insert_value(struct gkc_summary *s, double value);
+unsigned long gkc_query(struct gkc_summary *s, double q);
+void gkc_summary_free(struct gkc_summary *s);
+struct gkc_summary *gkc_summary_alloc(double epsilon);
+void gkc_summary_init(struct gkc_summary *s, double epsilon);
+void gkc_sanity_check(struct gkc_summary *s);
+struct gkc_summary *gkc_combine(struct gkc_summary *s1, struct gkc_summary *s2);
+
+#endif /* __GKC_H__ */

--- a/deps/libgkc/test.c
+++ b/deps/libgkc/test.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2016 Fastly, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "gkc.h"
+
+void print_query(struct gkc_summary *s, double q)
+{
+	double v = gkc_query(s, q);
+	fprintf(stderr, "queried: %.02f, found: %.02f\n", q, v);
+}
+
+int main(void)
+{
+#define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
+	unsigned int i;
+#if 0
+	double input[] = {
+		3658, 3673, 3693, 3715, 3723, 3724, 3724, 3690, 3695, 3689, 3695, 3700,
+		3690, 3699, 3699, 3701, 3704, 3704, 3714, 3707, 3698, 3701, 3697, 3697,
+		3712, 3713, 3714, 3715, 3717, 3712, 3712, 3717, 3728, 3728, 3744, 3751,
+		3764, 3751, 3798, 3802, 3800, 3824, 3810, 3824, 3811, 3802, 3811, 3801,
+		3791, 3796, 3803, 3817, 3819, 3818, 3815, 3804, 3796, 3784, 3783, 3784,
+		3774, 3776, 3776, 3764, 3763, 3806, 3819, 3835, 3825, 3786, 3795, 3795,
+		3776, 3760, 3789, 3786, 3771, 3778, 3782, 3776, 3781, 3784, 3801, 3810,
+		3815, 3792, 3764, 3770, 3746, 3741, 3746, 3756, 3755, 3775, 3776, 3773,
+		3777, 3801, 3804, 3807
+	};
+#else
+	double input[] = { 12, 6, 10, 1 };
+#endif
+	FILE *out;
+	struct gkc_summary *summary;
+	struct gkc_summary *s1, *s2, *snew;
+
+	summary = gkc_summary_alloc(0.01);
+	print_query(summary, 0.1);
+	goto test_combine;
+	summary = gkc_summary_alloc(0.01);
+
+#if 0
+	for (i = 0; i < ARRAY_SIZE(input); i++) {
+		gkc_insert_value(&summary, input[i]);
+	}
+	gkc_print_summary(&summary);
+	print_query(&summary, 0);
+	print_query(&summary, .25);
+	print_query(&summary, .5);
+	print_query(&summary, .75);
+	print_query(&summary, 1);
+	return 0;
+#else
+	(void)input;
+#endif
+
+#define tofile 0
+	if (tofile) {
+		out = fopen("data", "w+");
+	}
+	srandom(time(NULL));
+	for (i = 0; i < 10 * 1000 * 1000; i++) {
+		long r = random() % 10000;
+		gkc_insert_value(summary, r);
+		if (tofile) {
+			fprintf(out, "%ld\n", r);
+		}
+	}
+	if (tofile) {
+		fclose(out);
+	}
+	gkc_print_summary(summary);
+	print_query(summary, .02);
+	print_query(summary, .1);
+	print_query(summary, .25);
+	print_query(summary, .5);
+	print_query(summary, .75);
+	print_query(summary, .82);
+	print_query(summary, .88);
+	print_query(summary, .86);
+	print_query(summary, .99);
+
+	gkc_sanity_check(summary);
+
+	gkc_summary_free(summary);
+
+test_combine:
+	s1 = gkc_summary_alloc(0.01);
+	s2 = gkc_summary_alloc(0.01);
+
+	for (i = 0; i < 1 * 10 * 1000; i++) {
+		long r = random() % 10000;
+		gkc_insert_value(s1, r);
+	}
+#if 0
+	for (i = 0; i < 1 * 1 * 1000; i++) {
+		gkc_insert_value(s2, 111);
+	}
+#endif
+	snew = gkc_combine(s1, s2);
+	gkc_summary_free(s1);
+	gkc_summary_free(s2);
+
+	gkc_print_summary(snew);
+	print_query(snew, .02);
+	print_query(snew, .1);
+	print_query(snew, .25);
+	print_query(snew, .5);
+	print_query(snew, .75);
+	print_query(snew, .82);
+	print_query(snew, .88);
+	print_query(snew, .86);
+	print_query(snew, .99);
+
+	gkc_sanity_check(snew);
+
+	gkc_summary_free(snew);
+
+	return 0;
+}

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1962,28 +1962,14 @@ static inline void h2o_doublebuffer_consume(h2o_doublebuffer_t *db)
 }
 
 #define COMPUTE_DURATION(name, from, until) \
-        static inline int h2o_time_compute_##name##_sec_usec(struct st_h2o_req_t *req, int32_t *delta_sec, int32_t *delta_usec) \
+        static inline int h2o_time_compute_##name(struct st_h2o_req_t *req, int64_t *delta_usec) \
         { \
             if (h2o_timeval_is_null((from)) || h2o_timeval_is_null((until))) { \
                 return 0; \
             } \
-            *delta_sec = (int32_t)(until)->tv_sec - (int32_t)(from)->tv_sec; \
-            *delta_usec = (int32_t)(until)->tv_usec - (int32_t)(from)->tv_usec; \
-            if (*delta_usec < 0) { \
-                *delta_sec -= 1; \
-                *delta_usec += 1000000; \
-            } \
+            *delta_usec = h2o_timeval_subtract((from), (until)); \
             return 1; \
-        } \
-        static inline int64_t h2o_time_compute_##name##_usec(struct st_h2o_req_t *req, int *okp) \
-        { \
-            if (h2o_timeval_is_null((from)) || h2o_timeval_is_null((until))) { \
-                *okp = 0; \
-                return 0; \
-            } \
-            *okp = 1; \
-            return h2o_timeval_subtract((from), (until)); \
-        } \
+        }
 
  COMPUTE_DURATION(connect_time, &req->conn->connected_at, &req->timestamps.request_begin_at);
  COMPUTE_DURATION(header_time, &req->timestamps.request_begin_at, h2o_timeval_is_null(&req->timestamps.request_body_begin_at)

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1761,6 +1761,10 @@ void h2o_reproxy_register_configurator(h2o_globalconf_t *conf);
  */
 void h2o_status_register(h2o_pathconf_t *pathconf);
 /**
+ * registers the duration handler
+ */
+void h2o_duration_stats_register(h2o_globalconf_t *conf);
+/**
  * registers the configurator
  */
 void h2o_status_register_configurator(h2o_globalconf_t *conf);
@@ -1915,6 +1919,11 @@ inline void **h2o_context_get_storage(h2o_context_t *ctx, size_t *key, void (*di
 
     ctx->storage.entries[*key].dispose = dispose_cb;
     return &ctx->storage.entries[*key].data;
+}
+
+static inline void h2o_context_set_logger_context(h2o_context_t *ctx, h2o_logger_t *logger, void *logger_ctx)
+{
+    ctx->_module_configs[logger->_config_slot] = logger_ctx;
 }
 
 static inline void h2o_doublebuffer_init(h2o_doublebuffer_t *db, h2o_buffer_prototype_t *prototype)

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1982,7 +1982,7 @@ static inline void h2o_doublebuffer_consume(h2o_doublebuffer_t *db)
                 return 0; \
             } \
             *okp = 1; \
-            return h2o_timeval_substract((from), (until)); \
+            return h2o_timeval_subtract((from), (until)); \
         } \
 
  COMPUTE_DURATION(connect_time, &req->conn->connected_at, &req->timestamps.request_begin_at);

--- a/include/h2o/time_.h
+++ b/include/h2o/time_.h
@@ -23,6 +23,7 @@
 #define h2o__time_h
 
 #include <time.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,6 +44,20 @@ int h2o_time_parse_rfc1123(const char *s, size_t len, struct tm *tm);
  * builds an Apache log-style date string
  */
 void h2o_time2str_log(char *buf, time_t time);
+
+static inline int64_t h2o_timeval_substract(struct timeval *from, struct timeval *until)
+{
+    int32_t delta_sec = (int32_t)until->tv_sec - (int32_t)from->tv_sec;
+    int32_t delta_usec = (int32_t)until->tv_usec - (int32_t)from->tv_usec;
+    int64_t delta = (int64_t)((int64_t)delta_sec * 1000*1000L) + delta_usec;
+
+    return delta;
+}
+
+static inline int h2o_timeval_is_null(struct timeval *tv)
+{
+        return tv->tv_sec == 0;
+}
 
 #ifdef __cplusplus
 }

--- a/include/h2o/time_.h
+++ b/include/h2o/time_.h
@@ -59,6 +59,7 @@ static inline int h2o_timeval_is_null(struct timeval *tv)
         return tv->tv_sec == 0;
 }
 
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/h2o/time_.h
+++ b/include/h2o/time_.h
@@ -45,7 +45,7 @@ int h2o_time_parse_rfc1123(const char *s, size_t len, struct tm *tm);
  */
 void h2o_time2str_log(char *buf, time_t time);
 
-static inline int64_t h2o_timeval_substract(struct timeval *from, struct timeval *until)
+static inline int64_t h2o_timeval_subtract(struct timeval *from, struct timeval *until)
 {
     int32_t delta_sec = (int32_t)until->tv_sec - (int32_t)from->tv_sec;
     int32_t delta_usec = (int32_t)until->tv_usec - (int32_t)from->tv_usec;

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -218,7 +218,7 @@ int h2o_configurator_apply_commands(h2o_configurator_context_t *ctx, yoml_t *nod
             goto Exit;
     }
 
-    /* call on_enter of every configurator */
+    /* call on_exit of every configurator */
     if (setup_configurators(ctx, 0, node) != 0)
         goto Exit;
 

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -357,10 +357,12 @@ Fail:
 
 #define APPEND_DURATION(pos, name) \
     do { \
-        int32_t delta_sec, delta_usec; \
-        if (!h2o_time_compute_##name##_sec_usec(req, &delta_sec, &delta_usec)) { \
+        int64_t delta_usec; \
+        if (!h2o_time_compute_##name(req, &delta_usec)) { \
             *pos++ = '-'; \
         } else { \
+            int32_t delta_sec = delta_usec / (1000*1000); \
+            delta_usec -= ((int64_t)delta_sec * (1000 * 1000)); \
             pos += sprintf(pos, "%" PRId32, delta_sec); \
             if (delta_usec != 0) { \
                 int i; \

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -353,16 +353,11 @@ Fail:
     return pos;
 }
 
-static inline int timeval_is_null(struct timeval *tv)
-{
-    return tv->tv_sec == 0;
-}
-
 #define DURATION_MAX_LEN (sizeof(H2O_INT32_LONGEST_STR ".999999") - 1)
 
 static char *append_duration(char *pos, struct timeval *from, struct timeval *until)
 {
-    if (timeval_is_null(from) || timeval_is_null(until)) {
+    if (h2o_timeval_is_null(from) || h2o_timeval_is_null(until)) {
         *pos++ = '-';
     } else {
         int32_t delta_sec = (int32_t)until->tv_sec - (int32_t)from->tv_sec;
@@ -490,7 +485,7 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             pos += sprintf(pos, "%" PRId32, (int32_t)req->res.status);
             break;
         case ELEMENT_TYPE_TIMESTAMP: /* %t */
-            if (timeval_is_null(&req->processed_at.at))
+            if (h2o_timeval_is_null(&req->processed_at.at))
                 goto EmitDash;
             RESERVE(H2O_TIMESTR_LOG_LEN + 2);
             *pos++ = '[';
@@ -498,7 +493,7 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             *pos++ = ']';
             break;
         case ELEMENT_TYPE_TIMESTAMP_STRFTIME: /* %{...}t */
-            if (timeval_is_null(&req->processed_at.at))
+            if (h2o_timeval_is_null(&req->processed_at.at))
                 goto EmitDash;
             {
                 size_t bufsz, len;
@@ -513,33 +508,33 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             }
             break;
         case ELEMENT_TYPE_TIMESTAMP_SEC_SINCE_EPOCH: /* %{sec}t */
-            if (timeval_is_null(&req->processed_at.at))
+            if (h2o_timeval_is_null(&req->processed_at.at))
                 goto EmitDash;
             RESERVE(sizeof(H2O_UINT32_LONGEST_STR) - 1);
             pos += sprintf(pos, "%" PRIu32, (uint32_t)req->processed_at.at.tv_sec);
             break;
         case ELEMENT_TYPE_TIMESTAMP_MSEC_SINCE_EPOCH: /* %{msec}t */
-            if (timeval_is_null(&req->processed_at.at))
+            if (h2o_timeval_is_null(&req->processed_at.at))
                 goto EmitDash;
             RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
             pos += sprintf(pos, "%" PRIu64,
                            (uint64_t)req->processed_at.at.tv_sec * 1000 + (uint64_t)req->processed_at.at.tv_usec / 1000);
             break;
         case ELEMENT_TYPE_TIMESTAMP_USEC_SINCE_EPOCH: /* %{usec}t */
-            if (timeval_is_null(&req->processed_at.at))
+            if (h2o_timeval_is_null(&req->processed_at.at))
                 goto EmitDash;
             RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
             pos +=
                 sprintf(pos, "%" PRIu64, (uint64_t)req->processed_at.at.tv_sec * 1000000 + (uint64_t)req->processed_at.at.tv_usec);
             break;
         case ELEMENT_TYPE_TIMESTAMP_MSEC_FRAC: /* %{msec_frac}t */
-            if (timeval_is_null(&req->processed_at.at))
+            if (h2o_timeval_is_null(&req->processed_at.at))
                 goto EmitDash;
             RESERVE(3);
             pos += sprintf(pos, "%03u", (unsigned)(req->processed_at.at.tv_usec / 1000));
             break;
         case ELEMENT_TYPE_TIMESTAMP_USEC_FRAC: /* %{usec_frac}t */
-            if (timeval_is_null(&req->processed_at.at))
+            if (h2o_timeval_is_null(&req->processed_at.at))
                 goto EmitDash;
             RESERVE(6);
             pos += sprintf(pos, "%06u", (unsigned)req->processed_at.at.tv_usec);
@@ -602,7 +597,7 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
 
         case ELEMENT_TYPE_REQUEST_HEADER_TIME:
             RESERVE(DURATION_MAX_LEN);
-            pos = append_duration(pos, &req->timestamps.request_begin_at, timeval_is_null(&req->timestamps.request_body_begin_at)
+            pos = append_duration(pos, &req->timestamps.request_begin_at, h2o_timeval_is_null(&req->timestamps.request_body_begin_at)
                                                                               ? &req->processed_at.at
                                                                               : &req->timestamps.request_body_begin_at);
             break;

--- a/lib/handler/configurator/status.c
+++ b/lib/handler/configurator/status.c
@@ -35,11 +35,53 @@ static int on_config_status(h2o_configurator_command_t *cmd, h2o_configurator_co
     }
 }
 
+struct st_status_configurator {
+    h2o_configurator_t super;
+    int stack;
+    int duration_stats;
+};
+
+static int on_config_duration_stats(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct st_status_configurator *c = (void *)cmd->configurator;
+    int ret;
+    switch (ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON")) {
+    case 0: /* OFF */
+    case 1: /* ON */
+        c->duration_stats = ret;
+        return 0;
+    default: /* error */
+        return -1;
+    }
+}
+
+int on_enter_status(h2o_configurator_t *_conf, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct st_status_configurator *c= (void *)_conf;
+    c->stack++;
+    return 0;
+}
+
+int on_exit_status(h2o_configurator_t *_conf, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct st_status_configurator *c= (void *)_conf;
+    c->stack--;
+    if (!c->stack && c->duration_stats) {
+        h2o_duration_stats_register(ctx->globalconf);
+    }
+    return 0;
+}
+
 void h2o_status_register_configurator(h2o_globalconf_t *conf)
 {
-    h2o_configurator_t *c = h2o_configurator_create(conf, sizeof(*c));
+    struct st_status_configurator *c = (void *)h2o_configurator_create(conf, sizeof(*c));
+    c->super.enter = on_enter_status;
+    c->super.exit = on_exit_status;
 
-    h2o_configurator_define_command(c, "status", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_DEFERRED |
+    h2o_configurator_define_command(&c->super, "status", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_DEFERRED |
                                                      H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_status);
+
+    h2o_configurator_define_command(&c->super, "duration-stats", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_duration_stats);
 }

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -23,6 +23,7 @@
 
 extern h2o_status_handler_t events_status_handler;
 extern h2o_status_handler_t requests_status_handler;
+extern h2o_status_handler_t durations_status_handler;
 
 struct st_h2o_status_logger_t {
     h2o_logger_t super;
@@ -264,4 +265,5 @@ void h2o_status_register(h2o_pathconf_t *conf)
     self->super.on_req = on_req;
     h2o_config_register_status_handler(conf->global, requests_status_handler);
     h2o_config_register_status_handler(conf->global, events_status_handler);
+    h2o_config_register_status_handler(conf->global, durations_status_handler);
 }

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -141,20 +141,6 @@ static h2o_iovec_t durations_status_final(void *priv, h2o_globalconf_t *gconf, h
     return ret;
 }
 
-static int64_t diff_timeval(struct timeval *from, struct timeval *until)
-{
-    int32_t delta_sec = (int32_t)until->tv_sec - (int32_t)from->tv_sec;
-    int32_t delta_usec = (int32_t)until->tv_usec - (int32_t)from->tv_usec;
-    int64_t delta = (int64_t)(delta_sec * 1000*1000L) + delta_usec;
-
-    return delta;
-}
-
-static inline int timeval_is_null(struct timeval *tv)
-{
-        return tv->tv_sec == 0;
-}
-
 static void stat_access(h2o_logger_t *_self, h2o_req_t *req)
 {
     struct st_duration_stats_t *ctx_stats = h2o_context_get_logger_context(req->conn->ctx, _self);
@@ -168,15 +154,15 @@ static void stat_access(h2o_logger_t *_self, h2o_req_t *req)
         if (!((until)->tv_sec + (until)->tv_usec)) { \
             break; \
         } \
-        int64_t dur = diff_timeval((from), (until)); \
+        int64_t dur = h2o_timeval_substract((from), (until)); \
         gkc_insert_value(ctx_stats->x, dur); \
     } while(0)
 
     ADD_OBSERVATION(connect_time, &req->conn->connected_at, &req->timestamps.request_begin_at);
-    ADD_OBSERVATION(header_time, &req->timestamps.request_begin_at, timeval_is_null(&req->timestamps.request_body_begin_at)
+    ADD_OBSERVATION(header_time, &req->timestamps.request_begin_at, h2o_timeval_is_null(&req->timestamps.request_body_begin_at)
             ? &req->processed_at.at
             : &req->timestamps.request_body_begin_at);
-    ADD_OBSERVATION(body_time, timeval_is_null(&req->timestamps.request_body_begin_at)
+    ADD_OBSERVATION(body_time, h2o_timeval_is_null(&req->timestamps.request_body_begin_at)
             ? &req->processed_at.at
             : &req->timestamps.request_body_begin_at, &req->processed_at.at);
     ADD_OBSERVATION(request_total_time, &req->timestamps.request_begin_at, &req->processed_at.at);

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2016 Fastly
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "h2o.h"
+#include "gkc.h"
+#include <inttypes.h>
+#include <pthread.h>
+
+#define GK_EPSILON 0.01
+
+struct st_duration_stats_t {
+    struct gkc_summary *connect_time;
+    struct gkc_summary *header_time;
+    struct gkc_summary *body_time;
+    struct gkc_summary *request_total_time;
+    struct gkc_summary *process_time;
+    struct gkc_summary *response_time;
+    struct gkc_summary *duration;
+};
+
+struct st_duration_agg_stats_t {
+    struct st_duration_stats_t stats;
+    pthread_mutex_t mutex;
+};
+
+static h2o_logger_t *durations_logger;
+static void durations_status_per_thread(void *priv, h2o_context_t *ctx)
+{
+    struct st_duration_agg_stats_t *agg_stats = priv;
+    if (durations_logger) {
+        struct st_duration_stats_t *ctx_stats = h2o_context_get_logger_context(ctx, durations_logger);
+        pthread_mutex_lock(&agg_stats->mutex);
+#define ADD_DURATION(x) do { \
+        struct gkc_summary *tmp; \
+        tmp = gkc_combine(agg_stats->stats.x, ctx_stats->x); \
+        gkc_summary_free(agg_stats->stats.x); \
+        agg_stats->stats.x = tmp; \
+} while(0)
+        ADD_DURATION(connect_time);
+        ADD_DURATION(header_time);
+        ADD_DURATION(body_time);
+        ADD_DURATION(request_total_time);
+        ADD_DURATION(process_time);
+        ADD_DURATION(response_time);
+        ADD_DURATION(duration);
+#undef ADD_DURATION
+        pthread_mutex_unlock(&agg_stats->mutex);
+    }
+}
+
+static void duration_stats_init(struct st_duration_stats_t *stats)
+{
+    stats->connect_time = gkc_summary_alloc(GK_EPSILON);
+    stats->header_time = gkc_summary_alloc(GK_EPSILON);
+    stats->body_time = gkc_summary_alloc(GK_EPSILON);
+    stats->request_total_time = gkc_summary_alloc(GK_EPSILON);
+    stats->process_time = gkc_summary_alloc(GK_EPSILON);
+    stats->response_time = gkc_summary_alloc(GK_EPSILON);
+    stats->duration = gkc_summary_alloc(GK_EPSILON);
+}
+
+static void *durations_status_init(void)
+{
+    struct st_duration_agg_stats_t *agg_stats;
+
+    agg_stats = h2o_mem_alloc(sizeof(*agg_stats));
+
+    duration_stats_init(&agg_stats->stats);
+    pthread_mutex_init(&agg_stats->mutex, NULL);
+
+    return agg_stats;
+}
+
+static void duration_stats_free(struct st_duration_stats_t *stats)
+{
+    gkc_summary_free(stats->connect_time);
+    gkc_summary_free(stats->header_time);
+    gkc_summary_free(stats->body_time);
+    gkc_summary_free(stats->request_total_time);
+    gkc_summary_free(stats->process_time);
+    gkc_summary_free(stats->response_time);
+    gkc_summary_free(stats->duration);
+}
+
+static h2o_iovec_t durations_status_final(void *priv, h2o_globalconf_t *gconf, h2o_req_t *req)
+{
+    struct st_duration_agg_stats_t *agg_stats = priv;
+    h2o_iovec_t ret;
+
+#define BUFSIZE 16384
+    ret.base = h2o_mem_alloc_pool(&req->pool, BUFSIZE);
+    ret.len = snprintf(ret.base, BUFSIZE, ",\n"
+#define DURATION_FMT(x) \
+            " \"" #x "-0\": %" PRIu64 ",\n" \
+            " \"" #x "-25\": %" PRIu64 ",\n" \
+            " \"" #x "-50\": %" PRIu64 ",\n" \
+            " \"" #x "-75\": %" PRIu64 ",\n" \
+            " \"" #x "-99\": %" PRIu64 "\n"
+            DURATION_FMT(connect-time) ","
+            DURATION_FMT(header-time) ","
+            DURATION_FMT(body-time) ","
+            DURATION_FMT(request-total-time) ","
+            DURATION_FMT(process-time) ","
+            DURATION_FMT(response-time) ","
+            DURATION_FMT(duration),
+#undef DURATION_FMT
+#define DURATION_VALS(x) gkc_query(agg_stats->stats.x, 0), gkc_query(agg_stats->stats.x, 0.25), \
+                        gkc_query(agg_stats->stats.x, 0.5), gkc_query(agg_stats->stats.x, 0.75), \
+                        gkc_query(agg_stats->stats.x, 0.99)
+
+                        DURATION_VALS(connect_time), DURATION_VALS(header_time),
+                        DURATION_VALS(body_time), DURATION_VALS(request_total_time),
+                        DURATION_VALS(process_time), DURATION_VALS(response_time),
+                        DURATION_VALS(duration));
+#undef DURATION_VALS
+#undef BUFSIZE
+
+    duration_stats_free(&agg_stats->stats);
+    pthread_mutex_destroy(&agg_stats->mutex);
+
+    free(agg_stats);
+    return ret;
+}
+
+static int64_t diff_timeval(struct timeval *from, struct timeval *until)
+{
+    int32_t delta_sec = (int32_t)until->tv_sec - (int32_t)from->tv_sec;
+    int32_t delta_usec = (int32_t)until->tv_usec - (int32_t)from->tv_usec;
+    int64_t delta = (int64_t)(delta_sec * 1000*1000L) + delta_usec;
+
+    return delta;
+}
+
+static inline int timeval_is_null(struct timeval *tv)
+{
+        return tv->tv_sec == 0;
+}
+
+static void stat_access(h2o_logger_t *_self, h2o_req_t *req)
+{
+    struct st_duration_stats_t *ctx_stats = h2o_context_get_logger_context(req->conn->ctx, _self);
+#define ADD_OBSERVATION(x, from, until) \
+    do { \
+        /* skip zero values: this happens in h2 if a request is reset \
+         * before being sent */ \
+        if (!((from)->tv_sec + (from)->tv_usec)) { \
+            break; \
+        } \
+        if (!((until)->tv_sec + (until)->tv_usec)) { \
+            break; \
+        } \
+        int64_t dur = diff_timeval((from), (until)); \
+        gkc_insert_value(ctx_stats->x, dur); \
+    } while(0)
+
+    ADD_OBSERVATION(connect_time, &req->conn->connected_at, &req->timestamps.request_begin_at);
+    ADD_OBSERVATION(header_time, &req->timestamps.request_begin_at, timeval_is_null(&req->timestamps.request_body_begin_at)
+            ? &req->processed_at.at
+            : &req->timestamps.request_body_begin_at);
+    ADD_OBSERVATION(body_time, timeval_is_null(&req->timestamps.request_body_begin_at)
+            ? &req->processed_at.at
+            : &req->timestamps.request_body_begin_at, &req->processed_at.at);
+    ADD_OBSERVATION(request_total_time, &req->timestamps.request_begin_at, &req->processed_at.at);
+    ADD_OBSERVATION(process_time, &req->processed_at.at, &req->timestamps.response_start_at);
+    ADD_OBSERVATION(response_time, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
+    ADD_OBSERVATION(duration, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
+#undef ADD_OBSERVATION
+}
+
+void on_context_init(struct st_h2o_logger_t *self, h2o_context_t *ctx)
+{
+    struct st_duration_stats_t *duration_stats = h2o_mem_alloc(sizeof(struct st_duration_stats_t));
+    duration_stats_init(duration_stats);
+    h2o_context_set_logger_context(ctx, self, duration_stats);
+}
+
+void on_context_dispose(struct st_h2o_logger_t *self, h2o_context_t *ctx)
+{
+    struct st_duration_stats_t *duration_stats;
+    duration_stats = h2o_context_get_logger_context(ctx, self);
+    duration_stats_free(duration_stats);
+}
+
+void h2o_duration_stats_register(h2o_globalconf_t *conf)
+{
+    int i, k;
+    h2o_logger_t *logger;
+    h2o_hostconf_t *hconf;
+
+    durations_logger = logger = h2o_mem_alloc(sizeof(*logger));
+    memset(logger, 0, sizeof(*logger));
+    logger->_config_slot = conf->_num_config_slots++;
+    logger->log_access = stat_access;
+    logger->on_context_init = on_context_init;
+    logger->on_context_dispose = on_context_dispose;
+
+    for (k = 0; conf->hosts[k]; k++) {
+        hconf = conf->hosts[k];
+        for (i = 0; i < hconf->paths.size; i++) {
+            int j;
+            for (j = 0; j < hconf->paths.entries[i].handlers.size; j++) {
+                h2o_pathconf_t *pathconf = &hconf->paths.entries[i];
+                h2o_vector_reserve(NULL, &pathconf->loggers, pathconf->loggers.size + 1);
+                pathconf->loggers.entries[pathconf->loggers.size++] = (void *)logger;
+            }
+        }
+    }
+}
+
+h2o_status_handler_t durations_status_handler = {
+    {H2O_STRLIT("durations")}, durations_status_init, durations_status_per_thread, durations_status_final,
+};

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -146,9 +146,8 @@ static void stat_access(h2o_logger_t *_self, h2o_req_t *req)
     struct st_duration_stats_t *ctx_stats = h2o_context_get_logger_context(req->conn->ctx, _self);
 #define ADD_OBSERVATION(x, from, until) \
     do { \
-        int ok; \
-        int64_t dur = h2o_time_compute_##x##_usec(req, &ok); \
-        if (ok) { \
+        int64_t dur; \
+        if (h2o_time_compute_##x(req, &dur)) { \
             gkc_insert_value(ctx_stats->x, dur); \
         } \
     } while(0)

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -146,16 +146,11 @@ static void stat_access(h2o_logger_t *_self, h2o_req_t *req)
     struct st_duration_stats_t *ctx_stats = h2o_context_get_logger_context(req->conn->ctx, _self);
 #define ADD_OBSERVATION(x, from, until) \
     do { \
-        /* skip zero values: this happens in h2 if a request is reset \
-         * before being sent */ \
-        if (!((from)->tv_sec + (from)->tv_usec)) { \
-            break; \
+        int ok; \
+        int64_t dur = h2o_time_compute_##x##_usec(req, &ok); \
+        if (ok) { \
+            gkc_insert_value(ctx_stats->x, dur); \
         } \
-        if (!((until)->tv_sec + (until)->tv_usec)) { \
-            break; \
-        } \
-        int64_t dur = h2o_timeval_substract((from), (until)); \
-        gkc_insert_value(ctx_stats->x, dur); \
     } while(0)
 
     ADD_OBSERVATION(connect_time, &req->conn->connected_at, &req->timestamps.request_begin_at);

--- a/src/main.c
+++ b/src/main.c
@@ -139,9 +139,11 @@ static struct {
     volatile sig_atomic_t initialized_threads;
     struct {
         /* unused buffers exist to avoid false sharing of the cache line */
-        char _unused1[32];
-        int _num_connections; /* should use atomic functions to update the value */
-        char _unused2[32];
+        char _unused1_avoir_false_sharing[32];
+        int _num_connections;       /* number of currently handled incoming connections, should use atomic functions to update the value */
+        char _unused2_avoir_false_sharing[32];
+        unsigned long _num_sessions;    /* total number of opened incoming connections, should use atomic functions to update the value */
+        char _unused3_avoir_false_sharing[32];
     } state;
     char *crash_handler;
 } conf = {
@@ -1240,6 +1242,11 @@ static int num_connections(int delta)
     return __sync_fetch_and_add(&conf.state._num_connections, delta);
 }
 
+static unsigned long num_sessions(int delta)
+{
+    return __sync_fetch_and_add(&conf.state._num_sessions, delta);
+}
+
 static void on_socketclose(void *data)
 {
     int prev_num_connections = num_connections(-1);
@@ -1275,6 +1282,7 @@ static void on_accept(h2o_socket_t *listener, const char *err)
             break;
         }
         num_connections(1);
+        num_sessions(1);
 
         sock->on_close.cb = on_socketclose;
         sock->on_close.data = ctx->accept_ctx.ctx;
@@ -1460,13 +1468,67 @@ static int run_using_server_starter(const char *h2o_cmd, const char *config_file
     return EX_CONFIG;
 }
 
+/* make jemalloc linkage optional by marking the functions as 'weak',
+ * since upstream doesn't rely on it. */
+struct extra_status_jemalloc_cb_arg {
+    h2o_iovec_t outbuf;
+    int err;
+    size_t written;
+};
+
+static void extra_status_jemalloc_cb(void *ctx, const char *stats)
+{
+    size_t cur_len;
+    struct extra_status_jemalloc_cb_arg *out = ctx;
+    h2o_iovec_t outbuf = out->outbuf;
+    int i;
+
+    if (out->written >= out->outbuf.len || out->err) {
+        return;
+    }
+    cur_len = out->written;
+
+    i = 0;
+    while(cur_len < outbuf.len && stats[i]) {
+        switch (stats[i]) {
+#define JSON_ESCAPE(x, y)        case x: outbuf.base[cur_len++] = '\\'; if (cur_len >= outbuf.len) { goto err; } outbuf.base[cur_len] = y; break;
+        JSON_ESCAPE('\b', 'b');
+        JSON_ESCAPE('\f', 'f');
+        JSON_ESCAPE('\n', 'n');
+        JSON_ESCAPE('\r', 'r')
+        JSON_ESCAPE('\t', 't');
+        JSON_ESCAPE('/', '/');
+        JSON_ESCAPE('"', '"');
+        JSON_ESCAPE('\\', '\\');
+#undef JSON_ESCAPE
+        default:
+            outbuf.base[cur_len] = stats[i];
+        }
+        i++;
+        cur_len++;
+    }
+    if (cur_len < outbuf.len) {
+        out->written = cur_len;
+        return;
+    }
+
+err:
+    out->err = 1;
+    return;
+}
+
+#ifndef JEMALLOC_STATS
+#define JEMALLOC_STATS 0
+#endif
 static h2o_iovec_t on_extra_status(void *unused, h2o_globalconf_t *_conf, h2o_req_t *req)
 {
-#define BUFSIZE 1024
+#define BUFSIZE (16*1024)
     h2o_iovec_t ret;
+    struct extra_status_jemalloc_cb_arg arg;
     char current_time[H2O_TIMESTR_LOG_LEN + 1], restart_time[H2O_TIMESTR_LOG_LEN + 1];
-    const char *generation;
-    time_t now = time(NULL);
+    const char *generation; time_t now = time(NULL);
+    uint64_t epoch = 1;
+    size_t sz, allocated, active, metadata, resident, mapped;
 
     h2o_time2str_log(current_time, now);
     h2o_time2str_log(restart_time, conf.launch_time);
@@ -1484,13 +1546,69 @@ static h2o_iovec_t on_extra_status(void *unused, h2o_globalconf_t *_conf, h2o_re
                                           " \"connections\": %d,\n"
                                           " \"max-connections\": %d,\n"
                                           " \"listeners\": %zu,\n"
-                                          " \"worker-threads\": %zu",
+                                          " \"worker-threads\": %zu,\n"
+                                          " \"num-sessions\": %" PRIu64,
                        SSLeay_version(SSLEAY_VERSION), current_time, restart_time, (uint64_t)(now - conf.launch_time), generation,
-                       num_connections(0), conf.max_connections, conf.num_listeners, conf.num_threads);
+                       num_connections(0), conf.max_connections, conf.num_listeners, conf.num_threads, num_sessions(0));
     assert(ret.len < BUFSIZE);
 
+    /* no jemalloc stats? return */
+    if (!JEMALLOC_STATS) {
+        return ret;
+    }
+
+    /* internal jemalloc interface */
+    void malloc_stats_print(void (*write_cb) (void *, const char *), void *cbopaque, const char *opts);
+    int mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
+
+    arg.outbuf = h2o_iovec_init(alloca(BUFSIZE - ret.len), BUFSIZE - ret.len);
+    arg.err = 0;
+    arg.written = snprintf(arg.outbuf.base, arg.outbuf.len, ",\n"
+                                                           " \"jemalloc\": {\n"
+                                                           "   \"jemalloc-raw\": \"");
+    malloc_stats_print(extra_status_jemalloc_cb, &arg,
+                       "ga" /* omit general info, only aggregated stats */ );
+
+    if (arg.err || arg.written + 1 >= arg.outbuf.len) {
+        goto jemalloc_err;
+    }
+
+    /* terminate the jemalloc-raw json string */
+    arg.written += snprintf(&arg.outbuf.base[arg.written], arg.outbuf.len - arg.written, "\"");
+    if (arg.written + 1 >= arg.outbuf.len) {
+        goto jemalloc_err;
+    }
+
+    sz = sizeof(epoch);
+    mallctl("epoch", &epoch, &sz, &epoch, sz);
+
+    sz = sizeof(size_t);
+    if (!mallctl("stats.allocated", &allocated, &sz, NULL, 0)
+        && !mallctl("stats.active", &active, &sz, NULL, 0)
+		&& !mallctl("stats.metadata", &metadata, &sz, NULL, 0)
+		&& !mallctl("stats.resident", &resident, &sz, NULL, 0)
+		&& !mallctl("stats.mapped", &mapped, &sz, NULL, 0)) {
+        arg.written += snprintf(&arg.outbuf.base[arg.written], arg.outbuf.len - arg.written, ",\n"
+                                "   \"allocated\": %zu,\n"
+                                "   \"active\": %zu,\n"
+                                "   \"metadata\": %zu,\n"
+                                "   \"resident\": %zu,\n"
+                                "   \"mapped\": %zu }",
+                                allocated, active, metadata, resident, mapped);
+    }
+    if (arg.written + 1 >= arg.outbuf.len) {
+        goto jemalloc_err;
+    }
+
+    strncpy(&ret.base[ret.len], arg.outbuf.base, arg.written);
+    ret.base[ret.len + arg.written] = '\0';
+    ret.len += arg.written;
     return ret;
 #undef BUFSIZE
+jemalloc_err:
+    /* couldn't fit the jemalloc output, exiting */
+    ret.base[ret.len] = '\0';
+    return ret;
 }
 
 static void setup_configurators(void)

--- a/src/main.c
+++ b/src/main.c
@@ -1517,18 +1517,12 @@ err:
     return;
 }
 
-#ifndef JEMALLOC_STATS
-#define JEMALLOC_STATS 0
-#endif
 static h2o_iovec_t on_extra_status(void *unused, h2o_globalconf_t *_conf, h2o_req_t *req)
 {
 #define BUFSIZE (16*1024)
     h2o_iovec_t ret;
-    struct extra_status_jemalloc_cb_arg arg;
     char current_time[H2O_TIMESTR_LOG_LEN + 1], restart_time[H2O_TIMESTR_LOG_LEN + 1];
     const char *generation; time_t now = time(NULL);
-    uint64_t epoch = 1;
-    size_t sz, allocated, active, metadata, resident, mapped;
 
     h2o_time2str_log(current_time, now);
     h2o_time2str_log(restart_time, conf.launch_time);
@@ -1552,59 +1546,64 @@ static h2o_iovec_t on_extra_status(void *unused, h2o_globalconf_t *_conf, h2o_re
                        num_connections(0), conf.max_connections, conf.num_listeners, conf.num_threads, num_sessions(0));
     assert(ret.len < BUFSIZE);
 
-    if (JEMALLOC_STATS) {
-        /* internal jemalloc interface */
-        void malloc_stats_print(void (*write_cb) (void *, const char *), void *cbopaque, const char *opts);
-        int mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
+#if JEMALLOC_STATS == 1
+    struct extra_status_jemalloc_cb_arg arg;
+    size_t sz, allocated, active, metadata, resident, mapped;
+    uint64_t epoch = 1;
+    /* internal jemalloc interface */
+    void malloc_stats_print(void (*write_cb) (void *, const char *), void *cbopaque, const char *opts);
+    int mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
 
-        arg.outbuf = h2o_iovec_init(alloca(BUFSIZE - ret.len), BUFSIZE - ret.len);
-        arg.err = 0;
-        arg.written = snprintf(arg.outbuf.base, arg.outbuf.len, ",\n"
-                " \"jemalloc\": {\n"
-                "   \"jemalloc-raw\": \"");
-        malloc_stats_print(extra_status_jemalloc_cb, &arg,
-                "ga" /* omit general info, only aggregated stats */ );
+    arg.outbuf = h2o_iovec_init(alloca(BUFSIZE - ret.len), BUFSIZE - ret.len);
+    arg.err = 0;
+    arg.written = snprintf(arg.outbuf.base, arg.outbuf.len, ",\n"
+            " \"jemalloc\": {\n"
+            "   \"jemalloc-raw\": \"");
+    malloc_stats_print(extra_status_jemalloc_cb, &arg,
+            "ga" /* omit general info, only aggregated stats */ );
 
-        if (arg.err || arg.written + 1 >= arg.outbuf.len) {
-            goto jemalloc_err;
-        }
-
-        /* terminate the jemalloc-raw json string */
-        arg.written += snprintf(&arg.outbuf.base[arg.written], arg.outbuf.len - arg.written, "\"");
-        if (arg.written + 1 >= arg.outbuf.len) {
-            goto jemalloc_err;
-        }
-
-        sz = sizeof(epoch);
-        mallctl("epoch", &epoch, &sz, &epoch, sz);
-
-        sz = sizeof(size_t);
-        if (!mallctl("stats.allocated", &allocated, &sz, NULL, 0)
-                && !mallctl("stats.active", &active, &sz, NULL, 0)
-                && !mallctl("stats.metadata", &metadata, &sz, NULL, 0)
-                && !mallctl("stats.resident", &resident, &sz, NULL, 0)
-                && !mallctl("stats.mapped", &mapped, &sz, NULL, 0)) {
-            arg.written += snprintf(&arg.outbuf.base[arg.written], arg.outbuf.len - arg.written, ",\n"
-                    "   \"allocated\": %zu,\n"
-                    "   \"active\": %zu,\n"
-                    "   \"metadata\": %zu,\n"
-                    "   \"resident\": %zu,\n"
-                    "   \"mapped\": %zu }",
-                    allocated, active, metadata, resident, mapped);
-        }
-        if (arg.written + 1 >= arg.outbuf.len) {
-            goto jemalloc_err;
-        }
-
-        strncpy(&ret.base[ret.len], arg.outbuf.base, arg.written);
-        ret.base[ret.len + arg.written] = '\0';
-        ret.len += arg.written;
-        return ret;
-#undef BUFSIZE
-jemalloc_err:
-        /* couldn't fit the jemalloc output, exiting */
-        ret.base[ret.len] = '\0';
+    if (arg.err || arg.written + 1 >= arg.outbuf.len) {
+        goto jemalloc_err;
     }
+
+    /* terminate the jemalloc-raw json string */
+    arg.written += snprintf(&arg.outbuf.base[arg.written], arg.outbuf.len - arg.written, "\"");
+    if (arg.written + 1 >= arg.outbuf.len) {
+        goto jemalloc_err;
+    }
+
+    sz = sizeof(epoch);
+    mallctl("epoch", &epoch, &sz, &epoch, sz);
+
+    sz = sizeof(size_t);
+    if (!mallctl("stats.allocated", &allocated, &sz, NULL, 0)
+            && !mallctl("stats.active", &active, &sz, NULL, 0)
+            && !mallctl("stats.metadata", &metadata, &sz, NULL, 0)
+            && !mallctl("stats.resident", &resident, &sz, NULL, 0)
+            && !mallctl("stats.mapped", &mapped, &sz, NULL, 0)) {
+        arg.written += snprintf(&arg.outbuf.base[arg.written], arg.outbuf.len - arg.written, ",\n"
+                "   \"allocated\": %zu,\n"
+                "   \"active\": %zu,\n"
+                "   \"metadata\": %zu,\n"
+                "   \"resident\": %zu,\n"
+                "   \"mapped\": %zu }",
+                allocated, active, metadata, resident, mapped);
+    }
+    if (arg.written + 1 >= arg.outbuf.len) {
+        goto jemalloc_err;
+    }
+
+    strncpy(&ret.base[ret.len], arg.outbuf.base, arg.written);
+    ret.base[ret.len + arg.written] = '\0';
+    ret.len += arg.written;
+    return ret;
+#undef BUFSIZE
+
+jemalloc_err:
+    /* couldn't fit the jemalloc output, exiting */
+    ret.base[ret.len] = '\0';
+
+#endif /* JEMALLOC_STATS == 1 */
 
     return ret;
 }

--- a/t/50status.t
+++ b/t/50status.t
@@ -61,6 +61,28 @@ EOT
     is $jresp->{'status-errors.404'}, 1, "Found the 404 error";
 };
 
+subtest "duration stats" => sub {
+    my $server = spawn_h2o(<< "EOT");
+duration-stats: ON
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[ DOC_ROOT ]}
+      /s:
+        status: ON
+EOT
+
+    my $resp = `curl --silent -o /dev/stderr http://127.0.0.1:$server->{port}/s/json?noreqs 2>&1 > /dev/null`;
+    my $jresp = decode_json("$resp");
+    my @nr_requests = @{ $jresp->{'requests'} };
+    is $jresp->{'connections'}, 1, "One connection";
+    is scalar @nr_requests, 1, "One request";
+    is $jresp->{'status-errors.404'}, 0, "Additional errors";
+    is $jresp->{'connect-time-0'}, 0, "Duration stats";
+};
+
+
 
 
 done_testing();


### PR DESCRIPTION
This commit adds duration and jemalloc statistics, both are optional:
jemalloc is enabled at compile time and the duration statistics are
enabled by a 'duration-stats' configuration keyword.
The commit also adds a total number of connections counter.

Duration statistics build on the existing per request duration stats
that are available for logging, each observation is stored in a
structure that allows computing quantiles. When the status page is
queried, values for the minimal, 25th, 50th, 75th and 99th percentile
are output.