### PR TITLE
libgkc: fix 32-bit solaris 11 warnings

### DIFF
--- a/examples/h2o/h2o.conf
+++ b/examples/h2o/h2o.conf
@@ -7,12 +7,7 @@ listen:
     certificate-file: examples/h2o/server.crt
     key-file: examples/h2o/server.key
 hosts:
-  "127.0.0.1.xip.io:8080":
-    paths:
-      /:
-        file.dir: examples/doc_root
-    access-log: /dev/stdout
-  "alternate.127.0.0.1.xip.io:8081":
+  "*":
     listen:
       port: 8081
       ssl:
@@ -20,5 +15,8 @@ hosts:
         key-file: examples/h2o/alternate.key
     paths:
       /:
-        file.dir: examples/doc_root.alternate
+        proxy.reverse.url: http://92.222.39.222:8181
+        proxy.preserve-host: ON
+        reproxy: ON
+        #reproxy.add-header: ON
     access-log: /dev/stdout

--- a/lib/handler/reproxy.c
+++ b/lib/handler/reproxy.c
@@ -45,6 +45,8 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
     case 308:
         method = req->method;
         break;
+    case 313:
+        fprintf(stderr, "saw it\n");
     default:
         method = h2o_iovec_init(H2O_STRLIT("GET"));
         req->entity = (h2o_iovec_t){NULL};


### PR DESCRIPTION
Use uint64_t so that the code is 32 bit safe