### PR TITLE
Stop reading from the socket after sending a '400 Bad request'

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -414,6 +414,7 @@ static void send_bad_request(struct st_h2o_http1_conn_t *conn)
                                                 "Bad Request")};
 
     assert(conn->req.version == 0 && "request has not been parsed successfully");
+    assert(conn->req.http1_is_persistent == 0);
     h2o_socket_write(conn->sock, (h2o_iovec_t *)&resp, 1, send_bad_request_on_complete);
     h2o_socket_read_stop(conn->sock);
 }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -415,6 +415,7 @@ static void send_bad_request(struct st_h2o_http1_conn_t *conn)
 
     assert(conn->req.version == 0 && "request has not been parsed successfully");
     h2o_socket_write(conn->sock, (h2o_iovec_t *)&resp, 1, send_bad_request_on_complete);
+    h2o_socket_read_stop(conn->sock);
 }
 
 static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)


### PR DESCRIPTION
When sending a '400 Bad request', stop reading from the socket. Not
doing so risks having `handle_incoming_request` being called a second
time, and assert because a write is already scheduled:

```
do_write                h2o/lib/common/socket/evloop.c.h:257:5
h2o_socket_write        h2o/lib/common/socket.c:576:9
send_bad_request        h2o/lib/http1.c:413:5
handle_incoming_request h2o/lib/http1.c:490:13
reqread_on_read         h2o/lib/http1.c:506:9
read_on_ready           h2o/lib/common/socket/evloop.c.h:235:5
```