### PR TITLE
undefined behavior fixes

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -307,8 +307,10 @@ void h2o_append_to_null_terminated_list(void ***list, void *element);
 
 inline void *h2o_memcpy(void *dst, const void *src, size_t n)
 {
-    if (src)
+    if (src != NULL)
         return memcpy(dst, src, n);
+    else if (n != 0)
+        h2o_fatal("null pointer passed to memcpy");
     return dst;
 }
 

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -161,6 +161,10 @@ extern void *(*h2o_mem__set_secure)(void *, int, size_t);
 H2O_NORETURN void h2o__fatal(const char *msg);
 
 /**
+ * A version of memcpy that can take a NULL @src to avoid UB
+ */
+static void *h2o_memcpy(void *dst, const void *src, size_t n);
+/**
  * constructor for h2o_iovec_t
  */
 static h2o_iovec_t h2o_iovec_init(const void *base, size_t len);
@@ -300,6 +304,13 @@ void h2o_dump_memory(FILE *fp, const char *buf, size_t len);
 void h2o_append_to_null_terminated_list(void ***list, void *element);
 
 /* inline defs */
+
+inline void *h2o_memcpy(void *dst, const void *src, size_t n)
+{
+    if (src)
+        return memcpy(dst, src, n);
+    return dst;
+}
 
 inline h2o_iovec_t h2o_iovec_init(const void *base, size_t len)
 {

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -340,7 +340,7 @@ void h2o_vector__expand(h2o_mem_pool_t *pool, h2o_vector_t *vector, size_t eleme
         vector->capacity *= 2;
     if (pool != NULL) {
         new_entries = h2o_mem_alloc_pool(pool, element_size * vector->capacity);
-        memcpy(new_entries, vector->entries, element_size * vector->size);
+        h2o_memcpy(new_entries, vector->entries, element_size * vector->size);
     } else {
         new_entries = h2o_mem_realloc(vector->entries, element_size * vector->capacity);
     }

--- a/lib/common/string.c
+++ b/lib/common/string.c
@@ -38,7 +38,7 @@ h2o_iovec_t h2o_strdup(h2o_mem_pool_t *pool, const char *s, size_t slen)
     } else {
         ret.base = h2o_mem_alloc(slen + 1);
     }
-    memcpy(ret.base, s, slen);
+    h2o_memcpy(ret.base, s, slen);
     ret.base[slen] = '\0';
     ret.len = slen;
     return ret;
@@ -546,7 +546,7 @@ h2o_iovec_t h2o_concat_list(h2o_mem_pool_t *pool, h2o_iovec_t *list, size_t coun
     /* concatenate */
     ret.len = 0;
     for (i = 0; i != count; ++i) {
-        memcpy(ret.base + ret.len, list[i].base, list[i].len);
+        h2o_memcpy(ret.base + ret.len, list[i].base, list[i].len);
         ret.len += list[i].len;
     }
     ret.base[ret.len] = '\0';

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -235,9 +235,10 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
     }
 #define MAP_EXT_TO_PROTO(name, cb)                                                                                                 \
     if (h2o_lcstris(pt, quote_end - pt, H2O_STRLIT(name))) {                                                                       \
+        h2o_conn_callbacks_t dummy_;                                                                                               \
         NEW_ELEMENT(ELEMENT_TYPE_PROTOCOL_SPECIFIC);                                                                               \
         LAST_ELEMENT()->data.protocol_specific_callback_index =                                                                    \
-            &((h2o_conn_callbacks_t *)NULL)->log_.cb - ((h2o_conn_callbacks_t *)NULL)->log_.callbacks;                             \
+            &dummy_.log_.cb - dummy_.log_.callbacks;                                                                               \
         goto MAP_EXT_Found;                                                                                                        \
     }
                     MAP_EXT_TO_TYPE("connection-id", ELEMENT_TYPE_CONNECTION_ID);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -215,8 +215,8 @@ static void retain_original_response(h2o_req_t *req)
 
     req->res.original.status = req->res.status;
     h2o_vector_reserve(&req->pool, &req->res.original.headers, req->res.headers.size);
-    memcpy(req->res.original.headers.entries, req->res.headers.entries,
-           sizeof(req->res.headers.entries[0]) * req->res.headers.size);
+    h2o_memcpy(req->res.original.headers.entries, req->res.headers.entries,
+               sizeof(req->res.headers.entries[0]) * req->res.headers.size);
     req->res.original.headers.size = req->res.headers.size;
 }
 

