### PR TITLE
share mruby state and constants between handlers

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -2051,6 +2051,7 @@
 					"/usr/local/openssl-1.0.2/include",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					/usr/local/include,
+					deps/mruby/include,
 				);
 				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2194,6 +2195,7 @@
 					"/usr/local/openssl-1.0.2/include",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					/usr/local/include,
+					deps/mruby/include,
 				);
 				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2369,6 +2371,7 @@
 					"/usr/local/openssl-1.0.2/include",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					/usr/local/include,
+					deps/mruby/include,
 				);
 				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2385,6 +2388,7 @@
 					"/usr/local/openssl-1.0.2/include",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					/usr/local/include,
+					deps/mruby/include,
 				);
 				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -2051,7 +2051,6 @@
 					"/usr/local/openssl-1.0.2/include",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					/usr/local/include,
-					deps/mruby/include,
 				);
 				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2195,7 +2194,6 @@
 					"/usr/local/openssl-1.0.2/include",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					/usr/local/include,
-					deps/mruby/include,
 				);
 				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2371,7 +2369,6 @@
 					"/usr/local/openssl-1.0.2/include",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					/usr/local/include,
-					deps/mruby/include,
 				);
 				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2388,7 +2385,6 @@
 					"/usr/local/openssl-1.0.2/include",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					/usr/local/include,
