### PR TITLE
HTTP/1 proxying: preserve header cases

### DIFF
--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -35,7 +35,7 @@ static int cnt_left = 3;
 static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
                                           int *method_is_head);
 static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
-                                       h2o_iovec_t msg, h2o_http1client_header_t *headers, size_t num_headers);
+                                       h2o_iovec_t msg, h2o_http1client_header_t *headers, h2o_str_case_t **ocase, size_t num_headers);
 
 static void start_request(h2o_http1client_ctx_t *ctx)
 {
@@ -96,7 +96,7 @@ static int on_body(h2o_http1client_t *client, const char *errstr)
 }
 
 h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status, h2o_iovec_t msg,
-                                h2o_http1client_header_t *headers, size_t num_headers)
+                                h2o_http1client_header_t *headers, h2o_str_case_t **ocase, size_t num_headers)
 {
     size_t i;
 

--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -21,11 +21,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "h2o/hostinfo.h"
-#include "h2o/socketpool.h"
-#include "h2o/string_.h"
-#include "h2o/url.h"
-#include "h2o/http1client.h"
+#include "h2o.h"
 
 static h2o_socketpool_t *sockpool;
 static h2o_mem_pool_t pool;

--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -35,7 +35,7 @@ static int cnt_left = 3;
 static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
                                           int *method_is_head);
 static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
-                                       h2o_iovec_t msg, h2o_http1client_header_t *headers, h2o_str_case_t **ocase, size_t num_headers);
+                                       h2o_iovec_t msg, h2o_header_t *headers, size_t num_headers);
 
 static void start_request(h2o_http1client_ctx_t *ctx)
 {
@@ -96,7 +96,7 @@ static int on_body(h2o_http1client_t *client, const char *errstr)
 }
 
 h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status, h2o_iovec_t msg,
-                                h2o_http1client_header_t *headers, h2o_str_case_t **ocase, size_t num_headers)
+                                h2o_header_t *headers, size_t num_headers)
 {
     size_t i;
 
@@ -108,7 +108,7 @@ h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, i
 
     printf("HTTP/1.%d %d %.*s\n", minor_version, status, (int)msg.len, msg.base);
     for (i = 0; i != num_headers; ++i)
-        printf("%.*s: %.*s\n", (int)headers[i].name_len, headers[i].name, (int)headers[i].value_len, headers[i].value);
+        printf("%.*s: %.*s\n", (int)headers[i].name->len, headers[i].name->base, (int)headers[i].value.len, headers[i].value.base);
     printf("\n");
 
     if (errstr == h2o_http1client_error_is_eos) {

--- a/examples/libh2o/simple.c
+++ b/examples/libh2o/simple.c
@@ -53,7 +53,7 @@ static int chunked_test(h2o_handler_t *self, h2o_req_t *req)
     h2o_iovec_t body = h2o_strdup(&req->pool, "hello world\n", SIZE_MAX);
     req->res.status = 200;
     req->res.reason = "OK";
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("text/plain"));
     h2o_start_response(req, &generator);
     h2o_send(req, &body, 1, 1);
 
@@ -67,7 +67,7 @@ static int reproxy_test(h2o_handler_t *self, h2o_req_t *req)
 
     req->res.status = 200;
     req->res.reason = "OK";
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_X_REPROXY_URL, H2O_STRLIT("http://www.ietf.org/"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_X_REPROXY_URL, NULL, H2O_STRLIT("http://www.ietf.org/"));
     h2o_send_inline(req, H2O_STRLIT("you should never see this!\n"));
 
     return 0;
@@ -80,7 +80,7 @@ static int post_test(h2o_handler_t *self, h2o_req_t *req)
         static h2o_generator_t generator = {NULL, NULL};
         req->res.status = 200;
         req->res.reason = "OK";
-        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain; charset=utf-8"));
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("text/plain; charset=utf-8"));
         h2o_start_response(req, &generator);
         h2o_send(req, &req->entity, 1, 1);
         return 0;

--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -86,7 +86,7 @@ static int chunked_test(h2o_handler_t *self, h2o_req_t *req)
     h2o_iovec_t body = h2o_strdup(&req->pool, "hello world\n", SIZE_MAX);
     req->res.status = 200;
     req->res.reason = "OK";
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("text/plain"));
     h2o_start_response(req, &generator);
     h2o_send(req, &body, 1, H2O_SEND_STATE_FINAL);
 

--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -153,8 +153,9 @@ static void write_fully(int fd, char *buf, size_t len, int abort_on_err)
     }
 }
 
-#define OK_RESP "HTTP/1.0 200 OK\r\n" \
-                "Connection: Close\r\n\r\nOk"
+#define OK_RESP                                                                                                                    \
+    "HTTP/1.0 200 OK\r\n"                                                                                                          \
+    "Connection: Close\r\n\r\nOk"
 #define OK_RESP_LEN (sizeof(OK_RESP) - 1)
 
 void *upstream_thread(void *arg)
@@ -168,8 +169,8 @@ void *upstream_thread(void *arg)
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, path, sizeof(addr.sun_path)-1);
-    assert(bind(sd, (struct sockaddr*)&addr, sizeof(addr)) == 0);
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+    assert(bind(sd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
     assert(listen(sd, 100) == 0);
 
     while (1) {
@@ -349,7 +350,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT(unix_listener)), 65535);
         register_handler(hostconf, "/chunked-test", chunked_test);
         h2o_url_parse(unix_listener, strlen(unix_listener), &upstream);
-        void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstream, h2o_proxy_config_vars_t *config);
+        void h2o_proxy_register_reverse_proxy(h2o_pathconf_t * pathconf, h2o_url_t * upstream, h2o_proxy_config_vars_t * config);
         h2o_proxy_register_reverse_proxy(h2o_config_register_path(hostconf, "/reproxy-test", 0), &upstream, &proxy_config);
         h2o_file_register(h2o_config_register_path(hostconf, "/", 0), "./examples/doc_root", NULL, NULL, 0);
 
@@ -378,7 +379,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     /* Loop until the connection is closed by the client or server */
     while (is_valid_fd(c)) {
-	    h2o_evloop_run(ctx.loop, 10);
+        h2o_evloop_run(ctx.loop, 10);
     }
 
     pthread_barrier_wait(end);

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -389,11 +389,6 @@ struct st_h2o_globalconf_t {
          * a boolean flag if set to true, instructs the proxy to emit x-forwarded-proto and x-forwarded-for headers
          */
         int emit_x_forwarded_headers;
-        /**
-         * a boolean flag if set to true, instructs the proxy to forward headers in the same case they were received
-         * (only active in the HTTP/1 case)
-         */
-        int preserve_original_case;
     } proxy;
 
     /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -625,13 +625,13 @@ typedef struct st_h2o_header_t {
      */
     h2o_iovec_t *name;
     /**
+     * The name of the header as originally received from the client, same length as `name`
+     */
+    const char *orig_name;
+    /**
      * value of the header
      */
     h2o_iovec_t value;
-    /**
-     * The name of the header as originally received from the client
-     */
-    const char *orig_hname;
 } h2o_header_t;
 
 /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -639,9 +639,9 @@ typedef struct st_h2o_header_t {
      */
     h2o_iovec_t value;
     /**
-     * If non-NULL, contains a bitfield indicating whether a character in name was upper case
+     * If non-NULL, contains a bitfield indicating whether a character in @name was upper case
      */
-    h2o_str_case_t *orig_case;
+    h2o_str_case_t *orig_hname_case;
 } h2o_header_t;
 
 /**
@@ -1703,7 +1703,12 @@ void h2o_fastcgi_register_configurator(h2o_globalconf_t *conf);
 
 /* lib/file.c */
 
-enum { H2O_FILE_FLAG_NO_ETAG = 0x1, H2O_FILE_FLAG_DIR_LISTING = 0x2, H2O_FILE_FLAG_SEND_COMPRESSED = 0x4, H2O_FILE_FLAG_GUNZIP = 0x8 };
+enum {
+    H2O_FILE_FLAG_NO_ETAG = 0x1,
+    H2O_FILE_FLAG_DIR_LISTING = 0x2,
+    H2O_FILE_FLAG_SEND_COMPRESSED = 0x4,
+    H2O_FILE_FLAG_GUNZIP = 0x8
+};
 
 typedef struct st_h2o_file_handler_t h2o_file_handler_t;
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -639,9 +639,9 @@ typedef struct st_h2o_header_t {
      */
     h2o_iovec_t value;
     /**
-     * If non-NULL, contains a bitfield indicating whether a character in @name was upper case
+     * The name of the header as originally received from the client
      */
-    h2o_str_case_t *orig_hname_case;
+    const char *orig_hname;
 } h2o_header_t;
 
 /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1092,13 +1092,11 @@ ssize_t h2o_find_header_by_str(const h2o_headers_t *headers, const char *name, s
 /**
  * adds a header to list
  */
-h2o_header_t *h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value,
-                             size_t value_len);
+void h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *orig_name, const char *value, size_t value_len);
 /**
  * adds a header to list
  */
-h2o_header_t *h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len,
-                                    int maybe_token, const char *value, size_t value_len);
+void h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len, int maybe_token, const char *orig_name, const char *value, size_t value_len);
 /**
  * adds or replaces a header into the list
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -542,11 +542,6 @@ struct st_h2o_context_t {
     int shutdown_requested;
 
     /**
-     * flag indicating whether a proxy is forwarding headers with case sensitivity preserved
-     */
-    int proxy_preserve_case;
-
-    /**
      * SSL handshake timeout
      */
     h2o_timeout_t handshake_timeout;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1092,11 +1092,13 @@ ssize_t h2o_find_header_by_str(const h2o_headers_t *headers, const char *name, s
 /**
  * adds a header to list
  */
-void h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *orig_name, const char *value, size_t value_len);
+void h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *orig_name,
+                    const char *value, size_t value_len);
 /**
  * adds a header to list
  */
