### PR TITLE
adds better error message when preloads.rb not found

### DIFF
--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -65,11 +65,15 @@ void h2o_mruby_setup_globals(mrb_state *mrb)
     h2o_mruby_assert(mrb);
 
     /* require core modules and include built-in libraries */
-    h2o_mruby_eval_expr(mrb, "require \"preloads.rb\"");
+    h2o_mruby_eval_expr(mrb, "require \"#{$H2O_ROOT}/share/h2o/mruby/preloads.rb\"");
     if (mrb->exc != NULL) {
-        mrb_value obj = mrb_funcall(mrb, mrb_obj_value(mrb->exc), "inspect", 0);
-        struct RString *error = mrb_str_ptr(obj);
-        fprintf(stderr, "an error occurred while loading %s/%s: %s", root, "share/h2o/mruby/preloads.rb", error->as.heap.ptr);
+        if (mrb_obj_is_instance_of(mrb, mrb_obj_value(mrb->exc), mrb_class_get(mrb, "LoadError"))) {
+            fprintf(stderr, "file \"%s/%s\" not found. Did you forget to run `make install` ?", root, "share/h2o/mruby/preloads.rb");
+        } else {
+            mrb_value obj = mrb_funcall(mrb, mrb_obj_value(mrb->exc), "inspect", 0);
+            struct RString *error = mrb_str_ptr(obj);
+            fprintf(stderr, "an error occurred while loading %s/%s: %s", root, "share/h2o/mruby/preloads.rb", error->as.heap.ptr);
+        }
         abort();
     }
 }


### PR DESCRIPTION
By this PR, h2o
* outputs detailed error message in the case the user didn't run `make install` and `preloads.rb` cannot be found
* doesn't load `preloads.rb` from current directory