### PR TITLE
support x-http2-push-only in the mruby handler as well

### DIFF
--- a/t/40server-push-attrs.t
+++ b/t/40server-push-attrs.t
@@ -13,53 +13,71 @@ plan skip_all => 'nghttp not found'
 plan skip_all => 'mruby support is off'
     unless server_features()->{mruby};
 
-subtest "basic" => sub {
-    # spawn upstream
-    my $upstream_port = empty_port();
-    my $upstream = spawn_server(
-        argv     => [
-            qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
-        ],
-        is_ready => sub {
-            check_port($upstream_port);
-        },
-    );
-    # spawn server
-    my $server = spawn_h2o(<< "EOT");
+# spawn upstream
+my $upstream_port = empty_port();
+my $upstream = spawn_server(
+    argv     => [
+        qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
+    ],
+    is_ready => sub {
+        check_port($upstream_port);
+    },
+);
+# spawn server
+my $server = spawn_h2o(<< "EOT");
 hosts:
   default:
     paths:
+      /mruby:
+        mruby.handler: |
+          Proc.new do |env|
+            attr = env["QUERY_STRING"]
+            [399, {"link" => "</index.js>; rel=preload; as=script; #{attr}"}, []]
+          end
+        file.dir: @{[DOC_ROOT]}
       /assets:
         file.dir: @{[DOC_ROOT]}
       /:
         proxy.reverse.url: http://127.0.0.1:$upstream_port
 EOT
 
-    my $pushes_encoded = "</assets/index.txt.gz>; rel=preload, </assets/index.txt.gz?1>; rel=preload, </assets/index.txt.gz?nopush>; rel=preload; nopush";
-    $pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
-    my $resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
-    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz}is, "index.txt.gz is pushed";
-    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?1}is, "index.txt.gz?1 is pushed";
-    unlike $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?nopush}is, "index.txt.gz?nopush isn't pushed";
+my $pushes_encoded = "</assets/index.txt.gz>; rel=preload, </assets/index.txt.gz?1>; rel=preload, </assets/index.txt.gz?nopush>; rel=preload; nopush";
+$pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
+my $resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
+like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz}is, "index.txt.gz is pushed";
+like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?1}is, "index.txt.gz?1 is pushed";
+unlike $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?nopush}is, "index.txt.gz?nopush isn't pushed";
 
-    $pushes_encoded = "</assets/index.txt.gz>; rel=preload, </assets/index.txt.gz?1>; rel=preload, </assets/index.txt.gz?nopush>; rel=preload; nopush, </assets/index.txt.gz?push-only>; rel=preload; x-http2-push-only";
-    $pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
-    $resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
+$pushes_encoded = "</assets/index.txt.gz>; rel=preload, </assets/index.txt.gz?1>; rel=preload, </assets/index.txt.gz?nopush>; rel=preload; nopush, </assets/index.txt.gz?push-only>; rel=preload; x-http2-push-only";
+$pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
+$resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
 
-    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz}is, "index.txt.gz is pushed";
-    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?1}is, "index.txt.gz?1 is pushed";
-    unlike $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?nopush}is, "index.txt.gz?nopush isn't pushed";
-    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?push-only}is, "index.txt.gz?push-only is pushed";
-    like $resp, qr{link: </assets/index\.txt\.gz>; rel=preload, </assets/index\.txt\.gz\?1>; rel=preload, </assets/index\.txt\.gz\?nopush>; rel=preload; nopush\n}, "push-only doesn't appear in the link header";
+like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz}is, "index.txt.gz is pushed";
+like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?1}is, "index.txt.gz?1 is pushed";
+unlike $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?nopush}is, "index.txt.gz?nopush isn't pushed";
+like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?push-only}is, "index.txt.gz?push-only is pushed";
+like $resp, qr{link: </assets/index\.txt\.gz>; rel=preload, </assets/index\.txt\.gz\?1>; rel=preload, </assets/index\.txt\.gz\?nopush>; rel=preload; nopush\n}, "push-only doesn't appear in the link header";
 
-    # Check that the header is removed if there's only one link with x-http2-push-only
-    $pushes_encoded = "</assets/index.txt.gz?push-only>; rel=preload; x-http2-push-only";
-    $pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
-    $resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
+# Check that the header is removed if there's only one link with x-http2-push-only
+$pushes_encoded = "</assets/index.txt.gz?push-only>; rel=preload; x-http2-push-only";
+$pushes_encoded =~ s{([^A-Za-z0-9_])}{sprintf "%%%02x", ord $1}eg;
+$resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/push-attr?pushes=$pushes_encoded'`;
 
-    like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?push-only}is, "index.txt.gz?push-only is pushed";
-    unlike $resp, qr{link:\s*\n}, "push-only doesn't appear in the link header";
-};
+like $resp, qr{\nid\s*responseEnd\s.*\s/assets/index\.txt\.gz\?push-only}is, "index.txt.gz?push-only is pushed";
+unlike $resp, qr{link:\s*\n}, "push-only doesn't appear in the link header";
+
+# mruby
+$resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/mruby/'`;
+like $resp, qr{\nid\s*responseEnd\s.*\s/index\.js}is, "index.js is pushed";
+like $resp, qr{link: </index.js>; rel=preload; as=script;}, "Found link header";
+
+$resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/mruby/?nopush'`;
+unlike $resp, qr{\nid\s*responseEnd\s.*\s/index\.js}is, "index.js is NOT pushed";
+like $resp, qr{link: </index.js>; rel=preload; as=script;}, "Found link header";
+
+$resp = `nghttp -vn --stat 'https://127.0.0.1:$server->{tls_port}/mruby/?x-http2-push-only'`;
+like $resp, qr{\nid\s*responseEnd\s.*\s/index\.js}is, "index.js is pushed";
+unlike $resp, qr{link: </index.js>; rel=preload; as=script;}, "Didn't find link header";
 
 
 done_testing;


### PR DESCRIPTION
@worenga and @utrenkner mentioned [here](https://github.com/h2o/h2o/issues/1303#issuecomment-302641870) that `rel=preload` headers with `x-http2-push-only` would still present when the headers were added via the mruby directive. This PR fixes it and add mruby test coverage.