### PR TITLE
Add a `crash-handler.wait-pipe-close` parameter

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1330,7 +1330,7 @@ static void on_sigfatal(int signo)
         struct pollfd pfd[1];
         pfd[0].fd = crash_handler_fd;
         pfd[0].events = POLLERR | POLLHUP;
-        poll(pfd, 1, -1);
+        while (poll(pfd, 1, -1) == -1 && errno == EINTR);
     }
 
     raise(signo);

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #include <pthread.h>
 #include <pwd.h>
 #include <signal.h>
@@ -1326,8 +1327,10 @@ static void on_sigfatal(int signo)
     backtrace_symbols_fd(frames, framecnt, crash_handler_fd);
 
     if (conf.crash_handler_wait_pipe_close) {
-        while (write(crash_handler_fd, "", 1) != -1)
-            ;
+        struct pollfd pfd[1];
+        pfd[0].fd = crash_handler_fd;
+        pfd[0].events = POLLERR | POLLHUP;
+        poll(pfd, 1, -1);
     }
 
     raise(signo);

--- a/srcdoc/configure/base_directives.mt
+++ b/srcdoc/configure/base_directives.mt
@@ -642,4 +642,19 @@ standard input of the program.</p>
 <p>If the path is not absolute, it is prefixed with <code>${H2O_ROOT}/</code>.</p>
 ? })
 
+<?
+$ctx->{directive}->(
+    name   => "crash-handler.wait-pipe-close",
+    levels => [ qw(global) ],
+    desc   => q{Whether <code>h2o</code> should wait for the crash handler pipe to close before exiting.},
+    default  => q{crash-handler.wait-pipe-close: OFF},
+    since    => "2.1",
+)->(sub {
+?>
+<p>When this setting is <code>ON</code>, <code>h2o</code> will wait
+for the pipe to the crash handler to be closed before exiting.
+This can be useful if you use a custom handler that inspects the dying
+process.</p>
+? })
+
 ? })


### PR DESCRIPTION
If this parameter is set to true, the crash handler will wait until the
pipe opened to the crash handler is closed by it. This is useful if the
crash handler is ptracing the main process in order to get more
information.
