### PR TITLE
fix tcp-fastopen in osx

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -824,15 +824,15 @@ static int open_tcp_listener(h2o_configurator_command_t *cmd, yoml_t *node, cons
     /* set TCP_FASTOPEN; when tfo_queues is zero TFO is always disabled */
     if (conf.tfo_queues > 0) {
 #ifdef TCP_FASTOPEN
-        int tfo_ret = setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (const void *)&conf.tfo_queues, sizeof(conf.tfo_queues));
-        if (tfo_ret != 0 && errno == EINVAL) {
-            /* Fallback to 1 because, in OS X values greater than 1 are treated as invalid for TCP_FASTOPEN option */
-            int fallback = 1;
-            tfo_ret = setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (const void *)&fallback, sizeof(fallback));
-        }
-        if (tfo_ret != 0) {
+        int tfo_queues;
+#ifdef __APPLE__
+        /* In OS X, the option value for TCP_FASTOPEN must be 1 if is's enabled */
+        tfo_queues = 1;
+#else
+        tfo_queues = conf.tfo_queues;
+#endif
+        if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (const void *)&tfo_queues, sizeof(tfo_queues)) != 0)
             fprintf(stderr, "[warning] failed to set TCP_FASTOPEN:%s\n", strerror(errno));
-        }
 #else
         assert(!"conf.tfo_queues not zero on platform without TCP_FASTOPEN");
 #endif


### PR DESCRIPTION
Fixed the issue mentioned in https://github.com/h2o/h2o/issues/635.
To get TCP Fast Open works in OS X,
* `setsockopt` must be called while the socket is listening
* option_value for `setsockopt`must be `1`