### PR TITLE
Fixed typo in docs (brotli -> br)

### DIFF
--- a/doc/configure/compress_directives.html
+++ b/doc/configure/compress_directives.html
@@ -100,7 +100,7 @@ When both brotli and gzip are enabled and if the client supports both, H2O is ha
 compress: ON
 
 # enable by name
-compress: [ gzip, brotli ]
+compress: [ gzip, br ]
 
 # enable gzip only
 compress: [ gzip ]


### PR DESCRIPTION
"brotli" is invalid parameter in compress section. Replaced with br in docs.