### PR TITLE
Broken http/1.1 chunked body is silently relayed

### DIFF
--- a/deps/picohttpparser/picohttpparser.c
+++ b/deps/picohttpparser/picohttpparser.c
@@ -595,6 +595,11 @@ Exit:
   return ret;
 }
 
+int phr_decoder_in_data(struct phr_chunked_decoder *decoder)
+{
+    return decoder->_state == CHUNKED_IN_CHUNK_DATA;
+}
+
 #undef CHECK_EOF
 #undef EXPECT_CHAR
 #undef ADVANCE_TOKEN

--- a/deps/picohttpparser/picohttpparser.h
+++ b/deps/picohttpparser/picohttpparser.h
@@ -82,6 +82,8 @@ struct phr_chunked_decoder {
 ssize_t phr_decode_chunked(struct phr_chunked_decoder *decoder, char *buf,
                            size_t *bufsz);
 
+int phr_decoder_in_data(struct phr_chunked_decoder *decoder);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -640,7 +640,7 @@ typedef enum h2o_send_state {
 
 typedef h2o_send_state_t (*h2o_ostream_pull_cb)(h2o_generator_t *generator, h2o_req_t *req, h2o_iovec_t *buf);
 
-static inline int h2o_stream_send_state_is_final(h2o_send_state_t s)
+static inline int h2o_send_state_is_in_progress(h2o_send_state_t s)
 {
     return s != H2O_SEND_STATE_IN_PROGRESS;
 }
@@ -1844,7 +1844,7 @@ inline h2o_send_state_t h2o_pull(h2o_req_t *req, h2o_ostream_pull_cb cb, h2o_iov
     assert(req->_generator != NULL);
     send_state = cb(req->_generator, req, buf);
     req->bytes_sent += buf->len;
-    if (h2o_stream_send_state_is_final(send_state))
+    if (!h2o_send_state_is_in_progress(send_state))
         req->_generator = NULL;
     return send_state;
 }

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -642,7 +642,7 @@ typedef h2o_send_state_t (*h2o_ostream_pull_cb)(h2o_generator_t *generator, h2o_
 
 static inline int h2o_send_state_is_in_progress(h2o_send_state_t s)
 {
-    return s != H2O_SEND_STATE_IN_PROGRESS;
+    return s == H2O_SEND_STATE_IN_PROGRESS;
 }
 /**
  * an output stream that may alter the output.

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -179,6 +179,7 @@ struct st_h2o_http2_stream_t {
         h2o_linklist_t link;
         h2o_http2_scheduler_openref_t scheduler;
     } _refs;
+    unsigned send_rst_stream_on_close : 1;
     /* placed at last since it is large and has it's own ctor */
     h2o_req_t req;
 };

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -276,7 +276,6 @@ static void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, h2o_ht
 static void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_http2_stream_state_t new_state);
 static void h2o_http2_stream_prepare_for_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 void h2o_http2_stream_close(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
-void h2o_http2_stream_send_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum);
 void h2o_http2_stream_reset(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 static int h2o_http2_stream_has_pending_data(h2o_http2_stream_t *stream);

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -275,6 +275,7 @@ static void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, h2o_ht
 static void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_http2_stream_state_t new_state);
 static void h2o_http2_stream_prepare_for_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 void h2o_http2_stream_close(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
+void h2o_http2_stream_send_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum);
 void h2o_http2_stream_reset(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 static int h2o_http2_stream_has_pending_data(h2o_http2_stream_t *stream);

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -179,7 +179,7 @@ struct st_h2o_http2_stream_t {
         h2o_linklist_t link;
         h2o_http2_scheduler_openref_t scheduler;
     } _refs;
-    unsigned send_rst_stream_on_close : 1;
+    h2o_send_state_t send_state; /* steate of the ostream, only used in push mode */
     /* placed at last since it is large and has it's own ctor */
     h2o_req_t req;
 };

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -163,7 +163,18 @@ static void on_body_chunked(h2o_socket_t *sock, const char *err)
     h2o_timeout_unlink(&client->_timeout);
 
     if (err != NULL) {
-        on_body_error(client, "I/O error (body; chunked)");
+        if (err == h2o_socket_error_closed && !phr_decoder_in_data(&client->_body_decoder.chunked.decoder)) {
+            /*
+             * if the peer closed after a full chunk, treat this
+             * as if the transfer had complete, browsers appear to ignore
+             * a missing 0\r\n chunk
+             */
+            client->_can_keepalive = 0;
+            client->_cb.on_body(&client->super, h2o_http1client_error_is_eos);
+            close_client(client);
+        } else {
+            on_body_error(client, "I/O error (body; chunked)");
+        }
         return;
     }
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -284,14 +284,14 @@ static void do_send(struct rp_generator_t *self)
         veccnt = 1;
         is_eos = 0;
     }
-    enum h2o_stream_send_state ststate;
+    h2o_send_state_t ststate;
     if (self->had_body_error) {
-        ststate = H2O_STREAM_SEND_STATE_ERROR;
+        ststate = H2O_SEND_STATE_ERROR;
     } else {
         if (is_eos) {
-            ststate = H2O_STREAM_SEND_STATE_FINAL;
+            ststate = H2O_SEND_STATE_FINAL;
         } else {
-            ststate = H2O_STREAM_SEND_STATE_IN_PROGRESS;
+            ststate = H2O_SEND_STATE_IN_PROGRESS;
         }
     }
     h2o_send(self->src_req, vecs, veccnt, ststate);
@@ -425,7 +425,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
 
     if (errstr == h2o_http1client_error_is_eos) {
         self->client = NULL;
-        h2o_send(req, NULL, 0, H2O_STREAM_SEND_STATE_FINAL);
+        h2o_send(req, NULL, 0, H2O_SEND_STATE_FINAL);
         return NULL;
     }
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -267,7 +267,7 @@ static void do_send(struct rp_generator_t *self)
 {
     h2o_iovec_t vecs[1];
     size_t veccnt;
-    int is_eos;
+    h2o_send_state_t ststate;
 
     assert(self->sending.bytes_inflight == 0);
 
@@ -277,23 +277,17 @@ static void do_send(struct rp_generator_t *self)
 
     if (self->client == NULL && vecs[0].len == self->sending.buf->size && self->last_content_before_send->size == 0) {
         veccnt = vecs[0].len != 0 ? 1 : 0;
-        is_eos = 1;
+        ststate = H2O_SEND_STATE_FINAL;
     } else {
         if (vecs[0].len == 0)
             return;
         veccnt = 1;
-        is_eos = 0;
+        ststate = H2O_SEND_STATE_IN_PROGRESS;
     }
-    h2o_send_state_t ststate;
-    if (self->had_body_error) {
+
+    if (self->had_body_error)
         ststate = H2O_SEND_STATE_ERROR;
-    } else {
-        if (is_eos) {
-            ststate = H2O_SEND_STATE_FINAL;
-        } else {
-            ststate = H2O_SEND_STATE_IN_PROGRESS;
-        }
-    }
+
     h2o_send(self->src_req, vecs, veccnt, ststate);
 }
 

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -357,7 +357,7 @@ void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)
     }
 }
 
