### PR TITLE
add custom hosts for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: cpp
 compiler:
   - gcc
 
+addons:
+  hosts:
+    - 127.0.0.1.xip.io
+    - alternate.127.0.0.1.xip.io
+
 before_install:
   # upgrade g++ and libstdc++ to build nghttp2
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
@kazuho instead of https://github.com/h2o/h2o/pull/1027, I tried to use TravisCI's custom hostname feature.
I tried this in my private another repo, and it worked well.