### PR TITLE
in JSON logging, emit `null` without surrounding quotes

### DIFF
--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -244,8 +244,10 @@ subtest "json-null" => sub {
             my $server = shift;
             system("curl --silent http://127.0.0.1:$server->{port}/ > /dev/null");
         },
-        { format => '\\"%h\\" %l', escape => 'json' },
-        qr{^"127\.0\.0\.1" null$},
+        # single specifier surrounded by quotes that consist a string literal in JSON should be converted to `null` if the specifier
+        # resolves to null
+        { format => '\\"%h\\" %l \\"%l\\" \'%l\' \'%l \' \'\\"%l\\"\'', escape => 'json' },
+        qr{^"127\.0\.0\.1" null null null 'null ' '"null"'$},
     );
 };
 


### PR DESCRIPTION
by magically removing the surrounding quotes if the specifier is the only thing that is within a string literal.

The chart below shows when the surrounding quotes get removed.

|format string|when `%foo` is `bar`|when `%foo` is null|
|---|---|---|
|`%foo`|`bar`|`null`|
|`"%foo"`|`"bar"`|`null`|
|`"baz%foo"`|`"bazbar"`|`"baznull"`

amends #1208