-void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, enum h2o_stream_send_state state)
+void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
 {
     size_t i;
 
@@ -413,7 +413,7 @@ void h2o_req_bind_conf(h2o_req_t *req, h2o_hostconf_t *hostconf, h2o_pathconf_t 
         apply_env(req, pathconf->env);
 }
 
-void h2o_ostream_send_next(h2o_ostream_t *ostream, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, enum h2o_stream_send_state state)
+void h2o_ostream_send_next(h2o_ostream_t *ostream, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
 {
     if (h2o_stream_send_state_is_final(state)) {
         assert(req->_ostr_top == ostream);
@@ -452,9 +452,9 @@ void h2o_send_inline(h2o_req_t *req, const char *body, size_t len)
     h2o_start_response(req, &generator);
 
     if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
-        h2o_send(req, NULL, 0, H2O_STREAM_SEND_STATE_FINAL);
+        h2o_send(req, NULL, 0, H2O_SEND_STATE_FINAL);
     else
-        h2o_send(req, &buf, 1, H2O_STREAM_SEND_STATE_FINAL);
+        h2o_send(req, &buf, 1, H2O_SEND_STATE_FINAL);
 }
 
 void h2o_send_error_generic(h2o_req_t *req, int status, const char *reason, const char *body, int flags)
@@ -556,7 +556,7 @@ void h2o_send_redirect(h2o_req_t *req, int status, const char *reason, const cha
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_LOCATION, url, url_len);
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/html; charset=utf-8"));
     h2o_start_response(req, &generator);
-    h2o_send(req, bufs, bufcnt, H2O_STREAM_SEND_STATE_FINAL);
+    h2o_send(req, bufs, bufcnt, H2O_SEND_STATE_FINAL);
 }
 
 void h2o_send_redirect_internal(h2o_req_t *req, h2o_iovec_t method, const char *url_str, size_t url_len, int preserve_overrides)

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -363,7 +363,7 @@ void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t
 
     assert(req->_generator != NULL);
 
-    if (h2o_stream_send_state_is_final(state))
+    if (!h2o_send_state_is_in_progress(state))
         req->_generator = NULL;
 
     for (i = 0; i != bufcnt; ++i)
@@ -415,7 +415,7 @@ void h2o_req_bind_conf(h2o_req_t *req, h2o_hostconf_t *hostconf, h2o_pathconf_t 
 
 void h2o_ostream_send_next(h2o_ostream_t *ostream, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
 {
-    if (h2o_stream_send_state_is_final(state)) {
+    if (!h2o_send_state_is_in_progress(state)) {
         assert(req->_ostr_top == ostream);
         req->_ostr_top = ostream->next;
     } else if (bufcnt == 0) {

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -357,19 +357,19 @@ void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)
     }
 }
 
-void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, int is_final)
+void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, enum h2o_stream_send_state state)
 {
     size_t i;
 
     assert(req->_generator != NULL);
 
-    if (is_final)
+    if (h2o_stream_send_state_is_final(state))
         req->_generator = NULL;
 
     for (i = 0; i != bufcnt; ++i)
         req->bytes_sent += bufs[i].len;
 
-    req->_ostr_top->do_send(req->_ostr_top, req, bufs, bufcnt, is_final);
+    req->_ostr_top->do_send(req->_ostr_top, req, bufs, bufcnt, state);
 }
 
 h2o_req_prefilter_t *h2o_add_prefilter(h2o_req_t *req, size_t sz)
@@ -413,16 +413,16 @@ void h2o_req_bind_conf(h2o_req_t *req, h2o_hostconf_t *hostconf, h2o_pathconf_t 
         apply_env(req, pathconf->env);
 }
 
-void h2o_ostream_send_next(h2o_ostream_t *ostream, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, int is_final)
+void h2o_ostream_send_next(h2o_ostream_t *ostream, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, enum h2o_stream_send_state state)
 {
-    if (is_final) {
+    if (h2o_stream_send_state_is_final(state)) {
         assert(req->_ostr_top == ostream);
         req->_ostr_top = ostream->next;
     } else if (bufcnt == 0) {
         h2o_timeout_link(req->conn->ctx->loop, &req->conn->ctx->zero_timeout, &req->_timeout_entry);
         return;
     }
-    ostream->next->do_send(ostream->next, req, bufs, bufcnt, is_final);
+    ostream->next->do_send(ostream->next, req, bufs, bufcnt, state);
 }
 
 void h2o_req_fill_mime_attributes(h2o_req_t *req)
@@ -452,9 +452,9 @@ void h2o_send_inline(h2o_req_t *req, const char *body, size_t len)
     h2o_start_response(req, &generator);
 
     if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
-        h2o_send(req, NULL, 0, 1);
+        h2o_send(req, NULL, 0, H2O_STREAM_SEND_STATE_FINAL);
     else
-        h2o_send(req, &buf, 1, 1);
+        h2o_send(req, &buf, 1, H2O_STREAM_SEND_STATE_FINAL);
 }
 
 void h2o_send_error_generic(h2o_req_t *req, int status, const char *reason, const char *body, int flags)
@@ -556,7 +556,7 @@ void h2o_send_redirect(h2o_req_t *req, int status, const char *reason, const cha
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_LOCATION, url, url_len);
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/html; charset=utf-8"));
     h2o_start_response(req, &generator);
-    h2o_send(req, bufs, bufcnt, 1);
+    h2o_send(req, bufs, bufcnt, H2O_STREAM_SEND_STATE_FINAL);
 }
 
 void h2o_send_redirect_internal(h2o_req_t *req, h2o_iovec_t method, const char *url_str, size_t url_len, int preserve_overrides)

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -29,7 +29,7 @@ typedef struct st_chunked_encoder_t {
     char buf[64];
 } chunked_encoder_t;
 
-static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
+static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     chunked_encoder_t *self = (void *)_self;
     h2o_iovec_t *outbufs = alloca(sizeof(h2o_iovec_t) * (inbufcnt + 2));
@@ -49,9 +49,9 @@ static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         memcpy(outbufs + outbufcnt, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
         outbufcnt += inbufcnt;
         outbufs[outbufcnt].base = "\r\n0\r\n\r\n";
-        outbufs[outbufcnt].len = state == H2O_STREAM_SEND_STATE_FINAL ? 7 : 2;
+        outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? 7 : 2;
         outbufcnt++;
-    } else if (state == H2O_STREAM_SEND_STATE_FINAL) {
+    } else if (state == H2O_SEND_STATE_FINAL) {
         outbufs[outbufcnt].base = "0\r\n\r\n";
         outbufs[outbufcnt].len = 5;
         outbufcnt++;

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -48,11 +48,20 @@ static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         outbufcnt++;
         memcpy(outbufs + outbufcnt, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
         outbufcnt += inbufcnt;
-        outbufs[outbufcnt].base = "\r\n0\r\n\r\n";
-        outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? 7 : 2;
-        outbufcnt++;
+        if (state != H2O_SEND_STATE_ERROR) {
+            outbufs[outbufcnt].base = "\r\n0\r\n\r\n";
+            outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? 7 : 2;
+            outbufcnt++;
+        }
     } else if (state == H2O_SEND_STATE_FINAL) {
         outbufs[outbufcnt].base = "0\r\n\r\n";
+        outbufs[outbufcnt].len = 5;
+        outbufcnt++;
+    }
+
+    /* if state is error, send a broken chunk to pass the error down to the browser */
+    if (state == H2O_SEND_STATE_ERROR) {
+        outbufs[outbufcnt].base = "\r\n1\r\n";
         outbufs[outbufcnt].len = 5;
         outbufcnt++;
     }

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -29,7 +29,7 @@ typedef struct st_chunked_encoder_t {
     char buf[64];
 } chunked_encoder_t;
 
-static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final)
+static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
 {
     chunked_encoder_t *self = (void *)_self;
     h2o_iovec_t *outbufs = alloca(sizeof(h2o_iovec_t) * (inbufcnt + 2));
@@ -49,15 +49,15 @@ static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         memcpy(outbufs + outbufcnt, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
         outbufcnt += inbufcnt;
         outbufs[outbufcnt].base = "\r\n0\r\n\r\n";
-        outbufs[outbufcnt].len = is_final ? 7 : 2;
+        outbufs[outbufcnt].len = state == H2O_STREAM_SEND_STATE_FINAL ? 7 : 2;
         outbufcnt++;
-    } else if (is_final) {
+    } else if (state == H2O_STREAM_SEND_STATE_FINAL) {
         outbufs[outbufcnt].base = "0\r\n\r\n";
         outbufs[outbufcnt].len = 5;
         outbufcnt++;
     }
 
-    h2o_ostream_send_next(&self->super, req, outbufs, outbufcnt, is_final);
+    h2o_ostream_send_next(&self->super, req, outbufs, outbufcnt, state);
 }
 
 static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t **slot)

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -37,7 +37,7 @@ struct st_compress_encoder_t {
     h2o_compress_context_t *compressor;
 };
 
