### PR TITLE
Send PING frame only when ACK flag does not specified

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -741,8 +741,9 @@ static int handle_ping_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, c
     if ((ret = h2o_http2_decode_ping_payload(&payload, frame, err_desc)) != 0)
         return ret;
 
-    h2o_http2_encode_ping_frame(&conn->_write.buf, 1, payload.data);
-    h2o_http2_conn_request_write(conn);
+    if ((frame->flags & H2O_HTTP2_FRAME_FLAG_ACK) == 0)
+        h2o_http2_encode_ping_frame(&conn->_write.buf, 1, payload.data);
+        h2o_http2_conn_request_write(conn);
 
     return 0;
 }


### PR DESCRIPTION
This PR fixes a bug of loop of PING frame. Currently H2O will respond even if it is a PING frame with the ACK flag enabled. This behavior will cause a loop of PING frame.