-void h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len, int maybe_token, const char *orig_name, const char *value, size_t value_len);
+void h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len, int maybe_token,
+                           const char *orig_name, const char *value, size_t value_len);
 /**
  * adds or replaces a header into the list
  */

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -46,7 +46,7 @@ typedef struct st_h2o_http1client_header_t {
 typedef int (*h2o_http1client_body_cb)(h2o_http1client_t *client, const char *errstr);
 typedef h2o_http1client_body_cb (*h2o_http1client_head_cb)(h2o_http1client_t *client, const char *errstr, int minor_version,
                                                            int status, h2o_iovec_t msg, h2o_http1client_header_t *headers,
-                                                           h2o_str_case_t **header_orig_case, size_t num_headers);
+                                                           h2o_str_case_t **orig_hname_case, size_t num_headers);
 typedef h2o_http1client_head_cb (*h2o_http1client_connect_cb)(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs,
                                                               size_t *reqbufcnt, int *method_is_head);
 typedef int (*h2o_http1client_informational_cb)(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg,

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -32,25 +32,17 @@ extern "C" {
 #include "h2o/timeout.h"
 #include "h2o/cache.h"
 
-struct phr_header;
 typedef struct st_h2o_http1client_t h2o_http1client_t;
 
-/* the definition MUST match that of `struct phr_header` */
-typedef struct st_h2o_http1client_header_t {
-    const char *name;
-    size_t name_len;
-    const char *value;
-    size_t value_len;
-} h2o_http1client_header_t;
-
+struct st_h2o_header_t;
 typedef int (*h2o_http1client_body_cb)(h2o_http1client_t *client, const char *errstr);
 typedef h2o_http1client_body_cb (*h2o_http1client_head_cb)(h2o_http1client_t *client, const char *errstr, int minor_version,
-                                                           int status, h2o_iovec_t msg, h2o_http1client_header_t *headers,
-                                                           h2o_str_case_t **orig_hname_case, size_t num_headers);
+                                                           int status, h2o_iovec_t msg, struct st_h2o_header_t *headers,
+                                                           size_t num_headers);
 typedef h2o_http1client_head_cb (*h2o_http1client_connect_cb)(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs,
                                                               size_t *reqbufcnt, int *method_is_head);
 typedef int (*h2o_http1client_informational_cb)(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg,
-                                                h2o_http1client_header_t *headers, size_t num_headers);
+                                                struct st_h2o_header_t *headers, size_t num_headers);
 
 typedef struct st_h2o_http1client_ctx_t {
     h2o_loop_t *loop;

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -46,7 +46,7 @@ typedef struct st_h2o_http1client_header_t {
 typedef int (*h2o_http1client_body_cb)(h2o_http1client_t *client, const char *errstr);
 typedef h2o_http1client_body_cb (*h2o_http1client_head_cb)(h2o_http1client_t *client, const char *errstr, int minor_version,
                                                            int status, h2o_iovec_t msg, h2o_http1client_header_t *headers,
-                                                           size_t num_headers);
+                                                           h2o_str_case_t **header_orig_case, size_t num_headers);
 typedef h2o_http1client_head_cb (*h2o_http1client_connect_cb)(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs,
                                                               size_t *reqbufcnt, int *method_is_head);
 typedef int (*h2o_http1client_informational_cb)(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg,

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -91,7 +91,7 @@ size_t h2o_strtosize(const char *s, size_t len);
 size_t h2o_strtosizefwd(char **s, size_t len);
 
 typedef struct st_h2o_str_case_t {
-    uint8_t ucase[0];
+    uint8_t ucase[1];
 } h2o_str_case_t;
 
 static inline h2o_str_case_t *h2o_str_case_dup(h2o_mem_pool_t *pool, h2o_str_case_t *ucase, size_t strlen)

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -89,7 +89,6 @@ size_t h2o_strtosize(const char *s, size_t len);
  * *s will set to right after the number in string or right after the end of string.
  */
 size_t h2o_strtosizefwd(char **s, size_t len);
-
 /**
  * base64 url decoder
  */

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -94,46 +94,23 @@ typedef struct st_h2o_str_case_t {
     uint8_t ucase[1];
 } h2o_str_case_t;
 
-static inline h2o_str_case_t *h2o_str_case_dup(h2o_mem_pool_t *pool, h2o_str_case_t *ucase, size_t strlen)
-{
-    size_t ucase_len = (strlen / 8) + 1;
-    h2o_str_case_t *rc;
-    if (pool)
-        rc = (h2o_str_case_t *)h2o_mem_alloc_pool(pool, ucase_len);
-    else
-        rc = (h2o_str_case_t *)h2o_mem_alloc(ucase_len);
-    memcpy(rc, ucase, ucase_len);
-    return rc;
-}
-
-static inline h2o_str_case_t *h2o_str_case_record(h2o_mem_pool_t *pool, const char *str, size_t len)
-{
-    size_t i;
-    size_t ucase_len = (len / 8) + 1;
-    h2o_str_case_t *rc;
-    if (pool)
-        rc = (h2o_str_case_t *)h2o_mem_alloc_pool(pool, ucase_len);
-    else
-        rc = (h2o_str_case_t *)h2o_mem_alloc(ucase_len);
-    memset(rc, 0, ucase_len);
-    for (i = 0; i < len; i++)
-        if (str[i] >= 'A' && str[i] <= 'Z')
-            rc->ucase[i / 8] |= (1 << (i % 8));
-    return rc;
-}
-
-static inline void h2o_str_case_restore(h2o_str_case_t *hsc, char *str, size_t len)
-{
-    size_t i;
-    for (i = 0; i < len; i++) {
-        if (hsc->ucase[i / 8] & (1 << (i % 8)))
-            str[i] -= 0x20;
-    }
-}
+/**
+ * Copies an existing h2o_str_case_t structure
+ */
+static h2o_str_case_t *h2o_str_case_dup(h2o_mem_pool_t *pool, h2o_str_case_t *ucase, size_t strlen);
+/**
+ * Returns a h2o_str_case_t recording the place where upper case characters appear
+ */
+static h2o_str_case_t *h2o_str_case_record(h2o_mem_pool_t *pool, const char *str, size_t len);
 
 /**
-* base64 url decoder
-*/
+ * Given a pre-recorded @hsc, restore the upper case letters as they were at the time of recording
+ */
+static void h2o_str_case_restore(h2o_str_case_t *hsc, char *str, size_t len);
+
+/**
+ * base64 url decoder
+ */
 h2o_iovec_t h2o_decode_base64url(h2o_mem_pool_t *pool, const char *src, size_t len);
 /**
  * base64 encoder (note: the function emits trailing '\0')
@@ -227,6 +204,43 @@ inline int h2o_lcstris(const char *target, size_t target_len, const char *test, 
 inline size_t h2o_base64_encode_capacity(unsigned len)
 {
     return (((len) + 2) / 3 * 4 + 1);
+}
+
+inline h2o_str_case_t *h2o_str_case_dup(h2o_mem_pool_t *pool, h2o_str_case_t *ucase, size_t strlen)
+{
+    size_t ucase_len = (strlen / 8) + 1;
+    h2o_str_case_t *rc;
+    if (pool)
+        rc = (h2o_str_case_t *)h2o_mem_alloc_pool(pool, ucase_len);
+    else
+        rc = (h2o_str_case_t *)h2o_mem_alloc(ucase_len);
+    memcpy(rc, ucase, ucase_len);
+    return rc;
+}
+
+inline h2o_str_case_t *h2o_str_case_record(h2o_mem_pool_t *pool, const char *str, size_t len)
+{
+    size_t i;
+    size_t ucase_len = (len / 8) + 1;
+    h2o_str_case_t *rc;
+    if (pool)
+        rc = (h2o_str_case_t *)h2o_mem_alloc_pool(pool, ucase_len);
+    else
+        rc = (h2o_str_case_t *)h2o_mem_alloc(ucase_len);
+    memset(rc, 0, ucase_len);
+    for (i = 0; i < len; i++)
+        if (str[i] >= 'A' && str[i] <= 'Z')
+            rc->ucase[i / 8] |= (1 << (i % 8));
+    return rc;
+}
+
+inline void h2o_str_case_restore(h2o_str_case_t *hsc, char *str, size_t len)
+{
+    size_t i;
+    for (i = 0; i < len; i++) {
+        if (hsc->ucase[i / 8] & (1 << (i % 8)))
+            str[i] -= 0x20;
+    }
 }
 
 #ifdef __cplusplus

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -89,6 +89,48 @@ size_t h2o_strtosize(const char *s, size_t len);
  * *s will set to right after the number in string or right after the end of string.
  */
 size_t h2o_strtosizefwd(char **s, size_t len);
+
+typedef struct st_h2o_str_case_t {
+    uint8_t ucase[0];
+} h2o_str_case_t;
+
+static inline h2o_str_case_t *h2o_str_case_dup(h2o_mem_pool_t *pool, h2o_str_case_t *ucase, size_t strlen)
+{
+    size_t ucase_len = (strlen / 8) + 1;
+    h2o_str_case_t *rc;
+    if (pool)
+        rc = (h2o_str_case_t *)h2o_mem_alloc_pool(pool, ucase_len);
+    else
+        rc = (h2o_str_case_t *)h2o_mem_alloc(ucase_len);
+    memcpy(rc, ucase, ucase_len);
+    return rc;
+}
+
+static inline h2o_str_case_t *h2o_str_case_record(h2o_mem_pool_t *pool, const char *str, size_t len)
+{
+    size_t i;
+    size_t ucase_len = (len / 8) + 1;
+    h2o_str_case_t *rc;
+    if (pool)
+        rc = (h2o_str_case_t *)h2o_mem_alloc_pool(pool, ucase_len);
+    else
+        rc = (h2o_str_case_t *)h2o_mem_alloc(ucase_len);
+    memset(rc, 0, ucase_len);
+    for (i = 0; i < len; i++)
+        if (str[i] >= 'A' && str[i] <= 'Z')
+            rc->ucase[i / 8] |= (1 << (i % 8));
+    return rc;
+}
+
+static inline void h2o_str_case_restore(h2o_str_case_t *hsc, char *str, size_t len)
+{
+    size_t i;
+    for (i = 0; i < len; i++) {
+        if (hsc->ucase[i / 8] & (1 << (i % 8)))
+            str[i] -= 0x20;
+    }
+}
+
 /**
 * base64 url decoder
 */

--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -90,24 +90,6 @@ size_t h2o_strtosize(const char *s, size_t len);
  */
 size_t h2o_strtosizefwd(char **s, size_t len);
 
-typedef struct st_h2o_str_case_t {
-    uint8_t ucase[1];
-} h2o_str_case_t;
-
-/**
- * Copies an existing h2o_str_case_t structure
- */
-static h2o_str_case_t *h2o_str_case_dup(h2o_mem_pool_t *pool, h2o_str_case_t *ucase, size_t strlen);
-/**
- * Returns a h2o_str_case_t recording the place where upper case characters appear
- */
-static h2o_str_case_t *h2o_str_case_record(h2o_mem_pool_t *pool, const char *str, size_t len);
-
-/**
- * Given a pre-recorded @hsc, restore the upper case letters as they were at the time of recording
- */
-static void h2o_str_case_restore(h2o_str_case_t *hsc, char *str, size_t len);
-
 /**
  * base64 url decoder
  */
@@ -204,43 +186,6 @@ inline int h2o_lcstris(const char *target, size_t target_len, const char *test, 
 inline size_t h2o_base64_encode_capacity(unsigned len)
 {
     return (((len) + 2) / 3 * 4 + 1);
-}
-
-inline h2o_str_case_t *h2o_str_case_dup(h2o_mem_pool_t *pool, h2o_str_case_t *ucase, size_t strlen)
-{
-    size_t ucase_len = (strlen / 8) + 1;
-    h2o_str_case_t *rc;
-    if (pool)
-        rc = (h2o_str_case_t *)h2o_mem_alloc_pool(pool, ucase_len);
-    else
-        rc = (h2o_str_case_t *)h2o_mem_alloc(ucase_len);
-    memcpy(rc, ucase, ucase_len);
-    return rc;
-}
-
-inline h2o_str_case_t *h2o_str_case_record(h2o_mem_pool_t *pool, const char *str, size_t len)
-{
-    size_t i;
-    size_t ucase_len = (len / 8) + 1;
-    h2o_str_case_t *rc;
-    if (pool)
-        rc = (h2o_str_case_t *)h2o_mem_alloc_pool(pool, ucase_len);
-    else
-        rc = (h2o_str_case_t *)h2o_mem_alloc(ucase_len);
-    memset(rc, 0, ucase_len);
-    for (i = 0; i < len; i++)
-        if (str[i] >= 'A' && str[i] <= 'Z')
-            rc->ucase[i / 8] |= (1 << (i % 8));
-    return rc;
-}
-
-inline void h2o_str_case_restore(h2o_str_case_t *hsc, char *str, size_t len)
-{
-    size_t i;
-    for (i = 0; i < len; i++) {
-        if (hsc->ucase[i / 8] & (1 << (i % 8)))
-            str[i] -= 0x20;
-    }
 }
 
 #ifdef __cplusplus

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -26,10 +26,6 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include "picohttpparser.h"
-#include "h2o/string_.h"
-#include "h2o/hostinfo.h"
-#include "h2o/http1client.h"
-#include "h2o/url.h"
 #include "h2o.h"
 
 struct st_h2o_http1client_private_t {

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -253,9 +253,9 @@ static void on_head(h2o_socket_t *sock, const char *err)
 
         for (i = 0; i != num_headers; ++i) {
             const h2o_token_t *token;
-            char *orig_hname;
+            char *orig_name;
 
-            orig_hname = h2o_strdup(NULL, src_headers[i].name, src_headers[i].name_len).base;
+            orig_name = h2o_strdup(NULL, src_headers[i].name, src_headers[i].name_len).base;
             h2o_strtolower((char *)src_headers[i].name, src_headers[i].name_len);
             token = h2o_lookup_token(src_headers[i].name, src_headers[i].name_len);
             if (token != NULL) {
@@ -265,7 +265,7 @@ static void on_head(h2o_socket_t *sock, const char *err)
                 headers[i].name = &header_names[i];
             }
             headers[i].value = h2o_iovec_init(src_headers[i].value, src_headers[i].value_len);
-            headers[i].orig_hname = orig_hname;
+            headers[i].orig_name = orig_name;
         }
     }
 
@@ -346,7 +346,7 @@ static void on_head(h2o_socket_t *sock, const char *err)
 
 Exit:
     for (i = 0; i != num_headers; ++i)
-        free((void *)headers[i].orig_hname);
+        free((void *)headers[i].orig_name);
 #undef MAX_HEADERS
 }
 

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -30,6 +30,7 @@
 #include "h2o/hostinfo.h"
 #include "h2o/http1client.h"
 #include "h2o/url.h"
+#include "h2o.h"
 
 struct st_h2o_http1client_private_t {
     h2o_http1client_t super;
@@ -217,7 +218,7 @@ static void on_body_chunked(h2o_socket_t *sock, const char *err)
 static void on_error_before_head(struct st_h2o_http1client_private_t *client, const char *errstr)
 {
     assert(!client->_can_keepalive);
-    client->_cb.on_head(&client->super, errstr, 0, 0, h2o_iovec_init(NULL, 0), NULL, NULL, 0);
+    client->_cb.on_head(&client->super, errstr, 0, 0, h2o_iovec_init(NULL, 0), NULL, 0);
     close_client(client);
 }
 
@@ -227,8 +228,8 @@ static void on_head(h2o_socket_t *sock, const char *err)
     int minor_version, http_status, rlen, is_eos;
     const char *msg;
 #define MAX_HEADERS 100
-    struct phr_header headers[MAX_HEADERS];
-    h2o_str_case_t *header_name_case[MAX_HEADERS];
+    h2o_header_t headers[MAX_HEADERS];
+    h2o_iovec_t header_names[MAX_HEADERS];
     size_t msg_len, num_headers, i;
     h2o_socket_cb reader;
 
@@ -239,30 +240,47 @@ static void on_head(h2o_socket_t *sock, const char *err)
         return;
     }
 
-    /* parse response */
-    num_headers = sizeof(headers) / sizeof(headers[0]);
-    rlen = phr_parse_response(sock->input->bytes, sock->input->size, &minor_version, &http_status, &msg, &msg_len, headers,
-                              &num_headers, 0);
-    switch (rlen) {
-    case -1: /* error */
-        on_error_before_head(client, "failed to parse the response");
-        return;
-    case -2: /* incomplete */
-        h2o_timeout_link(client->super.ctx->loop, client->super.ctx->io_timeout, &client->_timeout);
-        return;
-    }
+    {
+        struct phr_header src_headers[MAX_HEADERS];
+        /* parse response */
+        num_headers = MAX_HEADERS;
+        rlen = phr_parse_response(sock->input->bytes, sock->input->size, &minor_version, &http_status, &msg, &msg_len, src_headers,
+                                  &num_headers, 0);
+        switch (rlen) {
+        case -1: /* error */
+            on_error_before_head(client, "failed to parse the response");
+            return;
+        case -2: /* incomplete */
+            h2o_timeout_link(client->super.ctx->loop, client->super.ctx->io_timeout, &client->_timeout);
+            return;
+        }
 
-    /* convert the header names to lowercase */
-    for (i = 0; i != num_headers; ++i) {
-        header_name_case[i] = h2o_str_case_record(NULL, headers[i].name, headers[i].name_len);
-        h2o_strtolower((char *)headers[i].name, headers[i].name_len);
+        for (i = 0; i != num_headers; ++i) {
+            const h2o_token_t *token;
+            char orig_hname[src_headers[i].name_len];
+
+            memcpy(orig_hname, src_headers[i].name, src_headers[i].name_len);
+            h2o_strtolower((char *)src_headers[i].name, src_headers[i].name_len);
+            token = h2o_lookup_token(src_headers[i].name, src_headers[i].name_len);
+
+            if (token != NULL) {
+                headers[i].name = (h2o_iovec_t *)&token->buf;
+                headers[i].value = h2o_iovec_init(src_headers[i].value, src_headers[i].value_len);
+                headers[i].orig_hname = h2o_strdup(NULL, orig_hname, src_headers[i].name_len).base;
+            } else {
+                header_names[i] = h2o_iovec_init(src_headers[i].name, src_headers[i].name_len);
+                headers[i].name = &header_names[i];
+                headers[i].value = h2o_iovec_init(src_headers[i].value, src_headers[i].value_len);
+                headers[i].orig_hname = h2o_strdup(NULL, orig_hname, src_headers[i].name_len).base;
+            }
+        }
     }
 
     /* handle 1xx response (except 101, which is handled by on_head callback) */
     if (100 <= http_status && http_status <= 199 && http_status != 101) {
         if (client->super.informational_cb != NULL &&
-            client->super.informational_cb(&client->super, minor_version, http_status, h2o_iovec_init(msg, msg_len),
-                                           (void *)headers, num_headers) != 0) {
+            client->super.informational_cb(&client->super, minor_version, http_status, h2o_iovec_init(msg, msg_len), headers,
+                                           num_headers) != 0) {
             close_client(client);
             return;
         }
@@ -275,25 +293,25 @@ static void on_head(h2o_socket_t *sock, const char *err)
     reader = on_body_until_close;
     client->_can_keepalive = minor_version >= 1;
     for (i = 0; i != num_headers; ++i) {
-        if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("connection"))) {
-            if (h2o_contains_token(headers[i].value, headers[i].value_len, H2O_STRLIT("keep-alive"), ',')) {
+        if (headers[i].name == &H2O_TOKEN_CONNECTION->buf) {
+            if (h2o_contains_token(headers[i].value.base, headers[i].value.len, H2O_STRLIT("keep-alive"), ',')) {
                 client->_can_keepalive = 1;
             } else {
                 client->_can_keepalive = 0;
             }
-        } else if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("transfer-encoding"))) {
-            if (h2o_memis(headers[i].value, headers[i].value_len, H2O_STRLIT("chunked"))) {
+        } else if (headers[i].name == &H2O_TOKEN_TRANSFER_ENCODING->buf) {
+            if (h2o_memis(headers[i].value.base, headers[i].value.len, H2O_STRLIT("chunked"))) {
                 /* precond: _body_decoder.chunked is zero-filled */
                 client->_body_decoder.chunked.decoder.consume_trailer = 1;
                 reader = on_body_chunked;
-            } else if (h2o_memis(headers[i].value, headers[i].value_len, H2O_STRLIT("identity"))) {
+            } else if (h2o_memis(headers[i].value.base, headers[i].value.len, H2O_STRLIT("identity"))) {
                 /* continue */
             } else {
                 on_error_before_head(client, "unexpected type of transfer-encoding");
                 return;
             }
-        } else if (h2o_memis(headers[i].name, headers[i].name_len, H2O_STRLIT("content-length"))) {
-            if ((client->_body_decoder.content_length.bytesleft = h2o_strtosize(headers[i].value, headers[i].value_len)) ==
+        } else if (headers[i].name == &H2O_TOKEN_CONTENT_LENGTH->buf) {
+            if ((client->_body_decoder.content_length.bytesleft = h2o_strtosize(headers[i].value.base, headers[i].value.len)) ==
                 SIZE_MAX) {
                 on_error_before_head(client, "invalid content-length");
                 return;
@@ -314,11 +332,8 @@ static void on_head(h2o_socket_t *sock, const char *err)
     }
 
     /* call the callback */
-    client->_cb.on_body =
-        client->_cb.on_head(&client->super, is_eos ? h2o_http1client_error_is_eos : NULL, minor_version, http_status,
-                            h2o_iovec_init(msg, msg_len), (void *)headers, header_name_case, num_headers);
-    for (i = 0; i != num_headers; ++i)
-        free(header_name_case[i]);
+    client->_cb.on_body = client->_cb.on_head(&client->super, is_eos ? h2o_http1client_error_is_eos : NULL, minor_version,
+                                              http_status, h2o_iovec_init(msg, msg_len), headers, num_headers);
 
     if (is_eos) {
         close_client(client);

--- a/lib/core/headers.c
+++ b/lib/core/headers.c
@@ -34,6 +34,7 @@ static h2o_header_t *add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2
     slot->name = name;
     slot->value.base = (char *)value;
     slot->value.len = value_len;
+    slot->orig_case = NULL;
 
     return slot;
 }
@@ -59,27 +60,27 @@ ssize_t h2o_find_header_by_str(const h2o_headers_t *headers, const char *name, s
     return -1;
 }
 
-void h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value, size_t value_len)
+h2o_header_t *h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value,
+                             size_t value_len)
 {
-    add_header(pool, headers, (h2o_iovec_t *)&token->buf, value, value_len);
+    return add_header(pool, headers, (h2o_iovec_t *)&token->buf, value, value_len);
 }
 
-void h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len, int maybe_token,
-                           const char *value, size_t value_len)
+h2o_header_t *h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len,
+                                    int maybe_token, const char *value, size_t value_len)
 {
     h2o_iovec_t *name_buf;
 
     if (maybe_token) {
         const h2o_token_t *token = h2o_lookup_token(name, name_len);
         if (token != NULL) {
-            add_header(pool, headers, (h2o_iovec_t *)token, value, value_len);
-            return;
+            return add_header(pool, headers, (h2o_iovec_t *)token, value, value_len);
         }
     }
     name_buf = h2o_mem_alloc_pool(pool, sizeof(h2o_iovec_t));
     name_buf->base = (char *)name;
     name_buf->len = name_len;
-    add_header(pool, headers, name_buf, value, value_len);
+    return add_header(pool, headers, name_buf, value, value_len);
 }
 
 void h2o_set_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value, size_t value_len,

--- a/lib/core/headers.c
+++ b/lib/core/headers.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include "h2o.h"
 
-static h2o_header_t *add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2o_iovec_t *name, const char *value,
+static void add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2o_iovec_t *name, const char *orig_name, const char *value,
                                 size_t value_len)
 {
     h2o_header_t *slot;
@@ -34,9 +34,7 @@ static h2o_header_t *add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2
     slot->name = name;
     slot->value.base = (char *)value;
     slot->value.len = value_len;
-    slot->orig_name = NULL;
-
-    return slot;
+    slot->orig_name = orig_name ? h2o_strdup(pool, orig_name, name->len).base : NULL;
 }
 
 ssize_t h2o_find_header(const h2o_headers_t *headers, const h2o_token_t *token, ssize_t cursor)
@@ -60,27 +58,26 @@ ssize_t h2o_find_header_by_str(const h2o_headers_t *headers, const char *name, s
     return -1;
 }
 
-h2o_header_t *h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value,
-                             size_t value_len)
+void h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *orig_name, const char *value, size_t value_len)
 {
-    return add_header(pool, headers, (h2o_iovec_t *)&token->buf, value, value_len);
+    add_header(pool, headers, (h2o_iovec_t *)&token->buf, orig_name, value, value_len);
 }
 
