### PR TITLE
[proxy]: Add a knob controlling the `via:` header

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -395,6 +395,10 @@ struct st_h2o_globalconf_t {
          * a boolean flag if set to true, instructs the proxy to emit x-forwarded-proto and x-forwarded-for headers
          */
         int emit_x_forwarded_headers;
+        /**
+         * a boolean flag if set to true, instructs the proxy to emit a via header
+         */
+        int emit_via_header;
     } proxy;
 
     /**

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -183,6 +183,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http2.graceful_shutdown_timeout = H2O_DEFAULT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT;
     config->proxy.io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
     config->proxy.emit_x_forwarded_headers = 1;
+    config->proxy.emit_via_header = 1;
     config->http2.max_concurrent_requests_per_connection = H2O_HTTP2_SETTINGS_HOST.max_concurrent_streams;
     config->http2.max_streams_for_priority = 16;
     config->http2.latency_optimization.min_rtt = 50; // milliseconds

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -268,6 +268,15 @@ static int on_config_emit_x_forwarded_headers(h2o_configurator_command_t *cmd, h
     return 0;
 }
 
+static int on_config_emit_via_header(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    ctx->globalconf->proxy.emit_via_header = (int)ret;
+    return 0;
+}
+
 static int on_config_preserve_x_forwarded_proto(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
@@ -376,5 +385,8 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "proxy.emit-x-forwarded-headers",
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_emit_x_forwarded_headers);
+    h2o_configurator_define_command(&c->super, "proxy.emit-via-header",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_emit_via_header);
     h2o_configurator_define_headers_commands(conf, &c->super, "proxy.header", get_headers_commands);
 }


### PR DESCRIPTION
This commit adds a `emit-via-header` knob. When set to true, the `via:`
header is added by the proxy layer (concatenating to an existing header
if necessary), otherwise the header is left as-is. The setting defaults
to true.