--- a/lib/handler/configurator/errordoc.c
+++ b/lib/handler/configurator/errordoc.c
@@ -127,7 +127,7 @@ static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t
     /* copy vars */
     memset(&self->vars[1], 0, sizeof(self->vars[1]));
     h2o_vector_reserve(&self->pool, &self->vars[1], self->vars[0].size);
-    memcpy(self->vars[1].entries, self->vars[0].entries, sizeof(self->vars[0].entries[0]) * self->vars[0].size);
+    h2o_memcpy(self->vars[1].entries, self->vars[0].entries, sizeof(self->vars[0].entries[0]) * self->vars[0].size);
     self->vars[1].size = self->vars[0].size;
 
     ++self->vars;

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -480,7 +480,7 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
 
     { /* headers */
         h2o_header_t *headers_sorted = alloca(sizeof(*headers_sorted) * generator->req->headers.size);
-        memcpy(headers_sorted, generator->req->headers.entries, sizeof(*headers_sorted) * generator->req->headers.size);
+        h2o_memcpy(headers_sorted, generator->req->headers.entries, sizeof(*headers_sorted) * generator->req->headers.size);
         qsort(headers_sorted, generator->req->headers.size, sizeof(*headers_sorted), build_env_sort_header_cb);
         size_t i = 0;
         for (i = 0; i != generator->req->headers.size; ++i) {

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -836,7 +836,7 @@ void h2o_http1_upgrade(h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o
         h2o_mem_alloc_pool(&conn->req.pool, flatten_headers_estimate_size(&conn->req, conn->super.ctx->globalconf->server_name.len +
                                                                                           sizeof("upgrade") - 1));
     bufs[0].len = flatten_headers(bufs[0].base, &conn->req, "upgrade");
-    memcpy(bufs + 1, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
+    h2o_memcpy(bufs + 1, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
 
     h2o_socket_write(conn->sock, bufs, inbufcnt + 1, on_upgrade_complete);
 }

--- a/lib/http2/cache_digests.c
+++ b/lib/http2/cache_digests.c
@@ -180,7 +180,8 @@ static int lookup(h2o_cache_digests_frame_vector_t *vector, const char *url, siz
         do {
             h2o_cache_digests_frame_t *frame = vector->entries + i;
             uint64_t key = hash >> (64 - frame->capacity_bits);
-            if (bsearch(&key, frame->keys.entries, frame->keys.size, sizeof(frame->keys.entries[0]), cmp_key) != NULL)
+            if (frame->keys.entries != NULL &&
+                bsearch(&key, frame->keys.entries, frame->keys.size, sizeof(frame->keys.entries[0]), cmp_key) != NULL)
                 return is_fresh ? H2O_CACHE_DIGESTS_STATE_FRESH : H2O_CACHE_DIGESTS_STATE_STALE;
         } while (++i != vector->size);
     }

--- a/lib/http2/frame.c
+++ b/lib/http2/frame.c
@@ -99,7 +99,7 @@ void h2o_http2_encode_goaway_frame(h2o_buffer_t **buf, uint32_t last_stream_id, 
     uint8_t *dst = allocate_frame(buf, 8 + additional_data.len, H2O_HTTP2_FRAME_TYPE_GOAWAY, 0, 0);
     dst = h2o_http2_encode32u(dst, last_stream_id);
     dst = h2o_http2_encode32u(dst, (uint32_t)-errnum);
-    memcpy(dst, additional_data.base, additional_data.len);
+    h2o_memcpy(dst, additional_data.base, additional_data.len);
 }
 
 void h2o_http2_encode_window_update_frame(h2o_buffer_t **buf, uint32_t stream_id, int32_t window_size_increment)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -93,7 +93,7 @@ static void spawn_cache_cleanup_thread(SSL_CTX **_contexts, size_t num_contexts)
 {
     /* copy the list of contexts */
     SSL_CTX **contexts = malloc(sizeof(*contexts) * (num_contexts + 1));
-    memcpy(contexts, _contexts, sizeof(*contexts) * num_contexts);
+    h2o_memcpy(contexts, _contexts, sizeof(*contexts) * num_contexts);
     contexts[num_contexts] = NULL;
 
     /* launch the thread */


### PR DESCRIPTION
This PR contains fixes for issues detected by `ubsan` when running `make check`. There a three commits:
- Passing `NULL` and `0` as`src` and `len` respectively to `memcpy`
- Passing the `base` argument to `bsearch` as NULL
- Using `((type *)0)->a - ((type *)0)->b` to compute an offset in a struct

To my knowledge, these doesn't alter the behavior of H2O, nor they fix an existing real life issue.