### PR TITLE
enable TCP latency optimization by default

### DIFF
--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -183,7 +183,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->proxy.emit_x_forwarded_headers = 1;
     config->http2.max_concurrent_requests_per_connection = H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams;
     config->http2.max_streams_for_priority = 16;
-    config->http2.latency_optimization.min_rtt = UINT_MAX;
+    config->http2.latency_optimization.min_rtt = 50; // milliseconds
     config->http2.latency_optimization.max_additional_delay = 10;
     config->http2.latency_optimization.max_cwnd = 65535;
     config->http2.callbacks = H2O_HTTP2_CALLBACKS;


### PR DESCRIPTION
changes the default value of `min_rtt` from `UINT_MAX` (effectively disables the feature) to 50ms.

50ms has been chosen as a default, with the expectation that mobile connections would typically benefit from this optimization.