### PR TITLE
stop removing session cache from memcached

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -292,8 +292,7 @@ void h2o_socket_ssl_resume_server_handshake(h2o_socket_t *sock, h2o_iovec_t sess
 /**
  * registers callbacks to be called for handling session data
  */
-void h2o_socket_ssl_async_resumption_init(h2o_socket_ssl_resumption_get_async_cb get_cb, h2o_socket_ssl_resumption_new_cb new_cb,
-                                          h2o_socket_ssl_resumption_remove_cb remove_cb);
+void h2o_socket_ssl_async_resumption_init(h2o_socket_ssl_resumption_get_async_cb get_cb, h2o_socket_ssl_resumption_new_cb new_cb);
 /**
  * setups the SSL context to use the async resumption
  */

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -806,6 +806,10 @@ static int on_async_resumption_new(SSL *ssl, SSL_SESSION *session)
 
 static void on_async_resumption_remove(SSL_CTX *ssl_ctx, SSL_SESSION *session)
 {
+    if (resumption_remove == NULL) {
+        return;
+    }
+
     unsigned idlen;
     const unsigned char *id = SSL_SESSION_get_id(session, &idlen);
     resumption_remove(h2o_iovec_init(id, idlen));

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -91,16 +91,11 @@ static void async_resumption_new(h2o_iovec_t session_id, h2o_iovec_t session_dat
                       H2O_MEMCACHED_ENCODE_KEY | H2O_MEMCACHED_ENCODE_VALUE);
 }
 
-static void async_resumption_remove(h2o_iovec_t session_id)
-{
-    h2o_memcached_delete(async_resumption_context.memc, session_id, H2O_MEMCACHED_ENCODE_KEY);
-}
-
 void h2o_accept_setup_async_ssl_resumption(h2o_memcached_context_t *memc, unsigned expiration)
 {
     async_resumption_context.memc = memc;
     async_resumption_context.expiration = expiration;
-    h2o_socket_ssl_async_resumption_init(async_resumption_get, async_resumption_new, async_resumption_remove);
+    h2o_socket_ssl_async_resumption_init(async_resumption_get, async_resumption_new, NULL);
 }
 
 void on_accept_timeout(h2o_timeout_entry_t *entry)

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -95,7 +95,7 @@ void h2o_accept_setup_async_ssl_resumption(h2o_memcached_context_t *memc, unsign
 {
     async_resumption_context.memc = memc;
     async_resumption_context.expiration = expiration;
-    h2o_socket_ssl_async_resumption_init(async_resumption_get, async_resumption_new, NULL);
+    h2o_socket_ssl_async_resumption_init(async_resumption_get, async_resumption_new);
 }
 
 void on_accept_timeout(h2o_timeout_entry_t *entry)


### PR DESCRIPTION
as discussed at https://github.com/h2o/h2o/pull/1087#discussion_r98603694, we shouldn't remove tls session cache actively.

Regarding [the manual](https://www.openssl.org/docs/man1.0.1/ssl/SSL_CTX_sess_set_remove_cb.html), there are 3 triggers the remove callback gets called:

> The remove_session_cb() is called, whenever the SSL engine removes a session from the internal cache. This happens
> 
> * when the session is removed because it is expired
> * or when a connection was not shutdown cleanly.
> * It also happens for all sessions in the internal session cache when SSL_CTX_free is called.

For the first one, currently we're using memcached (and redis in near future) which have their own expiration feature, so there's no need to remove explicitly.
For the second, we would not want to remove a cache entry when a connection is abruptly shut down, which is often the case with the browsers.
For the last, the session cache should also still be alive.

For above reasons, I believe that we should do nothing when the remove events get fired
