### PR TITLE
Remove superfluous san/cov flags for fuzz builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ IF (BUILD_FUZZER)
     ADD_EXECUTABLE(h2o-fuzzer-url fuzz/driver_url.cc)
     SET_TARGET_PROPERTIES(h2o-fuzzer-http1 PROPERTIES COMPILE_FLAGS "-DHTTP1")
     SET_TARGET_PROPERTIES(h2o-fuzzer-http2 PROPERTIES COMPILE_FLAGS "-DHTTP2")
-    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_C_FLAGS}")
     IF (OSS_FUZZ)
         # Use https://github.com/google/oss-fuzz compatible options
         SET(LIB_FUZZER FuzzingEngine)

--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -175,7 +175,7 @@ void *upstream_thread(void *arg)
 
     while (1) {
         struct sockaddr_un caddr;
-        socklen_t slen;
+        socklen_t slen = 0;
         int cfs = accept(sd, (struct sockaddr *)&caddr, &slen);
         if (cfs < 0) {
             continue;


### PR DESCRIPTION
The existing `CMakeLists.txt` contains a superfluous linker directive for `-fsanitize=address`. google/oss-fuzz has recently started experimenting with additional Clang sanitizers; [this directive causes build errors](https://github.com/google/oss-fuzz/issues/585) when used with other sanitizer/coverage options.

This patch removes the superfluous directive and fixes an error in `fuzz/driver.cc` that was causing memsan fuzz runs to report a bug and exit immediately.