### PR TITLE
proxy http/2 to http/1: POST+body is missing a content-length

### DIFF
--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -100,6 +100,35 @@ static h2o_iovec_t build_request_merge_headers(h2o_mem_pool_t *pool, h2o_iovec_t
     return merged;
 }
 
+/*
+ * https://tools.ietf.org/html/rfc7230#section-3.3.2:
+ *
+ *   A sender MUST NOT send a Content-Length header field in any message
+ *   that contains a Transfer-Encoding header field.
+
+ *   A user agent SHOULD send a Content-Length in a request message when
+ *   no Transfer-Encoding is sent and the request method defines a meaning
+ *   for an enclosed payload body.  For example, a Content-Length header
+ *   field is normally sent in a POST request even when the value is 0
+ *   (indicating an empty payload body).  A user agent SHOULD NOT send a
+ *   Content-Length header field when the request message does not contain
+ *   a payload body and the method semantics do not anticipate such a
+ *   body.
+ *
+ * PUT and POST define a meaning for the payload body, let's emit a
+ * Content-Length header if it doesn't exist already, since the server
+ * might send a '411 Length Required' response.
+ */
+static int req_requires_content_length(h2o_req_t *req)
+{
+    int is_put_or_post = (req->method.len >= 1 && req->method.base[0] == 'P' &&
+                          (h2o_memis(req->method.base, req->method.len, H2O_STRLIT("POST")) ||
+                           h2o_memis(req->method.base, req->method.len, H2O_STRLIT("PUT"))));
+
+    return is_put_or_post && h2o_find_header(&req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, -1) == -1;
+
+}
+
 static h2o_iovec_t build_request(h2o_req_t *req, int keepalive, int is_websocket_handshake, int use_proxy_protocol)
 {
     h2o_iovec_t buf;
@@ -170,7 +199,7 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive, int is_websocket
     buf.base[offset++] = '\r';
     buf.base[offset++] = '\n';
     assert(offset <= buf.len);
-    if (req->entity.base != NULL) {
+    if (req->entity.base != NULL || req_requires_content_length(req)) {
         RESERVE(sizeof("content-length: " H2O_UINT64_LONGEST_STR) - 1);
         offset += sprintf(buf.base + offset, "content-length: %zu\r\n", req->entity.len);
     }

--- a/t/80reverse-proxy-missing-content-length-for-post.t
+++ b/t/80reverse-proxy-missing-content-length-for-post.t
@@ -1,0 +1,74 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+my $upstream_port = empty_port();
+$| = 1;
+my $socket = new IO::Socket::INET (
+    LocalHost => '127.0.0.1',
+    LocalPort => $upstream_port,
+    Proto => 'tcp',
+    Listen => 1,
+    Reuse => 1
+);
+die "cannot create socket $!\n" unless $socket;
+
+check_port($upstream_port) or die "can't connect to server socket";
+# accept and close check_port's connection
+my $client_socket = $socket->accept();
+close($client_socket);
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+sub doit {
+    my $cmd = shift;
+    my $should_see_cl = shift;
+    my $cl_value = shift;
+    system($cmd);
+
+    my $req;
+    $client_socket = $socket->accept();
+    $client_socket->recv($req, 1 * 1024);
+    $client_socket->send("HTTP/1.1 200 Ok\r\nConnection:close\r\n\r\nBody\r\n");
+    close($client_socket);
+
+    my $cl_actual_value = -1;
+    my $cl_headers = 0;
+    foreach (split(/\r\n/, $req)) {
+        if (/^content-length:(.*)$/i) {
+            $cl_headers++;
+            $cl_actual_value = $1;
+        }
+    }
+    if ($should_see_cl) {
+        ok($cl_headers == 1, "Saw one, and only one content-length: header");
+        ok($cl_actual_value == $cl_value, "content-length: header has the expected value");
+    } else {
+        ok($cl_headers == 0, "Saw no content-length: header");
+    }
+}
+my $file_size = 512;
+my $file = create_data_file($file_size);
+
+# curl doesn't add a CL header when using -X POST
+doit("curl -so /dev/null --http2 -X POST http://127.0.0.1:$server->{'port'}/ &", 1, 0);
+# curl adds a content-length:0 header when using --data ''
+doit("curl -so /dev/null --http2 --data '' http://127.0.0.1:$server->{'port'}/ &", 1, 0);
+
+# check that an existing CL header is preserved
+doit("curl -so /dev/null --http2 --data 'a=b' http://127.0.0.1:$server->{'port'}/ &", 1, 3);
+doit("curl -so /dev/null --http2 --header 'transfer-encoding: chunked' --data-binary \@$file -X POST http://127.0.0.1:$server->{'port'}/ &", 1, $file_size);
+
+$socket->close();
+done_testing();


### PR DESCRIPTION
The RFC encourages senders to send a `content-length:` header, even
when it's zero for POST or PUT when no `transfer-encoding` header is
present.

Failing to do so actually leads to some servers issuing a `411 Length
Required` response over HTTP/1, since it's not possible for them to tell
if they got the full request body.

This ambiguity doesn't exist over HTTP/2, since the protocol provides
framing, so some browsers (Safari and Chrome) omit the `content-length:`
header over HTTP/2. H2O should add the header when translating such
requests to HTTP/1.

This commit has the proxy translation layer add a `content-length:`
header if needed, that is when a POST or PUT method is used and there's
no `transfer-encoding` header.