### PR TITLE
fix mruby code lineno

### DIFF
--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -61,7 +61,7 @@ static int on_config_mruby_handler(h2o_configurator_command_t *cmd, h2o_configur
     /* set source */
     self->vars->source = h2o_strdup(NULL, node->data.scalar, SIZE_MAX);
     self->vars->path = node->filename;
-    self->vars->lineno = (int)node->line;
+    self->vars->lineno = (int)node->line + 1;
 
     /* check if there is any error in source */
     char errbuf[1024];

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -812,6 +812,7 @@ h2o_mruby_handler_t *h2o_mruby_register(h2o_pathconf_t *pathconf, h2o_mruby_conf
     handler->config.source = h2o_strdup(NULL, vars->source.base, vars->source.len);
     if (vars->path != NULL)
         handler->config.path = h2o_strdup(NULL, vars->path, SIZE_MAX).base;
+    handler->config.lineno = vars->lineno;
 
     return handler;
 }


### PR DESCRIPTION
I think there are 3 problems:

1. lineno parsed in compilation phase is not passed to mruby handler (this causes lineno mismatch when mruby exception is raised)
2. yaml's lineno is 0-origin, but we want 1-origin lineno
3. problems with Block Scalar Style (see: https://github.com/h2o/yoml/pull/6)