### PR TITLE
fix scan format to use SCN*

### DIFF
--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -118,7 +118,7 @@ static int config_timeout(h2o_configurator_command_t *cmd, yoml_t *node, uint64_
 {
     uint64_t timeout_in_secs;
 
-    if (h2o_configurator_scanf(cmd, node, "%" PRIu64, &timeout_in_secs) != 0)
+    if (h2o_configurator_scanf(cmd, node, "%" SCNu64, &timeout_in_secs) != 0)
         return -1;
 
     *slot = timeout_in_secs * 1000;

--- a/lib/handler/configurator/expires.c
+++ b/lib/handler/configurator/expires.c
@@ -40,7 +40,7 @@ static int on_config_expires(h2o_configurator_command_t *cmd, h2o_configurator_c
     if (strcasecmp(node->data.scalar, "OFF") == 0) {
         free(*self->args);
         *self->args = NULL;
-    } else if (sscanf(node->data.scalar, "%" PRIu64 " %31s", &value, unit) == 2) {
+    } else if (sscanf(node->data.scalar, "%" SCNu64 " %31s", &value, unit) == 2) {
         /* convert value to seconds depending on the unit */
         if (strncasecmp(unit, H2O_STRLIT("second")) == 0) {
             /* ok */

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -42,13 +42,13 @@ struct fastcgi_configurator_t {
 static int on_config_timeout_io(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct fastcgi_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%" PRIu64, &self->vars->io_timeout);
+    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->io_timeout);
 }
 
 static int on_config_timeout_keepalive(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct fastcgi_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%" PRIu64, &self->vars->keepalive_timeout);
+    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->keepalive_timeout);
 }
 
 static int on_config_document_root(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -37,13 +37,13 @@ struct proxy_configurator_t {
 static int on_config_timeout_io(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%" PRIu64, &self->vars->io_timeout);
+    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->io_timeout);
 }
 
 static int on_config_timeout_keepalive(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%" PRIu64, &self->vars->keepalive_timeout);
+    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->keepalive_timeout);
 }
 
 static int on_config_preserve_host(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
@@ -69,7 +69,7 @@ static int on_config_proxy_protocol(h2o_configurator_command_t *cmd, h2o_configu
 static int on_config_websocket_timeout(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%" PRIu64, &self->vars->websocket.timeout);
+    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->websocket.timeout);
 }
 
 static int on_config_websocket(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)


### PR DESCRIPTION
Changes the format strings of scan functions to use `SCN*`, not `PRI*`