### PR TITLE
Fixed bad link in File Directives documentation

### DIFF
--- a/doc/configure/file_directives.html
+++ b/doc/configure/file_directives.html
@@ -395,7 +395,7 @@ For example, if a client requests a file named <code>index.html</code> with <cod
 <dd>
 <p>
 Obsoleted in 2.0.
-Synonym of <a href="configure/file_directives.html#send-compressed"><code>send-compressed</code></a>.
+Synonym of <a href="configure/file_directives.html#file.send-compressed"><code>file.send-compressed</code></a>.
 
 </p>
 

--- a/srcdoc/configure/file_directives.mt
+++ b/srcdoc/configure/file_directives.mt
@@ -227,7 +227,7 @@ $ctx->{directive}->(
     levels   => [ qw(global host path) ],
     desc     => <<'EOT',
 Obsoleted in 2.0.
-Synonym of <a href="configure/file_directives.html#send-compressed"><code>send-compressed</code></a>.
+Synonym of <a href="configure/file_directives.html#file.send-compressed"><code>file.send-compressed</code></a>.
 EOT
 )->(sub {})
 ?>


### PR DESCRIPTION
The `file.send-gzip` documentation contained a (maybe legacy) link to `file_directives.html#send-compressed` which does not exist and was changed to `file_directives.html#file.send-compressed`.

Also, the prefix was added to the link text, as this is common throughout the documentation.