-static void do_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
+static void do_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     struct st_compress_encoder_t *self = (void *)_self;
     h2o_iovec_t *outbufs;

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -37,14 +37,14 @@ struct st_compress_encoder_t {
     h2o_compress_context_t *compressor;
 };
 
-static void do_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final)
+static void do_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
 {
     struct st_compress_encoder_t *self = (void *)_self;
     h2o_iovec_t *outbufs;
     size_t outbufcnt;
 
-    self->compressor->compress(self->compressor, inbufs, inbufcnt, is_final, &outbufs, &outbufcnt);
-    h2o_ostream_send_next(&self->super, req, outbufs, outbufcnt, is_final);
+    self->compressor->compress(self->compressor, inbufs, inbufcnt, state, &outbufs, &outbufcnt);
+    h2o_ostream_send_next(&self->super, req, outbufs, outbufcnt, state);
 }
 
 static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t **slot)

--- a/lib/handler/compress/brotli.cc
+++ b/lib/handler/compress/brotli.cc
@@ -52,9 +52,9 @@ namespace {
         void _clear_bufs();
         void _emit(bool is_last, bool force_flush);
         void _compress(h2o_iovec_t *inbufs, size_t inbufcnt, int is_final, h2o_iovec_t **outbufs, size_t *outbufcnt);
-        static void _compress(h2o_compress_context_t *self, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final,
+        static void _compress(h2o_compress_context_t *self, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state,
                               h2o_iovec_t **outbufs, size_t *outbufcnt) {
-            static_cast<brotli_context*>(self)->_compress(inbufs, inbufcnt, is_final, outbufs, outbufcnt);
+            static_cast<brotli_context*>(self)->_compress(inbufs, inbufcnt, h2o_stream_send_state_is_final(state), outbufs, outbufcnt);
         }
         static void _update_lgwin(brotli::BrotliParams &params, size_t estimated_content_length);
     };

--- a/lib/handler/compress/brotli.cc
+++ b/lib/handler/compress/brotli.cc
@@ -52,7 +52,7 @@ namespace {
         void _clear_bufs();
         void _emit(bool is_last, bool force_flush);
         void _compress(h2o_iovec_t *inbufs, size_t inbufcnt, int is_final, h2o_iovec_t **outbufs, size_t *outbufcnt);
-        static void _compress(h2o_compress_context_t *self, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state,
+        static void _compress(h2o_compress_context_t *self, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
                               h2o_iovec_t **outbufs, size_t *outbufcnt) {
             static_cast<brotli_context*>(self)->_compress(inbufs, inbufcnt, h2o_stream_send_state_is_final(state), outbufs, outbufcnt);
         }

--- a/lib/handler/compress/brotli.cc
+++ b/lib/handler/compress/brotli.cc
@@ -54,7 +54,7 @@ namespace {
         void _compress(h2o_iovec_t *inbufs, size_t inbufcnt, int is_final, h2o_iovec_t **outbufs, size_t *outbufcnt);
         static void _compress(h2o_compress_context_t *self, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
                               h2o_iovec_t **outbufs, size_t *outbufcnt) {
-            static_cast<brotli_context*>(self)->_compress(inbufs, inbufcnt, h2o_stream_send_state_is_final(state), outbufs, outbufcnt);
+            static_cast<brotli_context*>(self)->_compress(inbufs, inbufcnt, !h2o_send_state_is_in_progress(state), outbufs, outbufcnt);
         }
         static void _update_lgwin(brotli::BrotliParams &params, size_t estimated_content_length);
     };

--- a/lib/handler/compress/gzip.c
+++ b/lib/handler/compress/gzip.c
@@ -82,7 +82,7 @@ static size_t compress_chunk(struct st_gzip_context_t *self, const void *src, si
     return bufindex;
 }
 
-static void do_compress(h2o_compress_context_t *_self, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state, h2o_iovec_t **outbufs,
+static void do_compress(h2o_compress_context_t *_self, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state, h2o_iovec_t **outbufs,
                         size_t *outbufcnt)
 {
     struct st_gzip_context_t *self = (void *)_self;

--- a/lib/handler/compress/gzip.c
+++ b/lib/handler/compress/gzip.c
@@ -100,12 +100,12 @@ static void do_compress(h2o_compress_context_t *_self, h2o_iovec_t *inbufs, size
     } else {
         last_buf = h2o_iovec_init(NULL, 0);
     }
-    outbufindex = compress_chunk(self, last_buf.base, last_buf.len, h2o_stream_send_state_is_final(state) ? Z_FINISH : Z_SYNC_FLUSH, outbufindex);
+    outbufindex = compress_chunk(self, last_buf.base, last_buf.len, h2o_send_state_is_in_progress(state) ? Z_SYNC_FLUSH : Z_FINISH, outbufindex);
 
     *outbufs = self->bufs.entries;
     *outbufcnt = outbufindex + 1;
 
-    if (h2o_stream_send_state_is_final(state)) {
+    if (!h2o_send_state_is_in_progress(state)) {
         deflateEnd(&self->zs);
         self->zs_is_open = 0;
     }

--- a/lib/handler/compress/gzip.c
+++ b/lib/handler/compress/gzip.c
@@ -82,7 +82,7 @@ static size_t compress_chunk(struct st_gzip_context_t *self, const void *src, si
     return bufindex;
 }
 
-static void do_compress(h2o_compress_context_t *_self, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final, h2o_iovec_t **outbufs,
+static void do_compress(h2o_compress_context_t *_self, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state, h2o_iovec_t **outbufs,
                         size_t *outbufcnt)
 {
     struct st_gzip_context_t *self = (void *)_self;
@@ -100,12 +100,12 @@ static void do_compress(h2o_compress_context_t *_self, h2o_iovec_t *inbufs, size
     } else {
         last_buf = h2o_iovec_init(NULL, 0);
     }
-    outbufindex = compress_chunk(self, last_buf.base, last_buf.len, is_final ? Z_FINISH : Z_SYNC_FLUSH, outbufindex);
+    outbufindex = compress_chunk(self, last_buf.base, last_buf.len, h2o_stream_send_state_is_final(state) ? Z_FINISH : Z_SYNC_FLUSH, outbufindex);
 
     *outbufs = self->bufs.entries;
     *outbufcnt = outbufindex + 1;
 
-    if (is_final) {
+    if (h2o_stream_send_state_is_final(state)) {
         deflateEnd(&self->zs);
         self->zs_is_open = 0;
     }

--- a/lib/handler/errordoc.c
+++ b/lib/handler/errordoc.c
@@ -67,7 +67,7 @@ static void on_prefilter_setup_stream(h2o_req_prefilter_t *_self, h2o_req_t *req
     h2o_setup_next_prefilter(&self->super, req, slot);
 }
 
-static void on_ostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
+static void on_ostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     /* nothing to do */
 }

--- a/lib/handler/errordoc.c
+++ b/lib/handler/errordoc.c
@@ -67,7 +67,7 @@ static void on_prefilter_setup_stream(h2o_req_prefilter_t *_self, h2o_req_t *req
     h2o_setup_next_prefilter(&self->super, req, slot);
 }
 
-static void on_ostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final)
+static void on_ostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
 {
     /* nothing to do */
 }

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -457,7 +457,7 @@ static void do_send(struct st_fcgi_generator_t *generator)
             return;
         is_final = 0;
     }
-    h2o_send(generator->req, vecs, veccnt, is_final ? H2O_STREAM_SEND_STATE_FINAL : H2O_STREAM_SEND_STATE_IN_PROGRESS);
+    h2o_send(generator->req, vecs, veccnt, is_final ? H2O_SEND_STATE_FINAL : H2O_SEND_STATE_IN_PROGRESS);
 }
 
 static void send_eos_and_close(struct st_fcgi_generator_t *generator, int can_keepalive)

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -457,7 +457,7 @@ static void do_send(struct st_fcgi_generator_t *generator)
             return;
         is_final = 0;
     }
-    h2o_send(generator->req, vecs, veccnt, is_final);
+    h2o_send(generator->req, vecs, veccnt, is_final ? H2O_STREAM_SEND_STATE_FINAL : H2O_STREAM_SEND_STATE_IN_PROGRESS);
 }
 
 static void send_eos_and_close(struct st_fcgi_generator_t *generator, int can_keepalive)

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -212,10 +212,8 @@ static h2o_send_state_t do_pull(h2o_generator_t *_self, h2o_req_t *req, h2o_iove
     if (rret <= 0) {
         buf->len = 0;
         self->bytesleft = 0;
-        if (rret < 0) {
-            do_close(&self->super, req);
-            return H2O_SEND_STATE_ERROR;
-        }
+        do_close(&self->super, req);
+        return H2O_SEND_STATE_ERROR;
     } else {
         buf->len = rret;
         self->file.off += rret;

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -116,7 +116,7 @@ static void do_proceed(h2o_generator_t *_self, h2o_req_t *req)
     size_t rlen;
     ssize_t rret;
     h2o_iovec_t vec;
-    int is_final;
+    enum h2o_stream_send_state stream_state;
 
     /* read the file */
     rlen = self->bytesleft;
@@ -126,19 +126,23 @@ static void do_proceed(h2o_generator_t *_self, h2o_req_t *req)
         ;
     if (rret == -1) {
         req->http1_is_persistent = 0; /* FIXME need a better interface to dispose an errored response w. content-length */
-        h2o_send(req, NULL, 0, 1);
+        h2o_send(req, NULL, 0, H2O_STREAM_SEND_STATE_FINAL);
         do_close(&self->super, req);
         return;
     }
     self->file.off += rret;
     self->bytesleft -= rret;
-    is_final = self->bytesleft == 0;
+    if (self->bytesleft == 0) {
+        stream_state = H2O_STREAM_SEND_STATE_FINAL;
+    } else {
+        stream_state = H2O_STREAM_SEND_STATE_IN_PROGRESS;
+    }
 
     /* send (and close if done) */
     vec.base = self->buf;
     vec.len = rret;
-    h2o_send(req, &vec, 1, is_final);
-    if (is_final)
+    h2o_send(req, &vec, 1, stream_state);
+    if (stream_state == H2O_STREAM_SEND_STATE_FINAL)
         do_close(&self->super, req);
 }
 
@@ -148,7 +152,7 @@ static void do_multirange_proceed(h2o_generator_t *_self, h2o_req_t *req)
     size_t rlen, used_buf = 0;
     ssize_t rret, vecarrsize;
     h2o_iovec_t vec[2];
-    int is_finished;
+    enum h2o_stream_send_state stream_state;
 
     if (self->bytesleft == 0) {
         size_t *range_cur = self->ranged.range_infos + 2 * self->ranged.current_range;
@@ -181,24 +185,24 @@ static void do_multirange_proceed(h2o_generator_t *_self, h2o_req_t *req)
         vec[1].base = h2o_mem_alloc_pool(&req->pool, sizeof("\r\n--") - 1 + BOUNDARY_SIZE + sizeof("--\r\n"));
         vec[1].len = sprintf(vec[1].base, "\r\n--%s--\r\n", self->ranged.boundary.base);
         vecarrsize = 2;
-        is_finished = 1;
+        stream_state = H2O_STREAM_SEND_STATE_FINAL;
     } else {
         vecarrsize = 1;
-        is_finished = 0;
+        stream_state = H2O_STREAM_SEND_STATE_IN_PROGRESS;
     }
-    h2o_send(req, vec, vecarrsize, is_finished);
-    if (is_finished)
+    h2o_send(req, vec, vecarrsize, stream_state);
+    if (stream_state == H2O_STREAM_SEND_STATE_FINAL)
         do_close(&self->super, req);
     return;
 
 Error:
     req->http1_is_persistent = 0;
-    h2o_send(req, NULL, 0, 1);
+    h2o_send(req, NULL, 0, H2O_STREAM_SEND_STATE_ERROR);
     do_close(&self->super, req);
     return;
 }
 
-static int do_pull(h2o_generator_t *_self, h2o_req_t *req, h2o_iovec_t *buf)
+static enum h2o_stream_send_state do_pull(h2o_generator_t *_self, h2o_req_t *req, h2o_iovec_t *buf)
 {
     struct st_h2o_sendfile_generator_t *self = (void *)_self;
     ssize_t rret;
@@ -218,9 +222,9 @@ static int do_pull(h2o_generator_t *_self, h2o_req_t *req, h2o_iovec_t *buf)
     }
 
     if (self->bytesleft != 0)
-        return 0;
+        return H2O_STREAM_SEND_STATE_IN_PROGRESS;
     do_close(&self->super, req);
-    return 1;
+    return H2O_STREAM_SEND_STATE_FINAL;
 }
 
 static struct st_h2o_sendfile_generator_t *create_generator(h2o_req_t *req, const char *path, size_t path_len, int *is_dir,
@@ -329,7 +333,7 @@ static void do_send_file(struct st_h2o_sendfile_generator_t *self, h2o_req_t *re
     if (!is_get || self->bytesleft == 0) {
         static h2o_generator_t generator = {NULL, NULL};
         h2o_start_response(req, &generator);
-        h2o_send(req, NULL, 0, 1);
+        h2o_send(req, NULL, 0, H2O_STREAM_SEND_STATE_FINAL);
         do_close(&self->super, req);
         return;
     }
@@ -397,7 +401,7 @@ static int send_dir_listing(h2o_req_t *req, const char *path, size_t path_len, i
 
     /* send data */
     h2o_start_response(req, &generator);
-    h2o_send(req, &bodyvec, 1, 1);
+    h2o_send(req, &bodyvec, 1, H2O_STREAM_SEND_STATE_FINAL);
     return 0;
 }
 

--- a/lib/handler/http2_debug_state.c
+++ b/lib/handler/http2_debug_state.c
@@ -54,7 +54,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
 
     h2o_start_response(req, &generator);
     h2o_send(req, debug_state->json.entries,
-             h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : debug_state->json.size, H2O_STREAM_SEND_STATE_FINAL);
+             h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : debug_state->json.size, H2O_SEND_STATE_FINAL);
     return 0;
 }
 

--- a/lib/handler/http2_debug_state.c
+++ b/lib/handler/http2_debug_state.c
@@ -54,7 +54,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
 
     h2o_start_response(req, &generator);
     h2o_send(req, debug_state->json.entries,
-             h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : debug_state->json.size, 1);
+             h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : debug_state->json.size, H2O_STREAM_SEND_STATE_FINAL);
     return 0;
 }
 

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -720,7 +720,7 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
     /* send the entire response immediately */
     if (h2o_memis(generator->req->input.method.base, generator->req->input.method.len, H2O_STRLIT("HEAD"))) {
         h2o_start_response(generator->req, &generator->super);
-        h2o_send(generator->req, NULL, 0, 1);
+        h2o_send(generator->req, NULL, 0, H2O_STREAM_SEND_STATE_FINAL);
     } else {
         if (content.len < generator->req->res.content_length) {
             generator->req->res.content_length = content.len;
@@ -728,7 +728,7 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
             content.len = generator->req->res.content_length;
         }
         h2o_start_response(generator->req, &generator->super);
-        h2o_send(generator->req, &content, 1, 1);
+        h2o_send(generator->req, &content, 1, H2O_STREAM_SEND_STATE_FINAL);
     }
     return;
 

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -720,7 +720,7 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
     /* send the entire response immediately */
     if (h2o_memis(generator->req->input.method.base, generator->req->input.method.len, H2O_STRLIT("HEAD"))) {
         h2o_start_response(generator->req, &generator->super);
-        h2o_send(generator->req, NULL, 0, H2O_STREAM_SEND_STATE_FINAL);
+        h2o_send(generator->req, NULL, 0, H2O_SEND_STATE_FINAL);
     } else {
         if (content.len < generator->req->res.content_length) {
             generator->req->res.content_length = content.len;
@@ -728,7 +728,7 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
             content.len = generator->req->res.content_length;
         }
         h2o_start_response(generator->req, &generator->super);
-        h2o_send(generator->req, &content, 1, H2O_STREAM_SEND_STATE_FINAL);
+        h2o_send(generator->req, &content, 1, H2O_SEND_STATE_FINAL);
     }
     return;
 

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -63,7 +63,7 @@ static void do_send(h2o_mruby_generator_t *generator, h2o_buffer_t **input, int 
         is_final = 0;
     }
 
