### PR TITLE
add timeout for closing connections at the graceful shutdown

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -81,6 +81,8 @@ extern "C" {
 #define H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2 1
 #define H2O_DEFAULT_HTTP2_IDLE_TIMEOUT_IN_SECS 10
 #define H2O_DEFAULT_HTTP2_IDLE_TIMEOUT (H2O_DEFAULT_HTTP2_IDLE_TIMEOUT_IN_SECS * 1000)
+#define H2O_DEFAULT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT_IN_SECS 0 /* no timeout */
+#define H2O_DEFAULT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT (H2O_DEFAULT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_PROXY_IO_TIMEOUT_IN_SECS 30
 #define H2O_DEFAULT_PROXY_IO_TIMEOUT (H2O_DEFAULT_PROXY_IO_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT_IN_SECS 300
@@ -352,6 +354,10 @@ struct st_h2o_globalconf_t {
          */
         uint64_t idle_timeout;
         /**
+         * graceful shutdown timeout (in milliseconds)
+         */
+        uint64_t graceful_shutdown_timeout;
+        /**
          * maximum number of HTTP2 requests (per connection) to be handled simultaneously internally.
          * H2O accepts at most 256 requests over HTTP/2, but internally limits the number of in-flight requests to the value
          * specified by this property in order to limit the resources allocated to a single connection.
@@ -565,6 +571,10 @@ struct st_h2o_context_t {
          * link-list of h2o_http2_conn_t
          */
         h2o_linklist_t _conns;
+        /**
+         * graceful shutdown timeout
+         */
+        h2o_timeout_t graceful_shutdown_timeout;
         /**
          * timeout entry used for graceful shutdown
          */

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -180,6 +180,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http1.upgrade_to_http2 = H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2;
     config->http1.callbacks = H2O_HTTP1_CALLBACKS;
     config->http2.idle_timeout = H2O_DEFAULT_HTTP2_IDLE_TIMEOUT;
+    config->http2.graceful_shutdown_timeout = H2O_DEFAULT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT;
     config->proxy.io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
     config->proxy.emit_x_forwarded_headers = 1;
     config->http2.max_concurrent_requests_per_connection = H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams;

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -414,6 +414,11 @@ static int on_config_http2_idle_timeout(h2o_configurator_command_t *cmd, h2o_con
     return config_timeout(cmd, node, &ctx->globalconf->http2.idle_timeout);
 }
 
+static int on_config_http2_graceful_shutdown_timeout(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    return config_timeout(cmd, node, &ctx->globalconf->http2.graceful_shutdown_timeout);
+}
+
 static int on_config_http2_max_concurrent_requests_per_connection(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx,
                                                                   yoml_t *node)
 {
@@ -870,6 +875,9 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(&c->super, "http2-idle-timeout",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_idle_timeout);
+        h2o_configurator_define_command(&c->super, "http2-graceful-shutdown-timeout",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http2_graceful_shutdown_timeout);
         h2o_configurator_define_command(&c->super, "http2-max-concurrent-requests-per-connection",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_max_concurrent_requests_per_connection);

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -145,6 +145,7 @@ void h2o_context_dispose(h2o_context_t *ctx)
     h2o_timeout_dispose(ctx->loop, &ctx->handshake_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http1.req_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http2.idle_timeout);
+    h2o_timeout_dispose(ctx->loop, &ctx->http2.graceful_shutdown_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->proxy.io_timeout);
     /* what should we do here? assert(!h2o_linklist_is_empty(&ctx->http2._conns); */
 

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -100,6 +100,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     h2o_timeout_init(ctx->loop, &ctx->http1.req_timeout, config->http1.req_timeout);
     h2o_linklist_init_anchor(&ctx->http1._conns);
     h2o_timeout_init(ctx->loop, &ctx->http2.idle_timeout, config->http2.idle_timeout);
+    h2o_timeout_init(ctx->loop, &ctx->http2.graceful_shutdown_timeout, config->http2.graceful_shutdown_timeout);
     h2o_linklist_init_anchor(&ctx->http2._conns);
     ctx->proxy.client_ctx.loop = loop;
     h2o_timeout_init(ctx->loop, &ctx->proxy.io_timeout, config->proxy.io_timeout);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -81,17 +81,39 @@ static void enqueue_goaway(h2o_http2_conn_t *conn, int errnum, h2o_iovec_t addit
     }
 }
 
+static void graceful_shutdown_close_stragglers(h2o_timeout_entry_t *entry)
+{
+    h2o_context_t *ctx = H2O_STRUCT_FROM_MEMBER(h2o_context_t, http2._graceful_shutdown_timeout, entry);
+    h2o_linklist_t *node, *next;
+
+    /* We've sent two GOAWAY frames, close the remaining connections */
+    for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = next) {
+        h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
+        next = node->next;
+        if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING) {
+            close_connection(conn);
+        }
+    }
+}
+
 static void graceful_shutdown_resend_goaway(h2o_timeout_entry_t *entry)
 {
     h2o_context_t *ctx = H2O_STRUCT_FROM_MEMBER(h2o_context_t, http2._graceful_shutdown_timeout, entry);
     h2o_linklist_t *node;
+    int do_close_stragglers = 0;
 
     for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = node->next) {
         h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
         if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED) {
             enqueue_goaway(conn, H2O_HTTP2_ERROR_NONE, (h2o_iovec_t){NULL});
-            close_connection(conn);
+            do_close_stragglers = 1;
         }
