### PR TITLE
introduce function for extracting attributes from YOML mapping

### DIFF
--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -177,8 +177,12 @@ ssize_t h2o_configurator_get_one_of(h2o_configurator_command_t *cmd, yoml_t *nod
 /**
  * extracts values from yoml-mapping to a NULL-terminated name-value list
  */
-int h2o_configurator_parse_attributes(h2o_configurator_command_t *cmd, yoml_t *node,
-                                      h2o_configurator_parse_attribute_t *attributes);
+#define h2o_configurator_parse_attributes(cmd, node, ...)                                                                          \
+    h2o_configurator__do_parse_attributes((cmd), (node), (h2o_configurator_parse_attribute_t[]){__VA_ARGS__},                      \
+                                          sizeof((h2o_configurator_parse_attribute_t[]){__VA_ARGS__}) /                            \
+                                              sizeof(h2o_configurator_parse_attribute_t))
+int h2o_configurator__do_parse_attributes(h2o_configurator_command_t *cmd, yoml_t *node, h2o_configurator_parse_attribute_t *attrs,
+                                          size_t numattr);
 /**
  * returns the absolute paths of supplementary commands
  */

--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -124,7 +124,7 @@ typedef struct st_h2o_configurator_parse_attribute_t {
      */
     const char *name;
     /**
-     * parsed value (left unmodified if not found)
+     * parsed value (*value is set to the corresponding value or to NULL if not found)
      */
     yoml_t **value;
 } h2o_configurator_parse_attribute_t;

--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -118,6 +118,17 @@ struct st_h2o_configurator_t {
     H2O_VECTOR(h2o_configurator_command_t) commands;
 };
 
+typedef struct st_h2o_configurator_parse_attribute_t {
+    /**
+     * name af the attribute (NULL to indicate end of the attribute list)
+     */
+    const char *name;
+    /**
+     * parsed value (left unmodified if not found)
+     */
+    yoml_t **value;
+} h2o_configurator_parse_attribute_t;
+
 /**
  * registers a configurator
  */
@@ -163,6 +174,11 @@ int h2o_configurator_scanf(h2o_configurator_command_t *cmd, yoml_t *node, const 
  * @return index of the matched string within the given list, or -1 if none of them matched
  */
 ssize_t h2o_configurator_get_one_of(h2o_configurator_command_t *cmd, yoml_t *node, const char *candidates);
+/**
+ * extracts values from yoml-mapping to a NULL-terminated name-value list
+ */
+int h2o_configurator_parse_attributes(h2o_configurator_command_t *cmd, yoml_t *node,
+                                      h2o_configurator_parse_attribute_t *attributes);
 /**
  * returns the absolute paths of supplementary commands
  */

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -572,7 +572,7 @@ static int set_mimetypes(h2o_configurator_command_t *cmd, h2o_mimemap_t *mimemap
         case YOML_TYPE_MAPPING: {
             yoml_t *is_compressible, *priority, *extensions;
             if (h2o_configurator_parse_attributes(cmd, value, {"is-compressible", &is_compressible},
-                                                  {"is_compressioble", &is_compressible}, {"priority", &priority},
+                                                  {"is_compressible", &is_compressible}, {"priority", &priority},
                                                   {"extensions", &extensions}) != 0)
                 return -1;
             h2o_mime_attributes_t attr;

--- a/lib/handler/configurator/access_log.c
+++ b/lib/handler/configurator/access_log.c
@@ -42,8 +42,7 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
         format = NULL;
         break;
     case YOML_TYPE_MAPPING:
-        if (h2o_configurator_parse_attributes(
-                cmd, node, (h2o_configurator_parse_attribute_t[]){{"path", &path}, {"format", &format}, {NULL}}) != 0)
+        if (h2o_configurator_parse_attributes(cmd, node, {"path", &path}, {"format", &format}) != 0)
             return -1;
         if (path == NULL) {
             h2o_configurator_errprintf(cmd, node, "could not find mandatory attribute `path`");

--- a/lib/handler/configurator/compress.c
+++ b/lib/handler/configurator/compress.c
@@ -105,8 +105,7 @@ static int on_config_compress(h2o_configurator_command_t *cmd, h2o_configurator_
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t *gzip, *br;
-        if (h2o_configurator_parse_attributes(cmd, node,
-                                              (h2o_configurator_parse_attribute_t[]){{"gzip", &gzip}, {"br", &br}, {NULL}}) != 0)
+        if (h2o_configurator_parse_attributes(cmd, node, {"gzip", &gzip}, {"br", &br}) != 0)
             return -1;
         *self->vars = all_off;
         if (gzip != NULL && obtain_quality(gzip, 1, 9, DEFAULT_GZIP_QUALITY, &self->vars->gzip.quality) != 0) {

--- a/lib/handler/configurator/compress.c
+++ b/lib/handler/configurator/compress.c
@@ -103,29 +103,23 @@ static int on_config_compress(h2o_configurator_command_t *cmd, h2o_configurator_
             }
         }
         break;
-    case YOML_TYPE_MAPPING:
+    case YOML_TYPE_MAPPING: {
+        yoml_t *gzip, *br;
+        if (h2o_configurator_parse_attributes(cmd, node,
+                                              (h2o_configurator_parse_attribute_t[]){{"gzip", &gzip}, {"br", &br}, {NULL}}) != 0)
+            return -1;
         *self->vars = all_off;
-        for (i = 0; i != node->data.mapping.size; ++i) {
-            yoml_t *key = node->data.mapping.elements[i].key;
-            yoml_t *value = node->data.mapping.elements[i].value;
-            if (key->type == YOML_TYPE_SCALAR && strcasecmp(key->data.scalar, "gzip") == 0) {
-                if (obtain_quality(node, 1, 9, DEFAULT_GZIP_QUALITY, &self->vars->gzip.quality) != 0) {
-                    h2o_configurator_errprintf(
-                        cmd, value, "value of gzip attribute must be either of `OFF`, `ON` or an integer value between 1 and 9");
-                    return -1;
-                }
-            } else if (key->type == YOML_TYPE_SCALAR && strcasecmp(key->data.scalar, "br") == 0) {
-                if (obtain_quality(node, 0, 11, DEFAULT_BROTLI_QUALITY, &self->vars->brotli.quality) != 0) {
-                    h2o_configurator_errprintf(
-                        cmd, value, "value of br attribute must be either of `OFF`, `ON` or an integer between 0 and 11");
-                    return -1;
-                }
-            } else {
-                h2o_configurator_errprintf(cmd, key, "key must be either of: `gzip`, `br`");
-                return -1;
-            }
+        if (gzip != NULL && obtain_quality(gzip, 1, 9, DEFAULT_GZIP_QUALITY, &self->vars->gzip.quality) != 0) {
+            h2o_configurator_errprintf(cmd, gzip,
+                                       "value of gzip attribute must be either of `OFF`, `ON` or an integer value between 1 and 9");
+            return -1;
         }
-        break;
+        if (br != NULL && obtain_quality(br, 0, 11, DEFAULT_BROTLI_QUALITY, &self->vars->brotli.quality) != 0) {
+            h2o_configurator_errprintf(cmd, br,
+                                       "value of br attribute must be either of `OFF`, `ON` or an integer between 0 and 11");
+            return -1;
+        }
+    } break;
     default:
         h2o_fatal("unexpected node type");
         break;

--- a/lib/handler/configurator/errordoc.c
+++ b/lib/handler/configurator/errordoc.c
@@ -34,8 +34,7 @@ static int register_errordoc(h2o_configurator_command_t *cmd, h2o_configurator_c
     yoml_t *status_node, *url;
     int status;
 
-    if (h2o_configurator_parse_attributes(
-            cmd, hash, (h2o_configurator_parse_attribute_t[]){{"status", &status_node}, {"url", &url}, {NULL}}) != 0)
+    if (h2o_configurator_parse_attributes(cmd, hash, {"status", &status_node}, {"url", &url}) != 0)
         return -1;
 
     if (status_node == NULL) {

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -91,9 +91,7 @@ static int on_config_connect(h2o_configurator_command_t *cmd, h2o_configurator_c
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t *host_node, *port_node, *type_node;
-        if (h2o_configurator_parse_attributes(cmd, node,
-                                              (h2o_configurator_parse_attribute_t[]){
-                                                  {"host", &host_node}, {"port", &port_node}, {"type", &type_node}, {NULL}}) != 0)
+        if (h2o_configurator_parse_attributes(cmd, node, {"host", &host_node}, {"port", &port_node}, {"type", &type_node}) != 0)
             return -1;
         if (host_node != NULL) {
             if (host_node->type != YOML_TYPE_SCALAR) {
@@ -247,8 +245,7 @@ static int on_config_spawn(h2o_configurator_command_t *cmd, h2o_configurator_con
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t *command_node, *user_node;
-        if (h2o_configurator_parse_attributes(
-                cmd, node, (h2o_configurator_parse_attribute_t[]){{"command", &command_node}, {"user", &user_node}, {NULL}}) != 0)
+        if (h2o_configurator_parse_attributes(cmd, node, {"command", &command_node}, {"user", &user_node}) != 0)
             return -1;
         if (command_node == NULL) {
             h2o_configurator_errprintf(cmd, node, "mandatory attribute `command` does not exist");

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -90,29 +90,33 @@ static int on_config_connect(h2o_configurator_command_t *cmd, h2o_configurator_c
         servname = node->data.scalar;
         break;
     case YOML_TYPE_MAPPING: {
-        yoml_t *t;
-        if ((t = yoml_get(node, "host")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, t, "`host` is not a string");
+        yoml_t *host_node, *port_node, *type_node;
+        if (h2o_configurator_parse_attributes(cmd, node,
+                                              (h2o_configurator_parse_attribute_t[]){
+                                                  {"host", &host_node}, {"port", &port_node}, {"type", &type_node}, {NULL}}) != 0)
+            return -1;
+        if (host_node != NULL) {
+            if (host_node->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, host_node, "`host` is not a string");
                 return -1;
             }
-            hostname = t->data.scalar;
+            hostname = host_node->data.scalar;
         }
-        if ((t = yoml_get(node, "port")) == NULL) {
+        if (port_node != NULL) {
             h2o_configurator_errprintf(cmd, node, "cannot find mandatory property `port`");
             return -1;
         }
-        if (t->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, node, "`port` is not a string");
+        if (port_node->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, port_node, "`port` is not a string");
             return -1;
         }
-        servname = t->data.scalar;
-        if ((t = yoml_get(node, "type")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, t, "`type` is not a string");
+        servname = port_node->data.scalar;
+        if (type_node != NULL) {
+            if (type_node->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, type_node, "`type` is not a string");
                 return -1;
             }
-            type = t->data.scalar;
+            type = type_node->data.scalar;
         }
     } break;
     default:
@@ -242,23 +246,27 @@ static int on_config_spawn(h2o_configurator_command_t *cmd, h2o_configurator_con
         spawn_cmd = node->data.scalar;
         break;
     case YOML_TYPE_MAPPING: {
-        yoml_t *t;
-        if ((t = yoml_get(node, "command")) == NULL) {
+        yoml_t *command_node, *user_node;
+        if (h2o_configurator_parse_attributes(
+                cmd, node, (h2o_configurator_parse_attribute_t[]){{"command", &command_node}, {"user", &user_node}, {NULL}}) != 0)
+            return -1;
+        if (command_node == NULL) {
             h2o_configurator_errprintf(cmd, node, "mandatory attribute `command` does not exist");
             return -1;
         }
-        if (t->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, node, "attribute `command` must be scalar");
+        if (command_node->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, command_node, "attribute `command` must be scalar");
             return -1;
         }
-        spawn_cmd = t->data.scalar;
-        spawn_user = ctx->globalconf->user;
-        if ((t = yoml_get(node, "user")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, node, "attribute `user` must be scalar");
+        spawn_cmd = command_node->data.scalar;
+        if (user_node != NULL) {
+            if (user_node->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, user_node, "attribute `user` must be scalar");
                 return -1;
             }
-            spawn_user = t->data.scalar;
+            spawn_user = user_node->data.scalar;
+        } else {
+            spawn_user = ctx->globalconf->user;
         }
     } break;
     default:

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -100,7 +100,7 @@ static int on_config_connect(h2o_configurator_command_t *cmd, h2o_configurator_c
             }
             hostname = host_node->data.scalar;
         }
-        if (port_node != NULL) {
+        if (port_node == NULL) {
             h2o_configurator_errprintf(cmd, node, "cannot find mandatory property `port`");
             return -1;
         }

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -183,9 +183,7 @@ static int on_config_ssl_session_cache(h2o_configurator_command_t *cmd, h2o_conf
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t *capacity_node, *lifetime_node;
-        if (h2o_configurator_parse_attributes(
-                cmd, node,
-                (h2o_configurator_parse_attribute_t[]){{"capacity", &capacity_node}, {"lifetime", &lifetime_node}, {NULL}}) != 0)
+        if (h2o_configurator_parse_attributes(cmd, node, {"capacity", &capacity_node}, {"lifetime", &lifetime_node}) != 0)
             return -1;
         if (!(capacity_node != NULL && lifetime_node != NULL)) {
             h2o_configurator_errprintf(cmd, node, "`capacity` and `lifetime` attributes must be set");

--- a/lib/handler/configurator/redirect.c
+++ b/lib/handler/configurator/redirect.c
@@ -34,9 +34,8 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t *status_node, *internal_node;
-        if (h2o_configurator_parse_attributes(
-                cmd, node, (h2o_configurator_parse_attribute_t[]){
-                               {"url", &url}, {"status", &status_node}, {"internal", &internal_node}, {NULL}}) != 0)
+        if (h2o_configurator_parse_attributes(cmd, node, {"url", &url}, {"status", &status_node}, {"internal", &internal_node}) !=
+            0)
             return -1;
         if (url == NULL) {
             h2o_configurator_errprintf(cmd, node, "mandatory property `url` is missing");

--- a/lib/handler/configurator/redirect.c
+++ b/lib/handler/configurator/redirect.c
@@ -24,46 +24,50 @@
 
 static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
-    const char *dest;
+    yoml_t *dest;
     int status = 302; /* default is temporary redirect */
     int internal = 0; /* default is external redirect */
     yoml_t *t;
 
     switch (node->type) {
     case YOML_TYPE_SCALAR:
-        dest = node->data.scalar;
+        dest = node;
         break;
-    case YOML_TYPE_MAPPING:
-        if ((t = yoml_get(node, "url")) == NULL) {
+    case YOML_TYPE_MAPPING: {
+        yoml_t *status_node, *internal_node;
+        if (h2o_configurator_parse_attributes(
+                cmd, node, (h2o_configurator_parse_attribute_t[]){
+                               {"url", &dest}, {"status", &status_node}, {"internal", &internal_node}, {NULL}}) != 0)
+            return -1;
+        if (dest == NULL) {
             h2o_configurator_errprintf(cmd, node, "mandatory property `url` is missing");
             return -1;
         }
-        if (t->type != YOML_TYPE_SCALAR) {
+        if (dest->type != YOML_TYPE_SCALAR) {
             h2o_configurator_errprintf(cmd, t, "property `url` must be a string");
             return -1;
         }
-        dest = t->data.scalar;
-        if ((t = yoml_get(node, "status")) == NULL) {
+        if (status_node != NULL) {
             h2o_configurator_errprintf(cmd, node, "mandatory property `status` is missing");
             return -1;
         }
-        if (h2o_configurator_scanf(cmd, t, "%d", &status) != 0)
+        if (h2o_configurator_scanf(cmd, status_node, "%d", &status) != 0)
             return -1;
         if (!(300 <= status && status <= 399)) {
-            h2o_configurator_errprintf(cmd, t, "value of property `status` should be within 300 to 399");
+            h2o_configurator_errprintf(cmd, status_node, "value of property `status` should be within 300 to 399");
             return -1;
         }
-        if ((t = yoml_get(node, "internal")) != NULL) {
-            if ((internal = (int)h2o_configurator_get_one_of(cmd, t, "NO,YES")) == -1)
+        if (internal_node != NULL) {
+            if ((internal = (int)h2o_configurator_get_one_of(cmd, internal_node, "NO,YES")) == -1)
                 return -1;
         }
-        break;
+    } break;
     default:
         h2o_configurator_errprintf(cmd, node, "value must be a string or a mapping");
         return -1;
     }
 
-    h2o_redirect_register(ctx->pathconf, internal, status, dest);
+    h2o_redirect_register(ctx->pathconf, internal, status, dest->data.scalar);
 
     return 0;
 }

--- a/lib/handler/configurator/redirect.c
+++ b/lib/handler/configurator/redirect.c
@@ -45,7 +45,7 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
             h2o_configurator_errprintf(cmd, url, "property `url` must be a string");
             return -1;
         }
-        if (status_node != NULL) {
+        if (status_node == NULL) {
             h2o_configurator_errprintf(cmd, node, "mandatory property `status` is missing");
             return -1;
         }

--- a/lib/handler/configurator/redirect.c
+++ b/lib/handler/configurator/redirect.c
@@ -24,27 +24,26 @@
 
 static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
-    yoml_t *dest;
+    yoml_t *url;
     int status = 302; /* default is temporary redirect */
     int internal = 0; /* default is external redirect */
-    yoml_t *t;
 
     switch (node->type) {
     case YOML_TYPE_SCALAR:
-        dest = node;
+        url = node;
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t *status_node, *internal_node;
         if (h2o_configurator_parse_attributes(
                 cmd, node, (h2o_configurator_parse_attribute_t[]){
-                               {"url", &dest}, {"status", &status_node}, {"internal", &internal_node}, {NULL}}) != 0)
+                               {"url", &url}, {"status", &status_node}, {"internal", &internal_node}, {NULL}}) != 0)
             return -1;
-        if (dest == NULL) {
+        if (url == NULL) {
             h2o_configurator_errprintf(cmd, node, "mandatory property `url` is missing");
             return -1;
         }
-        if (dest->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, t, "property `url` must be a string");
+        if (url->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, url, "property `url` must be a string");
             return -1;
         }
         if (status_node != NULL) {
@@ -67,7 +66,7 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
         return -1;
     }
 
-    h2o_redirect_register(ctx->pathconf, internal, status, dest->data.scalar);
+    h2o_redirect_register(ctx->pathconf, internal, status, url->data.scalar);
 
     return 0;
 }


### PR DESCRIPTION
Until now, every configuration directive that (optionally) takes a YOML mapping has written it's own attribute parser.

The fact has not only make the code-base unnecessary complex but also has caused inconsistency between the parsers in how they deal with unknown or duplicate key.

This PR aims to resolve the issue by introducing a function to be used for fetching named values from a YOML mapping.
