### PR TITLE
Don't send GOAWAY if a PRIORITY frame is sent before the HEADERS

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -548,9 +548,11 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
             if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_HEADERS) == 0)
                 goto PREPARE_FOR_CONTINUATION;
             return handle_trailing_headers(conn, stream, payload.headers, payload.headers_len, err_desc);
+        } else if (!stream || stream->state != H2O_HTTP2_STREAM_STATE_IDLE) {
+            /* it's legit that stream exists and is IDLE if a PRIORITY frame was received earlier */
+            *err_desc = "invalid stream id in HEADERS frame";
+            return H2O_HTTP2_ERROR_STREAM_CLOSED;
         }
-        *err_desc = "invalid stream id in HEADERS frame";
-        return H2O_HTTP2_ERROR_STREAM_CLOSED;
     }
     if (frame->stream_id == payload.priority.dependency) {
         *err_desc = "stream cannot depend on itself";


### PR DESCRIPTION
The RFC states that 'PRIORITY can be sent and received in any stream
state'. We correctly accept the `PRIORITY` frame on an `IDLE` stream,
however the code in `handle_headers_frame` would then send a `GOAWAY`
frame on a subsequent `HEADERS` frame.

This happened because the existing code would expect `stream` to only
exist if the `HEADERS` frame had been received, but that also happens
when a `PRIORITY` frame has been received.

We fix this by having `handle_headers_frame` accept `HEADERS` frames if
`stream` exists and is `IDLE`.

This issue was reported by @Lukasa, including a repro case here:
https://github.com/python-hyper/hyper-h2/issues/302