### PR TITLE
Add 'vary: accept-encoding' when we did not compress due to the contents of the 'accept-encoding' header

### DIFF
--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -93,6 +93,8 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
         if (self->args.gzip.quality != -1 && (compressible_types & H2O_COMPRESSIBLE_GZIP) != 0) {
         compressor = h2o_compress_gzip_open(&req->pool, self->args.gzip.quality);
     } else {
+        /* let proxies know that we looked at accept-encoding when deciding not to compress */
+        h2o_set_header_token(&req->pool, &req->res.headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
         goto Next;
     }
 


### PR DESCRIPTION
This seems like the right thing to do, since we would send a compressed
object, should a client send the right headers. This mimics the behavior
of mod_deflate: https://github.com/apache/httpd/blob/trunk/modules/filters/mod_deflate.c#L728