### PR TITLE
Set content-length header to '0' if method == HEAD

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -310,7 +310,11 @@ static void on_head(h2o_socket_t *sock, const char *err)
                 goto Exit;
             }
         } else if (headers[i].name == &H2O_TOKEN_CONTENT_LENGTH->buf) {
-            if ((client->_body_decoder.content_length.bytesleft = h2o_strtosize(headers[i].value.base, headers[i].value.len)) ==
+            if (client->_method_is_head) {
+                headers[i].value.base[0] = 0x30;
+                headers[i].value.len = 1;
+            }
+            else if ((client->_body_decoder.content_length.bytesleft = h2o_strtosize(headers[i].value.base, headers[i].value.len)) ==
                 SIZE_MAX) {
                 on_error_before_head(client, "invalid content-length");
                 goto Exit;


### PR DESCRIPTION
When requesting headers via method == HEAD, ensure content-length header returns 0.  As a method request of type HEAD will never return a body.