### PR TITLE
http2: one byte window connection hung

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -301,7 +301,8 @@ static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta
     ssize_t cur = h2o_http2_window_get_window(&stream->output_window);
     if (h2o_http2_window_update(&stream->output_window, delta) != 0)
         return -1;
-    if (cur <= 0 && h2o_http2_window_get_window(&stream->output_window) > 0 && h2o_http2_stream_has_pending_data(stream)) {
+    if (cur <= 0 && h2o_http2_window_get_window(&stream->output_window) > 0
+        && (h2o_http2_stream_has_pending_data(stream) || stream->state >= H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL)) {
         assert(!h2o_linklist_is_linked(&stream->_refs.link));
         h2o_http2_scheduler_activate(&stream->_refs.scheduler);
     }

--- a/t/80one-byte-window.t
+++ b/t/80one-byte-window.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+
+plan skip_all => 'nc not found'
+    unless prog_exists('nc');
+
+my $upstream_port = empty_port();
+$| = 1;
+my $socket = new IO::Socket::INET (
+    LocalHost => '127.0.0.1',
+    LocalPort => $upstream_port,
+    Proto => 'tcp',
+    Listen => 1,
+    Reuse => 1
+);
+die "cannot create socket $!\n" unless $socket;
+
+check_port($upstream_port) or die "can't connect to server socket";
+# accent and close check_port's connection
+my $client_socket = $socket->accept();
+close($client_socket);
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+my $msg = "this is the message";
+open(NGHTTP, "nghttp -t 3 -w 1 -v http://127.0.0.1:$server->{'port'}/ -H 'host: host.example.com' 2>&1 |");
+
+my $req;
+$client_socket = $socket->accept();
+$client_socket->recv($req, 1024);
+$client_socket->send("HTTP/1.1 200 Ok\r\nConnection:close\r\n\r\n$msg");
+close($client_socket);
+
+my $worked = 1;
+while(<NGHTTP>) {
+    if (/Timeout/) {
+        $worked = 0;
+    }
+}
+
+ok($worked == 1, "The connection didn't timeout");
+
+$socket->close();
+done_testing();


### PR DESCRIPTION

When receiving a window update message, mark the stream as active if the
stream is about to close. This allows the http2 subsystem to properly
close the stream.

The stream could otherwise become stuck if it stopped writing because
there was no space available in the stream, since no other activity
would wake it up.

I believe this fixes issue https://github.com/h2o/h2o/issues/1035 . When this is addressed, we'll be able to revert c7f376b6a8686ac174e2f74d29e7f90eb34a5a8e in PR #1031 , I've verified that this fix does address the issue.