### PR TITLE
fix OCSP stapling failure when LibreSSL ised used

### DIFF
--- a/share/h2o/fetch-ocsp-response
+++ b/share/h2o/fetch-ocsp-response
@@ -88,7 +88,7 @@ if (! defined $issuer_fn) {
 print STDERR "sending OCSP request to $ocsp_uri\n";
 my $resp = run_openssl(
     "ocsp -issuer $issuer_fn -cert $cert_fn -url $ocsp_uri"
-    . ($openssl_version =~ /^(OpenSSL 1\.|LibreSSL )/is ? " -header Host@{[$openssl_version =~ /^OpenSSL 1\.0\./is ? ' ' : '=']}$ocsp_host" : "")
+    . ($openssl_version =~ /^(OpenSSL 1\.|LibreSSL )/is ? " -header Host@{[$openssl_version =~ /^(OpenSSL 1\.0\.|LibreSSL )/is ? ' ' : '=']}$ocsp_host" : "")
     . " -noverify -respout $tempdir/resp.der " . join(' ', @ARGV),
     1,
 );


### PR DESCRIPTION
As pointed out in #1274, the version check code introduced in #1270 did not take the case of LibreSSL into consideration.

This PR fixes the issue by applying the patch provided by @csmk in #1274.