### PR TITLE
Don't bump `conn->pull_stream_ids.max_open` for PRIORITY frames

### DIFF
--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -259,7 +259,7 @@ int h2o_http2_decode_window_update_payload(h2o_http2_window_update_payload_t *pa
                                            const char **err_desc, int *err_is_stream_level);
 
 /* connection */
-void h2o_http2_conn_register_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
+void h2o_http2_conn_register_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, int is_prio);
 void h2o_http2_conn_unregister_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 static h2o_http2_stream_t *h2o_http2_conn_get_stream(h2o_http2_conn_t *conn, uint32_t stream_id);
 void h2o_http2_conn_push_path(h2o_http2_conn_t *conn, h2o_iovec_t path, h2o_http2_stream_t *src_stream);
@@ -271,7 +271,7 @@ static void h2o_http2_conn_init_casper(h2o_http2_conn_t *conn, unsigned capacity
 /* stream */
 static int h2o_http2_stream_is_push(uint32_t stream_id);
 h2o_http2_stream_t *h2o_http2_stream_open(h2o_http2_conn_t *conn, uint32_t stream_id, h2o_req_t *src_req,
-                                          const h2o_http2_priority_t *received_priority);
+                                          const h2o_http2_priority_t *received_priority, int is_prio);
 static void h2o_http2_stream_update_open_slot(h2o_http2_stream_t *stream, h2o_http2_conn_num_streams_t *slot);
 static void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_http2_stream_state_t new_state);
 static void h2o_http2_stream_prepare_for_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -178,12 +178,12 @@ static void execute_or_enqueue_request(h2o_http2_conn_t *conn, h2o_http2_stream_
     update_idle_timeout(conn);
 }
 
-void h2o_http2_conn_register_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
+void h2o_http2_conn_register_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, int is_prio)
 {
     khiter_t iter;
     int r;
 
-    if (!h2o_http2_stream_is_push(stream->stream_id) && conn->pull_stream_ids.max_open < stream->stream_id)
+    if (!is_prio && !h2o_http2_stream_is_push(stream->stream_id) && conn->pull_stream_ids.max_open < stream->stream_id)
         conn->pull_stream_ids.max_open = stream->stream_id;
 
     iter = kh_put(h2o_http2_stream_t, conn->streams, stream->stream_id, &r);
@@ -569,7 +569,7 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
             stream->received_priority = payload.priority;
         }
     } else {
-        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL, &payload.priority);
+        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL, &payload.priority, 0);
         set_priority(conn, stream, &payload.priority, 0);
     }
     h2o_http2_stream_prepare_for_request(conn, stream);
@@ -629,7 +629,7 @@ static int handle_priority_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *fram
              */
             return H2O_HTTP2_ERROR_ENHANCE_YOUR_CALM;
         }
-        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL, &payload);
+        stream = h2o_http2_stream_open(conn, frame->stream_id, NULL, &payload, 1);
         set_priority(conn, stream, &payload, 0);
     }
 
@@ -1256,7 +1256,7 @@ static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_le
 
     /* open the stream */
     conn->push_stream_ids.max_open += 2;
-    h2o_http2_stream_t *stream = h2o_http2_stream_open(conn, conn->push_stream_ids.max_open, NULL, &h2o_http2_default_priority);
+    h2o_http2_stream_t *stream = h2o_http2_stream_open(conn, conn->push_stream_ids.max_open, NULL, &h2o_http2_default_priority, 0);
     stream->received_priority.dependency = src_stream->stream_id;
     stream->push.parent_stream_id = src_stream->stream_id;
     h2o_http2_scheduler_open(&stream->_refs.scheduler, &src_stream->_refs.scheduler.node, 16, 0);
@@ -1352,7 +1352,7 @@ int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval connected_at)
     }
 
     /* open the stream, now that the function is guaranteed to succeed */
-    stream = h2o_http2_stream_open(http2conn, 1, req, &h2o_http2_default_priority);
+    stream = h2o_http2_stream_open(http2conn, 1, req, &h2o_http2_default_priority, 0);
     h2o_http2_scheduler_open(&stream->_refs.scheduler, &http2conn->scheduler, h2o_http2_default_priority.weight, 0);
     h2o_http2_stream_prepare_for_request(http2conn, stream);
 

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -32,7 +32,7 @@ static size_t sz_min(size_t x, size_t y)
 }
 
 h2o_http2_stream_t *h2o_http2_stream_open(h2o_http2_conn_t *conn, uint32_t stream_id, h2o_req_t *src_req,
-                                          const h2o_http2_priority_t *received_priority)
+                                          const h2o_http2_priority_t *received_priority, int is_prio)
 {
     h2o_http2_stream_t *stream = h2o_mem_alloc(sizeof(*stream));
 
@@ -54,7 +54,7 @@ h2o_http2_stream_t *h2o_http2_stream_open(h2o_http2_conn_t *conn, uint32_t strea
         memset(&stream->req.upgrade, 0, sizeof(stream->req.upgrade));
     stream->req._ostr_top = &stream->_ostr_final;
 
-    h2o_http2_conn_register_stream(conn, stream);
+    h2o_http2_conn_register_stream(conn, stream, is_prio);
 
     ++conn->num_streams.priority.open;
     stream->_num_streams_slot = &conn->num_streams.priority;


### PR DESCRIPTION
`PRIORITY` frames can be sent for idle streams, and shouldn't affect the
number of open streams. When registering a stream, determine whether the
registration comes from a `PRIORITY` frame or not, and if it is, don't
affect the `max_open` stream id.

Not doing so resulted in the server closing the connection with a
`PROTOCOL_ERROR` when a `PRIORITY` frame for stream id 3 was followed by
a `HEADER` frame for stream id 1.

@Kriechi provided a minimal repro case
here: https://github.com/mitmproxy/mitmproxy/issues/1824#issuecomment-265709060

I've proposed a PR for h2spec to cover the case:
https://github.com/summerwind/h2spec/pull/67/files