-					deps/mruby/include,
 				);
 				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -470,7 +470,7 @@ enum {
  * holds various data related to the context
  */
 typedef struct st_h2o_context_storage_item_t {
-    void (*dispose)(struct st_h2o_context_storage_item_t *self, h2o_context_t *ctx);
+    void (*dispose)(void *data);
     void *data;
 } h2o_context_storage_item_t;
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1891,9 +1891,10 @@ inline void *h2o_context_get_logger_context(h2o_context_t *ctx, h2o_logger_t *lo
 }
 
 inline void **h2o_context_get_storage(h2o_context_t *ctx, size_t *key, void (*dispose_cb)(void *))
-//inline void h2o_context_get_storage_index(h2o_context_t *ctx, size_t *key)
 {
-    if (*key == SIZE_MAX)
+    /* SIZE_MAX might not be available in case the file is included from a C++ source file */
+    size_t size_max = (size_t) - 1;
+    if (*key == size_max)
         *key = ctx->storage.size;
     if (ctx->storage.size <= *key) {
         h2o_vector_reserve(NULL, &ctx->storage, *key + 1);

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -474,7 +474,7 @@ typedef struct st_h2o_context_storage_item_t {
     void *data;
 } h2o_context_storage_item_t;
 
-typedef H2O_VECTOR(h2o_context_storage_item_t *) h2o_context_storage_t;
+typedef H2O_VECTOR(h2o_context_storage_item_t) h2o_context_storage_t;
 
 /**
  * context of the http server.
@@ -1896,6 +1896,7 @@ inline void h2o_context_get_storage_index(h2o_context_t *ctx, size_t *key)
         *key = ctx->storage.size;
     if (ctx->storage.size <= *key) {
         h2o_vector_reserve(NULL, &ctx->storage, *key + 1);
+        memset(ctx->storage.entries + ctx->storage.size, 0, (*key + 1 - ctx->storage.size) * sizeof(ctx->storage.entries[0]));
         ctx->storage.size = *key + 1;
     }
 }

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -96,6 +96,9 @@ typedef struct st_h2o_hostconf_t h2o_hostconf_t;
 typedef struct st_h2o_globalconf_t h2o_globalconf_t;
 typedef struct st_h2o_mimemap_t h2o_mimemap_t;
 typedef struct st_h2o_logconf_t h2o_logconf_t;
+#if H2O_USE_MRUBY
+typedef struct st_h2o_mruby_shared_context_t h2o_mruby_shared_context_t;
+#endif
 
 /**
  * a predefined, read-only, fast variant of h2o_iovec_t, defined in h2o/token.h
@@ -504,6 +507,12 @@ struct st_h2o_context_t {
      * open file cache
      */
     h2o_filecache_t *filecache;
+#if H2O_USE_MRUBY
+    /**
+     * shared mruby context (will be lazily initialized)
+     */
+    h2o_mruby_shared_context_t *mruby_shared_context;
+#endif
     /**
      * flag indicating if shutdown has been requested
      */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1893,7 +1893,7 @@ inline void *h2o_context_get_logger_context(h2o_context_t *ctx, h2o_logger_t *lo
 inline void **h2o_context_get_storage(h2o_context_t *ctx, size_t *key, void (*dispose_cb)(void *))
 {
     /* SIZE_MAX might not be available in case the file is included from a C++ source file */
-    size_t size_max = (size_t) - 1;
+    size_t size_max = (size_t)-1;
     if (*key == size_max)
         *key = ctx->storage.size;
     if (ctx->storage.size <= *key) {
@@ -1904,7 +1904,6 @@ inline void **h2o_context_get_storage(h2o_context_t *ctx, size_t *key, void (*di
 
     ctx->storage.entries[*key].dispose = dispose_cb;
     return &ctx->storage.entries[*key].data;
-
 }
 
 static inline void h2o_doublebuffer_init(h2o_doublebuffer_t *db, h2o_buffer_prototype_t *prototype)

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1327,9 +1327,9 @@ static void h2o_context_set_filter_context(h2o_context_t *ctx, h2o_filter_t *fil
  */
 static void *h2o_context_get_logger_context(h2o_context_t *ctx, h2o_logger_t *logger);
 /*
- * assign and set the index of the context storage
+ * return the address associated with the key in the context storage
  */
-static void h2o_context_get_storage_index(h2o_context_t *ctx, size_t *key);
+static void **h2o_context_get_storage(h2o_context_t *ctx, size_t *key, void (*dispose_cb)(void *));
 
 /* built-in generators */
 
@@ -1890,7 +1890,8 @@ inline void *h2o_context_get_logger_context(h2o_context_t *ctx, h2o_logger_t *lo
     return ctx->_module_configs[logger->_config_slot];
 }
 
-inline void h2o_context_get_storage_index(h2o_context_t *ctx, size_t *key)
+inline void **h2o_context_get_storage(h2o_context_t *ctx, size_t *key, void (*dispose_cb)(void *))
+//inline void h2o_context_get_storage_index(h2o_context_t *ctx, size_t *key)
 {
     if (*key == SIZE_MAX)
         *key = ctx->storage.size;
@@ -1899,6 +1900,10 @@ inline void h2o_context_get_storage_index(h2o_context_t *ctx, size_t *key)
         memset(ctx->storage.entries + ctx->storage.size, 0, (*key + 1 - ctx->storage.size) * sizeof(ctx->storage.entries[0]));
         ctx->storage.size = *key + 1;
     }
+
+    ctx->storage.entries[*key].dispose = dispose_cb;
+    return &ctx->storage.entries[*key].data;
+
 }
 
 static inline void h2o_doublebuffer_init(h2o_doublebuffer_t *db, h2o_buffer_prototype_t *prototype)

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -77,13 +77,7 @@ typedef struct st_h2o_mruby_handler_t {
     h2o_mruby_config_vars_t config;
 } h2o_mruby_handler_t;
 
-typedef struct st_h2o_mruby_context_t {
-    h2o_mruby_handler_t *handler;
-    mrb_value proc;
-    h2o_mruby_shared_context_t *shared;
-} h2o_mruby_context_t;
-
-struct st_h2o_mruby_shared_context_t {
+typedef struct st_h2o_mruby_shared_context_t {
     mrb_state *mrb;
     mrb_value constants;
     struct {
@@ -94,7 +88,13 @@ struct st_h2o_mruby_shared_context_t {
         mrb_sym sym_body;
         mrb_sym sym_async;
     } symbols;
-};
+} h2o_mruby_shared_context_t;
+
+typedef struct st_h2o_mruby_context_t {
+    h2o_mruby_handler_t *handler;
+    mrb_value proc;
+    h2o_mruby_shared_context_t *shared;
+} h2o_mruby_context_t;
 
 typedef struct st_h2o_mruby_chunked_t h2o_mruby_chunked_t;
 typedef struct st_h2o_mruby_http_request_context_t h2o_mruby_http_request_context_t;

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -79,8 +79,12 @@ typedef struct st_h2o_mruby_handler_t {
 
 typedef struct st_h2o_mruby_context_t {
     h2o_mruby_handler_t *handler;
-    mrb_state *mrb;
     mrb_value proc;
+    h2o_mruby_shared_context_t *shared;
+} h2o_mruby_context_t;
+
+struct st_h2o_mruby_shared_context_t {
+    mrb_state *mrb;
     mrb_value constants;
     struct {
         mrb_sym sym_call;
@@ -90,7 +94,7 @@ typedef struct st_h2o_mruby_context_t {
         mrb_sym sym_body;
         mrb_sym sym_async;
     } symbols;
-} h2o_mruby_context_t;
+};
 
 typedef struct st_h2o_mruby_chunked_t h2o_mruby_chunked_t;
 typedef struct st_h2o_mruby_http_request_context_t h2o_mruby_http_request_context_t;
@@ -141,6 +145,7 @@ mrb_value h2o_mruby_to_str(mrb_state *mrb, mrb_value v);
 mrb_value h2o_mruby_eval_expr(mrb_state *mrb, const char *expr);
 void h2o_mruby_define_callback(mrb_state *mrb, const char *name, int id);
 mrb_value h2o_mruby_create_data_instance(mrb_state *mrb, mrb_value class_obj, void *ptr, const mrb_data_type *type);
+void h2o_mruby_setup_globals(mrb_state *mrb);
 mrb_value h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config, char *errbuf);
 h2o_mruby_handler_t *h2o_mruby_register(h2o_pathconf_t *pathconf, h2o_mruby_config_vars_t *config);
 void h2o_mruby_run_fiber(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value input, int *is_delegate);
@@ -149,7 +154,7 @@ int h2o_mruby_iterate_headers(h2o_mruby_context_t *handler_ctx, mrb_value header
                               int (*cb)(h2o_mruby_context_t *, h2o_iovec_t, h2o_iovec_t, void *), void *cb_data);
 
 /* handler/mruby/chunked.c */
-void h2o_mruby_send_chunked_init_context(h2o_mruby_context_t *ctx);
+void h2o_mruby_send_chunked_init_context(h2o_mruby_shared_context_t *ctx);
 void h2o_mruby_send_chunked_close(h2o_mruby_generator_t *generator);
 mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_value body);
 void h2o_mruby_send_chunked_dispose(h2o_mruby_generator_t *generator);
@@ -157,7 +162,7 @@ mrb_value h2o_mruby_send_chunked_eos_callback(h2o_mruby_generator_t *generator, 
                                               int *next_action);
 
 /* handler/mruby/http_request.c */
-void h2o_mruby_http_request_init_context(h2o_mruby_context_t *ctx);
+void h2o_mruby_http_request_init_context(h2o_mruby_shared_context_t *ctx);
 mrb_value h2o_mruby_http_join_response_callback(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value args,
                                                 int *next_action);
 mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value input,

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -152,9 +152,9 @@ void h2o_context_dispose(h2o_context_t *ctx)
 
     /* clear storage */
     for (i = 0; i != ctx->storage.size; ++i) {
-        h2o_context_storage_item_t item = ctx->storage.entries[i];
-        if (item.dispose != NULL) {
-            item.dispose(item.data);
+        h2o_context_storage_item_t *item = ctx->storage.entries + i;
+        if (item->dispose != NULL) {
+            item->dispose(item->data);
         }
     }
     free(ctx->storage.entries);

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -153,10 +153,8 @@ void h2o_context_dispose(h2o_context_t *ctx)
     /* clear storage */
     for (i = 0; i != ctx->storage.size; ++i) {
         h2o_context_storage_item_t item = ctx->storage.entries[i];
-        if (item.data != NULL) {
-            if (item.dispose != NULL) {
-                item.dispose(item.data);
-            }
+        if (item.dispose != NULL) {
+            item.dispose(item.data);
         }
     }
     free(ctx->storage.entries);

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -24,9 +24,6 @@
 #include <sys/time.h>
 #include "h2o.h"
 #include "h2o/memcached.h"
-#if H2O_USE_MRUBY
-#include "h2o/mruby_.h"
-#endif
 
 void h2o_context_init_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pathconf)
 {
@@ -153,10 +150,17 @@ void h2o_context_dispose(h2o_context_t *ctx)
     h2o_filecache_destroy(ctx->filecache);
     ctx->filecache = NULL;
 
-#if H2O_USE_MRUBY
-    mrb_close(ctx->mruby_shared_context->mrb);
-    ctx->mruby_shared_context = NULL;
-#endif
+    /* clear storage */
+    for (i = 0; i != ctx->storage.size; ++i) {
+        h2o_context_storage_item_t *item = ctx->storage.entries[i];
+        if (item != NULL) {
+            if (item->dispose != NULL) {
+                item->dispose(item, ctx);
+            }
+            free(item);
+        }
+    }
+    free(ctx->storage.entries);
 
     /* TODO assert that the all the getaddrinfo threads are idle */
     h2o_multithread_unregister_receiver(ctx->queue, &ctx->receivers.hostinfo_getaddr);

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -24,6 +24,9 @@
 #include <sys/time.h>
 #include "h2o.h"
 #include "h2o/memcached.h"
+#if H2O_USE_MRUBY
+#include "h2o/mruby_.h"
+#endif
 
 void h2o_context_init_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pathconf)
 {
@@ -149,6 +152,11 @@ void h2o_context_dispose(h2o_context_t *ctx)
 
     h2o_filecache_destroy(ctx->filecache);
     ctx->filecache = NULL;
+
+#if H2O_USE_MRUBY
+    mrb_close(ctx->mruby_shared_context->mrb);
+    ctx->mruby_shared_context = NULL;
+#endif
 
     /* TODO assert that the all the getaddrinfo threads are idle */
     h2o_multithread_unregister_receiver(ctx->queue, &ctx->receivers.hostinfo_getaddr);

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -155,7 +155,7 @@ void h2o_context_dispose(h2o_context_t *ctx)
         h2o_context_storage_item_t *item = ctx->storage.entries[i];
         if (item != NULL) {
             if (item->dispose != NULL) {
-                item->dispose(item, ctx);
+                item->dispose(item->data);
             }
             free(item);
         }

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -152,12 +152,11 @@ void h2o_context_dispose(h2o_context_t *ctx)
 
     /* clear storage */
     for (i = 0; i != ctx->storage.size; ++i) {
-        h2o_context_storage_item_t *item = ctx->storage.entries[i];
-        if (item != NULL) {
-            if (item->dispose != NULL) {
-                item->dispose(item->data);
+        h2o_context_storage_item_t item = ctx->storage.entries[i];
+        if (item.data != NULL) {
+            if (item.dispose != NULL) {
+                item.dispose(item.data);
             }
-            free(item);
         }
     }
     free(ctx->storage.entries);

--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -31,21 +31,27 @@ struct mruby_configurator_t {
     h2o_configurator_t super;
     h2o_mruby_config_vars_t *vars;
     h2o_mruby_config_vars_t _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
+    mrb_state *mrb; /* will be lazily initialized */
 };
 
-static int compile_test(h2o_mruby_config_vars_t *config, char *errbuf)
+static int compile_test(mrb_state *mrb, h2o_mruby_config_vars_t *config, char *errbuf)
 {
-    mrb_state *mrb;
-
-    if ((mrb = mrb_open()) == NULL) {
-        fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
-        abort();
-    }
     mrb_value result = h2o_mruby_compile_code(mrb, config, errbuf);
     int ok = !mrb_nil_p(result);
-    mrb_close(mrb);
-
     return ok;
+}
+
+static mrb_state *maybe_init_mrb(struct mruby_configurator_t *self)
+{
+    if (self->mrb == NULL) {
+        self->mrb = mrb_open();
+        if (self->mrb == NULL) {
+            fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
+            abort();
+        }
+        h2o_mruby_setup_globals(self->mrb);
+    }
+    return self->mrb;
 }
 
 static int on_config_mruby_handler(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
@@ -59,7 +65,7 @@ static int on_config_mruby_handler(h2o_configurator_command_t *cmd, h2o_configur
 
     /* check if there is any error in source */
     char errbuf[1024];
-    if (!compile_test(self->vars, errbuf)) {
+    if (!compile_test(maybe_init_mrb(self), self->vars, errbuf)) {
         h2o_configurator_errprintf(cmd, node, "ruby compile error:%s", errbuf);
         return -1;
     }
@@ -100,7 +106,7 @@ static int on_config_mruby_handler_file(h2o_configurator_command_t *cmd, h2o_con
 
     /* check if there is any error in source */
     char errbuf[1024];
-    if (!compile_test(self->vars, errbuf)) {
+    if (!compile_test(maybe_init_mrb(self), self->vars, errbuf)) {
         h2o_configurator_errprintf(cmd, node, "failed to compile file:%s:%s", node->data.scalar, errbuf);
         goto Exit;
     }
@@ -142,6 +148,13 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
         free(self->vars->source.base);
 
     --self->vars;
+
+    /* release mrb only when global configuration exited */
+    if (self->mrb != NULL && ctx->parent == NULL) {
+        mrb_close(self->mrb);
+        self->mrb = NULL;
+    }
+
     return 0;
 }
 

--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -41,7 +41,7 @@ static int compile_test(mrb_state *mrb, h2o_mruby_config_vars_t *config, char *e
     return ok;
 }
 
-static mrb_state *maybe_init_mrb(struct mruby_configurator_t *self)
+static mrb_state *get_mrb(struct mruby_configurator_t *self)
 {
     if (self->mrb == NULL) {
         self->mrb = mrb_open();
@@ -65,7 +65,7 @@ static int on_config_mruby_handler(h2o_configurator_command_t *cmd, h2o_configur
 
     /* check if there is any error in source */
     char errbuf[1024];
-    if (!compile_test(maybe_init_mrb(self), self->vars, errbuf)) {
+    if (!compile_test(get_mrb(self), self->vars, errbuf)) {
         h2o_configurator_errprintf(cmd, node, "ruby compile error:%s", errbuf);
         return -1;
     }
@@ -106,7 +106,7 @@ static int on_config_mruby_handler_file(h2o_configurator_command_t *cmd, h2o_con
 
     /* check if there is any error in source */
     char errbuf[1024];
-    if (!compile_test(maybe_init_mrb(self), self->vars, errbuf)) {
+    if (!compile_test(get_mrb(self), self->vars, errbuf)) {
         h2o_configurator_errprintf(cmd, node, "failed to compile file:%s:%s", node->data.scalar, errbuf);
         goto Exit;
     }

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -350,6 +350,8 @@ static h2o_mruby_shared_context_t *create_shared_context(h2o_context_t *ctx)
 
 static void dispose_storage_item(void *data)
 {
+    if (data == NULL)
+        return;
     h2o_mruby_shared_context_t *shared_ctx = (h2o_mruby_shared_context_t *)data;
     mrb_close(shared_ctx->mrb);
 }

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -178,7 +178,8 @@ mrb_value h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config
     }
 
     /* call post_handler_generation hooks */
-    mrb_funcall_argv(mrb, h2o_mruby_eval_expr(mrb, "H2O::ConfigurationContext.instance"), mrb_intern_lit(mrb, "post_handler_generation"), 1, &result);
+    mrb_funcall_argv(mrb, h2o_mruby_eval_expr(mrb, "H2O::ConfigurationContext.instance"),
+                     mrb_intern_lit(mrb, "call_post_handler_generation_hooks"), 1, &result);
     if (mrb->exc != NULL) {
         mrb_value obj = mrb_funcall(mrb, mrb_obj_value(mrb->exc), "inspect", 0);
         struct RString *error = mrb_str_ptr(obj);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -53,7 +53,7 @@ void h2o_mruby__assert_failed(mrb_state *mrb, const char *file, int line)
     abort();
 }
 
-static void setup_globals(mrb_state *mrb)
+void h2o_mruby_setup_globals(mrb_state *mrb)
 {
     const char *root = getenv("H2O_ROOT");
     if (root == NULL)
@@ -125,8 +125,6 @@ mrb_value h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config
     struct RProc *proc = NULL;
     mrb_value result = mrb_nil_value();
 
-    setup_globals(mrb);
-
     /* parse */
     if ((cxt = mrbc_context_new(mrb)) == NULL) {
         fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
@@ -174,8 +172,8 @@ mrb_value h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config
         goto Exit;
     }
 
-    /* validate proc by calling H2O.validate_handler method */
-    mrb_funcall_argv(mrb, h2o_mruby_eval_expr(mrb, "H2O"), mrb_intern_lit(mrb, "validate_handler"), 1, &result);
+    /* calls H2O.after_generate_handler hook */
+    mrb_funcall_argv(mrb, h2o_mruby_eval_expr(mrb, "H2O"), mrb_intern_lit(mrb, "after_generate_handler"), 1, &result);
     if (mrb->exc != NULL) {
         mrb_value obj = mrb_funcall(mrb, mrb_obj_value(mrb->exc), "inspect", 0);
         struct RString *error = mrb_str_ptr(obj);
@@ -327,6 +325,29 @@ static mrb_value build_constants(mrb_state *mrb, const char *server_name, size_t
     return ary;
 }
 
+static h2o_mruby_shared_context_t *create_shared_context(h2o_context_t *ctx)
+{
+    /* init mruby in every thread */
+    h2o_mruby_shared_context_t *shared_ctx = h2o_mem_alloc(sizeof(*shared_ctx));
+    if ((shared_ctx->mrb = mrb_open()) == NULL) {
+        fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
+        abort();
+    }
+    h2o_mruby_setup_globals(shared_ctx->mrb);
+    shared_ctx->constants = build_constants(shared_ctx->mrb, ctx->globalconf->server_name.base, ctx->globalconf->server_name.len);
+    shared_ctx->symbols.sym_call = mrb_intern_lit(shared_ctx->mrb, "call");
+    shared_ctx->symbols.sym_close = mrb_intern_lit(shared_ctx->mrb, "close");
+    shared_ctx->symbols.sym_method = mrb_intern_lit(shared_ctx->mrb, "method");
+    shared_ctx->symbols.sym_headers = mrb_intern_lit(shared_ctx->mrb, "headers");
+    shared_ctx->symbols.sym_body = mrb_intern_lit(shared_ctx->mrb, "body");
+    shared_ctx->symbols.sym_async = mrb_intern_lit(shared_ctx->mrb, "async");
+
+    h2o_mruby_send_chunked_init_context(shared_ctx);
+    h2o_mruby_http_request_init_context(shared_ctx);
+
+    return shared_ctx;
+}
+
 static void on_context_init(h2o_handler_t *_handler, h2o_context_t *ctx)
 {
     h2o_mruby_handler_t *handler = (void *)_handler;
@@ -334,31 +355,22 @@ static void on_context_init(h2o_handler_t *_handler, h2o_context_t *ctx)
 
     handler_ctx->handler = handler;
 
-    /* init mruby in every thread */
-    if ((handler_ctx->mrb = mrb_open()) == NULL) {
-        fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
-        abort();
+    /* lazy initialize shared context */
+    if (ctx->mruby_shared_context == NULL) {
+        ctx->mruby_shared_context = create_shared_context(ctx);
     }
-    handler_ctx->constants = build_constants(handler_ctx->mrb, ctx->globalconf->server_name.base, ctx->globalconf->server_name.len);
-    handler_ctx->symbols.sym_call = mrb_intern_lit(handler_ctx->mrb, "call");
-    handler_ctx->symbols.sym_close = mrb_intern_lit(handler_ctx->mrb, "close");
-    handler_ctx->symbols.sym_method = mrb_intern_lit(handler_ctx->mrb, "method");
-    handler_ctx->symbols.sym_headers = mrb_intern_lit(handler_ctx->mrb, "headers");
-    handler_ctx->symbols.sym_body = mrb_intern_lit(handler_ctx->mrb, "body");
-    handler_ctx->symbols.sym_async = mrb_intern_lit(handler_ctx->mrb, "async");
-
-    h2o_mruby_send_chunked_init_context(handler_ctx);
-    h2o_mruby_http_request_init_context(handler_ctx);
+    handler_ctx->shared = ctx->mruby_shared_context;
 
     /* compile code (must be done for each thread) */
-    int arena = mrb_gc_arena_save(handler_ctx->mrb);
-    mrb_value proc = h2o_mruby_compile_code(handler_ctx->mrb, &handler->config, NULL);
+    int arena = mrb_gc_arena_save(handler_ctx->shared->mrb);
+    mrb_value proc = h2o_mruby_compile_code(handler_ctx->shared->mrb, &handler->config, NULL);
 
-    handler_ctx->proc = mrb_funcall_argv(handler_ctx->mrb, mrb_ary_entry(handler_ctx->constants, H2O_MRUBY_PROC_APP_TO_FIBER),
-                                         handler_ctx->symbols.sym_call, 1, &proc);
-    h2o_mruby_assert(handler_ctx->mrb);
-    mrb_gc_arena_restore(handler_ctx->mrb, arena);
-    mrb_gc_protect(handler_ctx->mrb, handler_ctx->proc);
+    handler_ctx->proc =
+        mrb_funcall_argv(handler_ctx->shared->mrb, mrb_ary_entry(handler_ctx->shared->constants, H2O_MRUBY_PROC_APP_TO_FIBER),
+                         handler_ctx->shared->symbols.sym_call, 1, &proc);
+    h2o_mruby_assert(handler_ctx->shared->mrb);
+    mrb_gc_arena_restore(handler_ctx->shared->mrb, arena);
+    mrb_gc_protect(handler_ctx->shared->mrb, handler_ctx->proc);
 
     h2o_context_set_handler_context(ctx, &handler->super, handler_ctx);
 }
@@ -371,7 +383,6 @@ static void on_context_dispose(h2o_handler_t *_handler, h2o_context_t *ctx)
     if (handler_ctx == NULL)
         return;
 
-    mrb_close(handler_ctx->mrb);
     free(handler_ctx);
 }
 
@@ -435,52 +446,53 @@ static int build_env_sort_header_cb(const void *_x, const void *_y)
 
 static mrb_value build_env(h2o_mruby_generator_t *generator)
 {
-    mrb_state *mrb = generator->ctx->mrb;
+    h2o_mruby_shared_context_t *shared = generator->ctx->shared;
+    mrb_state *mrb = shared->mrb;
     mrb_value env = mrb_hash_new_capa(mrb, 16);
 
     /* environment */
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_REQUEST_METHOD),
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_REQUEST_METHOD),
                  mrb_str_new(mrb, generator->req->method.base, generator->req->method.len));
     size_t confpath_len_wo_slash = generator->req->pathconf->path.len;
     if (generator->req->pathconf->path.base[generator->req->pathconf->path.len - 1] == '/')
         --confpath_len_wo_slash;
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_SCRIPT_NAME),
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SCRIPT_NAME),
                  mrb_str_new(mrb, generator->req->pathconf->path.base, confpath_len_wo_slash));
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_PATH_INFO),
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_PATH_INFO),
                  mrb_str_new(mrb, generator->req->path_normalized.base + confpath_len_wo_slash,
                              generator->req->path_normalized.len - confpath_len_wo_slash));
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_QUERY_STRING),
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_QUERY_STRING),
                  generator->req->query_at != SIZE_MAX ? mrb_str_new(mrb, generator->req->path.base + generator->req->query_at + 1,
                                                                     generator->req->path.len - (generator->req->query_at + 1))
                                                       : mrb_str_new_lit(mrb, ""));
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_SERVER_NAME),
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SERVER_NAME),
                  mrb_str_new(mrb, generator->req->hostconf->authority.host.base, generator->req->hostconf->authority.host.len));
     {
         mrb_value h, p;
         stringify_address(generator->req->conn, generator->req->conn->callbacks->get_sockname, mrb, &h, &p);
         if (!mrb_nil_p(h))
-            mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_SERVER_ADDR), h);
+            mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SERVER_ADDR), h);
         if (!mrb_nil_p(p))
-            mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_SERVER_PORT), p);
+            mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SERVER_PORT), p);
     }
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_TOKEN_HOST - h2o__tokens),
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_TOKEN_HOST - h2o__tokens),
                  mrb_str_new(mrb, generator->req->authority.base, generator->req->authority.len));
     if (generator->req->entity.base != NULL) {
         char buf[32];
         int l = sprintf(buf, "%zu", generator->req->entity.len);
-        mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_CONTENT_LENGTH), mrb_str_new(mrb, buf, l));
+        mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_CONTENT_LENGTH), mrb_str_new(mrb, buf, l));
         generator->rack_input = mrb_input_stream_value(mrb, NULL, 0);
         mrb_input_stream_set_data(mrb, generator->rack_input, generator->req->entity.base, (mrb_int)generator->req->entity.len, 0,
                                   on_rack_input_free, &generator->rack_input);
