### PR TITLE
log session id

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -754,6 +754,7 @@ typedef struct st_h2o_conn_callbacks_t {
                 h2o_iovec_t (*session_reused)(h2o_req_t *req);
                 h2o_iovec_t (*cipher)(h2o_req_t *req);
                 h2o_iovec_t (*cipher_bits)(h2o_req_t *req);
+                h2o_iovec_t (*session_id)(h2o_req_t *req);
             } ssl;
             struct {
                 h2o_iovec_t (*request_index)(h2o_req_t *req);

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -264,6 +264,8 @@ static h2o_iovec_t h2o_socket_log_ssl_protocol_version(h2o_socket_t *sock, h2o_m
 static h2o_iovec_t h2o_socket_log_ssl_session_reused(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 static h2o_iovec_t h2o_socket_log_ssl_cipher(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 h2o_iovec_t h2o_socket_log_ssl_cipher_bits(h2o_socket_t *sock, h2o_mem_pool_t *pool);
+h2o_iovec_t h2o_socket_log_ssl_session_id(h2o_socket_t *sock, h2o_mem_pool_t *pool);
+
 /**
  * compares socket addresses
  */

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -77,6 +77,10 @@ static void h2o_strtoupper(char *s, size_t len);
  */
 static int h2o_lcstris(const char *target, size_t target_len, const char *test, size_t test_len);
 /**
+ * turns the length of a string into the length of the same string encoded in base64
+ */
+static size_t h2o_base64_encode_capacity(unsigned len);
+/**
  * parses a positive number of return SIZE_MAX if failed
  */
 size_t h2o_strtosize(const char *s, size_t len);

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -178,6 +178,11 @@ inline int h2o_lcstris(const char *target, size_t target_len, const char *test, 
     return h2o__lcstris_core(target, test, test_len);
 }
 
+inline size_t h2o_base64_encode_capacity(unsigned len)
+{
+    return (((len) + 2) / 3 * 4 + 1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -682,6 +682,31 @@ int h2o_socket_get_ssl_cipher_bits(h2o_socket_t *sock)
     return sock->ssl != NULL ? SSL_get_cipher_bits(sock->ssl->ssl, NULL) : 0;
 }
 
+
+h2o_iovec_t h2o_socket_log_ssl_session_id(h2o_socket_t *sock, h2o_mem_pool_t *pool)
+{
+    h2o_iovec_t key;
+    unsigned id_len;
+    const unsigned char *id;
+    SSL_SESSION *session = SSL_get_session(sock->ssl->ssl);
+    if (session == NULL)
+      return h2o_iovec_init(H2O_STRLIT("-"));
+
+    switch (sock->ssl->handshake.server.async_resumption.state) {
+        case ASYNC_RESUMPTION_STATE_COMPLETE:
+
+            id = SSL_SESSION_get_id(session, &id_len);
+            
+            key.base = (char *)(pool != NULL ? h2o_mem_alloc_pool(pool, h2o_base64_encode_capacity(id_len))
+                                            : h2o_mem_alloc(h2o_base64_encode_capacity(id_len)));
+            
+            key.len = h2o_base64_encode(key.base, id, id_len, 1);
+            return key;
+        default:
+            return h2o_iovec_init(H2O_STRLIT("-"));
+    }
+}
+
 h2o_iovec_t h2o_socket_log_ssl_cipher_bits(h2o_socket_t *sock, h2o_mem_pool_t *pool)
 {
     int bits = h2o_socket_get_ssl_cipher_bits(sock);

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -191,6 +191,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_PROTO("ssl.session-reused", ssl.session_reused);
                     MAP_EXT_TO_PROTO("ssl.cipher", ssl.cipher);
                     MAP_EXT_TO_PROTO("ssl.cipher-bits", ssl.cipher_bits);
+                    MAP_EXT_TO_PROTO("ssl.session-id", ssl.session_id);
                     { /* not found */
                         h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
                         NEW_ELEMENT(ELEMENT_TYPE_EXTENDED_VAR);

--- a/lib/handler/status/requests.c
+++ b/lib/handler/status/requests.c
@@ -102,7 +102,7 @@ static void *requests_status_init(void)
                 SEPARATOR
         /* connection */
         X_ELEMENT("connection-id") SEPARATOR X_ELEMENT("ssl.protocol-version") SEPARATOR X_ELEMENT("ssl.session-reused")
-            SEPARATOR X_ELEMENT("ssl.cipher") SEPARATOR X_ELEMENT("ssl.cipher-bits") SEPARATOR
+            SEPARATOR X_ELEMENT("ssl.cipher") SEPARATOR X_ELEMENT("ssl.cipher-bits") SEPARATOR X_ELEMENT("ssl.session-ticket") SEPARATOR
         /* http1 */
         X_ELEMENT("http1.request-index") SEPARATOR
         /* http2 */

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -767,6 +767,7 @@ DEFINE_TLS_LOGGER(protocol_version)
 DEFINE_TLS_LOGGER(session_reused)
 DEFINE_TLS_LOGGER(cipher)
 DEFINE_TLS_LOGGER(cipher_bits)
+DEFINE_TLS_LOGGER(session_id)
 
 #undef DEFINE_TLS_LOGGER
 
@@ -800,7 +801,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
         get_socket,   /* get underlying socket */
         NULL,         /* get debug state */
         {{
-            {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits}, /* ssl */
+            {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits, log_session_id}, /* ssl */
             {log_request_index},                                                     /* http1 */
             {NULL}                                                                   /* http2 */
         }}};

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1072,7 +1072,7 @@ DEFINE_TLS_LOGGER(protocol_version)
 DEFINE_TLS_LOGGER(session_reused)
 DEFINE_TLS_LOGGER(cipher)
 DEFINE_TLS_LOGGER(cipher_bits)
-
+DEFINE_TLS_LOGGER(session_id)
 #undef DEFINE_TLS_LOGGER
 
 static h2o_iovec_t log_stream_id(h2o_req_t *req)
@@ -1161,7 +1161,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
         get_socket,                /* get underlying socket */
         h2o_http2_get_debug_state, /* get debug state */
         {{
-            {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits}, /* ssl */
+            {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits, log_session_id}, /* ssl */
             {NULL},                                                                  /* http1 */
             {log_stream_id, log_priority_received, log_priority_received_exclusive, log_priority_received_parent,
              log_priority_received_weight, log_priority_actual, log_priority_actual_parent, log_priority_actual_weight} /* http2 */

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -181,13 +181,13 @@ subtest 'extensions' => sub {
     );
 };
 
-subtest 'ssltest' => sub {
+subtest 'ssl-log' => sub {
     doit(
         sub {
             my $server = shift;
-            system("curl --silent https://127.0.0.1:$server->{tls_port}/ > /dev/null");
+            system("curl --silent -k https://127.0.0.1:$server->{tls_port}/ > /dev/null");
         },
-        '%{error}x',
+        '%{ssl.session-id}x',
         qr{^\S+$}s,
     );
 };

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -15,6 +15,9 @@ sub doit {
     unlink "$tempdir/access_log";
 
     my $server = spawn_h2o(<< "EOT");
+ssl-session-resumption:
+  mode: cache
+  cache-store: internal
 hosts:
   default:
     paths:
@@ -175,6 +178,17 @@ subtest 'extensions' => sub {
             }
             @expected;
         },
+    );
+};
+
+subtest 'ssltest' => sub {
+    doit(
+        sub {
+            my $server = shift;
+            system("curl --silent https://127.0.0.1:$server->{tls_port}/ > /dev/null");
+        },
+        '%{error}x',
+        qr{^\S+$}s,
     );
 };
 


### PR DESCRIPTION
replaces https://github.com/h2o/h2o/pull/1147 because somehow i messed that up.

i tried to fix the issues, but i'm unsure about the correct algo for `h2o_base64_encode_capacity`.

http://stackoverflow.com/questions/1533113/calculate-the-size-to-a-base-64-encoded-message
suggests:
`((len * 4) / 3) + (len / 96) + 6`


also not sure why the ci fails
