### PR TITLE
fix alpn

### DIFF
--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -456,6 +456,7 @@ h2o_iovec_t h2o_build_destination(h2o_req_t *req, const char *prefix, size_t pre
         H2O_STRLIT(s)                                                                                                              \
     }
 #define ALPN_PROTOCOLS_CORE ALPN_ENTRY("h2"), ALPN_ENTRY("h2-16"), ALPN_ENTRY("h2-14")
+#define ALPN_TERMINATOR ALPN_ENTRY("")
 #define NPN_PROTOCOLS_CORE                                                                                                         \
     "\x02"                                                                                                                         \
     "h2"                                                                                                                           \
@@ -464,10 +465,10 @@ h2o_iovec_t h2o_build_destination(h2o_req_t *req, const char *prefix, size_t pre
     "\x05"                                                                                                                         \
     "h2-14"
 
-static const h2o_iovec_t http2_alpn_protocols[] = {ALPN_PROTOCOLS_CORE};
+static const h2o_iovec_t http2_alpn_protocols[] = {ALPN_PROTOCOLS_CORE, ALPN_TERMINATOR};
 const h2o_iovec_t *h2o_http2_alpn_protocols = http2_alpn_protocols;
 
-static const h2o_iovec_t alpn_protocols[] = {ALPN_PROTOCOLS_CORE, {H2O_STRLIT("http/1.1")}};
+static const h2o_iovec_t alpn_protocols[] = {ALPN_PROTOCOLS_CORE, ALPN_ENTRY("http/1.1"), ALPN_TERMINATOR};
 const h2o_iovec_t *h2o_alpn_protocols = alpn_protocols;
 
 const char *h2o_http2_npn_protocols = NPN_PROTOCOLS_CORE;


### PR DESCRIPTION
I found this problem while running e2e tests in my local environment.
`h2o_alpn_protocols ` may be allocated right after `h2o_http2_alpn_protocols`  in memory (perhaps depends on compiler or environment).
If it happens, this iteration ( https://github.com/h2o/h2o/blob/master/lib/core/util.c#L130 ) reaches to `h2o_alpn_protocols`, which contains `http/1.1`.
As a result, when the client requests via https/1.1 without ALPN negotiation, the server will mistakenly regard it as http/2 request and expect connection preface, and errors happen (close connection).

The following commit causes this problem, what did you intend?
https://github.com/h2o/h2o/commit/9b70b61b0705ccce22a188e65363cdb506285ff1#diff-21c51c8b09f9529919a2ebd1a4f76270L467