### PR TITLE
Fixed typo in docs source (brotli -> br)

### DIFF
--- a/srcdoc/configure/compress_directives.mt
+++ b/srcdoc/configure/compress_directives.mt
@@ -42,7 +42,7 @@ When both brotli and gzip are enabled and if the client supports both, H2O is ha
 compress: ON
 
 # enable by name
-compress: [ gzip, brotli ]
+compress: [ gzip, br ]
 
 # enable gzip only
 compress: [ gzip ]


### PR DESCRIPTION
"brotli" is invalid parameter in compress section. Replaced with br in srcdocs.