### PR TITLE
implementation of h2o_evloop_destroy

### DIFF
--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -556,7 +556,7 @@ void h2o_evloop_destroy(h2o_evloop_t *loop)
     
     //now all socket are disposedand and placed in linked list statechanged
     //we can freeing memory in cycle by next_statechanged,
-    while(sock=(loop->_statechanged.head->_next_statechanged) != NULL){
+    while((struct st_h2o_evloop_socket_t*)sock=(loop->_statechanged.head->_next_statechanged)) != NULL){
         free(loop->_statechanged.head);
         loop->_statechanged.head=loop->_statechanged.head->_next_statechanged;
     }

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -556,7 +556,8 @@ void h2o_evloop_destroy(h2o_evloop_t *loop)
     
     //now all socket are disposedand and placed in linked list statechanged
     //we can freeing memory in cycle by next_statechanged,
-    while((struct st_h2o_evloop_socket_t*)sock=(loop->_statechanged.head->_next_statechanged)) != NULL){
+    while((struct st_h2o_evloop_socket_t*)(sock=loop->_statechanged.head->_next_statechanged) != NULL){
+
         free(loop->_statechanged.head);
         loop->_statechanged.head=loop->_statechanged.head->_next_statechanged;
     }

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -559,7 +559,7 @@ void h2o_evloop_destroy(h2o_evloop_t *loop)
     while((struct st_h2o_evloop_socket_t*)(sock=loop->_statechanged.head->_next_statechanged) != NULL){
 
         free(loop->_statechanged.head);
-        loop->_statechanged.head=loop->_statechanged.head->_next_statechanged;
+        loop->_statechanged.head=sock;
     }
     sock=loop->_statechanged.head;
     free(sock);

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -557,7 +557,6 @@ void h2o_evloop_destroy(h2o_evloop_t *loop)
     //now all socket are disposedand and placed in linked list statechanged
     //we can freeing memory in cycle by next_statechanged,
     while((struct st_h2o_evloop_socket_t*)(sock=loop->_statechanged.head->_next_statechanged) != NULL){
-
         free(loop->_statechanged.head);
         loop->_statechanged.head=sock;
     }

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -535,6 +535,37 @@ static void run_pending(h2o_evloop_t *loop)
     }
 }
 
+void h2o_evloop_destroy(h2o_evloop_t *loop)
+{
+    struct st_h2o_evloop_socket_t *sock;
+    //dispose all socket
+    while (loop->_pending_as_server != NULL || loop->_pending_as_client != NULL) {
+        while ((sock = loop->_pending_as_client) != NULL) {
+            loop->_pending_as_client = sock->_next_pending;
+            sock->_next_pending = sock;
+            do_dispose_socket((h2o_socket_t *)sock);
+        }
+        if ((sock = loop->_pending_as_server) != NULL) {
+            loop->_pending_as_server = sock->_next_pending;
+            sock->_next_pending = sock;        
+            do_dispose_socket((h2o_socket_t *)sock);
+        }
+    }
+      //looks like no need to free  _timeouts 
+      //h2o_timeout__do_dispose(loop,  loop->_timeouts);
+    
+    //now all socket are disposedand and placed in linked list statechanged
+    //we can freeing memory in cycle by next_statechanged,
+    while(sock=(loop->_statechanged.head->_next_statechanged) != NULL){
+        free(loop->_statechanged.head);
+        loop->_statechanged.head=loop->_statechanged.head->_next_statechanged;
+    }
+    sock=loop->_statechanged.head;
+    free(sock);
+    //lastly we need to free loop memory
+    free(loop);
+}
+
 int h2o_evloop_run(h2o_evloop_t *loop, int32_t max_wait)
 {
     h2o_linklist_t *node;


### PR DESCRIPTION
How about such realization of h2o_evloop_destroy?
It is nicely commented. 
In short: dispose all sockets, free memory used by sockets and then free memory used by event loop structure.
some warnings on compilation  warning: assignment makes pointer from integer without a cast [-Wint-conversion], but compiling fine.