-    h2o_send(generator->req, &buf, bufcnt, is_final);
+    h2o_send(generator->req, &buf, bufcnt, is_final?H2O_STREAM_SEND_STATE_FINAL:H2O_STREAM_SEND_STATE_IN_PROGRESS);
 }
 
 static void do_proceed(h2o_generator_t *_generator, h2o_req_t *req)

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -63,7 +63,7 @@ static void do_send(h2o_mruby_generator_t *generator, h2o_buffer_t **input, int 
         is_final = 0;
     }
 
-    h2o_send(generator->req, &buf, bufcnt, is_final?H2O_STREAM_SEND_STATE_FINAL:H2O_STREAM_SEND_STATE_IN_PROGRESS);
+    h2o_send(generator->req, &buf, bufcnt, is_final?H2O_SEND_STATE_FINAL:H2O_SEND_STATE_IN_PROGRESS);
 }
 
 static void do_proceed(h2o_generator_t *_generator, h2o_req_t *req)

--- a/lib/handler/reproxy.c
+++ b/lib/handler/reproxy.c
@@ -21,7 +21,7 @@
  */
 #include "h2o.h"
 
-static void on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final)
+static void on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
 {
     /* nothing to do */
 }

--- a/lib/handler/reproxy.c
+++ b/lib/handler/reproxy.c
@@ -21,7 +21,7 @@
  */
 #include "h2o.h"
 
