### PR TITLE
[doc] rel=preload examples missing `as=` attribute

### DIFF
--- a/srcdoc/configure/http2_directives.mt
+++ b/srcdoc/configure/http2_directives.mt
@@ -32,7 +32,7 @@ See also:
 H2O recognizes <code>link</code> headers with <a href="https://w3c.github.io/preload/">preload</a> keyword sent by a backend application server (reverse proxy or FastCGI) or an mruby handler, and pushes the designated resource to a client.
 </p>
 <?= $ctx->{example}->('A link response header triggering HTTP/2 push', <<'EOT')
-link: </assets/jquery.js>; rel=preload
+link: </assets/jquery.js>; rel=preload; as=script
 EOT
 ?>
 
@@ -60,8 +60,8 @@ The following example shows how such responses would look like.
 </p>
 <?= $ctx->{example}->('100 response with link headers', <<'EOT')
 HTTP/1.1 100 Continue
-Link: </assets/style.css>; rel=preload
-Link: </assets/jquery.js>; rel=preload
+Link: </assets/style.css>; rel=preload; as=style
+Link: </assets/jquery.js>; rel=preload; as=script
 
 HTTP/1.1 200 OK
 Content-Type: text/html; charset=utf-8

--- a/srcdoc/configure/mruby.mt
+++ b/srcdoc/configure/mruby.mt
@@ -115,10 +115,10 @@ paths:
         push_paths = []
         # push css and js when request is to dir root or HTML
         if /(\/|\.html)\z/.match(env["PATH_INFO"])
-          push_paths << "/css/style.css"
-          push_paths << "/js/app.js"
+          push_paths << ["/css/style.css", "style"]
+          push_paths << ["/js/app.js", "script"]
         end
-        [399, push_paths.empty? ? {} : {"link" => push_paths.map{|p| "<#{p}>; rel=preload"}.join("\n")}, []]
+        [399, push_paths.empty? ? {} : {"link" => push_paths.map{|p| "<#{p[0]}>; rel=preload; as=#{p[1]}"}.join("\n")}, []]
       end
     fastcgi.connect: ...
 EOT


### PR DESCRIPTION
Not setting the `as=` attribute might be technically incorrect (i'm
still trying to figure that out), and definitely causes interoperability
issues with Chrome, causing it to re-fetch pushed resources.