-        mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_RACK_INPUT), generator->rack_input);
+        mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_RACK_INPUT), generator->rack_input);
     }
     {
         mrb_value h, p;
         stringify_address(generator->req->conn, generator->req->conn->callbacks->get_peername, mrb, &h, &p);
         if (!mrb_nil_p(h))
-            mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_REMOTE_ADDR), h);
+            mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_REMOTE_ADDR), h);
         if (!mrb_nil_p(p))
-            mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_REMOTE_PORT), p);
+            mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_REMOTE_PORT), p);
     }
     {
         size_t i;
@@ -502,7 +514,7 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
                 const h2o_token_t *token = H2O_STRUCT_FROM_MEMBER(h2o_token_t, buf, header->name);
                 if (token == H2O_TOKEN_TRANSFER_ENCODING)
                     continue;
-                n = mrb_ary_entry(generator->ctx->constants, (mrb_int)(token - h2o__tokens));
+                n = mrb_ary_entry(shared->constants, (mrb_int)(token - h2o__tokens));
             } else {
                 h2o_iovec_t vec = convert_header_name_to_env(&generator->req->pool, header->name->base, header->name->len);
                 n = mrb_str_new(mrb, vec.base, vec.len);
@@ -513,9 +525,9 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
                                header->name->len))
                     break;
                 header = headers_sorted + ++i;