-static void on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
+static void on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     /* nothing to do */
 }

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -115,7 +115,7 @@ static void send_response(struct st_h2o_status_collector_t *collector)
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain; charset=utf-8"));
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("no-cache, no-store"));
     h2o_start_response(req, &generator);
-    h2o_send(req, resp, h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : nr_resp, 1);
+    h2o_send(req, resp, h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : nr_resp, H2O_STREAM_SEND_STATE_FINAL);
     h2o_mem_release_shared(collector);
 }
 

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -115,7 +115,7 @@ static void send_response(struct st_h2o_status_collector_t *collector)
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain; charset=utf-8"));
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("no-cache, no-store"));
     h2o_start_response(req, &generator);
-    h2o_send(req, resp, h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : nr_resp, H2O_STREAM_SEND_STATE_FINAL);
+    h2o_send(req, resp, h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : nr_resp, H2O_SEND_STATE_FINAL);
     h2o_mem_release_shared(collector);
 }
 

--- a/lib/handler/throttle_resp.c
+++ b/lib/handler/throttle_resp.c
@@ -41,7 +41,7 @@ typedef struct st_throttle_resp_t {
     h2o_req_t *req;
     struct {
         iovec_vector_t bufs;
-        enum h2o_stream_send_state stream_state;
+        h2o_send_state_t stream_state;
     } state;
 } throttle_resp_t;
 
@@ -75,7 +75,7 @@ static void add_token(h2o_timeout_entry_t *entry)
         real_send(self);
 }
 
-static void on_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
+static void on_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     throttle_resp_t *self = (void *)_self;
     size_t i;

--- a/lib/handler/throttle_resp.c
+++ b/lib/handler/throttle_resp.c
@@ -60,7 +60,7 @@ static void real_send(throttle_resp_t *self)
     self->tokens -= token_consume;
 
     h2o_ostream_send_next(&self->super, self->req, self->state.bufs.entries, self->state.bufs.size, self->state.stream_state);
-    if (h2o_stream_send_state_is_final(self->state.stream_state))
+    if (!h2o_send_state_is_in_progress(self->state.stream_state))
         h2o_timeout_unlink(&self->timeout_entry);
 }
 

--- a/lib/handler/throttle_resp.c
+++ b/lib/handler/throttle_resp.c
@@ -41,7 +41,7 @@ typedef struct st_throttle_resp_t {
     h2o_req_t *req;
     struct {
         iovec_vector_t bufs;
-        int is_final;
+        enum h2o_stream_send_state stream_state;
     } state;
 } throttle_resp_t;
 
@@ -59,8 +59,8 @@ static void real_send(throttle_resp_t *self)
 
     self->tokens -= token_consume;
 
-    h2o_ostream_send_next(&self->super, self->req, self->state.bufs.entries, self->state.bufs.size, self->state.is_final);
-    if (self->state.is_final)
+    h2o_ostream_send_next(&self->super, self->req, self->state.bufs.entries, self->state.bufs.size, self->state.stream_state);
+    if (h2o_stream_send_state_is_final(self->state.stream_state))
         h2o_timeout_unlink(&self->timeout_entry);
 }
 
@@ -75,7 +75,7 @@ static void add_token(h2o_timeout_entry_t *entry)
         real_send(self);
 }
 
-static void on_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final)
+static void on_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
 {
     throttle_resp_t *self = (void *)_self;
     size_t i;
@@ -87,7 +87,7 @@ static void on_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, s
         self->state.bufs.entries[i] = inbufs[i];
     }
     self->state.bufs.size = inbufcnt;
-    self->state.is_final = is_final;
+    self->state.stream_state = state;
 
     /* if there's token, we try to send */
     if (self->tokens > 0)

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -634,7 +634,7 @@ static void proceed_pull(struct st_h2o_http1_conn_t *conn, size_t nfilled)
     }
 
     /* write */
-    h2o_socket_write(conn->sock, &buf, 1, h2o_stream_send_state_is_final(send_state) ? on_send_complete : on_send_next_pull);
+    h2o_socket_write(conn->sock, &buf, 1, h2o_send_state_is_in_progress(send_state) ? on_send_next_pull : on_send_complete);
 }
 
 static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb)
@@ -692,7 +692,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
     bufcnt += inbufcnt;
 
     if (bufcnt != 0) {
-        h2o_socket_write(conn->sock, bufs, bufcnt, h2o_stream_send_state_is_final(state) ? on_send_complete : on_send_next_push);
+        h2o_socket_write(conn->sock, bufs, bufcnt, h2o_send_state_is_in_progress(state) ? on_send_next_push : on_send_complete);
     } else {
         on_send_complete(conn->sock, 0);
     }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -77,7 +77,7 @@ struct st_h2o_http1_chunked_entity_reader {
 
 static void proceed_pull(struct st_h2o_http1_conn_t *conn, size_t nfilled);
 static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb);
-static void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state);
+static void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state);
 static void reqread_on_read(h2o_socket_t *sock, const char *err);
 static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata);
 
