### PR TITLE
Remove listeners from epoll on SIGTERM

### DIFF
--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -58,6 +58,7 @@ h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *listener);
 h2o_evloop_t *h2o_evloop_create(void);
 void h2o_evloop_destroy(h2o_evloop_t *loop);
 int h2o_evloop_run(h2o_evloop_t *loop);
+void h2o_evloop_update_status(h2o_evloop_t *loop);
 
 /* inline definitions */
 

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -535,6 +535,11 @@ static void run_pending(h2o_evloop_t *loop)
     }
 }
 
+void h2o_evloop_update_status(h2o_evloop_t *loop)
+{
+    evloop_update_status(loop);
+}
+
 int h2o_evloop_run(h2o_evloop_t *loop)
 {
     h2o_linklist_t *node;

--- a/lib/common/socket/evloop/epoll.c.h
+++ b/lib/common/socket/evloop/epoll.c.h
@@ -100,6 +100,12 @@ static int update_status(struct st_h2o_evloop_epoll_t *loop)
     return 0;
 }
 
+void evloop_update_status(h2o_evloop_t *_loop)
+{
+    struct st_h2o_evloop_epoll_t *loop = (struct st_h2o_evloop_epoll_t *)_loop;
+    update_status(loop);
+}
+
 int evloop_do_proceed(h2o_evloop_t *_loop)
 {
     struct st_h2o_evloop_epoll_t *loop = (struct st_h2o_evloop_epoll_t *)_loop;

--- a/lib/common/socket/evloop/kqueue.c.h
+++ b/lib/common/socket/evloop/kqueue.c.h
@@ -102,6 +102,10 @@ static int collect_status(struct st_h2o_socket_loop_kqueue_t *loop, struct keven
 #undef SET_AND_UPDATE
 }
 
+void evloop_update_status(h2o_evloop_t *_loop)
+{
+}
+
 int evloop_do_proceed(h2o_evloop_t *_loop)
 {
     struct st_h2o_socket_loop_kqueue_t *loop = (struct st_h2o_socket_loop_kqueue_t *)_loop;

--- a/lib/common/socket/evloop/poll.c.h
+++ b/lib/common/socket/evloop/poll.c.h
@@ -71,6 +71,12 @@ static void update_socks(struct st_h2o_evloop_poll_t *loop)
     loop->super._statechanged.tail_ref = &loop->super._statechanged.head;
 }
 
+void evloop_update_status(h2o_evloop_t *_loop)
+{
+    struct st_h2o_evloop_poll_t *loop = (struct st_h2o_evloop_poll_t *)_loop;
+    update_socks(loop);
+}
+
 int evloop_do_proceed(h2o_evloop_t *_loop)
 {
     struct st_h2o_evloop_poll_t *loop = (struct st_h2o_evloop_poll_t *)_loop;

--- a/src/main.c
+++ b/src/main.c
@@ -1462,7 +1462,11 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     if (thread_index == 0)
         fprintf(stderr, "received SIGTERM, gracefully shutting down\n");
 
-    /* shutdown requested, close the listeners, notify the protocol handlers */
+    /* shutdown requested, unregister, close the listeners and notify the protocol handlers */
+    for (i = 0; i != conf.num_listeners; ++i) {
+        h2o_socket_read_stop(listeners[i].sock);
+        h2o_evloop_update_status(conf.threads[thread_index].ctx.loop);
+    }
     for (i = 0; i != conf.num_listeners; ++i) {
         h2o_socket_close(listeners[i].sock);
         listeners[i].sock = NULL;


### PR DESCRIPTION
Closing an fd is not enough to stop receiving epoll events, if the
underlying resource is still alive.

This is the case if `h2o` is run in `master` mode: the listener will
still be alive in Server::Starter and the new `h2o` instance. This
results in epoll events being triggered in the old instance, and the
following message to be displayed:

  `ignoring epoll event (fd:-1,event:1)`

We fix this by unregistering the fd from epoll before closing it.