-h2o_header_t *h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len,
-                                    int maybe_token, const char *value, size_t value_len)
+void h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len, int maybe_token, const char *orig_name, const char *value, size_t value_len)
 {
     h2o_iovec_t *name_buf;
 
     if (maybe_token) {
         const h2o_token_t *token = h2o_lookup_token(name, name_len);
         if (token != NULL) {
-            return add_header(pool, headers, (h2o_iovec_t *)token, value, value_len);
+            add_header(pool, headers, (h2o_iovec_t *)token, orig_name, value, value_len);
+            return;
         }
     }
     name_buf = h2o_mem_alloc_pool(pool, sizeof(h2o_iovec_t));
     name_buf->base = (char *)name;
     name_buf->len = name_len;
-    return add_header(pool, headers, name_buf, value, value_len);
+    add_header(pool, headers, name_buf, orig_name, value, value_len);
 }
 
 void h2o_set_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *value, size_t value_len,
@@ -94,7 +91,7 @@ void h2o_set_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_toke
             slot->len = value_len;
         }
     } else {
-        h2o_add_header(pool, headers, token, value, value_len);
+        h2o_add_header(pool, headers, token, NULL, value, value_len);
     }
 }
 
@@ -122,7 +119,7 @@ void h2o_set_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const c
         h2o_iovec_t *name_buf = h2o_mem_alloc_pool(pool, sizeof(h2o_iovec_t));
         name_buf->base = (char *)name;
         name_buf->len = name_len;
-        add_header(pool, headers, name_buf, value, value_len);
+        add_header(pool, headers, name_buf, NULL, value, value_len);
     }
 }
 
@@ -141,7 +138,7 @@ void h2o_set_header_token(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2
     if (dest != NULL) {
         dest->value = h2o_concat(pool, dest->value, h2o_iovec_init(H2O_STRLIT(", ")), h2o_iovec_init(value, value_len));
     } else {
-        h2o_add_header(pool, headers, token, value, value_len);
+        h2o_add_header(pool, headers, token, NULL, value, value_len);
     }
 }
 

--- a/lib/core/headers.c
+++ b/lib/core/headers.c
@@ -34,7 +34,7 @@ static h2o_header_t *add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2
     slot->name = name;
     slot->value.base = (char *)value;
     slot->value.len = value_len;
-    slot->orig_case = NULL;
+    slot->orig_hname_case = NULL;
 
     return slot;
 }

--- a/lib/core/headers.c
+++ b/lib/core/headers.c
@@ -34,7 +34,7 @@ static h2o_header_t *add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2
     slot->name = name;
     slot->value.base = (char *)value;
     slot->value.len = value_len;
-    slot->orig_hname = NULL;
+    slot->orig_name = NULL;
 
     return slot;
 }

--- a/lib/core/headers.c
+++ b/lib/core/headers.c
@@ -34,7 +34,7 @@ static h2o_header_t *add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2
     slot->name = name;
     slot->value.base = (char *)value;
     slot->value.len = value_len;
-    slot->orig_hname_case = NULL;
+    slot->orig_hname = NULL;
 
     return slot;
 }

--- a/lib/core/headers.c
+++ b/lib/core/headers.c
@@ -24,7 +24,7 @@
 #include "h2o.h"
 
 static void add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2o_iovec_t *name, const char *orig_name, const char *value,
