### PR TITLE
Sync threads on startup

### DIFF
--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -57,6 +57,12 @@ typedef struct st_h2o_sem_t {
     ssize_t _capacity;
 } h2o_sem_t;
 
+typedef struct st_h2o_barrier_t {
+    pthread_mutex_t _mutex;
+    pthread_cond_t _cond;
+    size_t _count;
+} h2o_barrier_t;
+
 /**
  * creates a queue that is used for inter-thread communication
  */
@@ -92,5 +98,9 @@ void h2o_sem_destroy(h2o_sem_t *sem);
 void h2o_sem_wait(h2o_sem_t *sem);
 void h2o_sem_post(h2o_sem_t *sem);
 void h2o_sem_set_capacity(h2o_sem_t *sem, ssize_t new_capacity);
+
+#define H2O_BARRIER_INIT(count_) ((h2o_barrier_t){PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, count_})
+void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
+int h2o_barrier_wait(h2o_barrier_t *barrier);
 
 #endif

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -102,5 +102,6 @@ void h2o_sem_set_capacity(h2o_sem_t *sem, ssize_t new_capacity);
 #define H2O_BARRIER_INIT(count_) ((h2o_barrier_t){PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, count_})
 void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
 int h2o_barrier_wait(h2o_barrier_t *barrier);
+int h2o_barrier_done(h2o_barrier_t *barrier);
 
 #endif

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -231,3 +231,35 @@ void h2o_sem_set_capacity(h2o_sem_t *sem, ssize_t new_capacity)
     pthread_cond_broadcast(&sem->_cond);
     pthread_mutex_unlock(&sem->_mutex);
 }
+
+/* barrier */
+
+void h2o_barrier_init(h2o_barrier_t *barrier, size_t count)
+{
+    pthread_mutex_init(&barrier->_mutex, NULL);
+    pthread_cond_init(&barrier->_cond, NULL);
+    barrier->_count = count;
+}
+
+int h2o_barrier_wait(h2o_barrier_t *barrier)
+{
+    int ret;
+    pthread_mutex_lock(&barrier->_mutex);
+    barrier->_count--;
+    if (barrier->_count == 0) {
+        pthread_cond_broadcast(&barrier->_cond);
+        ret = 1;
+    } else {
+        while (barrier->_count)
+            pthread_cond_wait(&barrier->_cond, &barrier->_mutex);
+        ret = 0;
+    }
+    pthread_mutex_unlock(&barrier->_mutex);
+    return ret;
+}
+
+void h2o_barrier_destroy(h2o_barrier_t *barrier)
+{
+    pthread_mutex_destroy(&barrier->_mutex);
+    pthread_cond_destroy(&barrier->_cond);
+}

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -258,6 +258,11 @@ int h2o_barrier_wait(h2o_barrier_t *barrier)
     return ret;
 }
 
+int h2o_barrier_done(h2o_barrier_t *barrier)
+{
+    return barrier->_count == 0;
+}
+
 void h2o_barrier_destroy(h2o_barrier_t *barrier)
 {
     pthread_mutex_destroy(&barrier->_mutex);

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -260,7 +260,7 @@ int h2o_barrier_wait(h2o_barrier_t *barrier)
 
 int h2o_barrier_done(h2o_barrier_t *barrier)
 {
-    return barrier->_count == 0;
+    return __sync_add_and_fetch(&barrier->_count, 0) == 0;
 }
 
 void h2o_barrier_destroy(h2o_barrier_t *barrier)

--- a/src/main.c
+++ b/src/main.c
@@ -1628,6 +1628,12 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     update_listener_state(listeners);
 
     __sync_fetch_and_add(&conf.initialized_threads, 1);
+
+    /* make sure all threads are initialized before starting to serve requests */
+    while (__sync_fetch_and_add(&conf.initialized_threads, 0) != conf.num_threads) {
+        usleep(1000);
+    }
+
     /* the main loop */
     while (1) {
         if (conf.shutdown_requested)


### PR DESCRIPTION
It's possible that not all threads have started by the time other
threads start to serve requests.

This is in particular problematic with the status handler: the
on_req_json function relies on on_context_init being called for all
threads, but in fact the call of h2o_multithread_register_receiver
might be racing against the value of self->receivers.size.

This results in more threads being called than
collector->num_remaining_threads_atomic. A consequence of this can be
that either send_response is not called (and the fd of the request
is leaked), or on final() being called twice (leading to a possible
double free).

This commit solves the issue by introducing a barrier-like API that we use
as a synchronization point at startup time. By doing this, it's not possible
anymore that threads serve requests without all of them being initialized.