### PR TITLE
Improve format specifier for portability

### DIFF
--- a/lib/http2/http2_debug_state.c
+++ b/lib/http2/http2_debug_state.c
@@ -149,11 +149,11 @@ h2o_http2_debug_state_t *h2o_http2_get_debug_state(h2o_req_t *req, int hpack_ena
                                                    "      \"flowOut\": %zd,\n"
                                                    "      \"dataIn\": %zu,\n"
                                                    "      \"dataOut\": %zu,\n"
-                                                   "      \"created\": %lu\n"
+                                                   "      \"created\": %" PRIu64 "\n"
                                                    "    },",
                          stream->stream_id, state_string, stream->input_window._avail, stream->output_window._avail,
                          (stream->_req_body == NULL ? 0 : stream->_req_body->size), stream->req.bytes_sent,
-                         stream->req.timestamps.request_begin_at.tv_sec);
+                         (uint64_t)stream->req.timestamps.request_begin_at.tv_sec);
         });
 
         if (conn->streams->size > 0) {


### PR DESCRIPTION
Use PRIu64 instead of 'lu' for time_t.