### PR TITLE
proxy: don't normalize a unix path to lower case

### DIFF
--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -135,17 +135,18 @@ static void on_handler_dispose(h2o_handler_t *_self)
 
 void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstream, h2o_proxy_config_vars_t *config)
 {
+    struct sockaddr_un sa;
+    const char *to_sa_err;
     struct rp_handler_t *self = (void *)h2o_create_handler(pathconf, sizeof(*self));
     self->super.on_context_init = on_context_init;
     self->super.on_context_dispose = on_context_dispose;
     self->super.dispose = on_handler_dispose;
     self->super.on_req = on_req;
+    to_sa_err = h2o_url_host_to_sun(upstream->host, &sa);
     if (config->keepalive_timeout != 0) {
         self->sockpool = h2o_mem_alloc(sizeof(*self->sockpool));
-        struct sockaddr_un sa;
-        const char *to_sa_err;
         int is_ssl = upstream->scheme == &H2O_URL_SCHEME_HTTPS;
-        if ((to_sa_err = h2o_url_host_to_sun(upstream->host, &sa)) == h2o_url_host_to_sun_err_is_not_unix_socket) {
+        if (to_sa_err == h2o_url_host_to_sun_err_is_not_unix_socket) {
             h2o_socketpool_init_by_hostport(self->sockpool, upstream->host, h2o_url_get_port(upstream), is_ssl,
                                             SIZE_MAX /* FIXME */);
         } else {
@@ -154,7 +155,8 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
         }
     }
     h2o_url_copy(NULL, &self->upstream, upstream);
-    h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
+    if (to_sa_err)
+        h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
     self->config = *config;
     if (self->config.ssl_ctx != NULL)
         SSL_CTX_up_ref(self->config.ssl_ctx);


### PR DESCRIPTION
This came up when discussing https://github.com/h2o/h2o/pull/919, but i believe it's an issue that we can address separately. This only prevents lower casing unix socket paths, and doesn't address the header rewrite. I believe header rewrite might not make much sense with unix socket anyway? What do you think?