### PR TITLE
fix compiler warning

### DIFF
--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -99,7 +99,7 @@ void h2o_sem_wait(h2o_sem_t *sem);
 void h2o_sem_post(h2o_sem_t *sem);
 void h2o_sem_set_capacity(h2o_sem_t *sem, ssize_t new_capacity);
 
-#define H2O_BARRIER_INIT(count_) ((h2o_barrier_t){PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, count_})
+#define H2O_BARRIER_INITIALIZER(count_) {PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, count_}
 void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
 int h2o_barrier_wait(h2o_barrier_t *barrier);
 int h2o_barrier_done(h2o_barrier_t *barrier);

--- a/src/main.c
+++ b/src/main.c
@@ -184,7 +184,7 @@ static struct {
     0,                                      /* initialized in main() */
     NULL,                                   /* thread_ids */
     0,                                      /* shutdown_requested */
-    H2O_BARRIER_INIT(SIZE_MAX),             /* startup_sync_barrier */
+    H2O_BARRIER_INITIALIZER(SIZE_MAX),      /* startup_sync_barrier */
     {{0}},                                  /* state */
     "share/h2o/annotate-backtrace-symbols", /* crash_handler */
     0,                                      /* crash_handler_wait_pipe_close */
@@ -2221,7 +2221,7 @@ int main(int argc, char **argv)
 
     /* start the threads */
     conf.threads = alloca(sizeof(conf.threads[0]) * conf.num_threads);
-    conf.startup_sync_barrier = H2O_BARRIER_INIT(conf.num_threads);
+    h2o_barrier_init(&conf.startup_sync_barrier, conf.num_threads);
     size_t i;
     for (i = 1; i != conf.num_threads; ++i) {
         pthread_t tid;

--- a/src/main.c
+++ b/src/main.c
@@ -184,7 +184,7 @@ static struct {
     0,                                      /* initialized in main() */
     NULL,                                   /* thread_ids */
     0,                                      /* shutdown_requested */
-    {{{0}}},             		    /* startup_sync_barrier */
+    H2O_BARRIER_INIT(SIZE_MAX),             /* startup_sync_barrier */
     {{0}},                                  /* state */
     "share/h2o/annotate-backtrace-symbols", /* crash_handler */
     0,                                      /* crash_handler_wait_pipe_close */
@@ -1957,7 +1957,6 @@ int main(int argc, char **argv)
     conf.num_threads = h2o_numproc();
     conf.tfo_queues = H2O_DEFAULT_LENGTH_TCP_FASTOPEN_QUEUE;
     conf.launch_time = time(NULL);
-    conf.startup_sync_barrier = H2O_BARRIER_INIT(SIZE_MAX);
 
     h2o_hostinfo_max_threads = H2O_DEFAULT_NUM_NAME_RESOLUTION_THREADS;
 


### PR DESCRIPTION
The change made in #1300 implies that `pthread_mutex_t` is declared in a specific way even though the structure is organized in different ways depending on the OS.

The fact was leading for us seeing the following compiler warning on OS X.
```
/mydev/h2o/src/main.c:187:7: warning: braces around scalar initializer [-Wbraced-scalar-init]
    {{{0}}},                                /* startup_sync_barrier */
      ^~~
1 warning generated.
```

This PR attempts to fix the issue address by  #1300 in another way; by changing how `H2O_BARRIER_INIT` and avoiding use of the macro at runtime.