### PR TITLE
Proxy dont normalize unix path

### DIFF
--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -125,7 +125,7 @@ inline h2o_iovec_t h2o_url_stringify(h2o_mem_pool_t *pool, const h2o_url_t *url)
 
 /**
  * Compares to hostnames, taking into account whether they contain a
- * unix path (the comparison will be case insensitive) or not.
+ * unix path (the comparison will be case sensitive) or not.
  */
 static inline int h2o_url_hosts_are_equal(const h2o_url_t *url_a, const h2o_url_t *url_b)
 {
@@ -135,7 +135,7 @@ static inline int h2o_url_hosts_are_equal(const h2o_url_t *url_a, const h2o_url_
     if (!url_a->host_is_unix_path)
         return h2o_lcstris(url_a->host.base, url_a->host.len, url_b->host.base, url_b->host.len);
     else
-        return !strncasecmp(url_a->host.base, url_b->host.base, url_b->host.len);
+        return h2o_memis(url_a->host.base, url_a->host.len, url_b->host.base, url_b->host.len);
 }
 
 #endif

--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -123,10 +123,10 @@ inline h2o_iovec_t h2o_url_stringify(h2o_mem_pool_t *pool, const h2o_url_t *url)
 
 static inline int h2o_url_host_is_unix_path(h2o_iovec_t host)
 {
-    if (host.len < 6) {
+    if (host.len < 5) {
         return 0;
     }
-    return h2o_memis(host.base, 6, H2O_STRLIT("unix:/"));
+    return h2o_memis(host.base, 5, H2O_STRLIT("unix:"));
 }
 
 /**
@@ -138,7 +138,7 @@ static inline int h2o_url_hosts_are_equal(const h2o_url_t *url_a, const h2o_url_
     if (url_a->host.len != url_b->host.len)
         return 0;
 
-    if (h2o_url_host_is_unix_path(url_a->host) && h2o_url_host_is_unix_path(url_b->host))
+    if (h2o_url_host_is_unix_path(url_a->host))
         return h2o_memis(url_a->host.base, url_a->host.len, url_b->host.base, url_b->host.len);
     else
         return h2o_lcstris(url_a->host.base, url_a->host.len, url_b->host.base, url_b->host.len);

--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -127,11 +127,15 @@ inline h2o_iovec_t h2o_url_stringify(h2o_mem_pool_t *pool, const h2o_url_t *url)
  * Compares to hostnames, taking into account whether they contain a
  * unix path (the comparison will be case insensitive) or not.
  */
-static inline int h2o_url_compare_hosts(const h2o_iovec_t host_a, const h2o_iovec_t host_b, int host_is_unix_path)
+static inline int h2o_url_hosts_are_equal(const h2o_url_t *url_a, const h2o_url_t *url_b)
 {
-    if (!host_is_unix_path)
-        return h2o_lcstris(host_a.base, host_a.len, host_b.base, host_b.len);
-    return host_a.len == host_b.len && !strncasecmp(host_a.base, host_b.base, host_b.len);
+    if (url_a->host_is_unix_path != url_b->host_is_unix_path)
+        return 0;
+
+    if (!url_a->host_is_unix_path)
+        return h2o_lcstris(url_a->host.base, url_a->host.len, url_b->host.base, url_b->host.len);
+    else
+        return !strncasecmp(url_a->host.base, url_b->host.base, url_b->host.len);
 }
 
 #endif

--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -227,6 +227,7 @@ static int parse_authority_and_path(const char *src, const char *url_end, h2o_ur
     const char *p = h2o_url_parse_hostport(src, url_end - src, &parsed->host, &parsed->_port);
     if (p == NULL)
         return -1;
+    parsed->host_is_unix_path = 0;
     parsed->authority = h2o_iovec_init(src, p - src);
     if (p == url_end) {
         parsed->path = h2o_iovec_init(H2O_STRLIT("/"));
@@ -279,6 +280,7 @@ int h2o_url_parse_relative(const char *url, size_t url_len, h2o_url_t *parsed)
     /* reset authority, host, port, and set path */
     parsed->authority = (h2o_iovec_t){NULL};
     parsed->host = (h2o_iovec_t){NULL};
+    parsed->host_is_unix_path = 0;
     parsed->_port = 65535;
     parsed->path = h2o_iovec_init(p, url_end - p);
 

--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -227,7 +227,6 @@ static int parse_authority_and_path(const char *src, const char *url_end, h2o_ur
     const char *p = h2o_url_parse_hostport(src, url_end - src, &parsed->host, &parsed->_port);
     if (p == NULL)
         return -1;
-    parsed->host_is_unix_path = 0;
     parsed->authority = h2o_iovec_init(src, p - src);
     if (p == url_end) {
         parsed->path = h2o_iovec_init(H2O_STRLIT("/"));
@@ -280,7 +279,6 @@ int h2o_url_parse_relative(const char *url, size_t url_len, h2o_url_t *parsed)
     /* reset authority, host, port, and set path */
     parsed->authority = (h2o_iovec_t){NULL};
     parsed->host = (h2o_iovec_t){NULL};
-    parsed->host_is_unix_path = 0;
     parsed->_port = 65535;
     parsed->path = h2o_iovec_init(p, url_end - p);
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -66,7 +66,7 @@ static h2o_iovec_t rewrite_location(h2o_mem_pool_t *pool, const char *location, 
         goto NoRewrite;
     if (loc_parsed.scheme != &H2O_URL_SCHEME_HTTP)
         goto NoRewrite;
-    if (!h2o_url_compare_hosts(loc_parsed.host, match->host, match->host_is_unix_path))
+    if (!h2o_url_hosts_are_equal(&loc_parsed, match))
         goto NoRewrite;
     if (h2o_url_get_port(&loc_parsed) != h2o_url_get_port(match))
         goto NoRewrite;

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -66,7 +66,7 @@ static h2o_iovec_t rewrite_location(h2o_mem_pool_t *pool, const char *location, 
         goto NoRewrite;
     if (loc_parsed.scheme != &H2O_URL_SCHEME_HTTP)
         goto NoRewrite;
-    if (!h2o_lcstris(loc_parsed.host.base, loc_parsed.host.len, match->host.base, match->host.len))
+    if (!h2o_url_compare_hosts(loc_parsed.host, match->host, match->host_is_unix_path))
         goto NoRewrite;
     if (h2o_url_get_port(&loc_parsed) != h2o_url_get_port(match))
         goto NoRewrite;

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -135,17 +135,18 @@ static void on_handler_dispose(h2o_handler_t *_self)
 
 void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstream, h2o_proxy_config_vars_t *config)
 {
+    struct sockaddr_un sa;
+    const char *to_sa_err;
     struct rp_handler_t *self = (void *)h2o_create_handler(pathconf, sizeof(*self));
     self->super.on_context_init = on_context_init;
     self->super.on_context_dispose = on_context_dispose;
     self->super.dispose = on_handler_dispose;
     self->super.on_req = on_req;
+    to_sa_err = h2o_url_host_to_sun(upstream->host, &sa);
     if (config->keepalive_timeout != 0) {
         self->sockpool = h2o_mem_alloc(sizeof(*self->sockpool));
-        struct sockaddr_un sa;
-        const char *to_sa_err;
         int is_ssl = upstream->scheme == &H2O_URL_SCHEME_HTTPS;
-        if ((to_sa_err = h2o_url_host_to_sun(upstream->host, &sa)) == h2o_url_host_to_sun_err_is_not_unix_socket) {
+        if (to_sa_err == h2o_url_host_to_sun_err_is_not_unix_socket) {
             h2o_socketpool_init_by_hostport(self->sockpool, upstream->host, h2o_url_get_port(upstream), is_ssl,
                                             SIZE_MAX /* FIXME */);
         } else {
@@ -154,7 +155,8 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
         }
     }
     h2o_url_copy(NULL, &self->upstream, upstream);
-    h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
+    if (to_sa_err)
+        h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
     self->config = *config;
     if (self->config.ssl_ctx != NULL)
         SSL_CTX_up_ref(self->config.ssl_ctx);

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -157,8 +157,6 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
     h2o_url_copy(NULL, &self->upstream, upstream);
     if (to_sa_err) {
         h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
-    } else {
-        self->upstream.host_is_unix_path = 1;
     }
     self->config = *config;
     if (self->config.ssl_ctx != NULL)

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -155,8 +155,11 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
         }
     }
     h2o_url_copy(NULL, &self->upstream, upstream);
-    if (to_sa_err)
+    if (to_sa_err) {
         h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
+    } else {
+        self->upstream.host_is_unix_path = 1;
+    }
     self->config = *config;
     if (self->config.ssl_ctx != NULL)
         SSL_CTX_up_ref(self->config.ssl_ctx);


### PR DESCRIPTION
This is a fixed version of #1130 . It adds a boolean in the `h2o_url_t` structure to indicate whether the host name contains a unix path or not. The matching for header rewrite takes that into account, and uses `strcasecmp` when appropriate.