### PR TITLE
reset OCSP stapling data when the updater returns a permanent failure

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -334,6 +334,7 @@ static void *ocsp_updater_thread(void *_ssl_conf)
             }
             break;
         default: /* permanent failure */
+            update_ocsp_stapling(ssl_conf, NULL);
             fprintf(stderr, "[OCSP Stapling] disabled for certificate file:%s\n", ssl_conf->certificate_file);
             goto Exit;
         }


### PR DESCRIPTION
Otherwise, the server will continue to return an outdated OCSP response if the updater first succeeds and then fails returning a parmanent failure, as reported in #1102.