### PR TITLE
t/50fastcgi.t: cover the (!tcp, keepalive) case

### DIFF
--- a/t/50fastcgi.t
+++ b/t/50fastcgi.t
@@ -89,7 +89,7 @@ EOT
 
 doit(0, 0);
 doit(1, 0);
-doit(1, 1);
+doit(0, 1);
 doit(1, 1);
 
 subtest 'httpoxy' => sub {


### PR DESCRIPTION
I stumbled on this while tracking down test failures. It sounds like the
intent was to test the 2x2 matrix rather than testing the (1,1) case
twice.