-                v = mrb_str_append(mrb, v, mrb_ary_entry(generator->ctx->constants, header->name == &H2O_TOKEN_COOKIE->buf
-                                                                                        ? H2O_MRUBY_LIT_SEPARATOR_SEMICOLON
-                                                                                        : H2O_MRUBY_LIT_SEPARATOR_COMMA));
+                v = mrb_str_append(mrb, v, mrb_ary_entry(shared->constants, header->name == &H2O_TOKEN_COOKIE->buf
+                                                                                ? H2O_MRUBY_LIT_SEPARATOR_SEMICOLON
+                                                                                : H2O_MRUBY_LIT_SEPARATOR_COMMA));
                 v = mrb_str_append(mrb, v, mrb_str_new(mrb, header->value.base, header->value.len));
             }
             mrb_hash_set(mrb, env, n, v);
@@ -524,19 +536,19 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
 
     /* rack.* */
     /* TBD rack.version? */
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_RACK_URL_SCHEME),
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_RACK_URL_SCHEME),
                  mrb_str_new(mrb, generator->req->scheme->name.base, generator->req->scheme->name.len));
     /* we are using shared-none architecture, and therefore declare ourselves as multiprocess */
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_RACK_MULTITHREAD), mrb_false_value());
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_RACK_MULTIPROCESS), mrb_true_value());
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_RACK_RUN_ONCE), mrb_false_value());
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_RACK_HIJACK_), mrb_false_value());
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_RACK_ERRORS),
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_RACK_MULTITHREAD), mrb_false_value());
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_RACK_MULTIPROCESS), mrb_true_value());
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_RACK_RUN_ONCE), mrb_false_value());
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_RACK_HIJACK_), mrb_false_value());
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_RACK_ERRORS),
                  mrb_gv_get(mrb, mrb_intern_lit(mrb, "$stderr")));
 
     /* server name */