@@ -623,18 +623,18 @@ static size_t flatten_headers(char *buf, h2o_req_t *req, const char *connection)
 static void proceed_pull(struct st_h2o_http1_conn_t *conn, size_t nfilled)
 {
     h2o_iovec_t buf = {conn->_ostr_final.pull.buf, nfilled};
-    enum h2o_stream_send_state stream_state;
+    h2o_send_state_t send_state;
 
     if (buf.len < MAX_PULL_BUF_SZ) {
         h2o_iovec_t cbuf = {buf.base + buf.len, MAX_PULL_BUF_SZ - buf.len};
-        stream_state = h2o_pull(&conn->req, conn->_ostr_final.pull.cb, &cbuf);
+        send_state = h2o_pull(&conn->req, conn->_ostr_final.pull.cb, &cbuf);
         buf.len += cbuf.len;
     } else {
-        stream_state = H2O_STREAM_SEND_STATE_IN_PROGRESS;
+        send_state = H2O_SEND_STATE_IN_PROGRESS;
     }
 
     /* write */
-    h2o_socket_write(conn->sock, &buf, 1, h2o_stream_send_state_is_final(stream_state) ? on_send_complete : on_send_next_pull);
+    h2o_socket_write(conn->sock, &buf, 1, h2o_stream_send_state_is_final(send_state) ? on_send_complete : on_send_next_pull);
 }
 
 static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb)
@@ -669,7 +669,7 @@ static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb
     proceed_pull(conn, headers_len);
 }
 
-void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state state)
+void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     struct st_h2o_http1_finalostream_t *self = (void *)_self;
     struct st_h2o_http1_conn_t *conn = (struct st_h2o_http1_conn_t *)req->conn;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -62,6 +62,7 @@ static int do_emit_writereq(h2o_http2_conn_t *conn);
 static void on_read(h2o_socket_t *sock, const char *err);
 static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_len);
 static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata);
+static void stream_send_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum);
 
 const h2o_protocol_callbacks_t H2O_HTTP2_CALLBACKS = {initiate_graceful_shutdown, foreach_request};
 
@@ -163,7 +164,7 @@ static void execute_or_enqueue_request(h2o_http2_conn_t *conn, h2o_http2_stream_
 
     if (stream->_req_body != NULL && stream->_expected_content_length != SIZE_MAX &&
         stream->_req_body->size != stream->_expected_content_length) {
-        h2o_http2_stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
+        stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
         h2o_http2_stream_reset(conn, stream);
         return;
     }
@@ -277,7 +278,7 @@ int close_connection(h2o_http2_conn_t *conn)
     return 0;
 }
 
-void h2o_http2_stream_send_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum)
+static void stream_send_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum)
 {
     assert(stream_id != 0);
     assert(conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING);
@@ -350,7 +351,7 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     return 0;
 
 SendRSTStream:
-    h2o_http2_stream_send_error(conn, stream->stream_id, ret);
+    stream_send_error(conn, stream->stream_id, ret);
     h2o_http2_stream_reset(conn, stream);
     return 0;
 }
@@ -415,7 +416,7 @@ static ssize_t expect_continuation_of_headers(h2o_http2_conn_t *conn, const uint
         }
     } else {
         /* request is too large (TODO log) */
-        h2o_http2_stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
+        stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
         h2o_http2_stream_reset(conn, stream);
     }
 
@@ -482,17 +483,17 @@ static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, c
     /* save the input in the request body buffer, or send error (and close the stream) */
     if (stream == NULL) {
         if (frame->stream_id <= conn->pull_stream_ids.max_open) {
-            h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
+            stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
         } else {
             *err_desc = "invalid DATA frame";
             return H2O_HTTP2_ERROR_PROTOCOL;
         }
     } else if (stream->state != H2O_HTTP2_STREAM_STATE_RECV_BODY) {
-        h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
+        stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
         h2o_http2_stream_reset(conn, stream);
         stream = NULL;
     } else if (stream->_req_body->size + payload.length > conn->super.ctx->globalconf->max_request_entity_size) {
-        h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
+        stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
         h2o_http2_stream_reset(conn, stream);
         stream = NULL;
     } else {
@@ -508,7 +509,7 @@ static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, c
             }
         } else {
             /* memory allocation failed */
-            h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
+            stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
             h2o_http2_stream_reset(conn, stream);
             stream = NULL;
         }
@@ -684,7 +685,7 @@ static int handle_window_update_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t 
             h2o_http2_stream_t *stream = h2o_http2_conn_get_stream(conn, frame->stream_id);
             if (stream != NULL)
                 h2o_http2_stream_reset(conn, stream);
-            h2o_http2_stream_send_error(conn, frame->stream_id, ret);
+            stream_send_error(conn, frame->stream_id, ret);
             return 0;
         } else {
             return ret;
@@ -701,7 +702,7 @@ static int handle_window_update_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t 
         if (stream != NULL) {
             if (update_stream_output_window(stream, payload.window_size_increment) != 0) {
                 h2o_http2_stream_reset(conn, stream);
-                h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_FLOW_CONTROL);
+                stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_FLOW_CONTROL);
                 return 0;
             }
         }

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -57,7 +57,6 @@ static __thread h2o_buffer_prototype_t wbuf_buffer_prototype = {{16}, {H2O_HTTP2
 
 static void initiate_graceful_shutdown(h2o_context_t *ctx);
 static int close_connection(h2o_http2_conn_t *conn);
-static void send_stream_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum);
 static ssize_t expect_default(h2o_http2_conn_t *conn, const uint8_t *src, size_t len, const char **err_desc);
 static int do_emit_writereq(h2o_http2_conn_t *conn);
 static void on_read(h2o_socket_t *sock, const char *err);
@@ -164,7 +163,7 @@ static void execute_or_enqueue_request(h2o_http2_conn_t *conn, h2o_http2_stream_
 
     if (stream->_req_body != NULL && stream->_expected_content_length != SIZE_MAX &&
         stream->_req_body->size != stream->_expected_content_length) {
-        send_stream_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
+        h2o_http2_stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
         h2o_http2_stream_reset(conn, stream);
         return;
     }
@@ -278,7 +277,7 @@ int close_connection(h2o_http2_conn_t *conn)
     return 0;
 }
 
-void send_stream_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum)
+void h2o_http2_stream_send_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum)
 {
     assert(stream_id != 0);
     assert(conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING);
@@ -351,7 +350,7 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     return 0;
 
 SendRSTStream:
-    send_stream_error(conn, stream->stream_id, ret);
+    h2o_http2_stream_send_error(conn, stream->stream_id, ret);
     h2o_http2_stream_reset(conn, stream);
     return 0;
 }