+    }
+
+    /* after waiting a second, we still had active connections, wait one more second */
+    if (do_close_stragglers) {
+        ctx->http2._graceful_shutdown_timeout.cb = graceful_shutdown_close_stragglers;
+        h2o_timeout_link(ctx->loop, &ctx->one_sec_timeout, &ctx->http2._graceful_shutdown_timeout);
     }
 }
 

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -88,8 +88,10 @@ static void graceful_shutdown_resend_goaway(h2o_timeout_entry_t *entry)
 
     for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = node->next) {
         h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
-        if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED)
+        if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED) {
             enqueue_goaway(conn, H2O_HTTP2_ERROR_NONE, (h2o_iovec_t){NULL});
+            close_connection(conn);
+        }
     }
 }
 

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -110,10 +110,11 @@ static void graceful_shutdown_resend_goaway(h2o_timeout_entry_t *entry)
         }
     }
 
-    /* after waiting a second, we still had active connections, wait one more second */
-    if (do_close_stragglers) {
+    /* After waiting a second, we still had active connections. If configured, wait one
+     * final timeout before closing the connections */
+    if (do_close_stragglers && ctx->globalconf->http2.graceful_shutdown_timeout) {
         ctx->http2._graceful_shutdown_timeout.cb = graceful_shutdown_close_stragglers;
-        h2o_timeout_link(ctx->loop, &ctx->one_sec_timeout, &ctx->http2._graceful_shutdown_timeout);
+        h2o_timeout_link(ctx->loop, &ctx->http2.graceful_shutdown_timeout, &ctx->http2._graceful_shutdown_timeout);
     }
 }
 

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -90,9 +90,7 @@ static void graceful_shutdown_close_stragglers(h2o_timeout_entry_t *entry)
     for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = next) {
         h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
         next = node->next;
-        if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING) {
-            close_connection(conn);
-        }
+        close_connection(conn);
     }
 }
 

--- a/srcdoc/configure/http2_directives.mt
+++ b/srcdoc/configure/http2_directives.mt
@@ -333,4 +333,15 @@ Technically speaking, it does the following:
 </p>
 ? });
 
+<?
+$ctx->{directive}->(
+    name    => "http2-graceful-shutdown-timeout",
+    levels  => [ qw(global) ],
+    default => 'http2-graceful-shutdown-timeout: 0',
+    desc    => <<'EOT',
+A timeout in seconds. How long to wait before closing the connection on graceful shutdown. Setting the timeout to <code>0</code> deactivates the feature: H2O will wait for the peer to close the connections.
+EOT
+)->(sub {});
+
+
 ? })

--- a/t/80graceful-shutdown.t
+++ b/t/80graceful-shutdown.t
@@ -1,0 +1,80 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'nghttp not found'
+    unless prog_exists('nghttp');
+
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $upstream_port = empty_port();
+my $upstream_hostport = "127.0.0.1:$upstream_port";
+
+sub create_upstream {
+    my @args = (
+        qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen),
+        $upstream_hostport,
+        ASSETS_DIR . "/upstream.psgi",
+    );
+    spawn_server(
+        argv     => \@args,
+        is_ready =>  sub {
+            $upstream_hostport =~ /:([0-9]+)$/s
+                or die "failed to extract port number";
+            check_port($1);
+        },
+    );
+};
+
+sub doit {
+    my $timeout = shift;
+    my $server = spawn_h2o(<< "EOT");
+http2-graceful-shutdown-timeout: $timeout
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+    my $upstream = create_upstream();
+    my $nghttp_pid = open(NGHTTP, "nghttp -w 1 -v http://127.0.0.1:$server->{'port'}/infinite-stream 2>&1 |");
+
+    my $nghttp_interrupted=0;
+    eval {
+        local $SIG{ALRM} = sub { die "Timeout" };
+        my $stopped=0;
+        alarm(5);
+        while (<NGHTTP>) {
+            if (/recv DATA frame/ && !$stopped) {
+                # after the request started, stop H2O
+                kill 'TERM', $server->{pid};
+                $stopped = 1;
+            }
+            if (/Some requests were not processed/) {
+                $nghttp_interrupted = 1;
+            }
+        }
+        alarm(0);
+    };
+    my $err = $@;
+    if ($timeout == 1) {
+        ok($nghttp_interrupted == 1, "nghttp was interrupted");
+        ok($err !~ /^Timeout/, "nghttp didn't timeout");
+    } else {
+        kill 'TERM', $nghttp_pid;
+        ok($nghttp_interrupted == 0, "nghttp was not interrupted");
+        ok($err =~ /^Timeout/, "nghttp did timeout");
+    }
+}
+
+doit(0);
+doit(1);
+
+done_testing();

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -119,6 +119,17 @@ builder {
             ],
         ];
     };
+    mount "/infinite-stream" => sub {
+        my $env = shift;
+        return sub {
+            my $responder = shift;
+            my $writer = $responder->([ 200, [ 'content-type' => 'text/plain' ] ]);
+            while ($writer->write("lorem ipsum dolor sit amet")) {
+                sleep 0.1;
+            }
+            $writer->close;
+        };
+    };
     mount "/infinite-redirect" => sub {
         my $env = shift;
         return [


### PR DESCRIPTION
On graceful shutdown, after the second GOAWAY message has been written,
it should be possible for use to safely close the connection, without
necessarily waiting for all streams to be processed.
