### PR TITLE
The null byte isn't url encoded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,8 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/http2/hpack.c
     t/00unit/lib/http2/scheduler.c
     t/00unit/src/ssl.c
-    t/00unit/issues/293.c)
+    t/00unit/issues/293.c
+    t/00unit/issues/percent-encode-zero-byte.c)
 LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/common/cache.c
     lib/common/hostinfo.c

--- a/lib/common/string.c
+++ b/lib/common/string.c
@@ -333,10 +333,10 @@ h2o_iovec_t h2o_uri_escape(h2o_mem_pool_t *pool, const char *s, size_t l, const 
     */
     for (i = 0; i != l; ++i) {
         int ch = s[i];
-        if (ch >= 0x80 || ('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z') || ('0' <= ch && ch <= '9') || ch == '-' ||
-            ch == '.' || ch == '_' || ch == '~' || ch == '!' || ch == '$' || ch == '&' || ch == '\'' || ch == '(' || ch == ')' ||
-            ch == '*' || ch == '+' || ch == ',' || ch == ';' || ch == '=' ||
-            (preserve_chars != NULL && strchr(preserve_chars, ch) != NULL)) {
+        if (ch && (ch >= 0x80 || ('A' <= ch && ch <= 'Z') || ('a' <= ch && ch <= 'z') || ('0' <= ch && ch <= '9') || ch == '-' ||
+                   ch == '.' || ch == '_' || ch == '~' || ch == '!' || ch == '$' || ch == '&' || ch == '\'' || ch == '(' || ch == ')' ||
+                   ch == '*' || ch == '+' || ch == ',' || ch == ';' || ch == '=' ||
+                   (preserve_chars != NULL && strchr(preserve_chars, ch) != NULL))) {
             encoded.base[encoded.len++] = ch;
         } else {
             encoded.base[encoded.len++] = '%';

--- a/t/00unit/issues/percent-encode-zero-byte.c
+++ b/t/00unit/issues/percent-encode-zero-byte.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016 DeNA Co., Fastly, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include "../test.h"
+
+void test_percent_encode_zero_byte(void)
+{
+    h2o_pathconf_t pathconf = {NULL, {H2O_STRLIT("/abc")}};
+    h2o_req_t req;
+    h2o_iovec_t dest;
+
+    h2o_init_request(&req, NULL, NULL);
+
+    /* basic pattern */
+    req.path_normalized = h2o_iovec_init(H2O_STRLIT("/abc/mno\0xyz"));
+    req.query_at = req.path_normalized.len;
+    req.path = h2o_concat(&req.pool, req.path_normalized, h2o_iovec_init(H2O_STRLIT("?q")));
+    req.pathconf = &pathconf;
+    dest = h2o_build_destination(&req, H2O_STRLIT("/def"), 1);
+    ok(h2o_memis(dest.base, dest.len, H2O_STRLIT("/def/mno%00xyz?q")));
+    dest = h2o_build_destination(&req, H2O_STRLIT("/def/"), 1);
+    ok(h2o_memis(dest.base, dest.len, H2O_STRLIT("/def/mno%00xyz?q")));
+
+    h2o_mem_clear_pool(&req.pool);
+}
+

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -184,6 +184,7 @@ int main(int argc, char **argv)
         subtest("lib/gzip.c", test_lib__handler__gzip_c);
         subtest("lib/redirect.c", test_lib__handler__redirect_c);
         subtest("issues/293.c", test_issues293);
+        subtest("issues/percent-encode-zero-byte.c", test_percent_encode_zero_byte);
 
 #if H2O_USE_LIBUV
         uv_loop_close(test_loop);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -71,5 +71,6 @@ void test_lib__http2__casper(void);
 void test_lib__http2__cache_digests(void);
 void test_src__ssl_c(void);
 void test_issues293(void);
+void test_percent_encode_zero_byte(void);
 
 #endif


### PR DESCRIPTION
When the incoming requests contains `%00` the byte gets turned into the
nul byte during normalization. The process of rebuilding the URL doesn't
turn it back into `%00` causing interoperability issues.