### PR TITLE
add SortIncludes: false

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ IndentWidth: 4
 ColumnLimit: 132
 BreakBeforeBraces: Linux
 AllowShortFunctionsOnASingleLine: None
+SortIncludes: false


### PR DESCRIPTION
Use `SortIncludes: false` to prevent clang-format from sorting the headers (requires clang-format 3.9).