-                                size_t value_len)
+                       size_t value_len)
 {
     h2o_header_t *slot;
 
@@ -58,12 +58,14 @@ ssize_t h2o_find_header_by_str(const h2o_headers_t *headers, const char *name, s
     return -1;
 }
 
-void h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *orig_name, const char *value, size_t value_len)
+void h2o_add_header(h2o_mem_pool_t *pool, h2o_headers_t *headers, const h2o_token_t *token, const char *orig_name,
+                    const char *value, size_t value_len)
 {
     add_header(pool, headers, (h2o_iovec_t *)&token->buf, orig_name, value, value_len);
 }
 
-void h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len, int maybe_token, const char *orig_name, const char *value, size_t value_len)
+void h2o_add_header_by_str(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char *name, size_t name_len, int maybe_token,
+                           const char *orig_name, const char *value, size_t value_len)
 {
     h2o_iovec_t *name_buf;
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -253,7 +253,7 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive, int is_websocket
                 continue;
         AddHeader:
             RESERVE(h->name->len + h->value.len + 2);
-            APPEND_ORIG_CASE(h->name->base, h->name->len, h->orig_case);
+            APPEND_ORIG_CASE(h->name->base, h->name->len, h->orig_hname_case);
             buf.base[offset++] = ':';
             buf.base[offset++] = ' ';
             APPEND(h->value.base, h->value.len);
@@ -407,7 +407,7 @@ static char compress_hint_to_enum(const char *val, size_t len)
 }
 
 h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status, h2o_iovec_t msg,
-                                h2o_http1client_header_t *headers, h2o_str_case_t **ocase, size_t num_headers)
+                                h2o_http1client_header_t *headers, h2o_str_case_t **orig_hname_case, size_t num_headers)
 {
     struct rp_generator_t *self = client->data;
     h2o_req_t *req = self->src_req;
@@ -471,15 +471,15 @@ h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, i
             value = h2o_strdup(&req->pool, headers[i].value, headers[i].value_len);
         AddHeader:
             h = h2o_add_header(&req->pool, &req->res.headers, token, value.base, value.len);
-            if (req->conn->ctx->globalconf->proxy.preserve_original_case && ocase)
-                h->orig_case = h2o_str_case_dup(&req->pool, ocase[i], headers[i].name_len);
+            if (req->conn->ctx->globalconf->proxy.preserve_original_case && orig_hname_case)
+                h->orig_hname_case = h2o_str_case_dup(&req->pool, orig_hname_case[i], headers[i].name_len);
         Skip:;
         } else {
             h2o_iovec_t name = h2o_strdup(&req->pool, headers[i].name, headers[i].name_len);
             h2o_iovec_t value = h2o_strdup(&req->pool, headers[i].value, headers[i].value_len);
             h = h2o_add_header_by_str(&req->pool, &req->res.headers, name.base, name.len, 0, value.base, value.len);
-            if (req->conn->ctx->globalconf->proxy.preserve_original_case && ocase)
-                h->orig_case = h2o_str_case_dup(&req->pool, ocase[i], headers[i].name_len);
+            if (req->conn->ctx->globalconf->proxy.preserve_original_case && orig_hname_case)
+                h->orig_hname_case = h2o_str_case_dup(&req->pool, orig_hname_case[i], headers[i].name_len);
         }
     }
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -417,7 +417,7 @@ h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, i
     req->res.reason = h2o_strdup(&req->pool, msg.base, msg.len).base;
     for (i = 0; i != num_headers; ++i) {
         h2o_header_t *h;
-        const h2o_token_t *token = h2o_lookup_token(headers[i].name->base, headers[i].name->len);
+        const h2o_token_t *token = H2O_STRUCT_FROM_MEMBER(h2o_token_t, buf, headers[i].name);
         h2o_iovec_t value;
         if (token != NULL) {
             if (token->proxy_should_drop) {

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -397,8 +397,8 @@ static char compress_hint_to_enum(const char *val, size_t len)
     return H2O_COMPRESS_HINT_AUTO;
 }
 
-static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status, h2o_iovec_t msg,
-                                       h2o_header_t *headers, size_t num_headers)
+static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
+                                       h2o_iovec_t msg, h2o_header_t *headers, size_t num_headers)
 {
     struct rp_generator_t *self = client->data;
     h2o_req_t *req = self->src_req;
@@ -465,7 +465,8 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
         } else {
             h2o_iovec_t name = h2o_strdup(&req->pool, headers[i].name->base, headers[i].name->len);
             h2o_iovec_t value = h2o_strdup(&req->pool, headers[i].value.base, headers[i].value.len);
-            h2o_add_header_by_str(&req->pool, &req->res.headers, name.base, name.len, 0, headers[i].orig_name, value.base, value.len);
+            h2o_add_header_by_str(&req->pool, &req->res.headers, name.base, name.len, 0, headers[i].orig_name, value.base,
+                                  value.len);
         }
     }
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -245,7 +245,7 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive, int is_websocket
                 continue;
         AddHeader:
             RESERVE(h->name->len + h->value.len + 2);
-            APPEND(h->orig_hname ? h->orig_hname : h->name->base, h->name->len);
+            APPEND(h->orig_name ? h->orig_name : h->name->base, h->name->len);
             buf.base[offset++] = ':';
             buf.base[offset++] = ' ';
             APPEND(h->value.base, h->value.len);
@@ -462,13 +462,13 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
             value = h2o_strdup(&req->pool, headers[i].value.base, headers[i].value.len);
         AddHeader:
             h = h2o_add_header(&req->pool, &req->res.headers, token, value.base, value.len);
-            h->orig_hname = h2o_strdup(&req->pool, headers[i].orig_hname, headers[i].name->len).base;
+            h->orig_name = h2o_strdup(&req->pool, headers[i].orig_name, headers[i].name->len).base;
         Skip:;
         } else {
             h2o_iovec_t name = h2o_strdup(&req->pool, headers[i].name->base, headers[i].name->len);
             h2o_iovec_t value = h2o_strdup(&req->pool, headers[i].value.base, headers[i].value.len);
             h = h2o_add_header_by_str(&req->pool, &req->res.headers, name.base, name.len, 0, value.base, value.len);
-            h->orig_hname = h2o_strdup(&req->pool, headers[i].orig_hname, headers[i].name->len).base;
+            h->orig_name = h2o_strdup(&req->pool, headers[i].orig_name, headers[i].name->len).base;
         }
     }
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -41,7 +41,6 @@ struct rp_generator_t {
     h2o_doublebuffer_t sending;
     int is_websocket_handshake;
     int had_body_error; /* set if an error happened while fetching the body so that we can propagate the error */
-    int preserve_case;
 };
 
 struct rp_ws_upgrade_info_t {
@@ -398,8 +397,8 @@ static char compress_hint_to_enum(const char *val, size_t len)
     return H2O_COMPRESS_HINT_AUTO;
 }
 
-h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status, h2o_iovec_t msg,
-                                h2o_header_t *headers, size_t num_headers)
+static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status, h2o_iovec_t msg,
+                                       h2o_header_t *headers, size_t num_headers)
 {
     struct rp_generator_t *self = client->data;
     h2o_req_t *req = self->src_req;

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -257,10 +257,10 @@ void h2o_init_request(h2o_req_t *req, h2o_conn_t *conn, h2o_req_t *src)
                 *dst_header->name = h2o_strdup(&req->pool, src_header->name->base, src_header->name->len);
             }
             dst_header->value = h2o_strdup(&req->pool, src_header->value.base, src_header->value.len);
-            if (!src_header->orig_hname)
-                dst_header->orig_hname = src_header->orig_hname;
+            if (!src_header->orig_name)
+                dst_header->orig_name = src_header->orig_name;
             else
-                dst_header->orig_hname = h2o_strdup(&req->pool, src_header->orig_hname, src_header->name->len).base;
+                dst_header->orig_name = h2o_strdup(&req->pool, src_header->orig_name, src_header->name->len).base;
         }
         if (src->env.size != 0) {
             h2o_vector_reserve(&req->pool, &req->env, src->env.size);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -258,7 +258,7 @@ void h2o_init_request(h2o_req_t *req, h2o_conn_t *conn, h2o_req_t *src)
             }
             dst_header->value = h2o_strdup(&req->pool, src_header->value.base, src_header->value.len);
             if (!src_header->orig_name)
-                dst_header->orig_name = src_header->orig_name;
+                dst_header->orig_name = NULL;
             else
                 dst_header->orig_name = h2o_strdup(&req->pool, src_header->orig_name, src_header->name->len).base;
         }
@@ -517,7 +517,7 @@ void h2o_send_error_generic(h2o_req_t *req, int status, const char *reason, cons
     if ((flags & H2O_SEND_ERROR_KEEP_HEADERS) == 0)
         memset(&req->res.headers, 0, sizeof(req->res.headers));
 
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain; charset=utf-8"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("text/plain; charset=utf-8"));
 
     h2o_send_inline(req, body, SIZE_MAX);
 }
@@ -617,8 +617,8 @@ void h2o_send_redirect(h2o_req_t *req, int status, const char *reason, const cha
     req->res.status = status;
     req->res.reason = reason;
     req->res.headers = (h2o_headers_t){NULL};
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_LOCATION, url, url_len);
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/html; charset=utf-8"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_LOCATION, NULL, url, url_len);
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("text/html; charset=utf-8"));
     h2o_start_response(req, &generator);
     h2o_send(req, bufs, bufcnt, H2O_SEND_STATE_FINAL);
 }

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -257,10 +257,10 @@ void h2o_init_request(h2o_req_t *req, h2o_conn_t *conn, h2o_req_t *src)
                 *dst_header->name = h2o_strdup(&req->pool, src_header->name->base, src_header->name->len);
             }
             dst_header->value = h2o_strdup(&req->pool, src_header->value.base, src_header->value.len);
-            if (!src_header->orig_hname_case)
-                dst_header->orig_hname_case = src_header->orig_hname_case;
+            if (!src_header->orig_hname)
+                dst_header->orig_hname = src_header->orig_hname;
             else
-                dst_header->orig_hname_case = h2o_str_case_dup(&req->pool, src_header->orig_hname_case, src_header->name->len);
+                dst_header->orig_hname = h2o_strdup(&req->pool, src_header->orig_hname, src_header->name->len).base;
         }
         if (src->env.size != 0) {
             h2o_vector_reserve(&req->pool, &req->env, src->env.size);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -257,10 +257,10 @@ void h2o_init_request(h2o_req_t *req, h2o_conn_t *conn, h2o_req_t *src)
                 *dst_header->name = h2o_strdup(&req->pool, src_header->name->base, src_header->name->len);
             }
             dst_header->value = h2o_strdup(&req->pool, src_header->value.base, src_header->value.len);
-            if (!src_header->orig_case)
-                dst_header->orig_case = src_header->orig_case;
+            if (!src_header->orig_hname_case)
+                dst_header->orig_hname_case = src_header->orig_hname_case;
             else
-                dst_header->orig_case = h2o_str_case_dup(&req->pool, src_header->orig_case, src_header->name->len);
+                dst_header->orig_hname_case = h2o_str_case_dup(&req->pool, src_header->orig_hname_case, src_header->name->len);
         }
         if (src->env.size != 0) {
             h2o_vector_reserve(&req->pool, &req->env, src->env.size);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -257,6 +257,10 @@ void h2o_init_request(h2o_req_t *req, h2o_conn_t *conn, h2o_req_t *src)
                 *dst_header->name = h2o_strdup(&req->pool, src_header->name->base, src_header->name->len);
             }
             dst_header->value = h2o_strdup(&req->pool, src_header->value.base, src_header->value.len);
+            if (!src_header->orig_case)
+                dst_header->orig_case = src_header->orig_case;
+            else
+                dst_header->orig_case = h2o_str_case_dup(&req->pool, src_header->orig_case, src_header->name->len);
         }
         if (src->env.size != 0) {
             h2o_vector_reserve(&req->pool, &req->env, src->env.size);

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -91,7 +91,7 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
         goto Next;
 
     /* set content-encoding header */
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, H2O_STRLIT("chunked"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, NULL, H2O_STRLIT("chunked"));
 
     /* setup filter */
     encoder = (void *)h2o_add_ostream(req, sizeof(chunked_encoder_t), slot);

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -114,12 +114,12 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
 
     /* adjust the response headers */
     req->res.content_length = SIZE_MAX;
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_ENCODING, compressor->name.base, compressor->name.len);
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_ENCODING, NULL, compressor->name.base, compressor->name.len);
     h2o_set_header_token(&req->pool, &req->res.headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
     if (accept_ranges_header_index != -1) {
         req->res.headers.entries[accept_ranges_header_index].value = h2o_iovec_init(H2O_STRLIT("none"));
     } else {
-        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ACCEPT_RANGES, H2O_STRLIT("none"));
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ACCEPT_RANGES, NULL, H2O_STRLIT("none"));
     }
 
     /* setup filter */

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -268,15 +268,6 @@ static int on_config_emit_x_forwarded_headers(h2o_configurator_command_t *cmd, h
     return 0;
 }
 
