### PR TITLE
accept sequence of mappings as path config node

### DIFF
--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -251,12 +251,13 @@ static yoml_t *convert_path_config_node(h2o_configurator_command_t *cmd, yoml_t 
         /* convert to mapping */
         yoml_t *map = h2o_mem_alloc(sizeof(yoml_t));
         *map = (yoml_t){YOML_TYPE_MAPPING};
-        map->filename = node->filename != NULL ? h2o_strdup(NULL, node->filename, SIZE_MAX).base : NULL;
+        if (node->filename != NULL)
+            map->filename = h2o_strdup(NULL, node->filename, SIZE_MAX).base;
         map->line = node->line;
         map->column = node->column;
-        map->anchor = node->anchor != NULL ? h2o_strdup(NULL, node->anchor, SIZE_MAX).base : NULL;
+        if (node->anchor != NULL)
+            map->anchor = h2o_strdup(NULL, node->anchor, SIZE_MAX).base;
         map->_refcnt = 1;
-        map->data.mapping.size = 0;
 
         for (i = 0; i != node->data.sequence.size; ++i) {
             yoml_t *elem = node->data.sequence.elements[i];

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -249,12 +249,12 @@ static yoml_t *convert_path_config_node(h2o_configurator_command_t *cmd, yoml_t 
         break;
     case YOML_TYPE_SEQUENCE: {
         /* convert to mapping */
-        yoml_t *map = h2o_mem_alloc(offsetof(yoml_t, data.mapping.elements));
-        map->type = YOML_TYPE_MAPPING;
-        map->filename = node->filename != NULL ? strdup(node->filename) : NULL;
+        yoml_t *map = h2o_mem_alloc(sizeof(yoml_t));
+        *map = (yoml_t){YOML_TYPE_MAPPING};
+        map->filename = node->filename != NULL ? h2o_strdup(NULL, node->filename, SIZE_MAX).base : NULL;
         map->line = node->line;
         map->column = node->column;
-        map->anchor = node->anchor != NULL ? strdup(node->anchor) : NULL;
+        map->anchor = node->anchor != NULL ? h2o_strdup(NULL, node->anchor, SIZE_MAX).base : NULL;
         map->_refcnt = 1;
         map->data.mapping.size = 0;
 

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -251,6 +251,10 @@ static yoml_t *convert_path_config_node(h2o_configurator_command_t *cmd, yoml_t 
         /* convert to mapping */
         yoml_t *map = h2o_mem_alloc(offsetof(yoml_t, data.mapping.elements));
         map->type = YOML_TYPE_MAPPING;
+        map->filename = node->filename != NULL ? strdup(node->filename) : NULL;
+        map->line = node->line;
+        map->column = node->column;
+        map->anchor = node->anchor != NULL ? strdup(node->anchor) : NULL;
         map->_refcnt = 1;
         map->data.mapping.size = 0;
 


### PR DESCRIPTION
Make `paths` directive accept a sequence of mappings.
As mentioned in https://github.com/h2o/h2o/issues/559#issuecomment-218327572 , `paths` directive expect a handler list, which ordering is important, so I believe a sequence is better and clearer than a mapping.

We can now write as follows:

```
paths:
  /:
    - mruby.handler: proc {|env| [399, {"foo"=>"FOO"}, []]}
    - mruby.handler: proc {|env| [399, {"bar"=>"BAR"}, []]}
    - file.dir: examples/doc_root
```