@@ -416,7 +415,7 @@ static ssize_t expect_continuation_of_headers(h2o_http2_conn_t *conn, const uint
         }
     } else {
         /* request is too large (TODO log) */
-        send_stream_error(conn, stream->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
+        h2o_http2_stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
         h2o_http2_stream_reset(conn, stream);
     }
 
@@ -483,17 +482,17 @@ static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, c
     /* save the input in the request body buffer, or send error (and close the stream) */
     if (stream == NULL) {
         if (frame->stream_id <= conn->pull_stream_ids.max_open) {
-            send_stream_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
+            h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
         } else {
             *err_desc = "invalid DATA frame";
             return H2O_HTTP2_ERROR_PROTOCOL;
         }
     } else if (stream->state != H2O_HTTP2_STREAM_STATE_RECV_BODY) {
-        send_stream_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
+        h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
         h2o_http2_stream_reset(conn, stream);
         stream = NULL;
     } else if (stream->_req_body->size + payload.length > conn->super.ctx->globalconf->max_request_entity_size) {
-        send_stream_error(conn, frame->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
+        h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
         h2o_http2_stream_reset(conn, stream);
         stream = NULL;
     } else {
@@ -509,7 +508,7 @@ static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, c
             }
         } else {
             /* memory allocation failed */
-            send_stream_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
+            h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
             h2o_http2_stream_reset(conn, stream);
             stream = NULL;
         }
@@ -685,7 +684,7 @@ static int handle_window_update_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t 
             h2o_http2_stream_t *stream = h2o_http2_conn_get_stream(conn, frame->stream_id);
             if (stream != NULL)
                 h2o_http2_stream_reset(conn, stream);
-            send_stream_error(conn, frame->stream_id, ret);
+            h2o_http2_stream_send_error(conn, frame->stream_id, ret);
             return 0;
         } else {
             return ret;
@@ -702,7 +701,7 @@ static int handle_window_update_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t 
         if (stream != NULL) {
             if (update_stream_output_window(stream, payload.window_size_increment) != 0) {
                 h2o_http2_stream_reset(conn, stream);
-                send_stream_error(conn, frame->stream_id, H2O_HTTP2_ERROR_FLOW_CONTROL);
+                h2o_http2_stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_FLOW_CONTROL);
                 return 0;
             }
         }

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -343,12 +343,7 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, s
     /* fallthru */
     case H2O_HTTP2_STREAM_STATE_SEND_BODY:
         if (state != H2O_SEND_STATE_IN_PROGRESS) {
-            if (state == H2O_SEND_STATE_FINAL) {
-                h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
-            } else {
-                /* state == H2O_SEND_STATE_ERROR */
-                h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
-            }
+            h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
         }
         break;
     case H2O_HTTP2_STREAM_STATE_END_STREAM:

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -340,8 +340,6 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, s
             h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
         } else if (state == H2O_STREAM_SEND_STATE_ERROR) {
             h2o_http2_stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
-            h2o_http2_stream_reset(conn, stream);
-            return;
         }
         break;
     case H2O_HTTP2_STREAM_STATE_END_STREAM:

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -24,7 +24,7 @@
 #include "h2o/http2_internal.h"
 
 static void finalostream_start_pull(h2o_ostream_t *self, h2o_ostream_pull_cb cb);
-static void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, int is_final);
+static void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, enum h2o_stream_send_state state);
 
 static size_t sz_min(size_t x, size_t y)
 {
@@ -122,11 +122,11 @@ static void encode_data_header_and_consume_window(h2o_http2_conn_t *conn, h2o_ht
     h2o_http2_window_consume_window(&stream->output_window, length);
 }
 
-static int send_data_pull(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
+static enum h2o_stream_send_state send_data_pull(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
 {
     size_t max_payload_size;
     h2o_iovec_t cbuf;
-    int is_final = 0;
+    enum h2o_stream_send_state stream_state = H2O_STREAM_SEND_STATE_IN_PROGRESS;
 
     if ((max_payload_size = calc_max_payload_size(conn, stream)) == 0)
         goto Exit;
@@ -135,15 +135,15 @@ static int send_data_pull(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     /* obtain content */
     cbuf.base = conn->_write.buf->bytes + conn->_write.buf->size + H2O_HTTP2_FRAME_HEADER_SIZE;
     cbuf.len = max_payload_size;
-    is_final = h2o_pull(&stream->req, stream->_pull_cb, &cbuf);
+    stream_state = h2o_pull(&stream->req, stream->_pull_cb, &cbuf);
     /* write the header */
     encode_data_header_and_consume_window(conn, stream, (void *)(conn->_write.buf->bytes + conn->_write.buf->size), cbuf.len,
-                                          is_final);
+                                          h2o_stream_send_state_is_final(stream_state));
     /* adjust the write buf size */
     conn->_write.buf->size += H2O_HTTP2_FRAME_HEADER_SIZE + cbuf.len;
 
 Exit:
-    return is_final;
+    return stream_state;
 }
 
 static h2o_iovec_t *send_data_push(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_iovec_t *bufs, size_t bufcnt,
@@ -322,7 +322,7 @@ void finalostream_start_pull(h2o_ostream_t *self, h2o_ostream_pull_cb cb)
     h2o_http2_conn_register_for_proceed_callback(conn, stream);
 }
 
-void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, int is_final)
+void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, enum h2o_stream_send_state state)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _ostr_final, self);
     h2o_http2_conn_t *conn = (h2o_http2_conn_t *)req->conn;
@@ -336,8 +336,13 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, s
             return;
     /* fallthru */
     case H2O_HTTP2_STREAM_STATE_SEND_BODY:
-        if (is_final)
+        if (state == H2O_STREAM_SEND_STATE_FINAL) {
             h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
+        } else if (state == H2O_STREAM_SEND_STATE_ERROR) {
+            h2o_http2_stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
+            h2o_http2_stream_reset(conn, stream);
+            return;
+        }
         break;
     case H2O_HTTP2_STREAM_STATE_END_STREAM:
         /* might get set by h2o_http2_stream_reset */
@@ -364,7 +369,7 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
     if (stream->_pull_cb != NULL) {
         /* pull mode */
         assert(stream->state != H2O_HTTP2_STREAM_STATE_END_STREAM);
-        if (send_data_pull(conn, stream)) {
+        if (h2o_stream_send_state_is_final(send_data_pull(conn, stream))) {
             /* sent all data */
             stream->_data.size = 0;
             h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -341,7 +341,7 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, s
                 h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
             } else {
                 /* state == H2O_SEND_STATE_ERROR */
-                if (h2o_http2_stream_has_pending_data(stream)) {
+                if (h2o_http2_stream_has_pending_data(stream) || bufcnt != 0) {
                     h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL);
                 } else {
                     h2o_http2_stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -112,8 +112,8 @@ static size_t calc_max_payload_size(h2o_http2_conn_t *conn, h2o_http2_stream_t *
     return sz_min(sz_min(conn_max, stream_max), conn->peer_settings.max_frame_size);
 }
 
-static void encode_data_header_and_consume_window(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_buffer_t **outbuf,
-                                                  size_t length, h2o_send_state_t send_state)
+static void commit_data_header(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_buffer_t **outbuf,
+                               size_t length, h2o_send_state_t send_state)
 {
     assert(outbuf != NULL);
     /* send a DATA frame if there's data or the END_STREAM flag to send */
@@ -146,7 +146,7 @@ static h2o_send_state_t send_data_pull(h2o_http2_conn_t *conn, h2o_http2_stream_
     cbuf.len = max_payload_size;
     send_state = h2o_pull(&stream->req, stream->_pull_cb, &cbuf);
     /* write the header */
-    encode_data_header_and_consume_window(conn, stream, &conn->_write.buf, cbuf.len, send_state);
+    commit_data_header(conn, stream, &conn->_write.buf, cbuf.len, send_state);
 
 Exit:
     return send_state;
@@ -193,10 +193,10 @@ static h2o_iovec_t *send_data_push(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     /* commit the DATA frame if we have actually emitted payload */
     if (dst.len != max_payload_size || !h2o_send_state_is_in_progress(send_state)) {
         size_t payload_len = max_payload_size - dst.len;
-        if (bufcnt != 0 && send_state == H2O_SEND_STATE_FINAL) {
+        if (bufcnt != 0) {
             send_state = H2O_SEND_STATE_IN_PROGRESS;
         }
-        encode_data_header_and_consume_window(conn, stream, &conn->_write.buf, payload_len, send_state);
+        commit_data_header(conn, stream, &conn->_write.buf, payload_len, send_state);
     }
 
 Exit:

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -24,7 +24,7 @@
 #include "../../src/standalone.h"
 #include "./test.h"
 
-static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, int is_final)
+static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state stream_state)
 {
     h2o_loopback_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_loopback_conn_t, _ostr_final, self);
     size_t i;
@@ -35,7 +35,7 @@ static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *i
         conn->body->size += inbufs[i].len;
     }
 
-    if (is_final)
+    if (h2o_stream_send_state_is_final(stream_state))
         conn->_is_complete = 1;
     else
         h2o_proceed_response(&conn->req);

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -35,10 +35,10 @@ static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *i
         conn->body->size += inbufs[i].len;
     }
 
-    if (h2o_stream_send_state_is_final(send_state))
-        conn->_is_complete = 1;
-    else
+    if (h2o_send_state_is_in_progress(send_state))
         h2o_proceed_response(&conn->req);
+    else
+        conn->_is_complete = 1;
 }
 
 static socklen_t get_sockname(h2o_conn_t *conn, struct sockaddr *sa)

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -24,7 +24,7 @@
 #include "../../src/standalone.h"
 #include "./test.h"
 
-static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, enum h2o_stream_send_state stream_state)
+static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t send_state)
 {
     h2o_loopback_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_loopback_conn_t, _ostr_final, self);
     size_t i;
@@ -35,7 +35,7 @@ static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *i
         conn->body->size += inbufs[i].len;
     }
 