-static int on_config_preserve_original_case(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
-    if (ret == -1)
-        return -1;
-    ctx->globalconf->proxy.preserve_original_case = (int)ret;
-    return 0;
-}
-
 static int on_config_preserve_x_forwarded_proto(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
@@ -386,7 +377,4 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_emit_x_forwarded_headers);
     h2o_configurator_define_headers_commands(conf, &c->super, "proxy.header", get_headers_commands);
-    h2o_configurator_define_command(&c->super, "proxy.preserve-original-case",
-                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
-                                    on_config_preserve_original_case);
 }

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -268,6 +268,15 @@ static int on_config_emit_x_forwarded_headers(h2o_configurator_command_t *cmd, h
     return 0;
 }
 
+static int on_config_preserve_original_case(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    ctx->globalconf->proxy.preserve_original_case = (int)ret;
+    return 0;
+}
+
 static int on_config_preserve_x_forwarded_proto(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
@@ -377,4 +386,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_emit_x_forwarded_headers);
     h2o_configurator_define_headers_commands(conf, &c->super, "proxy.header", get_headers_commands);
+    h2o_configurator_define_command(&c->super, "proxy.preserve-original-case",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_preserve_original_case);
 }

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -524,7 +524,7 @@ static int fill_headers(h2o_req_t *req, struct phr_header *headers, size_t num_h
                 RFC suggests abs-path-style Location headers should trigger an internal redirection, but is that how the web servers
                 work?
                  */
-                h2o_add_header(&req->pool, &req->res.headers, token,
+                h2o_add_header(&req->pool, &req->res.headers, token, NULL,
                                h2o_strdup(&req->pool, headers[i].value, headers[i].value_len).base, headers[i].value_len);
                 if (token == H2O_TOKEN_LINK)
                     h2o_push_path_in_link_header(req, headers[i].value, headers[i].value_len);
@@ -541,7 +541,7 @@ static int fill_headers(h2o_req_t *req, struct phr_header *headers, size_t num_h
         } else {
             h2o_iovec_t name_duped = h2o_strdup(&req->pool, headers[i].name, headers[i].name_len),
                         value_duped = h2o_strdup(&req->pool, headers[i].value, headers[i].value_len);
-            h2o_add_header_by_str(&req->pool, &req->res.headers, name_duped.base, name_duped.len, 0, value_duped.base,
+            h2o_add_header_by_str(&req->pool, &req->res.headers, name_duped.base, name_duped.len, 0, NULL, value_duped.base,
                                   value_duped.len);
         }
     }

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -263,7 +263,7 @@ static struct st_h2o_sendfile_generator_t *create_generator(h2o_req_t *req, cons
     if ((fileref = h2o_filecache_open_file(req->conn->ctx->filecache, path, O_RDONLY | O_CLOEXEC)) != NULL) {
         goto Opened;
     }
-    if ((flags & H2O_FILE_FLAG_GUNZIP) != 0 && req->version >= 0x101){
+    if ((flags & H2O_FILE_FLAG_GUNZIP) != 0 && req->version >= 0x101) {
         char *variant_path = h2o_mem_alloc_pool(&req->pool, path_len + sizeof(".gz"));
         memcpy(variant_path, path, path_len);
         strcpy(variant_path + path_len, ".gz");

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -306,7 +306,7 @@ static void add_headers_unconditional(struct st_h2o_sendfile_generator_t *self, 
      * guiding cache updates. */
     if (self->send_etag) {
         size_t etag_len = h2o_filecache_get_etag(self->file.ref, self->header_bufs.etag);
-        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ETAG, self->header_bufs.etag, etag_len);
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ETAG, NULL, self->header_bufs.etag, etag_len);
     }
     if (self->send_vary)
         h2o_set_header_token(&req->pool, &req->res.headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
@@ -338,22 +338,22 @@ static void do_send_file(struct st_h2o_sendfile_generator_t *self, h2o_req_t *re
         mime_type.base = h2o_mem_alloc_pool(&req->pool, 52);
         mime_type.len = sprintf(mime_type.base, "multipart/byteranges; boundary=%s", self->ranged.boundary.base);
     }
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, mime_type.base, mime_type.len);
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, mime_type.base, mime_type.len);
     h2o_filecache_get_last_modified(self->file.ref, self->header_bufs.last_modified);
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_LAST_MODIFIED, self->header_bufs.last_modified,
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_LAST_MODIFIED, NULL, self->header_bufs.last_modified,
                    H2O_TIMESTR_RFC1123_LEN);
     add_headers_unconditional(self, req);
     if (self->content_encoding.base != NULL)
-        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_ENCODING, self->content_encoding.base,
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_ENCODING, NULL, self->content_encoding.base,
                        self->content_encoding.len);
     if (self->ranged.range_count == 0)
-        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ACCEPT_RANGES, H2O_STRLIT("bytes"));
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ACCEPT_RANGES, NULL, H2O_STRLIT("bytes"));
     else if (self->ranged.range_count == 1) {
         h2o_iovec_t content_range;
         content_range.base = h2o_mem_alloc_pool(&req->pool, 128);
         content_range.len = sprintf(content_range.base, "bytes %zd-%zd/%zd", self->ranged.range_infos[0],
                                     self->ranged.range_infos[0] + self->ranged.range_infos[1] - 1, self->ranged.filesize);
-        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_RANGE, content_range.base, content_range.len);
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_RANGE, NULL, content_range.base, content_range.len);
     }
 
     /* special path for cases where we do not need to send any data */
@@ -425,7 +425,7 @@ static int send_dir_listing(h2o_req_t *req, const char *path, size_t path_len, i
     /* send response */
     req->res.status = 200;
     req->res.reason = "OK";
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/html; charset=utf-8"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("text/html; charset=utf-8"));
 
     /* send headers */
     if (!is_get) {
@@ -599,7 +599,7 @@ static int try_dynamic_request(h2o_file_handler_t *self, h2o_req_t *req, char *r
 
 static void send_method_not_allowed(h2o_req_t *req)
 {
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ALLOW, H2O_STRLIT("GET, HEAD"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_ALLOW, NULL, H2O_STRLIT("GET, HEAD"));
     h2o_send_error_405(req, "Method Not Allowed", "method not allowed", H2O_SEND_ERROR_KEEP_HEADERS);
 }
 
@@ -659,7 +659,7 @@ static int serve_with_generator(struct st_h2o_sendfile_generator_t *generator, h
             h2o_iovec_t content_range;
             content_range.base = h2o_mem_alloc_pool(&req->pool, 32);
             content_range.len = sprintf(content_range.base, "bytes */%zu", generator->bytesleft);
-            h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_RANGE, content_range.base, content_range.len);
+            h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_RANGE, NULL, content_range.base, content_range.len);
             h2o_send_error_416(req, "Request Range Not Satisfiable", "requested range not satisfiable",
                                H2O_SEND_ERROR_KEEP_HEADERS);
             goto Close;

--- a/lib/handler/headers_util.c
+++ b/lib/handler/headers_util.c
@@ -91,9 +91,9 @@ void h2o_rewrite_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2o_heade
 
 AddHeader:
     if (h2o_iovec_is_token(cmd->name)) {
-        h2o_add_header(pool, headers, (void *)cmd->name, cmd->value.base, cmd->value.len);
+        h2o_add_header(pool, headers, (void *)cmd->name, NULL, cmd->value.base, cmd->value.len);
     } else {
-        h2o_add_header_by_str(pool, headers, cmd->name->base, cmd->name->len, 0, cmd->value.base, cmd->value.len);
+        h2o_add_header_by_str(pool, headers, cmd->name->base, cmd->name->len, 0, NULL, cmd->value.base, cmd->value.len);
     }
     return;
 

--- a/lib/handler/http2_debug_state.c
+++ b/lib/handler/http2_debug_state.c
@@ -50,7 +50,8 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("application/json; charset=utf-8"));
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, NULL, H2O_STRLIT("no-cache, no-store"));
     h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("conn-flow-in"), 0, NULL, conn_flow_in.base, conn_flow_in.len);
