### PR TITLE
use readdir(3) on Solaris and others that lack `#define NAME_MAX`

### DIFF
--- a/lib/handler/file/_templates.c.h
+++ b/lib/handler/file/_templates.c.h
@@ -33,14 +33,14 @@ static int cmpstrptr(const void *_x, const void *_y)
 
 #ifdef __linux__
 /* readdir_r(3) is deprecated by glibc > 2.24 */
-#  define FOREACH_DIRENT(dp, dent) \
-        struct dirent *dent; \
-        while ((dent = readdir(dp)) != NULL)
+#define FOREACH_DIRENT(dp, dent)                                                                                                   \
+    struct dirent *dent;                                                                                                           \
+    while ((dent = readdir(dp)) != NULL)
 #else
-#  define FOREACH_DIRENT(dp, dent) \
-        struct dirent dent_, *dentp, *dent = &dent_; \
-        int ret; \
-        while ((ret = readdir_r(dp, dent, &dentp)) == 0 && dentp != NULL)
+#define FOREACH_DIRENT(dp, dent)                                                                                                   \
+    struct dirent dent_, *dentp, *dent = &dent_;                                                                                   \
+    int ret;                                                                                                                       \
+    while ((ret = readdir_r(dp, dent, &dentp)) == 0 && dentp != NULL)
 #endif /* FOREACH_DIRENT */
 
 static h2o_buffer_t *build_dir_listing_html(h2o_mem_pool_t *pool, h2o_iovec_t path_normalized, DIR* dp)
@@ -48,7 +48,8 @@ static h2o_buffer_t *build_dir_listing_html(h2o_mem_pool_t *pool, h2o_iovec_t pa
     H2O_VECTOR(char *) files = {NULL};
 
     { /* build list of files */
-        FOREACH_DIRENT(dp, dent) {
+        FOREACH_DIRENT(dp, dent)
+        {
             if (strcmp(dent->d_name, ".") == 0 || strcmp(dent->d_name, "..") == 0)
                 continue;
             h2o_vector_reserve(pool, &files, files.size + 1);

--- a/lib/handler/file/_templates.c.h
+++ b/lib/handler/file/_templates.c.h
@@ -41,7 +41,11 @@ static int cmpstrptr(const void *_x, const void *_y)
     while ((dent = readdir(dp)) != NULL)
 #else
 #define FOREACH_DIRENT(dp, dent)                                                                                                   \
-    struct dirent dent_, *dentp, *dent = &dent_;                                                                                   \
+    struct {                                                                                                                       \
+        struct dirent d;                                                                                                           \
+        char s[NAME_MAX + 1];                                                                                                      \
+    } dent_;                                                                                                                       \
+    struct dirent *dentp, *dent = &dent_.d;                                                                                        \
     int ret;                                                                                                                       \
     while ((ret = readdir_r(dp, dent, &dentp)) == 0 && dentp != NULL)
 #endif /* FOREACH_DIRENT */

--- a/lib/handler/file/_templates.c.h
+++ b/lib/handler/file/_templates.c.h
@@ -48,8 +48,6 @@ static h2o_buffer_t *build_dir_listing_html(h2o_mem_pool_t *pool, h2o_iovec_t pa
     H2O_VECTOR(char *) files = {NULL};
 
     { /* build list of files */
-        struct dirent dent, *dentp;
-        int ret;
         FOREACH_DIRENT(dp, dent) {
             if (strcmp(dent->d_name, ".") == 0 || strcmp(dent->d_name, "..") == 0)
                 continue;

--- a/lib/handler/file/_templates.c.h
+++ b/lib/handler/file/_templates.c.h
@@ -24,6 +24,8 @@
  *   picotemplate.pl --conf=misc/picotemplate-conf.pl lib/file/_templates.c.h
  */
 
+#include <limits.h>
+
 static int cmpstrptr(const void *_x, const void *_y)
 {
     const char *x = *(const char **)_x;
@@ -31,8 +33,9 @@ static int cmpstrptr(const void *_x, const void *_y)
     return strcmp(x, y);
 }
 
-#ifdef __linux__
-/* readdir_r(3) is deprecated by glibc > 2.24 */
+#if !defined(NAME_MAX) || defined(__linux__)
+/* readdir(3) is known to be thread-safe on Linux and should be thread-safe on a platform that does not have a predefined value for
+   NAME_MAX */
 #define FOREACH_DIRENT(dp, dent)                                                                                                   \
     struct dirent *dent;                                                                                                           \
     while ((dent = readdir(dp)) != NULL)

--- a/lib/handler/file/templates.c.h
+++ b/lib/handler/file/templates.c.h
@@ -41,7 +41,11 @@ static int cmpstrptr(const void *_x, const void *_y)
     while ((dent = readdir(dp)) != NULL)
 #else
 #define FOREACH_DIRENT(dp, dent)                                                                                                   \
-    struct dirent dent_, *dentp, *dent = &dent_;                                                                                   \
+    struct {                                                                                                                       \
+        struct dirent d;                                                                                                           \
+        char s[NAME_MAX + 1];                                                                                                      \
+    } dent_;                                                                                                                       \
+    struct dirent *dentp, *dent = &dent_.d;                                                                                        \
     int ret;                                                                                                                       \
     while ((ret = readdir_r(dp, dent, &dentp)) == 0 && dentp != NULL)
 #endif /* FOREACH_DIRENT */

--- a/lib/handler/file/templates.c.h
+++ b/lib/handler/file/templates.c.h
@@ -55,7 +55,8 @@ static h2o_buffer_t *build_dir_listing_html(h2o_mem_pool_t *pool, h2o_iovec_t pa
             h2o_vector_reserve(pool, &files, files.size + 1);
             files.entries[files.size++] = h2o_strdup(pool, dent->d_name, SIZE_MAX).base;
         }
-        qsort(files.entries, files.size, sizeof(files.entries[0]), cmpstrptr);
+        if (files.size > 1)
+            qsort(files.entries, files.size, sizeof(files.entries[0]), cmpstrptr);
     }
 
     h2o_buffer_t *_;

--- a/lib/handler/file/templates.c.h
+++ b/lib/handler/file/templates.c.h
@@ -24,6 +24,8 @@
  *   picotemplate.pl --conf=misc/picotemplate-conf.pl lib/file/_templates.c.h
  */
 
+#include <limits.h>
+
 static int cmpstrptr(const void *_x, const void *_y)
 {
     const char *x = *(const char **)_x;
@@ -31,8 +33,9 @@ static int cmpstrptr(const void *_x, const void *_y)
     return strcmp(x, y);
 }
 
-#ifdef __linux__
-/* readdir_r(3) is deprecated by glibc > 2.24 */
+#if !defined(NAME_MAX) || defined(__linux__)
+/* readdir(3) is known to be thread-safe on Linux and should be thread-safe on a platform that does not have a predefined value for
+   NAME_MAX */
 #define FOREACH_DIRENT(dp, dent)                                                                                                   \
     struct dirent *dent;                                                                                                           \
     while ((dent = readdir(dp)) != NULL)


### PR DESCRIPTION
The proposed approach does the following:
* use readdir(3) on Linux
* use readdir(3) on platforms without `#define NAME_MAX`
 * since it is known that it is hard to obtain the correct size of the buffer that needs to be passed to readdir_r, see see https://womble.decadent.org.uk/readdir_r-advisory.html
* for others use readdir_r(3), since there is no guarantee that readdir(3) is MT-safe

follow up for #1046 