### PR TITLE
suppress registering kevent changes multiple times

### DIFF
--- a/lib/common/socket/evloop/kqueue.c.h
+++ b/lib/common/socket/evloop/kqueue.c.h
@@ -119,8 +119,11 @@ int evloop_do_proceed(h2o_evloop_t *_loop)
     ts.tv_sec = max_wait / 1000;
     ts.tv_nsec = max_wait % 1000 * 1000 * 1000;
     while ((nevents = kevent(loop->kq, changelist, nchanges, events, sizeof(events) / sizeof(events[0]), &ts)) == -1 &&
-           errno == EINTR)
-        ;
+           errno == EINTR) {
+        /* when kevent() call fails with EINTR error, all changes in the changelist have been applied */
+        nchanges = 0;
+    }
+
     update_now(&loop->super);
     if (nevents == -1)
         return -1;


### PR DESCRIPTION
The problem is, in kqueue, registering a change (more specifically `EV_DELETE` `EVFILT_WRITE` change event) multiple times  causes `ENOENT` error in result event list, and it causes the server crush (by assertion in `write_pending` function).

Quote [man kqueue](https://www.freebsd.org/cgi/man.cgi?query=kqueue) :
```
When kevent() call fails with EINTR error, all changes in the changelist have been applied.
```
This PR fixes that issue by suppressing multiple registering of the same changes.