-    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("conn-flow-out"), 0, NULL, conn_flow_out.base, conn_flow_out.len);
+    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("conn-flow-out"), 0, NULL, conn_flow_out.base,
+                          conn_flow_out.len);
 
     h2o_start_response(req, &generator);
     h2o_send(req, debug_state->json.entries,

--- a/lib/handler/http2_debug_state.c
+++ b/lib/handler/http2_debug_state.c
@@ -47,10 +47,10 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     conn_flow_out.len = sprintf(conn_flow_out.base, "%zd", debug_state->conn_flow_out);
 
     req->res.status = 200;
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("application/json; charset=utf-8"));
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("no-cache, no-store"));
-    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("conn-flow-in"), 0, conn_flow_in.base, conn_flow_in.len);
-    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("conn-flow-out"), 0, conn_flow_out.base, conn_flow_out.len);
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("application/json; charset=utf-8"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, NULL, H2O_STRLIT("no-cache, no-store"));
+    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("conn-flow-in"), 0, NULL, conn_flow_in.base, conn_flow_in.len);
+    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("conn-flow-out"), 0, NULL, conn_flow_out.base, conn_flow_out.len);
 
     h2o_start_response(req, &generator);
     h2o_send(req, debug_state->json.entries,

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -269,11 +269,13 @@ static mrb_value build_constants(mrb_state *mrb, const char *server_name, size_t
     h2o_mruby_eval_expr(mrb, H2O_MRUBY_CODE_CORE);
     h2o_mruby_assert(mrb);
 
-    mrb_ary_set(mrb, ary, H2O_MRUBY_PROC_EACH_TO_ARRAY, mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_h2o_proc_each_to_array", 0));
+    mrb_ary_set(mrb, ary, H2O_MRUBY_PROC_EACH_TO_ARRAY,
+                mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_h2o_proc_each_to_array", 0));
     h2o_mruby_assert(mrb);
 
     /* sends exception using H2O_MRUBY_CALLBACK_ID_EXCEPTION_RAISED */
-    mrb_ary_set(mrb, ary, H2O_MRUBY_PROC_APP_TO_FIBER, mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_h2o_proc_app_to_fiber", 0));
+    mrb_ary_set(mrb, ary, H2O_MRUBY_PROC_APP_TO_FIBER,
+                mrb_funcall(mrb, mrb_obj_value(mrb->kernel_module), "_h2o_proc_app_to_fiber", 0));
     h2o_mruby_assert(mrb);
 
     mrb_gc_arena_restore(mrb, gc_arena);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -541,7 +541,7 @@ static int handle_response_header(h2o_mruby_context_t *handler_ctx, h2o_iovec_t 
             if (token == H2O_TOKEN_LINK)
                 h2o_push_path_in_link_header(req, value.base, value.len);
             value = h2o_strdup(&req->pool, value.base, value.len);
-            h2o_add_header(&req->pool, &req->res.headers, token, value.base, value.len);
+            h2o_add_header(&req->pool, &req->res.headers, token, NULL, value.base, value.len);
         }
     } else if (name.len > fallthru_set_prefix.len &&
                h2o_memis(name.base, fallthru_set_prefix.len, fallthru_set_prefix.base, fallthru_set_prefix.len)) {
@@ -555,7 +555,7 @@ static int handle_response_header(h2o_mruby_context_t *handler_ctx, h2o_iovec_t 
         *slot = h2o_strdup(&req->pool, value.base, value.len);
     } else {
         value = h2o_strdup(&req->pool, value.base, value.len);
-        h2o_add_header_by_str(&req->pool, &req->res.headers, name.base, name.len, 0, value.base, value.len);
+        h2o_add_header_by_str(&req->pool, &req->res.headers, name.base, name.len, 0, NULL, value.base, value.len);
     }
 
     return 0;

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -162,9 +162,8 @@ static void post_response(struct st_h2o_mruby_http_request_context_t *ctx, int s
 
 static void post_error(struct st_h2o_mruby_http_request_context_t *ctx, const char *errstr)
 {
-    static h2o_iovec_t ct = {H2O_STRLIT("content-type")};
     static const h2o_header_t headers_sorted[] = {
-        {&ct, {H2O_STRLIT("text/plain; charset=utf-8")}},
+        {&H2O_TOKEN_CONTENT_TYPE->buf, {H2O_STRLIT("text/plain; charset=utf-8")}},
     };
 
     ctx->client = NULL;

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -238,7 +238,8 @@ static int headers_sort_cb(const void *_x, const void *_y)
 }
 
 static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
-                                       h2o_iovec_t msg, h2o_http1client_header_t *headers, size_t num_headers)
+                                       h2o_iovec_t msg, h2o_http1client_header_t *headers, h2o_str_case_t **ocase,
+                                       size_t num_headers)
 {
     struct st_h2o_mruby_http_request_context_t *ctx = client->data;
 

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -107,8 +107,8 @@ static void on_dispose(void *_ctx)
     }
 }
 
-static void post_response(struct st_h2o_mruby_http_request_context_t *ctx, int status,
-                          const h2o_http1client_header_t *headers_sorted, size_t num_headers)
+static void post_response(struct st_h2o_mruby_http_request_context_t *ctx, int status, const h2o_header_t *headers_sorted,
+                          size_t num_headers)
 {
     mrb_state *mrb = ctx->generator->ctx->shared->mrb;
     int gc_arena = mrb_gc_arena_save(mrb);
@@ -123,17 +123,17 @@ static void post_response(struct st_h2o_mruby_http_request_context_t *ctx, int s
     mrb_value headers_hash = mrb_hash_new_capa(mrb, (int)num_headers);
     for (i = 0; i < num_headers; ++i) {
         /* skip the headers, we determine the eos! */
-        if (h2o_memis(headers_sorted[i].name, headers_sorted[i].name_len, H2O_STRLIT("content-length")) ||
-            h2o_memis(headers_sorted[i].name, headers_sorted[i].name_len, H2O_STRLIT("transfer-encoding")))
+        if (h2o_memis(headers_sorted[i].name, headers_sorted[i].name->len, H2O_STRLIT("content-length")) ||
+            h2o_memis(headers_sorted[i].name, headers_sorted[i].name->len, H2O_STRLIT("transfer-encoding")))
             continue;
         /* build and set the hash entry */
-        mrb_value k = mrb_str_new(mrb, headers_sorted[i].name, headers_sorted[i].name_len);
-        mrb_value v = mrb_str_new(mrb, headers_sorted[i].value, headers_sorted[i].value_len);
-        while (i + 1 < num_headers && h2o_memis(headers_sorted[i].name, headers_sorted[i].name_len, headers_sorted[i + 1].name,
-                                                headers_sorted[i + 1].name_len)) {
+        mrb_value k = mrb_str_new(mrb, headers_sorted[i].name->base, headers_sorted[i].name->len);
+        mrb_value v = mrb_str_new(mrb, headers_sorted[i].value.base, headers_sorted[i].value.len);
+        while (i + 1 < num_headers && h2o_memis(headers_sorted[i].name->base, headers_sorted[i].name->len,
+                                                headers_sorted[i + 1].name->base, headers_sorted[i + 1].name->len)) {
             ++i;
             v = mrb_str_cat_lit(mrb, v, "\n");
-            v = mrb_str_cat(mrb, v, headers_sorted[i].value, headers_sorted[i].value_len);
+            v = mrb_str_cat(mrb, v, headers_sorted[i].value.base, headers_sorted[i].value.len);
         }
         mrb_hash_set(mrb, headers_hash, k, v);
     }
@@ -162,8 +162,10 @@ static void post_response(struct st_h2o_mruby_http_request_context_t *ctx, int s
 
 static void post_error(struct st_h2o_mruby_http_request_context_t *ctx, const char *errstr)
 {
-    static const h2o_http1client_header_t headers_sorted[] = {
-        {H2O_STRLIT("content-type"), H2O_STRLIT("text/plain; charset=utf-8")}};
+    static h2o_iovec_t ct = {H2O_STRLIT("content-type")};
+    static const h2o_header_t headers_sorted[] = {
+        {&ct, {H2O_STRLIT("text/plain; charset=utf-8")}},
+    };
 
     ctx->client = NULL;
     size_t errstr_len = strlen(errstr);
@@ -228,18 +230,17 @@ static int on_body(h2o_http1client_t *client, const char *errstr)
 
 static int headers_sort_cb(const void *_x, const void *_y)
 {
-    const h2o_http1client_header_t *x = _x, *y = _y;
+    const h2o_header_t *x = _x, *y = _y;
 
-    if (x->name_len < y->name_len)
+    if (x->name->len < y->name->len)
         return -1;
-    if (x->name_len > y->name_len)
+    if (x->name->len > y->name->len)
         return 1;
-    return memcmp(x->name, y->name, x->name_len);
+    return memcmp(x->name->base, y->name->base, x->name->len);
 }
 
 static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
-                                       h2o_iovec_t msg, h2o_http1client_header_t *headers, h2o_str_case_t **ocase,
-                                       size_t num_headers)
+                                       h2o_iovec_t msg, h2o_header_t *headers, size_t num_headers)
 {
     struct st_h2o_mruby_http_request_context_t *ctx = client->data;
 

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -163,7 +163,7 @@ static void post_response(struct st_h2o_mruby_http_request_context_t *ctx, int s
 static void post_error(struct st_h2o_mruby_http_request_context_t *ctx, const char *errstr)
 {
     static const h2o_header_t headers_sorted[] = {
-        {&H2O_TOKEN_CONTENT_TYPE->buf, {H2O_STRLIT("text/plain; charset=utf-8")}},
+        {&H2O_TOKEN_CONTENT_TYPE->buf, NULL, {H2O_STRLIT("text/plain; charset=utf-8")}},
     };
 
     ctx->client = NULL;

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -113,8 +113,8 @@ static void send_response(struct st_h2o_status_collector_t *collector)
     resp[cur_resp++] = (h2o_iovec_t){H2O_STRLIT("\n}\n")};
 
     req->res.status = 200;
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain; charset=utf-8"));
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("no-cache, no-store"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("text/plain; charset=utf-8"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, NULL, H2O_STRLIT("no-cache, no-store"));
     h2o_start_response(req, &generator);
     h2o_send(req, resp, h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")) ? 0 : nr_resp,
              H2O_SEND_STATE_FINAL);
@@ -208,7 +208,7 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
         if (root == NULL)
             root = H2O_TO_STR(H2O_ROOT);
         fn = h2o_concat(&req->pool, h2o_iovec_init(root, strlen(root)), h2o_iovec_init(H2O_STRLIT("/share/h2o/status/index.html")));
-        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("no-cache"));
+        h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, NULL, H2O_STRLIT("no-cache"));
         return h2o_file_send(req, 200, "OK", fn.base, h2o_iovec_init(H2O_STRLIT("text/html; charset=utf-8")), 0);
     } else if (h2o_memis(local_path.base, local_path.len, H2O_STRLIT("/json"))) {
         int ret;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -308,13 +308,13 @@ static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, const 
                     }
                 } else {
                     h = h2o_add_header(pool, headers, name_token, src[i].value, src[i].value_len);
-                    h->orig_hname = h2o_strdup(pool, orig_case, src[i].name_len).base;
+                    h->orig_name = h2o_strdup(pool, orig_case, src[i].name_len).base;
                     if (name_token == H2O_TOKEN_CONNECTION)
                         *connection = headers->entries[headers->size - 1].value;
                 }
             } else {
                 h = h2o_add_header_by_str(pool, headers, src[i].name, src[i].name_len, 0, src[i].value, src[i].value_len);
-                h->orig_hname = h2o_strdup(pool, orig_case, src[i].name_len).base;
+                h->orig_name = h2o_strdup(pool, orig_case, src[i].name_len).base;
             }
         }
     }
@@ -639,11 +639,11 @@ static size_t flatten_headers(char *buf, h2o_req_t *req, const char *connection)
                  * - https://www.igvita.com/2013/05/01/deploying-webp-via-accept-content-negotiation/
                  */
                 if (is_msie(req)) {
-                    static h2o_header_t cache_control_private = {&H2O_TOKEN_CACHE_CONTROL->buf, {H2O_STRLIT("private")}};
+                    static h2o_header_t cache_control_private = {&H2O_TOKEN_CACHE_CONTROL->buf, NULL, {H2O_STRLIT("private")}};
                     header = &cache_control_private;
                 }
             }
-            memcpy(dst, header->orig_hname ? header->orig_hname : header->name->base, header->name->len);
+            memcpy(dst, header->orig_name ? header->orig_name : header->name->base, header->name->len);
             dst += header->name->len;
             *dst++ = ':';
             *dst++ = ' ';

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -643,10 +643,7 @@ static size_t flatten_headers(char *buf, h2o_req_t *req, const char *connection)
                     header = &cache_control_private;
                 }
             }
-            if (header->orig_hname)
-                memcpy(dst, header->orig_hname, header->name->len);
-            else
-                memcpy(dst, header->name->base, header->name->len);
+            memcpy(dst, header->orig_hname ? header->orig_hname : header->name->base, header->name->len);
             dst += header->name->len;
             *dst++ = ':';
             *dst++ = ' ';

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -267,7 +267,7 @@ static int create_entity_reader(struct st_h2o_http1_conn_t *conn, const struct p
     return -1;
 }
 
-static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, int record_hname_case, const struct phr_header *src,
+static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, const struct phr_header *src,
                             size_t len, h2o_iovec_t *connection, h2o_iovec_t *host, h2o_iovec_t *upgrade, h2o_iovec_t *expect)
 {
     ssize_t entity_header_index = -1;
@@ -336,8 +336,7 @@ static ssize_t fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_header
 
     /* init headers */
     entity_header_index =
-        init_headers(&conn->req.pool, &conn->req.headers, conn->super.ctx->globalconf->proxy.preserve_original_case, headers,
-                     num_headers, &connection, &host, &upgrade, expect);
+        init_headers(&conn->req.pool, &conn->req.headers, headers, num_headers, &connection, &host, &upgrade, expect);
 
     /* copy the values to pool, since the buffer pointed by the headers may get realloced */
     if (entity_header_index != -1) {

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -307,15 +307,13 @@ static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, int re
                     }
                 } else {
                     h = h2o_add_header(pool, headers, name_token, src[i].value, src[i].value_len);
-                    if (record_case)
-                        h->orig_case = orig_case;
+                    h->orig_case = orig_case;
                     if (name_token == H2O_TOKEN_CONNECTION)
                         *connection = headers->entries[headers->size - 1].value;
                 }
             } else {
                 h = h2o_add_header_by_str(pool, headers, src[i].name, src[i].name_len, 0, src[i].value, src[i].value_len);
-                if (record_case)
-                    h->orig_case = orig_case;
+                h->orig_case = orig_case;
             }
         }
     }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -267,8 +267,8 @@ static int create_entity_reader(struct st_h2o_http1_conn_t *conn, const struct p
     return -1;
 }
 
-static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, const struct phr_header *src,
-                            size_t len, h2o_iovec_t *connection, h2o_iovec_t *host, h2o_iovec_t *upgrade, h2o_iovec_t *expect)
+static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, const struct phr_header *src, size_t len,
+                            h2o_iovec_t *connection, h2o_iovec_t *host, h2o_iovec_t *upgrade, h2o_iovec_t *expect)
 {
     ssize_t entity_header_index = -1;
 

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -280,7 +280,6 @@ static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, const 
         h2o_vector_reserve(pool, headers, len);
         for (i = 0; i != len; ++i) {
             const h2o_token_t *name_token;
-            h2o_header_t *h;
             char orig_case[src[i].name_len];
 
             /* preserve the original case */
@@ -307,14 +306,12 @@ static ssize_t init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, const 
                         assert(!"logic flaw");
                     }
                 } else {
-                    h = h2o_add_header(pool, headers, name_token, src[i].value, src[i].value_len);
-                    h->orig_name = h2o_strdup(pool, orig_case, src[i].name_len).base;
+                    h2o_add_header(pool, headers, name_token, orig_case, src[i].value, src[i].value_len);
                     if (name_token == H2O_TOKEN_CONNECTION)
                         *connection = headers->entries[headers->size - 1].value;
                 }
             } else {
-                h = h2o_add_header_by_str(pool, headers, src[i].name, src[i].name_len, 0, src[i].value, src[i].value_len);
-                h->orig_name = h2o_strdup(pool, orig_case, src[i].name_len).base;
+                h2o_add_header_by_str(pool, headers, src[i].name, src[i].name_len, 0, orig_case, src[i].value, src[i].value_len);
             }
         }
     }

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1275,7 +1275,7 @@ static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_le
             if (h2o_iovec_is_token(src_header->name)) {
                 h2o_token_t *token = H2O_STRUCT_FROM_MEMBER(h2o_token_t, buf, src_header->name);
                 if (token->copy_for_push_request) {
-                    h2o_add_header(&stream->req.pool, &stream->req.headers, token,
+                    h2o_add_header(&stream->req.pool, &stream->req.headers, token, NULL,
                                    h2o_strdup(&stream->req.pool, src_header->value.base, src_header->value.len).base,
                                    src_header->value.len);
                 }
@@ -1357,7 +1357,7 @@ int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval connected_at)
     /* send response */
     req->res.status = 101;
     req->res.reason = "Switching Protocols";
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_UPGRADE, H2O_STRLIT("h2c"));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_UPGRADE, NULL, H2O_STRLIT("h2c"));
     h2o_http1_upgrade(req, (h2o_iovec_t *)&SETTINGS_HOST_BIN, 1, on_upgrade_complete, http2conn);
 
     return 0;

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -564,10 +564,10 @@ int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_tab
                         /* TODO cache the decoded result in HPACK, as well as delay the decoding of the digest until being used */
                         h2o_cache_digests_load_header(digests, r.value->base, r.value->len);
                     }
