### PR TITLE
HTTP/1 -> HTTP/2 uprade error fixes

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -579,8 +579,10 @@ static void on_upgrade_complete(h2o_socket_t *socket, const char *err)
     if (err == 0) {
         sock = conn->sock;
         reqsize = conn->_reqsize;
+	close_connection(conn, 0);
+    } else {
+	close_connection(conn, 1);
     }
-    close_connection(conn, 0);
 
     cb(data, sock, reqsize);
 }

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1361,6 +1361,7 @@ int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval connected_at)
     return 0;
 Error:
     h2o_linklist_unlink(&http2conn->_conns);
+    kh_destroy(h2o_http2_stream_t, http2conn->streams);
     free(http2conn);
     return -1;
 }


### PR DESCRIPTION
This PR fixes two issues that can happen if the upgrade from HTTP/1 to HTTP/2 fails.