### PR TITLE
build fix under solaris based oses :

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -184,7 +184,7 @@ static struct {
     0,                                      /* initialized in main() */
     NULL,                                   /* thread_ids */
     0,                                      /* shutdown_requested */
-    H2O_BARRIER_INIT(SIZE_MAX),             /* startup_sync_barrier */
+    {{{0}}},             		    /* startup_sync_barrier */
     {{0}},                                  /* state */
     "share/h2o/annotate-backtrace-symbols", /* crash_handler */
     0,                                      /* crash_handler_wait_pipe_close */
@@ -1957,6 +1957,7 @@ int main(int argc, char **argv)
     conf.num_threads = h2o_numproc();
     conf.tfo_queues = H2O_DEFAULT_LENGTH_TCP_FASTOPEN_QUEUE;
     conf.launch_time = time(NULL);
+    conf.startup_sync_barrier = H2O_BARRIER_INIT(SIZE_MAX);
 
     h2o_hostinfo_max_threads = H2O_DEFAULT_NUM_NAME_RESOLUTION_THREADS;
 


### PR DESCRIPTION
- "Initialiser in not constant". related to the pthread barrier conf field.
- Initialising it in main instead.