### PR TITLE
provide option to emit request-level errors into access log

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -836,6 +836,14 @@ typedef struct st_h2o_filereq_t {
 } h2o_filereq_t;
 
 /**
+ * error message associated to a request
+ */
+typedef struct st_h2o_req_error_log_t {
+    const char *module;
+    h2o_iovec_t msg;
+} h2o_req_error_log_t;
+
+/**
  * a HTTP request
  */
 struct st_h2o_req_t {
@@ -962,6 +970,11 @@ struct st_h2o_req_t {
      * environment variables
      */
     h2o_iovec_vector_t env;
+
+    /**
+     * error logs
+     */
+    H2O_VECTOR(h2o_req_error_log_t) error_logs;
 
     /* flags */
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -221,6 +221,15 @@ typedef struct st_h2o_pathconf_t {
      * env
      */
     h2o_envconf_t *env;
+    /**
+     * error-log
+     */
+    struct {
+        /**
+         * if request-level errors should be emitted to stderr
+         */
+        unsigned emit_request_errors : 1;
+    } error_log;
 } h2o_pathconf_t;
 
 struct st_h2o_hostconf_t {

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -138,6 +138,7 @@ void h2o_config_init_pathconf(h2o_pathconf_t *pathconf, h2o_globalconf_t *global
         pathconf->path = h2o_strdup(NULL, path, SIZE_MAX);
     h2o_mem_addref_shared(mimemap);
     pathconf->mimemap = mimemap;
+    pathconf->error_log.emit_request_errors = 1;
 }
 
 void h2o_config_dispose_pathconf(h2o_pathconf_t *pathconf)

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -60,6 +60,7 @@ enum {
     ELEMENT_TYPE_PROCESS_TIME,               /* %{process-time}x */
     ELEMENT_TYPE_RESPONSE_TIME,              /* %{response-total-time}x */
     ELEMENT_TYPE_DURATION,                   /* %{duration}x */
+    ELEMENT_TYPE_ERROR,                      /* %{error}x */
     ELEMENT_TYPE_PROTOCOL_SPECIFIC,          /* %{protocol-specific...}x */
     NUM_ELEMENT_TYPES
 };
@@ -170,6 +171,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_TYPE("process-time", ELEMENT_TYPE_PROCESS_TIME);
                     MAP_EXT_TO_TYPE("response-time", ELEMENT_TYPE_RESPONSE_TIME);
                     MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_DURATION);
+                    MAP_EXT_TO_TYPE("error", ELEMENT_TYPE_ERROR);
                     MAP_EXT_TO_PROTO("http1.request-index", http1.request_index);
                     MAP_EXT_TO_PROTO("http2.stream-id", http2.stream_id);
                     MAP_EXT_TO_PROTO("http2.priority.received", http2.priority_received);
@@ -646,6 +648,20 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             RESERVE(DURATION_MAX_LEN);
             APPEND_DURATION(pos, duration);
             break;
+
+        case ELEMENT_TYPE_ERROR: {
+            size_t i;
+            for (i = 0; i != req->error_logs.size; ++i) {
+                h2o_req_error_log_t *log = req->error_logs.entries + i;
+                size_t module_len = strlen(log->module);
+                RESERVE(sizeof("[] ") - 1 + module_len + log->msg.len * unsafe_factor);
+                *pos++ = '[';
+                pos = append_safe_string(pos, log->module, module_len);
+                *pos++ = ']';
+                *pos++ = ' ';
+                pos = append_unsafe_string(pos, log->msg.base, log->msg.len);
+            }
+        } break;
 
         case ELEMENT_TYPE_PROTOCOL_SPECIFIC: {
             h2o_iovec_t (*cb)(h2o_req_t *) = req->conn->callbacks->log_.callbacks[element->data.protocol_specific_callback_index];

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -527,6 +527,10 @@ void h2o_req_log_error(h2o_req_t *req, const char *module, const char *fmt, ...)
 
 #undef INITIAL_BUF_SIZE
 
+    /* save the log */
+    h2o_vector_reserve(&req->pool, &req->error_logs, req->error_logs.size + 1);
+    req->error_logs.entries[req->error_logs.size++] = (h2o_req_error_log_t){module, h2o_iovec_init(errbuf, errlen)};
+
     /* we may want to disable logging to STDERR */
     if (1) {
         /* build prefix */

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -531,8 +531,7 @@ void h2o_req_log_error(h2o_req_t *req, const char *module, const char *fmt, ...)
     h2o_vector_reserve(&req->pool, &req->error_logs, req->error_logs.size + 1);
     req->error_logs.entries[req->error_logs.size++] = (h2o_req_error_log_t){module, h2o_iovec_init(errbuf, errlen)};
 
-    /* we may want to disable logging to STDERR */
-    if (1) {
+    if (req->pathconf->error_log.emit_request_errors) {
         /* build prefix */
         char *prefix = alloca(sizeof("[] in request::") + 32 + strlen(module)), *p = prefix;
         p += sprintf(p, "[%s] in request:", module);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -19,9 +19,15 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/uio.h>
 #include "h2o.h"
+
+#ifndef IOV_MAX
+#define IOV_MAX UIO_MAXIOV
+#endif
 
 #define INITIAL_INBUFSZ 8192
 
@@ -502,27 +508,45 @@ DECL_SEND_ERROR_DEFERRED(502)
 
 void h2o_req_log_error(h2o_req_t *req, const char *module, const char *fmt, ...)
 {
-#define PREFIX "[%s] in request:%.32s:"
-    char *fmt_prefixed = alloca(sizeof("[] in request::\n") + 32 + strlen(module) + strlen(fmt)), *p = fmt_prefixed;
+#define INITIAL_BUF_SIZE 256
 
-    p += sprintf(fmt_prefixed, "[%s] in request:", module);
-    if (req->path.len < 32) {
-        memcpy(p, req->path.base, req->path.len);
-        p += req->path.len;
-    } else {
-        memcpy(p, req->path.base, 29);
-        p += 29;
-        memcpy(p, "...", 3);
-        p += 3;
-    }
-    *p++ = ':';
-    strcpy(p, fmt);
-    strcat(p, "\n");
-
+    char *errbuf = h2o_mem_alloc_pool(&req->pool, INITIAL_BUF_SIZE);
+    int errlen;
     va_list args;
+
     va_start(args, fmt);
-    vfprintf(stderr, fmt_prefixed, args);
+    errlen = vsnprintf(errbuf, INITIAL_BUF_SIZE, fmt, args);
     va_end(args);
+
+    if (errlen >= INITIAL_BUF_SIZE) {
+        errbuf = h2o_mem_alloc_pool(&req->pool, errlen + 1);
+        va_start(args, fmt);
+        errlen = vsnprintf(errbuf, errlen + 1, fmt, args);
+        va_end(args);
+    }
+
+#undef INITIAL_BUF_SIZE
+
+    /* we may want to disable logging to STDERR */
+    if (1) {
+        /* build prefix */
+        char *prefix = alloca(sizeof("[] in request::") + 32 + strlen(module)), *p = prefix;
+        p += sprintf(p, "[%s] in request:", module);
+        if (req->path.len < 32) {
+            memcpy(p, req->path.base, req->path.len);
+            p += req->path.len;
+        } else {
+            memcpy(p, req->path.base, 29);
+            p += 29;
+            memcpy(p, "...", 3);
+            p += 3;
+        }
+        *p++ = ':';
+        /* use writev(2) to emit error atomically */
+        struct iovec vecs[] = {{prefix, p - prefix}, {errbuf, errlen}};
+        H2O_BUILD_ASSERT(sizeof(vecs) / sizeof(vecs[0]) < IOV_MAX);
+        writev(2, vecs, sizeof(vecs) / sizeof(vecs[0]));
+    }
 }
 
 void h2o_send_redirect(h2o_req_t *req, int status, const char *reason, const char *url, size_t url_len)

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -24,6 +24,7 @@ hosts:
         fastcgi.connect:
           port: /nonexistent
           type: unix
+        error-log.emit-request-errors: OFF
     access-log:
       format: "$format"
       path: $tempdir/access_log

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -20,6 +20,10 @@ hosts:
     paths:
       /:
         file.dir: @{[ DOC_ROOT ]}
+      /fastcgi:
+        fastcgi.connect:
+          port: /nonexistent
+          type: unix
     access-log:
       format: "$format"
       path: $tempdir/access_log
@@ -164,6 +168,17 @@ subtest 'extensions' => sub {
             }
             @expected;
         },
+    );
+};
+
+subtest 'error' => sub {
+    doit(
+        sub {
+            my $server = shift;
+            system("curl --silent http://127.0.0.1:$server->{port}/fastcgi > /dev/null");
+        },
+        '%{error}x',
+        qr{^\[lib/handler/fastcgi\.c\] connection failed:}s,
     );
 };
 


### PR DESCRIPTION
The log directive for the purpose is `%{error}x`.

Also, a configuration directive named `error-log.emit-request-errors` is added to disable request-level logging to error log.