-    mrb_hash_set(mrb, env, mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_SERVER_SOFTWARE),
-                 mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_LIT_SERVER_SOFTWARE_VALUE));
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SERVER_SOFTWARE),
+                 mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SERVER_SOFTWARE_VALUE));
 
     return env;
 }
@@ -583,7 +595,7 @@ static int handle_response_header(h2o_mruby_context_t *handler_ctx, h2o_iovec_t 
 static void clear_rack_input(h2o_mruby_generator_t *generator)
 {
     if (!mrb_nil_p(generator->rack_input))
-        mrb_input_stream_set_data(generator->ctx->mrb, generator->rack_input, NULL, -1, 0, NULL, NULL);
+        mrb_input_stream_set_data(generator->ctx->shared->mrb, generator->rack_input, NULL, -1, 0, NULL, NULL);
 }
 
 static void on_generator_dispose(void *_generator)
@@ -600,8 +612,8 @@ static void on_generator_dispose(void *_generator)
 static int on_req(h2o_handler_t *_handler, h2o_req_t *req)
 {
     h2o_mruby_handler_t *handler = (void *)_handler;
-    h2o_mruby_context_t *handler_ctx = h2o_context_get_handler_context(req->conn->ctx, &handler->super);
-    int gc_arena = mrb_gc_arena_save(handler_ctx->mrb);
+    h2o_mruby_shared_context_t *shared = req->conn->ctx->mruby_shared_context;
+    int gc_arena = mrb_gc_arena_save(shared->mrb);
 
     h2o_mruby_generator_t *generator = h2o_mem_alloc_shared(&req->pool, sizeof(*generator), on_generator_dispose);
     generator->super.proceed = NULL;
@@ -616,7 +628,7 @@ static int on_req(h2o_handler_t *_handler, h2o_req_t *req)
     int is_delegate = 0;
     h2o_mruby_run_fiber(generator, generator->ctx->proc, env, &is_delegate);
 
-    mrb_gc_arena_restore(handler_ctx->mrb, gc_arena);
+    mrb_gc_arena_restore(shared->mrb, gc_arena);
     if (is_delegate)
         return -1;
     return 0;
@@ -624,7 +636,7 @@ static int on_req(h2o_handler_t *_handler, h2o_req_t *req)
 
 static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_value resp, int *is_delegate)
 {
-    mrb_state *mrb = generator->ctx->mrb;
+    mrb_state *mrb = generator->ctx->shared->mrb;
     mrb_value body;
     h2o_iovec_t content = {NULL};
 
@@ -707,7 +719,7 @@ GotException:
 
 void h2o_mruby_run_fiber(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value input, int *is_delegate)
 {
-    mrb_state *mrb = generator->ctx->mrb;
+    mrb_state *mrb = generator->ctx->shared->mrb;
     mrb_value output;
     mrb_int status;
 
@@ -720,7 +732,7 @@ void h2o_mruby_run_fiber(h2o_mruby_generator_t *generator, mrb_value receiver, m
 
     while (1) {
         /* send input to fiber */
-        output = mrb_funcall_argv(mrb, receiver, generator->ctx->symbols.sym_call, 1, &input);
+        output = mrb_funcall_argv(mrb, receiver, generator->ctx->shared->symbols.sym_call, 1, &input);
         if (mrb->exc != NULL)
             goto GotException;
         if (!mrb_array_p(output)) {
@@ -830,19 +842,21 @@ h2o_mruby_handler_t *h2o_mruby_register(h2o_pathconf_t *pathconf, h2o_mruby_conf
 
 mrb_value h2o_mruby_each_to_array(h2o_mruby_context_t *handler_ctx, mrb_value src)
 {
-    return mrb_funcall_argv(handler_ctx->mrb, mrb_ary_entry(handler_ctx->constants, H2O_MRUBY_PROC_EACH_TO_ARRAY),
-                            handler_ctx->symbols.sym_call, 1, &src);
+    return mrb_funcall_argv(handler_ctx->shared->mrb, mrb_ary_entry(handler_ctx->shared->constants, H2O_MRUBY_PROC_EACH_TO_ARRAY),
+                            handler_ctx->shared->symbols.sym_call, 1, &src);
 }
 
 static int iterate_headers_handle_pair(h2o_mruby_context_t *handler_ctx, mrb_value name, mrb_value value,
                                        int (*cb)(h2o_mruby_context_t *, h2o_iovec_t, h2o_iovec_t, void *), void *cb_data)
 {
+    mrb_state *mrb = handler_ctx->shared->mrb;
+
     /* convert name and value to string */
-    name = h2o_mruby_to_str(handler_ctx->mrb, name);
-    if (handler_ctx->mrb->exc != NULL)
+    name = h2o_mruby_to_str(mrb, name);
+    if (mrb->exc != NULL)
         return -1;
-    value = h2o_mruby_to_str(handler_ctx->mrb, value);
-    if (handler_ctx->mrb->exc != NULL)
+    value = h2o_mruby_to_str(mrb, value);
+    if (mrb->exc != NULL)
         return -1;
 
     /* call the callback, splitting the values with '\n' */
@@ -865,7 +879,7 @@ static int iterate_headers_handle_pair(h2o_mruby_context_t *handler_ctx, mrb_val
 int h2o_mruby_iterate_headers(h2o_mruby_context_t *handler_ctx, mrb_value headers,
                               int (*cb)(h2o_mruby_context_t *, h2o_iovec_t, h2o_iovec_t, void *), void *cb_data)
 {
-    mrb_state *mrb = handler_ctx->mrb;
+    mrb_state *mrb = handler_ctx->shared->mrb;
 
     if (!(mrb_hash_p(headers) || mrb_array_p(headers))) {
         headers = h2o_mruby_each_to_array(handler_ctx, headers);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -160,7 +160,7 @@ mrb_value h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config
     }
 
     /* reset configuration context */
-    h2o_mruby_eval_expr(mrb, "H2O::ConfigurationContext.instance = H2O::ConfigurationContext.new");
+    h2o_mruby_eval_expr(mrb, "H2O::ConfigurationContext.reset");
     h2o_mruby_assert(mrb);
 
     /* run code and generate handler */

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -354,13 +354,13 @@ static h2o_mruby_shared_context_t *get_shared_context(h2o_context_t *ctx)
 {
     static size_t key = SIZE_MAX;
     h2o_context_get_storage_index(ctx, &key);
-    if (ctx->storage.entries[key] == NULL) {
-        h2o_context_storage_item_t *item = h2o_mem_alloc(sizeof(*item));
-        item->data = create_shared_context(ctx);
-        item->dispose = dispose_storage_item;
+    if (ctx->storage.entries[key].data == NULL) {
+        h2o_context_storage_item_t item = {NULL};
+        item.data = create_shared_context(ctx);
+        item.dispose = dispose_storage_item;
         ctx->storage.entries[key] = item;
     }
-    return ctx->storage.entries[key]->data;
+    return ctx->storage.entries[key].data;
 }
 
 static void dispose_storage_item(void *data)

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -348,7 +348,7 @@ static h2o_mruby_shared_context_t *create_shared_context(h2o_context_t *ctx)
     return shared_ctx;
 }
 
-static void dispose_storage_item(struct st_h2o_context_storage_item_t *self, h2o_context_t *ctx);
+static void dispose_storage_item(void *data);
 
 static h2o_mruby_shared_context_t *get_shared_context(h2o_context_t *ctx)
 {
@@ -363,10 +363,10 @@ static h2o_mruby_shared_context_t *get_shared_context(h2o_context_t *ctx)
     return ctx->storage.entries[key]->data;
 }
 
-static void dispose_storage_item(struct st_h2o_context_storage_item_t *self, h2o_context_t *ctx)
+static void dispose_storage_item(void *data)
 {
-    mrb_state *mrb = get_shared_context(ctx)->mrb;
-    mrb_close(mrb);
+    h2o_mruby_shared_context_t *shared_ctx = (h2o_mruby_shared_context_t *)data;
+    mrb_close(shared_ctx->mrb);
 }
 
 static void on_context_init(h2o_handler_t *_handler, h2o_context_t *ctx)

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -353,18 +353,19 @@ static h2o_mruby_shared_context_t *create_shared_context(h2o_context_t *ctx)
     return shared_ctx;
 }
 
-static void dispose_storage_item(void *data)
+static void dispose_shared_context(void *data)
 {
     if (data == NULL)
         return;
     h2o_mruby_shared_context_t *shared_ctx = (h2o_mruby_shared_context_t *)data;
     mrb_close(shared_ctx->mrb);
+    free(shared_ctx);
 }
 
 static h2o_mruby_shared_context_t *get_shared_context(h2o_context_t *ctx)
 {
     static size_t key = SIZE_MAX;
-    void **data = h2o_context_get_storage(ctx, &key, dispose_storage_item);
+    void **data = h2o_context_get_storage(ctx, &key, dispose_shared_context);
     if (*data == NULL) {
         *data = create_shared_context(ctx);
     }

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -122,12 +122,12 @@ static void on_shortcut_notify(h2o_mruby_generator_t *generator)
 static void close_body_obj(h2o_mruby_generator_t *generator)
 {
     h2o_mruby_chunked_t *chunked = generator->chunked;
-    mrb_state *mrb = generator->ctx->mrb;
+    mrb_state *mrb = generator->ctx->shared->mrb;
 
     if (!mrb_nil_p(chunked->callback.body_obj)) {
         /* call close and throw away error */
-        if (mrb_respond_to(mrb, chunked->callback.body_obj, generator->ctx->symbols.sym_close))
-            mrb_funcall_argv(generator->ctx->mrb, chunked->callback.body_obj, generator->ctx->symbols.sym_close, 0, NULL);
+        if (mrb_respond_to(mrb, chunked->callback.body_obj, generator->ctx->shared->symbols.sym_close))
+            mrb_funcall_argv(mrb, chunked->callback.body_obj, generator->ctx->shared->symbols.sym_close, 0, NULL);
         mrb->exc = NULL;
         mrb_gc_unregister(mrb, chunked->callback.body_obj);
         chunked->callback.body_obj = mrb_nil_value();
@@ -144,7 +144,7 @@ mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_valu
     generator->super.proceed = do_proceed;
     generator->chunked = chunked;
 
-    if ((chunked->shortcut.client = h2o_mruby_http_set_shortcut(generator->ctx->mrb, body, on_shortcut_notify)) != NULL) {
+    if ((chunked->shortcut.client = h2o_mruby_http_set_shortcut(generator->ctx->shared->mrb, body, on_shortcut_notify)) != NULL) {
         chunked->type = H2O_MRUBY_CHUNKED_TYPE_SHORTCUT;
         chunked->shortcut.remaining = NULL;
         on_shortcut_notify(generator);
@@ -152,9 +152,9 @@ mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_valu
     } else {
         chunked->type = H2O_MRUBY_CHUNKED_TYPE_CALLBACK;
         h2o_buffer_init(&chunked->callback.receiving, &h2o_socket_buffer_prototype);
-        mrb_gc_register(generator->ctx->mrb, body);
+        mrb_gc_register(generator->ctx->shared->mrb, body);
         chunked->callback.body_obj = body;
-        return mrb_ary_entry(generator->ctx->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER);
+        return mrb_ary_entry(generator->ctx->shared->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER);
     }
 }
 
@@ -224,7 +224,7 @@ static mrb_value send_chunked_method(mrb_state *mrb, mrb_value self)
 mrb_value h2o_mruby_send_chunked_eos_callback(h2o_mruby_generator_t *generator, mrb_value receiver, mrb_value input,
                                               int *next_action)
 {
-    mrb_state *mrb = generator->ctx->mrb;
+    mrb_state *mrb = generator->ctx->shared->mrb;
 
     { /* precond check */
         mrb_value exc = check_precond(mrb, generator);
@@ -251,20 +251,21 @@ void h2o_mruby_send_chunked_close(h2o_mruby_generator_t *generator)
         do_send(generator, &chunked->callback.receiving, 1);
 }
 
-void h2o_mruby_send_chunked_init_context(h2o_mruby_context_t *ctx)
+void h2o_mruby_send_chunked_init_context(h2o_mruby_shared_context_t *shared_ctx)
 {
-    mrb_state *mrb = ctx->mrb;
+    mrb_state *mrb = shared_ctx->mrb;
 
     mrb_define_method(mrb, mrb->kernel_module, "_h2o_send_chunk", send_chunked_method, MRB_ARGS_ARG(1, 0));
     h2o_mruby_define_callback(mrb, "_h2o_send_chunk_eos", H2O_MRUBY_CALLBACK_ID_SEND_CHUNKED_EOS);
-    mrb_ary_set(mrb, ctx->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER, h2o_mruby_eval_expr(mrb, "Proc.new do |src|\n"
-                                                                                                    "  fiber = Fiber.new do\n"
-                                                                                                    "    src.each do |chunk|\n"
-                                                                                                    "      _h2o_send_chunk(chunk)\n"
-                                                                                                    "    end\n"
-                                                                                                    "    _h2o_send_chunk_eos()\n"
-                                                                                                    "  end\n"
-                                                                                                    "  fiber.resume\n"
-                                                                                                    "end"));
+    mrb_ary_set(mrb, shared_ctx->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER,
+                h2o_mruby_eval_expr(mrb, "Proc.new do |src|\n"
+                                         "  fiber = Fiber.new do\n"
+                                         "    src.each do |chunk|\n"
+                                         "      _h2o_send_chunk(chunk)\n"
+                                         "    end\n"
+                                         "    _h2o_send_chunk_eos()\n"
+                                         "  end\n"
+                                         "  fiber.resume\n"
+                                         "end"));
     h2o_mruby_assert(mrb);
 }

--- a/share/h2o/mruby/acl.rb
+++ b/share/h2o/mruby/acl.rb
@@ -25,17 +25,18 @@ module H2O
   module ACL
 
     def acl(&block)
-      if @acl_handler then
+      context = H2O::ConfigurationContext.instance
+      if context.get_value(:acl_handler) then
         raise "acl can be called only once for each handler configuration"
       end
-      @acl_handler = ACLHandler.new(&block)
-      H2O.add_after_generate_handler_hook(proc {|handler|
-        if handler != @acl_handler
+      acl_handler = ACLHandler.new(&block)
+      context.set_value(:acl_handler, acl_handler)
+      context.add_post_handler_generation_hook(proc {|handler|
+        if handler != acl_handler
           raise "acl configuration is ignored"
         end
-        @acl_handler = nil
       })
-      return @acl_handler
+      return acl_handler
     end
 
     class ACLHandler

--- a/share/h2o/mruby/acl.rb
+++ b/share/h2o/mruby/acl.rb
@@ -29,10 +29,11 @@ module H2O
         raise "acl can be called only once for each handler configuration"
       end
       @acl_handler = ACLHandler.new(&block)
-      H2O.add_handler_validator(proc {|handler|
+      H2O.add_after_generate_handler_hook(proc {|handler|
         if handler != @acl_handler
           raise "acl configuration is ignored"
         end
+        @acl_handler = nil
       })
       return @acl_handler
     end

--- a/share/h2o/mruby/bootstrap.rb
+++ b/share/h2o/mruby/bootstrap.rb
@@ -1,16 +1,24 @@
 module H2O
 
-  @@handler_validators = []
+  @@hooks = {
+    :after_generate_handler => [],
+  }
 
-  def self.validate_handler(handler)
-    @@handler_validators.each do |validator|
-      # will raise exception if handler is not valid
-      validator.call(handler)
-    end
+  def self.after_generate_handler(handler)
+    _call_hooks(:after_generate_handler, handler)
   end
 
-  def self.add_handler_validator(validator)
-    @@handler_validators << validator
+  def self.add_after_generate_handler_hook(hook)
+    _add_hook(:after_generate_handler, hook)
+  end
+
+  def self._call_hooks(type, *args)
+    @@hooks[type].each {|hook| hook.call(*args) }
+    @@hooks[type].clear
+  end
+
+  def self._add_hook(type, hook)
+    @@hooks[type] << hook
   end
 
 end

--- a/share/h2o/mruby/bootstrap.rb
+++ b/share/h2o/mruby/bootstrap.rb
@@ -4,8 +4,8 @@ module H2O
     def self.instance()
       @@instance
     end
-    def self.instance=(instance)
-      @@instance = instance
+    def self.reset()
+      @@instance = self.new()
     end
     def initialize()
       @values = {}

--- a/share/h2o/mruby/bootstrap.rb
+++ b/share/h2o/mruby/bootstrap.rb
@@ -1,24 +1,31 @@
 module H2O
 
-  @@hooks = {
-    :after_generate_handler => [],
-  }
-
-  def self.after_generate_handler(handler)
-    _call_hooks(:after_generate_handler, handler)
-  end
-
-  def self.add_after_generate_handler_hook(hook)
-    _add_hook(:after_generate_handler, hook)
-  end
-
-  def self._call_hooks(type, *args)
-    @@hooks[type].each {|hook| hook.call(*args) }
-    @@hooks[type].clear
-  end
-
-  def self._add_hook(type, hook)
-    @@hooks[type] << hook
+  class ConfigurationContext
+    def self.instance()
+      @@instance
+    end
+    def self.instance=(instance)
+      @@instance = instance
+    end
+    def initialize()
+      @values = {}
+      @post_handler_generation_hooks = []
+    end
+    def get_value(key)
+      @values[key]
+    end
+    def set_value(key, value)
+      @values[key] = value
+    end
+    def delete_value(key)
+      @values[key].delete
+    end
+    def add_post_handler_generation_hook(hook)
+      @post_handler_generation_hooks << hook
+    end
+    def post_handler_generation(handler)
+      @post_handler_generation_hooks.each {|hook| hook.call(handler) }
+    end
   end
 
 end

--- a/share/h2o/mruby/bootstrap.rb
+++ b/share/h2o/mruby/bootstrap.rb
@@ -23,7 +23,7 @@ module H2O
     def add_post_handler_generation_hook(hook)
       @post_handler_generation_hooks << hook
     end
-    def post_handler_generation(handler)
+    def call_post_handler_generation_hooks(handler)
       @post_handler_generation_hooks.each {|hook| hook.call(handler) }
     end
   end

--- a/t/00unit.mruby/acl.rb
+++ b/t/00unit.mruby/acl.rb
@@ -5,7 +5,7 @@ require 'acl.rb'
 class ACLTest < MTest::Unit::TestCase
     include H2O::ACL
     def setup
-        H2O::ConfigurationContext.instance = H2O::ConfigurationContext.new
+        H2O::ConfigurationContext.reset
     end
 
     def test_use

--- a/t/00unit.mruby/acl.rb
+++ b/t/00unit.mruby/acl.rb
@@ -5,10 +5,7 @@ require 'acl.rb'
 class ACLTest < MTest::Unit::TestCase
     include H2O::ACL
     def setup
-        $ACL = 0
-    end
-    def teardown
-        $ACL = nil
+        H2O::ConfigurationContext.instance = H2O::ConfigurationContext.new
     end
 
     def test_use


### PR DESCRIPTION
Fix the issue mentioned at https://github.com/h2o/h2o/issues/987
Let each thread share mruby context between handlers to reduce memory consumption.

I tried in my local macbook under the following condition:
* 64 thread
* 20 mruby handlers (simply fallthrough to the next handler)
* sent 1000 requests to warmup

The result is:
Before this fix: 912,612KB of resident size
After this fix: 64,852KB of resident size
