### PR TITLE
use examp1e.net in tests instead of xip.io

### DIFF
--- a/t/50reverse-dont-add-x-forwarded-headers.t
+++ b/t/50reverse-dont-add-x-forwarded-headers.t
@@ -30,7 +30,7 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.url: http://127.0.0.1.XIP.IO:$upstream_port
+        proxy.reverse.url: http://127.0.0.1.examp1e.net:$upstream_port
 EOT
 
     run_with_curl($server, sub {

--- a/t/90live-sni.t
+++ b/t/90live-sni.t
@@ -21,11 +21,11 @@ subtest "basic" => sub {
         my ($port, $tls_port) = @_;
         return << "EOT";
 hosts:
-  "127.0.0.1.xip.io:$tls_port":
+  "127.0.0.1.examp1e.net:$tls_port":
     paths:
       /:
         file.dir: examples/doc_root
-  "alternate.127.0.0.1.xip.io:$tls_port":
+  "alternate.127.0.0.1.examp1e.net:$tls_port":
     listen:
       port: $tls_port
       ssl:
@@ -38,12 +38,12 @@ EOT
     });
 
     do_test(
-        "127.0.0.1.xip.io:$server->{tls_port}",
+        "127.0.0.1.examp1e.net:$server->{tls_port}",
         md5_file("examples/doc_root/index.html"),
     );
 
     do_test(
-        "alternate.127.0.0.1.xip.io:$server->{tls_port}",
+        "alternate.127.0.0.1.examp1e.net:$server->{tls_port}",
         md5_file("examples/doc_root.alternate/index.txt"),
     );
 };
@@ -53,11 +53,11 @@ subtest "wildcard" => sub {
         my ($port, $tls_port) = @_;
         return << "EOT";
 hosts:
-  "127.0.0.1.xip.io:$tls_port":
+  "127.0.0.1.examp1e.net:$tls_port":
     paths:
       /:
         file.dir: examples/doc_root
-  "*.127.0.0.1.xip.io:$tls_port":
+  "*.127.0.0.1.examp1e.net:$tls_port":
     listen:
       port: $tls_port
       ssl:
@@ -70,12 +70,12 @@ EOT
     });
 
     do_test(
-        "127.0.0.1.xip.io:$server->{tls_port}",
+        "127.0.0.1.examp1e.net:$server->{tls_port}",
         md5_file("examples/doc_root/index.html"),
     );
 
     do_test(
-        "alternate.127.0.0.1.xip.io:$server->{tls_port}",
+        "alternate.127.0.0.1.examp1e.net:$server->{tls_port}",
         md5_file("examples/doc_root.alternate/index.txt"),
     );
 };


### PR DESCRIPTION
Tests often failes due to domain name resolution problem, so we should use `examp1e.net`, which we can control, instead of `xip.io`

As I told, please setup so that `alternate.127.0.01.examp1e.net` is resolved to `127.0.0.1` (like xip.io)