### PR TITLE
h2o_spawnp mapped fds closes wrong fd

### DIFF
--- a/include/h2o/serverutil.h
+++ b/include/h2o/serverutil.h
@@ -62,7 +62,7 @@ size_t h2o_server_starter_get_fds(int **_fds);
  *        pair is not -1.  If the second value is -1, then `close` is called with the first value as the argument.
  * @return pid of the process being spawned if successful, or -1 if otherwise
  */
-pid_t h2o_spawnp(const char *cmd, char *const *argv, const int *mapped_fds, int clocexec_mutex_is_locked);
+pid_t h2o_spawnp(const char *cmd, char *const *argv, int *mapped_fds, int clocexec_mutex_is_locked);
 
 /**
  * executes a command and returns its output

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -159,9 +159,11 @@ pid_t h2o_spawnp(const char *cmd, char *const *argv, const int *mapped_fds, int 
         /* in child process, map the file descriptors and execute; return the errnum through pipe if exec failed */
         if (mapped_fds != NULL) {
             for (; *mapped_fds != -1; mapped_fds += 2) {
-                if (mapped_fds[1] != -1)
-                    dup2(mapped_fds[0], mapped_fds[1]);
-                close(mapped_fds[0]);
+                if (mapped_fds[0] != mapped_fds[1]) {
+                    if (mapped_fds[1] != -1)
+                        dup2(mapped_fds[0], mapped_fds[1]);
+                    close(mapped_fds[0]);
+                }
             }
         }
         char **env = build_spawn_env();


### PR DESCRIPTION
It's possible that the mapped fds have the same value (in particular for
fastcgi, where the target fd is number 5). In that case, we end up
doing:
```
    dup2(5, 5);
    close(5);
```
ending up with no valid fd 5. This patch prevents the dup if the mapped
fd already has the expected value.