### PR TITLE
check avialability of correct address

### DIFF
--- a/t/40env.t
+++ b/t/40env.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
-use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 

--- a/t/40redis-session-resumption.t
+++ b/t/40redis-session-resumption.t
@@ -18,7 +18,7 @@ plan skip_all => "could not find openssl"
 
 sub spawn_redis {
     # start redis
-    my $redis_port = empty_port();
+    my $redis_port = empty_port({ host => '0.0.0.0' });
     my ($redis_guard, $pid) = spawn_server(
         argv     => [ qw(redis-server --port), $redis_port ],
         is_ready => sub {

--- a/t/40server-push-attrs.t
+++ b/t/40server-push-attrs.t
@@ -17,7 +17,7 @@ plan skip_all => 'mruby support is off'
 my $upstream_port = empty_port();
 my $upstream = spawn_server(
     argv     => [
-        qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
+        qw(plackup -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port", ASSETS_DIR . "/upstream.psgi",
     ],
     is_ready => sub {
         check_port($upstream_port);

--- a/t/40server-push-multiple.t
+++ b/t/40server-push-multiple.t
@@ -18,7 +18,7 @@ subtest "basic" => sub {
     my $upstream_port = empty_port();
     my $upstream = spawn_server(
         argv     => [
-            qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
+            qw(plackup -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port", ASSETS_DIR . "/upstream.psgi",
         ],
         is_ready => sub {
             check_port($upstream_port);

--- a/t/40websocket.t
+++ b/t/40websocket.t
@@ -14,7 +14,7 @@ plan skip_all => 'Starlet not found'
 my $upstream_port = empty_port();
 my $upstream = spawn_server(
     argv     => [
-        qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
+        qw(plackup -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port", ASSETS_DIR . "/upstream.psgi",
     ],
     is_ready => sub {
         check_port($upstream_port);

--- a/t/50fastcgi-cgi.t
+++ b/t/50fastcgi-cgi.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
-use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 

--- a/t/50fastcgi-php.t
+++ b/t/50fastcgi-php.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
-use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 

--- a/t/50fastcgi.t
+++ b/t/50fastcgi.t
@@ -30,7 +30,7 @@ sub doit {
         my $upstream = spawn_server(
             argv => [
                 qw(plackup -s FCGI --access-log /dev/null --listen),
-                ($tcp ? ":$fcgi_port" : "$tempdir/fcgi.sock"),
+                ($tcp ? "127.0.0.1:$fcgi_port" : "$tempdir/fcgi.sock"),
                 ASSETS_DIR . "/upstream.psgi",
             ],
             is_ready => sub {

--- a/t/50reverse-proxy-config.t
+++ b/t/50reverse-proxy-config.t
@@ -18,7 +18,7 @@ plan skip_all => 'curl not found'
 my $upstream_port = empty_port();
 my $upstream = spawn_server(
     argv     => [
-        qw(plackup -MPlack::App::File -s Starlet --access-log /dev/null -p), $upstream_port,
+        qw(plackup -MPlack::App::File -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port",
         ASSETS_DIR . "/upstream.psgi",
     ],
     is_ready =>  sub {

--- a/t/50reverse-proxy-https.t
+++ b/t/50reverse-proxy-https.t
@@ -7,7 +7,7 @@ use t::Util;
 plan skip_all => 'plackup not found'
     unless prog_exists('plackup');
 
-my $upstream_port = empty_port();
+my $upstream_port = empty_port({ host => '0.0.0.0' });
 my $upstream = spawn_server(
     argv => [
         qw(

--- a/t/50reverse-proxy-session-resumption.t
+++ b/t/50reverse-proxy-session-resumption.t
@@ -156,9 +156,9 @@ subtest 'reproxy' => sub {
     my $app_server = spawn_server(
         argv => [
             qw(
-                plackup -s Starlet --max-workers=1 --port
+                plackup -s Starlet --max-workers=1 --listen
             ),
-            $app_port, "-e sub { [200, ['X-Reproxy-URL' => 'https://127.0.0.1:$upstream_port/'], []] }"
+            "127.0.0.1:$app_port", "-e sub { [200, ['X-Reproxy-URL' => 'https://127.0.0.1:$upstream_port/'], []] }"
         ],
         is_ready => sub {
             check_port($app_port);

--- a/t/50servername.t
+++ b/t/50servername.t
@@ -56,7 +56,7 @@ EOT
 my $upstream_port = empty_port();
 
 my $upstream = spawn_server(
-	argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+	argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), "127.0.0.1:$upstream_port", ASSETS_DIR . "/upstream.psgi" ],
 	is_ready =>  sub {
 		check_port($upstream_port);
 	},

--- a/t/80invalid-h2-chars-in-headers.t
+++ b/t/80invalid-h2-chars-in-headers.t
@@ -1,6 +1,5 @@
 use strict;
 use warnings;
-use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 

--- a/t/80issues61.t
+++ b/t/80issues61.t
@@ -13,7 +13,7 @@ my $upstream_port = empty_port();
 
 my $upstream = spawn_server(
     argv     => [
-        qw(plackup -s Starlet --access-log /dev/null -p), $upstream_port, ASSETS_DIR . "/upstream.psgi",
+        qw(plackup -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port", ASSETS_DIR . "/upstream.psgi",
     ],
     is_ready => sub {
         check_port($upstream_port);

--- a/t/90root-fastcgi-php.t
+++ b/t/90root-fastcgi-php.t
@@ -3,7 +3,6 @@ use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
-use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -169,7 +169,7 @@ sub spawn_h2o {
     my @opts;
 
     # decide the port numbers
-    my ($port, $tls_port) = empty_ports(2);
+    my ($port, $tls_port) = empty_ports(2, { host => "0.0.0.0" });
 
     # setup the configuration file
     my ($conffh, $conffn) = tempfile(UNLINK => 1);
@@ -211,10 +211,10 @@ EOT
 }
 
 sub empty_ports {
-    my $n = shift;
+    my ($n, @ep_args) = @_;
     my @ports;
     while (@ports < $n) {
-        my $t = empty_port();
+        my $t = empty_port(@ep_args);
         push @ports, $t
             unless grep { $_ == $t } @ports;
     }


### PR DESCRIPTION
Even after https://github.com/tokuhirom/Test-TCP/pull/59 went in, we have been seeing occasional CI errors (for an example, see https://travis-ci.org/h2o/h2o/builds/238598895?utm_source=github_status&utm_medium=notification).

This might be (at least partly) due to us calling `empty_port` with no argument (thus looking for an empty port on 127.0.0.1) and then trying to use that port on 0.0.0.0.

This PR fixes the issue in either of the two ways depending on the tests being run:
* look for an empty port on 0.0.0.0 (by calling `empty_port({ host => '0.0.0.0' })`)
* bind using the loopback address (i.e. 127.0.0.1) to the empty port being found