### PR TITLE
Fix t/50http2_debug_state.t to dectect both HTTP/2 and HTTP/2.0

### DIFF
--- a/t/50http2_debug_state.t
+++ b/t/50http2_debug_state.t
@@ -26,7 +26,7 @@ EOT
         if ($curl_cmd =~ /--http2/) {
             subtest "single stream itself" => sub {
                 my ($headers, $body) = run_prog("$curl_cmd --dump-header /dev/stderr $url");
-                like($headers, qr!^HTTP/2 200!);
+                like($headers, qr!^HTTP/2(.0)? 200!);
                 my $data;
                 lives_ok { $data = decode_json($body) };
                 is($data->{streams}->{1}->{state}, 'HALF_CLOSED_REMOTE');
@@ -59,7 +59,7 @@ EOT
 
     subtest "with hpack state" => sub {
         my ($headers, $body) = run_prog("$curl_cmd $url");
-        like($headers, qr!^HTTP/2 200!);
+        like($headers, qr!^HTTP/2(.0)? 200!);
         my $data;
         lives_ok { $data = decode_json($body) };
         ok(exists $data->{hpack});

--- a/t/50http2_debug_state.t
+++ b/t/50http2_debug_state.t
@@ -26,7 +26,7 @@ EOT
         if ($curl_cmd =~ /--http2/) {
             subtest "single stream itself" => sub {
                 my ($headers, $body) = run_prog("$curl_cmd --dump-header /dev/stderr $url");
-                like($headers, qr!^HTTP/2(.0)? 200!);
+                like($headers, qr!^HTTP/2(\.0)? 200!);
                 my $data;
                 lives_ok { $data = decode_json($body) };
                 is($data->{streams}->{1}->{state}, 'HALF_CLOSED_REMOTE');
@@ -59,7 +59,7 @@ EOT
 
     subtest "with hpack state" => sub {
         my ($headers, $body) = run_prog("$curl_cmd $url");
-        like($headers, qr!^HTTP/2(.0)? 200!);
+        like($headers, qr!^HTTP/2(\.0)? 200!);
         my $data;
         lives_ok { $data = decode_json($body) };
         ok(exists $data->{hpack});


### PR DESCRIPTION
curl changed the way the HTTP/2 response status header is reported:
https://github.com/curl/curl/commit/8243a9581b7782bc2af29e8421952d0e669f9e9e

Before 7.49.1 it was HTTP/2.0, after that it's HTTP/2

Alter the regexp to reflect that.