### PR TITLE
Add a build time check for `h2o_http2_encode_rst_stream_frame`

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -86,6 +86,8 @@ extern "C" {
 #define H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT_IN_SECS 300
 #define H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT (H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT_IN_SECS * 1000)
 
+#define H2O_BUILD_ASSERT(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
+
 typedef struct st_h2o_conn_t h2o_conn_t;
 typedef struct st_h2o_context_t h2o_context_t;
 typedef struct st_h2o_req_t h2o_req_t;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -86,8 +86,6 @@ extern "C" {
 #define H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT_IN_SECS 300
 #define H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT (H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT_IN_SECS * 1000)
 
-#define H2O_BUILD_ASSERT(condition) ((void)sizeof(char[1 - 2*!!(condition)]))
-
 typedef struct st_h2o_conn_t h2o_conn_t;
 typedef struct st_h2o_context_t h2o_context_t;
 typedef struct st_h2o_req_t h2o_req_t;

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -239,9 +239,9 @@ int h2o_http2_update_peer_settings(h2o_http2_settings_t *settings, const uint8_t
 uint8_t *h2o_http2_encode_frame_header(uint8_t *dst, size_t length, uint8_t type, uint8_t flags, int32_t stream_id);
 
 #define h2o_http2_encode_rst_stream_frame(buf, stream_id, errnum) \
-    H2O_BUILD_ASSERT(__builtin_constant_p(errnum)?(errnum < 0):0); \
-    h2o_http2_encode_rst_stream_frame_(buf, stream_id, errnum);
-void h2o_http2_encode_rst_stream_frame_(h2o_buffer_t **buf, uint32_t stream_id, int errnum);
+    h2o_http2__encode_rst_stream_frame(buf, stream_id, (H2O_BUILD_ASSERT((errnum) > 0), errnum))
+
+void h2o_http2__encode_rst_stream_frame(h2o_buffer_t **buf, uint32_t stream_id, int errnum);
 void h2o_http2_encode_ping_frame(h2o_buffer_t **buf, int is_ack, const uint8_t *data);
 void h2o_http2_encode_goaway_frame(h2o_buffer_t **buf, uint32_t last_stream_id, int errnum, h2o_iovec_t additional_data);
 void h2o_http2_encode_window_update_frame(h2o_buffer_t **buf, uint32_t stream_id, int32_t window_size_increment);

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -237,7 +237,11 @@ int h2o_http2_update_peer_settings(h2o_http2_settings_t *settings, const uint8_t
 
 /* frames */
 uint8_t *h2o_http2_encode_frame_header(uint8_t *dst, size_t length, uint8_t type, uint8_t flags, int32_t stream_id);
-void h2o_http2_encode_rst_stream_frame(h2o_buffer_t **buf, uint32_t stream_id, int errnum);
+
+#define h2o_http2_encode_rst_stream_frame(buf, stream_id, errnum) \
+    H2O_BUILD_ASSERT(__builtin_constant_p(errnum)?(errnum < 0):0); \
+    h2o_http2_encode_rst_stream_frame_(buf, stream_id, errnum);
+void h2o_http2_encode_rst_stream_frame_(h2o_buffer_t **buf, uint32_t stream_id, int errnum);
 void h2o_http2_encode_ping_frame(h2o_buffer_t **buf, int is_ack, const uint8_t *data);
 void h2o_http2_encode_goaway_frame(h2o_buffer_t **buf, uint32_t last_stream_id, int errnum, h2o_iovec_t additional_data);
 void h2o_http2_encode_window_update_frame(h2o_buffer_t **buf, uint32_t stream_id, int32_t window_size_increment);

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -70,6 +70,8 @@ extern "C" {
 #define H2O_TO__STR(n) #n
 #define H2O_TO_STR(n) H2O_TO__STR(n)
 
+#define H2O_BUILD_ASSERT(condition) ((void)sizeof(char[2*!!(!__builtin_constant_p(condition) || (condition)) - 1]))
+
 typedef struct st_h2o_buffer_prototype_t h2o_buffer_prototype_t;
 
 /**

--- a/lib/http2/frame.c
+++ b/lib/http2/frame.c
@@ -81,7 +81,7 @@ static uint8_t *allocate_frame(h2o_buffer_t **buf, size_t length, uint8_t type, 
     return h2o_http2_encode_frame_header((uint8_t *)alloced.base, length, type, flags, stream_id);
 }
 
-void h2o_http2_encode_rst_stream_frame_(h2o_buffer_t **buf, uint32_t stream_id, int errnum)
+void h2o_http2__encode_rst_stream_frame(h2o_buffer_t **buf, uint32_t stream_id, int errnum)
 {
     uint8_t *dst = allocate_frame(buf, 4, H2O_HTTP2_FRAME_TYPE_RST_STREAM, 0, stream_id);
     dst = h2o_http2_encode32u(dst, errnum);

--- a/lib/http2/frame.c
+++ b/lib/http2/frame.c
@@ -81,7 +81,7 @@ static uint8_t *allocate_frame(h2o_buffer_t **buf, size_t length, uint8_t type, 
     return h2o_http2_encode_frame_header((uint8_t *)alloced.base, length, type, flags, stream_id);
 }
 
-void h2o_http2_encode_rst_stream_frame(h2o_buffer_t **buf, uint32_t stream_id, int errnum)
+void h2o_http2_encode_rst_stream_frame_(h2o_buffer_t **buf, uint32_t stream_id, int errnum)
 {
     uint8_t *dst = allocate_frame(buf, 4, H2O_HTTP2_FRAME_TYPE_RST_STREAM, 0, stream_id);
     dst = h2o_http2_encode32u(dst, errnum);


### PR DESCRIPTION
We introduce `H2O_BUILD_ASSERT` that can be used to write built-time
assertions.
We then use this macro in order to check that the `errnum` argument of
`h2o_http2_encode_rst_stream_frame` is positive.