### PR TITLE
Fix OCSP stapling error when OpenSSL 1.1.0 is used

### DIFF
--- a/share/h2o/fetch-ocsp-response
+++ b/share/h2o/fetch-ocsp-response
@@ -88,7 +88,7 @@ if (! defined $issuer_fn) {
 print STDERR "sending OCSP request to $ocsp_uri\n";
 my $resp = run_openssl(
     "ocsp -issuer $issuer_fn -cert $cert_fn -url $ocsp_uri"
-    . ($openssl_version =~ /^(OpenSSL 1\.|LibreSSL )/is ? " -header Host $ocsp_host" : "")
+    . ($openssl_version =~ /^(OpenSSL 1\.|LibreSSL )/is ? " -header Host@{[$openssl_version =~ /^OpenSSL 1\.0\./is ? ' ' : '=']}$ocsp_host" : "")
     . " -noverify -respout $tempdir/resp.der " . join(' ', @ARGV),
     1,
 );


### PR DESCRIPTION
due to an incompatible change introduced in OpenSSL 1.1.0. In prior versions, the `-header` argument took two arguments; first one being the name of the header and second being the value of the header. In 1.1.0, it became a single argument in form of `name=value`.

Fixes #1267