-                    h2o_add_header(&req->pool, &req->headers, token, r.value->base, r.value->len);
+                    h2o_add_header(&req->pool, &req->headers, token, NULL, r.value->base, r.value->len);
                 }
             } else {
-                h2o_add_header_by_str(&req->pool, &req->headers, r.name->base, r.name->len, 0, r.value->base, r.value->len);
+                h2o_add_header_by_str(&req->pool, &req->headers, r.name->base, r.name->len, 0, NULL, r.value->base, r.value->len);
             }
         }
     Next:;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -284,7 +284,8 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
 
     /* send HEADERS, as well as start sending body */
     if (h2o_http2_stream_is_push(stream->stream_id))
-        h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, NULL, H2O_STRLIT("pushed"));
+        h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, NULL,
+                              H2O_STRLIT("pushed"));
     h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
                                conn->peer_settings.max_frame_size, &stream->req.res, &ts, &conn->super.ctx->globalconf->server_name,
                                stream->req.res.content_length);
@@ -294,7 +295,8 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     return 0;
 
 CancelPush:
-    h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, NULL, H2O_STRLIT("cancelled"));
+    h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, NULL,
+                          H2O_STRLIT("cancelled"));
     h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);
     h2o_linklist_insert(&conn->_write.streams_to_proceed, &stream->_refs.link);
     if (stream->push.promise_sent) {

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -234,7 +234,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
 
     /* reset casper cookie in case cache-digests exist */
     if (stream->cache_digests != NULL && stream->req.hostconf->http2.casper.capacity_bits != 0) {
-        h2o_add_header(&stream->req.pool, &stream->req.res.headers, H2O_TOKEN_SET_COOKIE,
+        h2o_add_header(&stream->req.pool, &stream->req.res.headers, H2O_TOKEN_SET_COOKIE, NULL,
                        H2O_STRLIT("h2o_casper=; Path=/; Expires=Sat, 01 Jan 2000 00:00:00 GMT"));
     }
 
@@ -262,7 +262,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
                 goto SkipCookie;
         }
         h2o_iovec_t cookie = h2o_http2_casper_get_cookie(conn->casper);
-        h2o_add_header(&stream->req.pool, &stream->req.res.headers, H2O_TOKEN_SET_COOKIE, cookie.base, cookie.len);
+        h2o_add_header(&stream->req.pool, &stream->req.res.headers, H2O_TOKEN_SET_COOKIE, NULL, cookie.base, cookie.len);
     SkipCookie:;
     }
 
@@ -284,7 +284,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
 
     /* send HEADERS, as well as start sending body */
     if (h2o_http2_stream_is_push(stream->stream_id))
-        h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, H2O_STRLIT("pushed"));
+        h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, NULL, H2O_STRLIT("pushed"));
     h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
                                conn->peer_settings.max_frame_size, &stream->req.res, &ts, &conn->super.ctx->globalconf->server_name,
                                stream->req.res.content_length);
@@ -294,7 +294,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     return 0;
 
 CancelPush:
-    h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, H2O_STRLIT("cancelled"));
+    h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, NULL, H2O_STRLIT("cancelled"));
     h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);
     h2o_linklist_insert(&conn->_write.streams_to_proceed, &stream->_refs.link);
     if (stream->push.promise_sent) {

--- a/lib/websocket.c
+++ b/lib/websocket.c
@@ -150,8 +150,8 @@ h2o_websocket_conn_t *h2o_upgrade_to_websocket(h2o_req_t *req, const char *clien
     create_accept_key(accept_key, client_key);
     req->res.status = 101;
     req->res.reason = "Switching Protocols";
-    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_UPGRADE, H2O_STRLIT("websocket"));
-    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("sec-websocket-accept"), 0, accept_key, strlen(accept_key));
+    h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_UPGRADE, NULL, H2O_STRLIT("websocket"));
+    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("sec-websocket-accept"), 0, NULL, accept_key, strlen(accept_key));
 
     /* send */
     h2o_http1_upgrade(req, NULL, 0, on_complete, conn);

--- a/lib/websocket.c
+++ b/lib/websocket.c
@@ -151,7 +151,8 @@ h2o_websocket_conn_t *h2o_upgrade_to_websocket(h2o_req_t *req, const char *clien
     req->res.status = 101;
     req->res.reason = "Switching Protocols";
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_UPGRADE, NULL, H2O_STRLIT("websocket"));
-    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("sec-websocket-accept"), 0, NULL, accept_key, strlen(accept_key));
+    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("sec-websocket-accept"), 0, NULL, accept_key,
+                          strlen(accept_key));
 
     /* send */
     h2o_http1_upgrade(req, NULL, 0, on_complete, conn);

--- a/t/00unit/lib/common/string.c
+++ b/t/00unit/lib/common/string.c
@@ -320,53 +320,6 @@ static void test_at_position(void)
     ok(ret != 0);
 }
 
-static void test_str_case(void)
-{
-	int i, j;
-#define MAX_SIZE 256
-	char tests[][MAX_SIZE] = {
-		"",
-		"User-Agent",
-		"Date",
-		"date",
-	};
-    char tmp1[MAX_SIZE], tmp2[MAX_SIZE];
-
-    h2o_mem_pool_t pool;
-    h2o_mem_init_pool(&pool);
-
-	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
-        for (j = 0; j < 2; j++) {
-            h2o_str_case_t *rc1, *rc2;
-            size_t l;
-
-            l = strlen(tests[i]);
-            strcpy(tmp1, tests[i]);
-            strcpy(tmp2, tests[i]);
-
-            rc1 = h2o_str_case_record(j ? &pool : NULL, tmp1, l);
-            rc2 = h2o_str_case_dup(j ? &pool : NULL, rc1, l);
-
-            h2o_strtolower(tmp1, l);
-            h2o_strtolower(tmp2, l);
-
-
-            h2o_str_case_restore(rc1, tmp1, l);
-            h2o_str_case_restore(rc2, tmp2, l);
-
-            ok(!strcmp(tmp1, tmp2));
-            ok(!strcmp(tests[i], tmp2));
-
-            if (!j) {
-                free(rc1);
-                free(rc2);
-            }
-        }
-	}
-
-    h2o_mem_clear_pool(&pool);
-}
-
 void test_lib__common__string_c(void)
 {
     subtest("strstr", test_strstr);
@@ -379,5 +332,4 @@ void test_lib__common__string_c(void)
     subtest("htmlescape", test_htmlescape);
     subtest("uri_escape", test_uri_escape);
     subtest("at_position", test_at_position);
-    subtest("str_case", test_str_case);
 }

--- a/t/00unit/lib/common/string.c
+++ b/t/00unit/lib/common/string.c
@@ -320,6 +320,53 @@ static void test_at_position(void)
     ok(ret != 0);
 }
 
+static void test_str_case(void)
+{
+	int i, j;
+#define MAX_SIZE 256
+	char tests[][MAX_SIZE] = {
+		"",
+		"User-Agent",
+		"Date",
+		"date",
+	};
+    char tmp1[MAX_SIZE], tmp2[MAX_SIZE];
+
+    h2o_mem_pool_t pool;
+    h2o_mem_init_pool(&pool);
+
+	for (i = 0; i < sizeof(tests)/sizeof(tests[0]); i++) {
+        for (j = 0; j < 2; j++) {
+            h2o_str_case_t *rc1, *rc2;
+            size_t l;
+
+            l = strlen(tests[i]);
+            strcpy(tmp1, tests[i]);
+            strcpy(tmp2, tests[i]);
+
+            rc1 = h2o_str_case_record(j ? &pool : NULL, tmp1, l);
+            rc2 = h2o_str_case_dup(j ? &pool : NULL, rc1, l);
+
+            h2o_strtolower(tmp1, l);
+            h2o_strtolower(tmp2, l);
+
+
+            h2o_str_case_restore(rc1, tmp1, l);
+            h2o_str_case_restore(rc2, tmp2, l);
+
+            ok(!strcmp(tmp1, tmp2));
+            ok(!strcmp(tests[i], tmp2));
+
+            if (!j) {
+                free(rc1);
+                free(rc2);
+            }
+        }
+	}
+
+    h2o_mem_clear_pool(&pool);
+}
+
 void test_lib__common__string_c(void)
 {
     subtest("strstr", test_strstr);
@@ -332,4 +379,5 @@ void test_lib__common__string_c(void)
     subtest("htmlescape", test_htmlescape);
     subtest("uri_escape", test_uri_escape);
     subtest("at_position", test_at_position);
+    subtest("str_case", test_str_case);
 }

--- a/t/00unit/lib/handler/fastcgi.c
+++ b/t/00unit/lib/handler/fastcgi.c
@@ -85,8 +85,8 @@ static void test_build_request(void)
     conn->req.version = 0x101;
     conn->req.hostconf = *ctx.globalconf->hosts;
     conn->req.pathconf = conn->req.hostconf->paths.entries;
-    h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_COOKIE, H2O_STRLIT("foo=bar"));
-    h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_USER_AGENT,
+    h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_COOKIE, NULL, H2O_STRLIT("foo=bar"));
+    h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_USER_AGENT, NULL,
                    H2O_STRLIT("Mozilla/5.0 (X11; Linux) KHTML/4.9.1 (like Gecko) Konqueror/4.9"));
 
     /* build with max_record_size=65535 */
@@ -117,7 +117,7 @@ static void test_build_request(void)
 
     /* build with max_record_size=64, DOCUMENT_ROOT, additional cookie, and content */
     config.document_root = h2o_iovec_init(H2O_STRLIT("/var/www/htdocs"));
-    h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_COOKIE, H2O_STRLIT("hoge=fuga"));
+    h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_COOKIE, NULL, H2O_STRLIT("hoge=fuga"));
     conn->req.entity = h2o_iovec_init(H2O_STRLIT("The above copyright notice and this permission notice shall be included in all "
                                                  "copies or substantial portions of the Software."));
     build_request(&conn->req, &vecs, 0x1234, 64, &config);

--- a/t/00unit/lib/handler/file.c
+++ b/t/00unit/lib/handler/file.c
@@ -288,7 +288,7 @@ static void test_if_modified_since(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE, lm_date, H2O_TIMESTR_RFC1123_LEN);
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE, NULL, lm_date, H2O_TIMESTR_RFC1123_LEN);
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 304);
         ok(conn->body->size == 0);
@@ -300,7 +300,7 @@ static void test_if_modified_since(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE,
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE, NULL,
                        H2O_STRLIT("Sun, 06 Nov 1994 08:49:37 GMT"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 200);
@@ -311,7 +311,7 @@ static void test_if_modified_since(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE,
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_MODIFIED_SINCE, NULL,
                        H2O_STRLIT("Wed, 18 May 2033 12:33:20 GMT"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 304);
@@ -345,7 +345,7 @@ static void test_if_match(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_NONE_MATCH, etag.base, etag.len);
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_IF_NONE_MATCH, NULL, etag.base, etag.len);
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 304);
         ok(conn->body->size == 0);
@@ -377,7 +377,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=0-10"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=0-10"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 206);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -390,7 +390,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=990-1100"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=990-1100"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 206);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -403,7 +403,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=989-"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=989-"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 206);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -416,7 +416,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=-21"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=-21"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 206);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -429,7 +429,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=-2100"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=-2100"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 206);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -442,7 +442,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=-0-10, 9-, -10"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=-0-10, 9-, -10"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 416);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain; charset=utf-8"));
@@ -455,7 +455,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=0-10-12, 9-, -10"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=0-10-12, 9-, -10"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 416);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain; charset=utf-8"));
@@ -468,7 +468,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytfasdf"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytfasdf"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 416);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain; charset=utf-8"));
@@ -481,7 +481,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=-0"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=-0"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 416);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain; charset=utf-8"));
@@ -494,7 +494,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=1000-1001"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=1000-1001"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 416);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain; charset=utf-8"));
@@ -507,7 +507,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=900-100"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=900-100"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 416);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain; charset=utf-8"));
@@ -520,7 +520,7 @@ static void test_range_req(void)
         h2o_loopback_conn_t *conn = h2o_loopback_create(&ctx, ctx.globalconf->hosts);
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=-0, 0-0"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=-0, 0-0"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 206);
         ok(check_header(&conn->req.res, H2O_TOKEN_CONTENT_TYPE, "text/plain"));
