### PR TITLE
Pushes: support a x-http2-push-only attribute

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1139,12 +1139,12 @@ size_t h2o_stringify_proxy_header(h2o_conn_t *conn, char *buf);
 #define H2O_PROXY_HEADER_MAX_LENGTH                                                                                                \
     (sizeof("PROXY TCP6 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff 65535 65535\r\n") - 1)
 /**
- * extracts path to be pushed from `Link: rel=prelead` header, duplicating the chunk (or returns {NULL,0} if none)
+ * extracts path to be pushed from `Link: rel=preload` header, duplicating the chunk (or returns {NULL,0} if none)
  */
 h2o_iovec_vector_t h2o_extract_push_path_from_link_header(h2o_mem_pool_t *pool, const char *value, size_t value_len,
                                                           h2o_iovec_t base_path, const h2o_url_scheme_t *input_scheme,
                                                           h2o_iovec_t input_authority, const h2o_url_scheme_t *base_scheme,
-                                                          h2o_iovec_t *base_authority);
+                                                          h2o_iovec_t *base_authority, h2o_iovec_t *filtered_value);
 /**
  * return a bitmap of compressible types, by parsing the `accept-encoding` header
  */
@@ -1442,8 +1442,9 @@ void h2o_send_redirect_internal(h2o_req_t *req, h2o_iovec_t method, const char *
 h2o_iovec_t h2o_get_redirect_method(h2o_iovec_t method, int status);
 /**
  * registers push path (if necessary) by parsing a Link header
+ * this returns a version of `value` that removes the links that had the `x-http2-push-only` attribute
  */
-int h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len);
+h2o_iovec_t h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len);
 /**
  * logs an error
  */

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -431,7 +431,12 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
                 }
                 goto AddHeaderDuped;
             } else if (token == H2O_TOKEN_LINK) {
-                h2o_push_path_in_link_header(req, headers[i].value, headers[i].value_len);
+                h2o_iovec_t new_value;
+                new_value = h2o_push_path_in_link_header(req, headers[i].value, headers[i].value_len);
+                if (!new_value.len)
+                    goto Skip;
+                headers[i].value = new_value.base;
+                headers[i].value_len = new_value.len;
             } else if (token == H2O_TOKEN_X_COMPRESS_HINT) {
                 req->compress_hint = compress_hint_to_enum(headers[i].value, headers[i].value_len);
                 goto Skip;

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -659,20 +659,21 @@ h2o_iovec_t h2o_get_redirect_method(h2o_iovec_t method, int status)
     return method;
 }
 
-int h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
+h2o_iovec_t h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size_t value_len)
 {
     int i;
+    h2o_iovec_t ret = h2o_iovec_init(value, value_len);
     if (req->conn->callbacks->push_path == NULL)
-        return -1;
+        return ret;
 
     h2o_iovec_vector_t paths = h2o_extract_push_path_from_link_header(
         &req->pool, value, value_len, req->path_normalized, req->input.scheme, req->input.authority,
-        req->res_is_delegated ? req->scheme : NULL, req->res_is_delegated ? &req->authority : NULL);
+        req->res_is_delegated ? req->scheme : NULL, req->res_is_delegated ? &req->authority : NULL, &ret);
     if (paths.size == 0)
-        return -1;
+        return ret;
 
     for (i = 0; i < paths.size; i++) {
         req->conn->callbacks->push_path(req, paths.entries[i].base, paths.entries[i].len);
     }
-    return 0;
+    return ret;
 }

--- a/t/00unit/lib/core/util.c
+++ b/t/00unit/lib/core/util.c
@@ -255,7 +255,7 @@ static void test_extract_push_path_from_link_header_push_only(void)
     ok(h2o_memis(path.base, path.len, H2O_STRLIT("/thirdpath")));
     path = paths.entries[2];
     ok(h2o_memis(path.base, path.len, H2O_STRLIT("/fourthpath")));
-    value = h2o_iovec_init(H2O_STRLIT(" </secondpath>; rel=preload; nopush, </thirdpath>; rel=preload"));
+    value = h2o_iovec_init(H2O_STRLIT("</secondpath>; rel=preload; nopush, </thirdpath>; rel=preload"));
     ok(h2o_memis(value.base, value.len, filtered_value.base, filtered_value.len));
 
     value = h2o_iovec_init(H2O_STRLIT("</firstpath>; rel=preload, </secondpath>; rel=preload; x-http2-push-only, </thirdpath>; rel=preload; nopush, </fourthpath>; rel=preload; x-http2-push-only"));