-    if (h2o_stream_send_state_is_final(stream_state))
+    if (h2o_stream_send_state_is_final(send_state))
         conn->_is_complete = 1;
     else
         h2o_proceed_response(&conn->req);

--- a/t/50chunked-encoding-proxying.t
+++ b/t/50chunked-encoding-proxying.t
@@ -72,7 +72,7 @@ sub doit {
     ok($found_data eq $data, "Found the expected data");
 }
 
-for my $w (2 .. 5) {
+for my $w (1 .. 5) {
     doit("5\r\nHello\r\n50\r\nThere", "HelloThere", $w, 0, 1);
     doit("5\r\nHello\r\n50\r\nThere", "HelloThere", $w, 1, 1);
 }

--- a/t/50chunked-encoding-proxying.t
+++ b/t/50chunked-encoding-proxying.t
@@ -39,7 +39,7 @@ sub doit {
     my $stream_window_bits = shift;
     my $defer_close = shift;
     my $expect_rst_stream = shift;
-    open(NGHTTP, "nghttp -w $stream_window_bits -v http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' 2>&1 |");
+    open my $nghttp, "-|", "nghttp -w $stream_window_bits -v http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' 2>&1";
 
     my $req;
     $client_socket = $socket->accept();
@@ -52,7 +52,7 @@ sub doit {
 
     my $found_rst_stream=0;
     my $found_data="";
-    while(<NGHTTP>) {
+    while(<$nghttp>) {
         if (/^[\[|\s]/) {
             if (/RST_STREAM/) {
                 $found_rst_stream = 1;

--- a/t/50chunked-encoding-proxying.t
+++ b/t/50chunked-encoding-proxying.t
@@ -31,21 +31,32 @@ hosts:
         proxy.reverse.url: http://127.0.0.1:$upstream_port
 EOT
 
-open(NGHTTP, "nghttp -v http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' 2>&1 |");
+sub doit {
+    my $chunk = shift;
+    my $data = shift;
+    open(NGHTTP, "nghttp -v http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' 2>&1 |");
 
-my $req;
-$client_socket = $socket->accept();
-$client_socket->recv($req, 1024);
-$client_socket->send("HTTP/1.1 200 Ok\r\nTransfer-Encoding:chunked\r\nConnection:close\r\n\r\n5\r\nHello\r\n5\r\nThere\r\n");
-close($client_socket);
-$socket->close();
+    my $req;
+    $client_socket = $socket->accept();
+    $client_socket->recv($req, 1024);
+    $client_socket->send("HTTP/1.1 200 Ok\r\nTransfer-Encoding:chunked\r\nConnection:close\r\n\r\n$chunk");
+    close($client_socket);
 
-my $found_rst_stream=0;
-while(<NGHTTP>) {
-    if (/RST_STREAM/) {
-        $found_rst_stream = 1;
+    my $found_rst_stream=0;
+    my $found_data=0;
+    while(<NGHTTP>) {
+        if (/RST_STREAM/) {
+            $found_rst_stream = 1;
+        }
+        if (/$data/) {
+            $found_data = 1;
+        }
     }
+    ok($found_rst_stream == 1, "Found RST_STREAM");
+    ok($found_data == 1, "Found the expected data");
 }
-ok($found_rst_stream == 1, "Found RST_STREAM");
 
+doit("5\r\nHello\r\n5\r\nThere\r\n", "HelloThere");
+doit("5\r\nHello\r\n50\r\nThere", "HelloThere");
+$socket->close();
 done_testing();

--- a/t/50chunked-encoding-proxying.t
+++ b/t/50chunked-encoding-proxying.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'nc not found'
+    unless prog_exists('nc');
+
+my $upstream_port = empty_port();
+$| = 1;
+my $socket = new IO::Socket::INET (
+    LocalHost => '127.0.0.1',
+    LocalPort => $upstream_port,
+    Proto => 'tcp',
+    Listen => 1,
+    Reuse => 1
+);
+die "cannot create socket $!\n" unless $socket;
+
+check_port($upstream_port) or die "can't connect to server socket";
+# accent and close check_port's connection
+my $client_socket = $socket->accept();
+close($client_socket);
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+open(NGHTTP, "nghttp -v http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' 2>&1 |");
+
+my $req;
+$client_socket = $socket->accept();
+$client_socket->recv($req, 1024);
+$client_socket->send("HTTP/1.1 200 Ok\r\nTransfer-Encoding:chunked\r\nConnection:close\r\n\r\n5\r\nHello\r\n5\r\nThere\r\n");
+close($client_socket);
+$socket->close();
+
+my $found_rst_stream=0;
+while(<NGHTTP>) {
+    if (/RST_STREAM/) {
+        $found_rst_stream = 1;
+    }
+}
+ok($found_rst_stream == 1, "Found RST_STREAM");
+
+done_testing();

--- a/t/50chunked-encoding-proxying.t
+++ b/t/50chunked-encoding-proxying.t
@@ -34,7 +34,8 @@ EOT
 sub doit {
     my $chunk = shift;
     my $data = shift;
-    open(NGHTTP, "nghttp -v http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' 2>&1 |");
+    my $stream_window_bits = shift;
+    open(NGHTTP, "nghttp -w $stream_window_bits -v http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' 2>&1 |");
 
     my $req;
     $client_socket = $socket->accept();
@@ -56,7 +57,9 @@ sub doit {
     ok($found_data == 1, "Found the expected data");
 }
 
-doit("5\r\nHello\r\n5\r\nThere\r\n", "HelloThere");
-doit("5\r\nHello\r\n50\r\nThere", "HelloThere");
+doit("5\r\nHello\r\n5\r\nThere\r\n", "HelloThere", 14);
+doit("5\r\nHello\r\n50\r\nThere", "HelloThere", 14);
+doit("5\r\nHello\r\n50\r\nThere", "HelloThere", 1);
+
 $socket->close();
 done_testing();

--- a/t/50chunked-encoding-proxying.t
+++ b/t/50chunked-encoding-proxying.t
@@ -72,7 +72,7 @@ sub doit {
     ok($found_data eq $data, "Found the expected data");
 }
 
-for my $w (1 .. 5) {
+for my $w (2 .. 5) {
     doit("5\r\nHello\r\n50\r\nThere", "HelloThere", $w, 0, 1);
     doit("5\r\nHello\r\n50\r\nThere", "HelloThere", $w, 1, 1);
 }


### PR DESCRIPTION
When a `transfer-encoding:chunked` transfer is interrupted in the
backend by a connection close, H2O currently just closes the frontend
stream.
This makes it not possible for the client to know that it's receiving
truncated data, whereas it would be possible over plain HTTP/1.1, since
the last chunk would be missing - Chrome and curl both report errors on
truncated HTTP/1.1 chunked transfers, FF and Safari do not, as far as
I can tell -.
This adds a test that checks that a broken `transfer-encoding:chunked`
transfer is translated into a `RST_STREAM` over H2.