### PR TITLE
[WIP] place shared files into versioned directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ SET(LIB_SOURCE_FILES
     lib/common/memcached.c
     lib/common/memory.c
     lib/common/multithread.c
+    lib/common/path.c
     lib/common/serverutil.c
     lib/common/socket.c
     lib/common/socketpool.c
@@ -471,13 +472,13 @@ IF (NOT WITHOUT_LIBS)
     INSTALL(FILES "${CMAKE_BINARY_DIR}/libh2o-evloop.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 ENDIF ()
 
-INSTALL(PROGRAMS share/h2o/annotate-backtrace-symbols share/h2o/fastcgi-cgi share/h2o/fetch-ocsp-response share/h2o/kill-on-close share/h2o/setuidgid share/h2o/start_server DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o)
-INSTALL(FILES share/h2o/ca-bundle.crt DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o)
-INSTALL(FILES share/h2o/status/index.html DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o/status)
-INSTALL(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/h2o PATTERN "Makefile" EXCLUDE PATTERN "README.md" EXCLUDE)
-INSTALL(DIRECTORY examples/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/h2o/examples)
+INSTALL(PROGRAMS share/h2o/annotate-backtrace-symbols share/h2o/fastcgi-cgi share/h2o/fetch-ocsp-response share/h2o/kill-on-close share/h2o/setuidgid share/h2o/start_server DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o/${VERSION})
+INSTALL(FILES share/h2o/ca-bundle.crt DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o/${VERSION})
+INSTALL(FILES share/h2o/status/index.html DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o/${VERSION}/status)
+INSTALL(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/h2o/${VERSION} PATTERN "Makefile" EXCLUDE PATTERN "README.md" EXCLUDE)
+INSTALL(DIRECTORY examples/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/h2o/${VERSION}/examples)
 IF (WITH_MRUBY)
-    INSTALL(DIRECTORY share/h2o/mruby DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o)
+    INSTALL(DIRECTORY share/h2o/mruby DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o/${VERSION})
 ENDIF (WITH_MRUBY)
 
 # tests
@@ -515,14 +516,14 @@ ELSE (WITH_BUNDLED_SSL)
     ENDIF (OPENSSL_FOUND)
 ENDIF (WITH_BUNDLED_SSL)
 
-ADD_CUSTOM_TARGET(check env H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -v t/*.t
+ADD_CUSTOM_TARGET(check env H2O_ROOT=. H2O_SHARE_DIR=share/h2o BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -v t/*.t
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS h2o t-00unit-evloop.t)
 IF (LIBUV_FOUND)
     ADD_DEPENDENCIES(check t-00unit-libuv.t lib-examples)
 ENDIF (LIBUV_FOUND)
 
-ADD_CUSTOM_TARGET(check-as-root env H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -v t/90root-*.t
+ADD_CUSTOM_TARGET(check-as-root env H2O_ROOT=. H2O_SHARE_DIR=share/h2o BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -v t/90root-*.t
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 IF (BUILD_FUZZER)

--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include "h2o/hostinfo.h"
 #include "h2o/socketpool.h"
+#include "h2o/path_.h"
 #include "h2o/string_.h"
 #include "h2o/url.h"
 #include "h2o/http1client.h"
@@ -147,7 +148,7 @@ int main(int argc, char **argv)
     SSL_library_init();
     OpenSSL_add_all_algorithms();
     ctx.ssl_ctx = SSL_CTX_new(TLSv1_client_method());
-    SSL_CTX_load_verify_locations(ctx.ssl_ctx, H2O_TO_STR(H2O_ROOT) "/share/h2o/ca-bundle.crt", NULL);
+    SSL_CTX_load_verify_locations(ctx.ssl_ctx, h2o_get_shared_path(NULL, "ca-bundle.crt"), NULL);
     SSL_CTX_set_verify(ctx.ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
 
     if (argc != 2) {

--- a/examples/libh2o/socket-client.c
+++ b/examples/libh2o/socket-client.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include "h2o/path_.h"
 #include "h2o/socket.h"
 #include "h2o/string_.h"
 
@@ -110,7 +111,7 @@ int main(int argc, char **argv)
         SSL_library_init();
         OpenSSL_add_all_algorithms();
         ssl_ctx = SSL_CTX_new(TLSv1_client_method());
-        SSL_CTX_load_verify_locations(ssl_ctx, H2O_TO_STR(H2O_ROOT) "/share/h2o/ca-bundle.crt", NULL);
+        SSL_CTX_load_verify_locations(ssl_ctx, h2o_get_shared_path(NULL, "ca-bundle.crt"), NULL);
         SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
     }
     if (argc != 2)

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		080D35EB1D5E060D0029B7E5 /* http2_debug_state.c in Sources */ = {isa = PBXBuildFile; fileRef = 080D35EA1D5E060D0029B7E5 /* http2_debug_state.c */; };
+		0829CB211E4C1631001590BE /* path.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829CB201E4C1631001590BE /* path.c */; };
+		0829CB231E4C1747001590BE /* path_.h in Headers */ = {isa = PBXBuildFile; fileRef = 0829CB221E4C169B001590BE /* path_.h */; };
 		084FC7C11D54B90D00E89F66 /* http2_debug_state.c in Sources */ = {isa = PBXBuildFile; fileRef = 084FC7C01D54B90D00E89F66 /* http2_debug_state.c */; };
 		084FC7C51D54BB9200E89F66 /* http2_debug_state.c in Sources */ = {isa = PBXBuildFile; fileRef = 084FC7C31D54BB9200E89F66 /* http2_debug_state.c */; };
 		08E9CC4E1E41F6660049DD26 /* embedded.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 08E9CC4D1E41F6660049DD26 /* embedded.c.h */; };
@@ -348,6 +350,8 @@
 
 /* Begin PBXFileReference section */
 		080D35EA1D5E060D0029B7E5 /* http2_debug_state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http2_debug_state.c; sourceTree = "<group>"; };
+		0829CB201E4C1631001590BE /* path.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = path.c; sourceTree = "<group>"; };
+		0829CB221E4C169B001590BE /* path_.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = path_.h; sourceTree = "<group>"; };
 		084FC7C01D54B90D00E89F66 /* http2_debug_state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http2_debug_state.c; sourceTree = "<group>"; };
 		084FC7C31D54BB9200E89F66 /* http2_debug_state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http2_debug_state.c; sourceTree = "<group>"; };
 		08E9CC4D1E41F6660049DD26 /* embedded.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedded.c.h; sourceTree = "<group>"; };
@@ -792,6 +796,7 @@
 				10A3D3D11B4CDBDC00327CF9 /* memcached.c */,
 				107923BA19A3217300C52AD6 /* memory.c */,
 				10AA2EAB1A8DE0AE004322AC /* multithread.c */,
+				0829CB201E4C1631001590BE /* path.c */,
 				104B9A241A4A4FEE009EEE64 /* serverutil.c */,
 				101788B119B561AA0084C6D8 /* socket.c */,
 				1065E70919BF18A600686E72 /* socket */,
@@ -1188,6 +1193,7 @@
 				10AA2EA91A8DDC57004322AC /* multithread.h */,
 				10B38A711B8D34BB007DC191 /* mruby_.h */,
 				1058F6EC1D7CC81E00FFFFA3 /* openssl_backport.h */,
+				0829CB221E4C169B001590BE /* path_.h */,
 				1047A9FE1D0E6D5900CC4BCE /* rand.h */,
 				104B9A231A4A4FAF009EEE64 /* serverutil.h */,
 				10D0903F19F0B90A0043D458 /* socket */,
@@ -1618,6 +1624,7 @@
 				104B9A261A4A5041009EEE64 /* serverutil.h in Headers */,
 				1079239719A3210E00C52AD6 /* picohttpparser.h in Headers */,
 				1065E70C19BF664300686E72 /* evloop.h in Headers */,
+				0829CB231E4C1747001590BE /* path_.h in Headers */,
 				107923C819A3217300C52AD6 /* hpack_huffman_table.h in Headers */,
 				107D4D531B5B2412004A9B21 /* file.h in Headers */,
 				105534ED1A42AD5E00627ECB /* templates.c.h in Headers */,
@@ -1865,6 +1872,7 @@
 				101B670C19ADD3380084A351 /* access_log.c in Sources */,
 				10BA72AA19AAD6300059392A /* stream.c in Sources */,
 				107D4D551B5B30EE004A9B21 /* file.c in Sources */,
+				0829CB211E4C1631001590BE /* path.c in Sources */,
 				10D0907319F633B00043D458 /* proxy.c in Sources */,
 				10A3D3D21B4CDBDC00327CF9 /* memcached.c in Sources */,
 				107923CF19A3217300C52AD6 /* request.c in Sources */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -43,6 +43,7 @@ extern "C" {
 #include "h2o/http1client.h"
 #include "h2o/memory.h"
 #include "h2o/multithread.h"
+#include "h2o/path_.h"
 #include "h2o/rand.h"
 #include "h2o/socket.h"
 #include "h2o/string_.h"

--- a/include/h2o/path_.h
+++ b/include/h2o/path_.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 DeNA Co., Ltd., Ichito Nagata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef h2o__path_h
+#define h2o__path_h
+
+#include "h2o/memory.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *h2o_get_root(void);
+char *h2o_get_absolute_path(h2o_mem_pool_t *pool, const char *path);
+char *h2o_get_shared_path(h2o_mem_pool_t *pool, const char *path);
+    
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/common/path.c
+++ b/lib/common/path.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2017 DeNA Co., Ltd., Ichito Nagata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "h2o/path_.h"
+#include "h2o/string_.h"
+#include "h2o/version.h"
+
+const char *h2o_get_root(void)
+{
+    const char *root = getenv("H2O_ROOT");
+    if (root == NULL)
+        root = H2O_TO_STR(H2O_ROOT);
+    return root;
+}
+
+char *h2o_get_absolute_path(h2o_mem_pool_t *pool, const char *path)
+{
+    /* just return the cmd (being strdup'ed) in case we do not need to prefix the value */
+    if (path[0] == '/')
+        goto ReturnOrig;
+
+    /* build full-path and return */
+    const char *root = h2o_get_root();
+    size_t len = strlen(root) + strlen(path) + 2;
+    char *abspath;
+    if (pool != NULL) {
+        abspath = (char *)h2o_mem_alloc_pool(pool, len);
+    } else {
+        abspath = (char *)h2o_mem_alloc(len);
+    }
+    sprintf(abspath, "%s/%s", root, path);
+    return abspath;
+
+ReturnOrig:
+    return h2o_strdup(NULL, path, SIZE_MAX).base;
+}
+
+char *h2o_get_shared_path(h2o_mem_pool_t *pool, const char *path)
+{
+    const char *share_dir = getenv("H2O_SHARE_DIR");
+    if (share_dir == NULL)
+        share_dir = "share/h2o/" H2O_VERSION;
+
+    char *relative = (char *)h2o_mem_alloc(strlen(share_dir) + strlen(path) + 2);
+    sprintf(relative, "%s/%s", share_dir, path);
+    char *fullpath = h2o_get_absolute_path(pool, relative);
+    free(relative);
+    return fullpath;
+}

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -284,12 +284,12 @@ static int on_config_spawn(h2o_configurator_command_t *cmd, h2o_configurator_con
 
     { /* build args */
         size_t i = 0;
-        argv[i++] = kill_on_close_cmd_path = h2o_configurator_get_cmd_path("share/h2o/kill-on-close");
+        argv[i++] = kill_on_close_cmd_path = h2o_get_shared_path(NULL, "kill-on-close");
         argv[i++] = "--rm";
         argv[i++] = dirname;
         argv[i++] = "--";
         if (spawn_user != NULL) {
-            argv[i++] = setuidgid_cmd_path = h2o_configurator_get_cmd_path("share/h2o/setuidgid");
+            argv[i++] = setuidgid_cmd_path = h2o_get_shared_path(NULL, "setuidgid");
             argv[i++] = spawn_user;
         }
         argv[i++] = "/bin/sh";

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -289,7 +289,7 @@ static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t
     if (ctx->pathconf == NULL && ctx->hostconf == NULL) {
         /* is global conf, setup the default SSL context */
         self->vars->ssl_ctx = create_ssl_ctx();
-        char *ca_bundle = h2o_configurator_get_cmd_path("share/h2o/ca-bundle.crt");
+        char *ca_bundle = h2o_get_shared_path(NULL, "ca-bundle.crt");
         if (SSL_CTX_load_verify_locations(self->vars->ssl_ctx, ca_bundle, NULL) != 1)
             fprintf(stderr, "Warning: failed to load the default certificates file at %s. Proxying to HTTPS servers may fail.\n",
                     ca_bundle);

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -203,13 +203,9 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
 
     if (local_path.len == 0 || h2o_memis(local_path.base, local_path.len, H2O_STRLIT("/"))) {
         /* root of the handler returns HTML that renders the status */
-        h2o_iovec_t fn;
-        const char *root = getenv("H2O_ROOT");
-        if (root == NULL)
-            root = H2O_TO_STR(H2O_ROOT);
-        fn = h2o_concat(&req->pool, h2o_iovec_init(root, strlen(root)), h2o_iovec_init(H2O_STRLIT("/share/h2o/status/index.html")));
+        char *fn = h2o_get_shared_path(&req->pool, "status/index.html");
         h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CACHE_CONTROL, H2O_STRLIT("no-cache"));
-        return h2o_file_send(req, 200, "OK", fn.base, h2o_iovec_init(H2O_STRLIT("text/html; charset=utf-8")), 0);
+        return h2o_file_send(req, 200, "OK", fn, h2o_iovec_init(H2O_STRLIT("text/html; charset=utf-8")), 0);
     } else if (h2o_memis(local_path.base, local_path.len, H2O_STRLIT("/json"))) {
         int ret;
         /* "/json" maps to the JSON API */


### PR DESCRIPTION
To avoid dependency problem between installed versions, this PR installs shared files into versioned directory.
Developers have to set `H2O_SHARE_DIR` environment variable to `$H2O_ROOT/share/h2o` to run the server.

TODOs:
- [ ] fix paths in documents