### PR TITLE
add session_ticket

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -754,6 +754,7 @@ typedef struct st_h2o_conn_callbacks_t {
                 h2o_iovec_t (*session_reused)(h2o_req_t *req);
                 h2o_iovec_t (*cipher)(h2o_req_t *req);
                 h2o_iovec_t (*cipher_bits)(h2o_req_t *req);
+                h2o_iovec_t (*session_ticket)(h2o_req_t *req);
             } ssl;
             struct {
                 h2o_iovec_t (*request_index)(h2o_req_t *req);

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -264,6 +264,8 @@ static h2o_iovec_t h2o_socket_log_ssl_protocol_version(h2o_socket_t *sock, h2o_m
 static h2o_iovec_t h2o_socket_log_ssl_session_reused(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 static h2o_iovec_t h2o_socket_log_ssl_cipher(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 h2o_iovec_t h2o_socket_log_ssl_cipher_bits(h2o_socket_t *sock, h2o_mem_pool_t *pool);
+h2o_iovec_t h2o_socket_log_ssl_session_ticket(h2o_socket_t *sock, h2o_mem_pool_t *pool);
+
 /**
  * compares socket addresses
  */

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -185,6 +185,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_PROTO("ssl.session-reused", ssl.session_reused);
                     MAP_EXT_TO_PROTO("ssl.cipher", ssl.cipher);
                     MAP_EXT_TO_PROTO("ssl.cipher-bits", ssl.cipher_bits);
+                    MAP_EXT_TO_PROTO("ssl.session_ticket", ssl.session_ticket);
                     { /* not found */
                         h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
                         NEW_ELEMENT(ELEMENT_TYPE_EXTENDED_VAR);

--- a/lib/handler/status/requests.c
+++ b/lib/handler/status/requests.c
@@ -102,7 +102,7 @@ static void *requests_status_init(void)
                 SEPARATOR
         /* connection */
         X_ELEMENT("connection-id") SEPARATOR X_ELEMENT("ssl.protocol-version") SEPARATOR X_ELEMENT("ssl.session-reused")
-            SEPARATOR X_ELEMENT("ssl.cipher") SEPARATOR X_ELEMENT("ssl.cipher-bits") SEPARATOR
+            SEPARATOR X_ELEMENT("ssl.cipher") SEPARATOR X_ELEMENT("ssl.cipher-bits") SEPARATOR X_ELEMENT("ssl.session-ticket") SEPARATOR
         /* http1 */
         X_ELEMENT("http1.request-index") SEPARATOR
         /* http2 */


### PR DESCRIPTION
Still have some problems with linking new OpenSSL.

LibreSSL has not SSL_SESSION_get0_ticket. But if we need it, I will look if tickets can be accessed directly.

Do we need session_id?


The following info is for client code and we can not use it in server. SSL object or SSL_SESSION should  be used instead.
```c
            struct {
                char *server_name;
                h2o_cache_t *session_cache;
                h2o_iovec_t session_cache_key;
                h2o_cache_hashcode_t session_cache_key_hash;
            } client;
```