### PR TITLE
rewrite using standard C

### DIFF
--- a/deps/libgkc/gkc.c
+++ b/deps/libgkc/gkc.c
@@ -100,9 +100,7 @@ static inline void list_add_tail(struct list *l, struct list *n)
 #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
 #endif
 
-#define container_of(ptr, type, member) ({          \
-        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
-        (type *)( (char *)__mptr - offsetof(type,member) );})
+#define container_of(ptr, type, member) ((type *)((char *)(ptr) - offsetof(type, member)))
 
 struct freelist {
     struct freelist *next;


### PR DESCRIPTION
@deweerdt Does the change look reasonable? This is the only place we use `typeof` and `({...})`.