@@ -537,7 +537,7 @@ static void test_range_req(void)
         size_t mimebaselen = strlen("multipart/byteranges; boundary=");
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=-0, 0-9,-11"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=-0, 0-9,-11"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 206);
         if ((content_type_index = h2o_find_header(&conn->req.res.headers, H2O_TOKEN_CONTENT_TYPE, -1)) == -1) {
@@ -567,7 +567,7 @@ static void test_range_req(void)
         size_t mimebaselen = strlen("multipart/byteranges; boundary=");
         conn->req.input.method = h2o_iovec_init(H2O_STRLIT("GET"));
         conn->req.input.path = h2o_iovec_init(H2O_STRLIT("/1000.txt"));
-        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, H2O_STRLIT("bytes=,\t,1-3 ,, ,5-9,"));
+        h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_RANGE, NULL, H2O_STRLIT("bytes=,\t,1-3 ,, ,5-9,"));
         h2o_loopback_run_loop(conn);
         ok(conn->req.res.status == 206);
         if ((content_type_index = h2o_find_header(&conn->req.res.headers, H2O_TOKEN_CONTENT_TYPE, -1)) == -1) {

--- a/t/00unit/lib/handler/headers.c
+++ b/t/00unit/lib/handler/headers.c
@@ -38,10 +38,10 @@ static int headers_are(h2o_mem_pool_t *pool, h2o_headers_t *headers, const char 
 static void setup_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers)
 {
     *headers = (h2o_headers_t){NULL};
-    h2o_add_header(pool, headers, H2O_TOKEN_CONTENT_TYPE, H2O_STRLIT("text/plain"));
-    h2o_add_header(pool, headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("public, max-age=86400"));
-    h2o_add_header(pool, headers, H2O_TOKEN_SET_COOKIE, H2O_STRLIT("a=b"));
-    h2o_add_header_by_str(pool, headers, H2O_STRLIT("x-foo"), 0, H2O_STRLIT("bar"));
+    h2o_add_header(pool, headers, H2O_TOKEN_CONTENT_TYPE, NULL, H2O_STRLIT("text/plain"));
+    h2o_add_header(pool, headers, H2O_TOKEN_CACHE_CONTROL, NULL, H2O_STRLIT("public, max-age=86400"));
+    h2o_add_header(pool, headers, H2O_TOKEN_SET_COOKIE, NULL, H2O_STRLIT("a=b"));
+    h2o_add_header_by_str(pool, headers, H2O_STRLIT("x-foo"), 0, NULL, H2O_STRLIT("bar"));
 }
 
 void test_lib__handler__headers_c(void)

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -306,9 +306,9 @@ static void test_hpack(void)
         memset(&res, 0, sizeof(res));
         res.status = 302;
         res.reason = "Found";
-        h2o_add_header(&pool, &res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("private"));
-        h2o_add_header(&pool, &res.headers, H2O_TOKEN_DATE, H2O_STRLIT("Mon, 21 Oct 2013 20:13:21 GMT"));
-        h2o_add_header(&pool, &res.headers, H2O_TOKEN_LOCATION, H2O_STRLIT("https://www.example.com"));
+        h2o_add_header(&pool, &res.headers, H2O_TOKEN_CACHE_CONTROL, NULL, H2O_STRLIT("private"));
+        h2o_add_header(&pool, &res.headers, H2O_TOKEN_DATE, NULL, H2O_STRLIT("Mon, 21 Oct 2013 20:13:21 GMT"));
+        h2o_add_header(&pool, &res.headers, H2O_TOKEN_LOCATION, NULL, H2O_STRLIT("https://www.example.com"));
         check_flatten(&header_table, &res, H2O_STRLIT("\x08\x03\x33\x30\x32\x58\x85\xae\xc3\x77\x1a\x4b\x61\x96\xd0\x7a\xbe\x94\x10"
                                                       "\x54\xd4\x44\xa8\x20\x05\x95\x04\x0b\x81\x66\xe0\x82\xa6\x2d\x1b\xff\x6e\x91"
                                                       "\x9d\x29\xad\x17\x18\x63\xc7\x8f\x0b\x97\xc8\xe9\xae\x82\xae\x43\xd3"));
@@ -316,9 +316,9 @@ static void test_hpack(void)
         memset(&res, 0, sizeof(res));
         res.status = 307;
         res.reason = "Temporary Redirect";
-        h2o_add_header(&pool, &res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("private"));
-        h2o_add_header(&pool, &res.headers, H2O_TOKEN_DATE, H2O_STRLIT("Mon, 21 Oct 2013 20:13:21 GMT"));
-        h2o_add_header(&pool, &res.headers, H2O_TOKEN_LOCATION, H2O_STRLIT("https://www.example.com"));
+        h2o_add_header(&pool, &res.headers, H2O_TOKEN_CACHE_CONTROL, NULL, H2O_STRLIT("private"));
+        h2o_add_header(&pool, &res.headers, H2O_TOKEN_DATE, NULL, H2O_STRLIT("Mon, 21 Oct 2013 20:13:21 GMT"));
+        h2o_add_header(&pool, &res.headers, H2O_TOKEN_LOCATION, NULL, H2O_STRLIT("https://www.example.com"));
         check_flatten(&header_table, &res, H2O_STRLIT("\x08\x03\x33\x30\x37\xc0\xbf\xbe"));
 #if 0
         h2o_iovec_init(H2O_STRLIT("\x48\x03\x33\x30\x37\xc1\xc0\xbf")),
@@ -386,10 +386,10 @@ static void test_hpack_push(void)
     req.input.scheme = &H2O_URL_SCHEME_HTTPS;
     req.input.authority = authority;
     req.input.path = h2o_iovec_init(H2O_STRLIT("/"));
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_USER_AGENT, user_agent.base, user_agent.len);
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT, accept_root.base, accept_root.len);
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_LANGUAGE, accept_language.base, accept_language.len);
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_ENCODING, accept_encoding.base, accept_encoding.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_USER_AGENT, NULL, user_agent.base, user_agent.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT, NULL, accept_root.base, accept_root.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_LANGUAGE, NULL, accept_language.base, accept_language.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_ENCODING, NULL, accept_encoding.base, accept_encoding.len);
 
     /* serialize, deserialize, and compare */
     h2o_hpack_flatten_request(&buf, &encode_table, 0, 16384, &req, 0);
@@ -402,11 +402,11 @@ static void test_hpack_push(void)
     /* setup second request */
     req.input.path = h2o_iovec_init(H2O_STRLIT("/banner.jpg"));
     req.headers = (h2o_headers_t){NULL};
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_USER_AGENT, user_agent.base, user_agent.len);
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT, accept_images.base, accept_images.len);
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_LANGUAGE, accept_language.base, accept_language.len);
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_ENCODING, accept_encoding.base, accept_encoding.len);
-    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_REFERER, referer.base, referer.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_USER_AGENT, NULL, user_agent.base, user_agent.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT, NULL, accept_images.base, accept_images.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_LANGUAGE, NULL, accept_language.base, accept_language.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_ENCODING, NULL, accept_encoding.base, accept_encoding.len);
+    h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_REFERER, NULL, referer.base, referer.len);
 
     /* serialize, deserialize, and compare */
     h2o_hpack_flatten_request(&buf, &encode_table, 0, 16384, &req, 0);
@@ -484,7 +484,7 @@ void test_token_wo_hpack_id(void)
 
     res.status = 200;
     res.reason = "OK";
-    h2o_add_header(&pool, &res.headers, H2O_TOKEN_TE, H2O_STRLIT("test"));
+    h2o_add_header(&pool, &res.headers, H2O_TOKEN_TE, NULL, H2O_STRLIT("test"));
 
     h2o_hpack_flatten_response(&buf, &table, 1, H2O_HTTP2_SETTINGS_DEFAULT.max_frame_size, &res, NULL, NULL, SIZE_MAX);
     ok(h2o_memis(buf->bytes + 9, buf->size - 9, H2O_STRLIT("\x88"     /* :status:200 */

--- a/t/50reverse-proxy-preserve-case.t
+++ b/t/50reverse-proxy-preserve-case.t
@@ -1,0 +1,75 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $upstream_port = empty_port();
+
+my $upstream = new IO::Socket::INET (
+    LocalHost => '127.0.0.1',
+    LocalPort => $upstream_port,
+    Proto => 'tcp',
+    Listen => 1,
+    Reuse => 1
+);
+die "cannot create socket $!\n" unless $upstream;
+
+sub handler_curl {
+    my $socket = shift;
+    my $client_socket = $socket->accept();
+
+    my $data = "";
+    $client_socket->recv($data, 4906);
+
+    my $resp = "HTTP/1.0 200 Ok\r\nConnection: close\r\nMyResponseHeader:1\r\n\r\nOk";
+    $client_socket->send($resp);
+
+    close($client_socket);
+    return $data;
+};
+
+
+sub test_preserve_case {
+    my $preserve_case = shift;
+    my $preserve_case_str = $preserve_case ? "ON" : "OFF";
+    my $server = spawn_h2o(<< "EOT");
+proxy.preserve-original-case: $preserve_case_str
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1.XIP.IO:$upstream_port
+EOT
+
+    run_with_curl($server, sub {
+            my ($proto, $port, $curl) = @_;
+            open(CURL, "$curl -HUpper-Case:TheValue -svo /dev/null $proto://127.0.0.1:$port/ 2>&1 |");
+            my $forwarded = handler_curl($upstream);
+            my @lines;
+            while (<CURL>) {
+                push(@lines, $_);
+
+            }
+            my $resp = join("", @lines);
+            if ($preserve_case == 0 or $curl =~ /http2/) {
+                like($forwarded, qr{upper-case:\s*TheValue}, "Request header name is lowercase");
+                like($resp, qr{myresponseheader:\s*1}, "Response header name is lowercase");
+            } else {
+                like($forwarded, qr{Upper-Case:\s*TheValue}, "Request header name is lowercase");
+                like($resp, qr{MyResponseHeader:\s*1}, "Response header name has case preserved");
+            }
+        });
+}
+
+test_preserve_case(1);
+test_preserve_case(0);
+
+done_testing();

--- a/t/50reverse-proxy-preserve-case.t
+++ b/t/50reverse-proxy-preserve-case.t
@@ -29,8 +29,9 @@ sub handler_curl {
     my $data = "";
     $client_socket->recv($data, 4906);
 
-    my $resp = "HTTP/1.0 200 Ok\r\nConnection: close\r\nMyResponseHeader:1\r\n\r\nOk";
+    my $resp = "HTTP/1.0 200 Ok\r\nMyResponseHeader:1\r\nContent-Length:2\r\nConnection: close\r\n\r\nOk";
     $client_socket->send($resp);
+    $client_socket->flush;
 
     close($client_socket);
     return $data;
@@ -42,12 +43,12 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.url: http://127.0.0.1.XIP.IO:$upstream_port
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
 EOT
 
 run_with_curl($server, sub {
         my ($proto, $port, $curl) = @_;
-        open(CURL, "$curl -HUpper-Case:TheValue -svo /dev/null $proto://127.0.0.1:$port/ 2>&1 |");
+        open(CURL, "$curl -HUpper-Case:TheValue -kv $proto://127.0.0.1:$port/ 2>&1 |");
         my $forwarded = handler_curl($upstream);
         my @lines;
         while (<CURL>) {

--- a/t/50reverse-proxy-preserve-case.t
+++ b/t/50reverse-proxy-preserve-case.t
@@ -56,10 +56,10 @@ run_with_curl($server, sub {
         }
         my $resp = join("", @lines);
         if ($curl =~ /http2/) {
-            like($forwarded, qr{upper-case:\s*TheValue}, "Request header name is lowercase");
+            like($forwarded, qr{upper-case:\s*TheValue}, "Request header name is lowercased");
             like($resp, qr{myresponseheader:\s*1}, "Response header name is lowercase");
         } else {
-            like($forwarded, qr{Upper-Case:\s*TheValue}, "Request header name is lowercase");
+            like($forwarded, qr{Upper-Case:\s*TheValue}, "Request header name is not lowercased");
             like($resp, qr{MyResponseHeader:\s*1}, "Response header name has case preserved");
         }
     });


### PR DESCRIPTION
This patch adds a new parameter: `proxy.preserve-original-case`. When
this parameter is set, we record the casing of the received headers
(both in the reponse and request), and when forwarding the request (or
the response), we apply the original casing.