@@ -270,6 +270,20 @@ static void test_extract_push_path_from_link_header_push_only(void)
     path = paths.entries[2];
     ok(h2o_memis(path.base, path.len, H2O_STRLIT("/fourthpath")));
     value = h2o_iovec_init(H2O_STRLIT("</firstpath>; rel=preload, </thirdpath>; rel=preload; nopush"));
+    ok(h2o_memis(value.base, value.len, filtered_value.base, filtered_value.len));
+
+    value = h2o_iovec_init(H2O_STRLIT("</firstpath>; rel=preload; x-http2-push-only, </secondpath>; rel=preload, </thirdpath>; rel=preload; x-http2-push-only, </fourthpath>; rel=preload; nopush"));
+    paths = h2o_extract_push_path_from_link_header(
+        &pool, value.base, value.len, INPUT,
+        &H2O_URL_SCHEME_HTTP, &input_authority, &filtered_value);
+    ok(paths.size == 3);
+    path = paths.entries[0];
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/firstpath")));
+    path = paths.entries[1];
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/secondpath")));
+    path = paths.entries[2];
+    ok(h2o_memis(path.base, path.len, H2O_STRLIT("/thirdpath")));
+    value = h2o_iovec_init(H2O_STRLIT("</secondpath>; rel=preload, </fourthpath>; rel=preload; nopush"));
     ok(h2o_memis(value.base, value.len, filtered_value.base, filtered_value.len));
 
     value = h2o_iovec_init(H2O_STRLIT("firstpath; rel=preload, </secondpath>; rel=preload; x-http2-push-only, </thirdpath>; rel=preload; nopush, </fourthpath>; rel=preload; x-http2-push-only"));

--- a/t/40server-push-attrs.t
+++ b/t/40server-push-attrs.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+plan skip_all => 'nghttp not found'
+    unless prog_exists('nghttp');
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
+subtest "basic" => sub {
+    # spawn upstream
+    my $upstream_port = empty_port();
+    my $upstream = spawn_server(
+        argv     => [
+            qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
+        ],
+        is_ready => sub {
+            check_port($upstream_port);
+        },
+    );
+    # spawn server
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /assets:
+        file.dir: @{[DOC_ROOT]}
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+    my $pushes_encoded = "</assets/index.txt.gz>; rel=preload, </assets/index.txt.gz?1>; rel=preload, </assets/index.txt.gz?nopush>; rel=preload; nopush";
+    $pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
+    my $resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
+    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz}is, "index.txt.gz is pushed";
+    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?1}is, "index.txt.gz?1 is pushed";
+    unlike $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?nopush}is, "index.txt.gz?nopush isn't pushed";
+
+    $pushes_encoded = "</assets/index.txt.gz>; rel=preload, </assets/index.txt.gz?1>; rel=preload, </assets/index.txt.gz?nopush>; rel=preload; nopush, </assets/index.txt.gz?push-only>; rel=preload; x-http2-push-only";
+    $pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
+    $resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
+
+    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz}is, "index.txt.gz is pushed";
+    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?1}is, "index.txt.gz?1 is pushed";
+    unlike $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?nopush}is, "index.txt.gz?nopush isn't pushed";
+    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?push-only}is, "index.txt.gz?push-only is pushed";
+    like $resp, qr{link: </assets/index\.txt\.gz>; rel=preload, </assets/index\.txt\.gz\?1>; rel=preload, </assets/index\.txt\.gz\?nopush>; rel=preload; nopush\n}, "push-only doesn't appear in the link header";
+
+    # Check that the header is removed if there's only one link with x-http2-push-only
+    $pushes_encoded = "</assets/index.txt.gz?push-only>; rel=preload; x-http2-push-only";
+    $pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
+    $resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
+
+    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?push-only}is, "index.txt.gz?push-only is pushed";
+    unlike $resp, qr{link:\s*\n}, "push-only doesn't appear in the link header";
+};
+
+
+done_testing;

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -175,4 +175,9 @@ builder {
         sleep 1.1;
         [200, ["content-type" => "text/plain; charset=utf-8", "content-length" => 11], ["hello world"]];
     };
+    mount "/push-attr" => sub {
+        my $env = shift;
+        my $query = Plack::Request->new($env)->query_parameters;
+        [200, ["content-type" => "text/plain; charset=utf-8", "content-length" => 11, "link" => "$query->{'pushes'}"], ["hello world"]];
+    };
 };


### PR DESCRIPTION
When this is set, H2O will interpret the `rel=preload` link as a header
we only want to use for H2 pushes, rather than something we also want to
push to the client. So we'll be removing that attribute from the link
header. If there's only one link, we remove the full header.

This is change is there to allow HTTP/1 clients to express HTTP/2 pushes
in a way that doesn't affect the response sent to the client.