### PR TITLE
mark js, json as compressible by default

### DIFF
--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -396,7 +396,8 @@ void h2o_mimemap_get_default_attributes(const char *_mime, h2o_mime_attributes_t
         h2o_memis(mime, type_end_at - mime, H2O_STRLIT("text/javascript"))) {
         attr->is_compressible = 1;
         attr->priority = H2O_MIME_ATTRIBUTE_PRIORITY_HIGHEST;
-    } else if (strncmp(mime, "text/", 5) == 0 || h2o_strstr(mime, type_end_at - mime, H2O_STRLIT("+xml")) != SIZE_MAX) {
+    } else if (h2o_memis(mime, type_end_at - mime, H2O_STRLIT("application/json")) || strncmp(mime, "text/", 5) == 0 ||
+               h2o_strstr(mime, type_end_at - mime, H2O_STRLIT("+xml")) != SIZE_MAX) {
         attr->is_compressible = 1;
     }
 }

--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -389,12 +389,14 @@ void h2o_mimemap_get_default_attributes(const char *_mime, h2o_mime_attributes_t
 
     *attr = (h2o_mime_attributes_t){0};
 
-    if (strncmp(mime, "text/", 5) == 0 || h2o_strstr(mime, type_end_at - mime, H2O_STRLIT("+xml")) != SIZE_MAX)
-        attr->is_compressible = 1;
     if (h2o_memis(mime, type_end_at - mime, H2O_STRLIT("text/css")) ||
         h2o_memis(mime, type_end_at - mime, H2O_STRLIT("application/ecmascript")) ||
         h2o_memis(mime, type_end_at - mime, H2O_STRLIT("application/javascript")) ||
         h2o_memis(mime, type_end_at - mime, H2O_STRLIT("text/ecmascript")) ||
-        h2o_memis(mime, type_end_at - mime, H2O_STRLIT("text/javascript")))
+        h2o_memis(mime, type_end_at - mime, H2O_STRLIT("text/javascript"))) {
+        attr->is_compressible = 1;
         attr->priority = H2O_MIME_ATTRIBUTE_PRIORITY_HIGHEST;
+    } else if (strncmp(mime, "text/", 5) == 0 || h2o_strstr(mime, type_end_at - mime, H2O_STRLIT("+xml")) != SIZE_MAX) {
+        attr->is_compressible = 1;
+    }
 }


### PR DESCRIPTION
This PR changes the default `is_compressible` attribute of JavaScript and JSON files from OFF to ON.

fixes #655 