### PR TITLE
send replay identifier to upstream if ClientFinished is yet unseen

### DIFF
--- a/deps/picotls/include/picotls.h
+++ b/deps/picotls/include/picotls.h
@@ -394,6 +394,13 @@ typedef union st_ptls_handshake_properties_t {
         unsigned negotiate_before_key_exchange : 1;
     } client;
     struct {
+        /**
+         * psk binder being selected (len is set to zero if none)
+         */
+        struct {
+            uint8_t base[PTLS_MAX_DIGEST_SIZE];
+            size_t len;
+        } selected_psk_binder;
     } server;
 } ptls_handshake_properties_t;
 

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -308,6 +308,10 @@ h2o_iovec_t h2o_socket_ssl_get_selected_protocol(h2o_socket_t *sock);
 /**
  *
  */
+h2o_iovec_t h2o_socket_ssl_get_replay_identifier(h2o_socket_t *sock);
+/**
+ *
+ */
 struct st_ptls_context_t *h2o_socket_ssl_get_picotls_context(SSL_CTX *ossl);
 /**
  * associates a picotls context to SSL_CTX

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -295,8 +295,8 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive, int is_websocket
         h2o_socket_t *sock = req->conn->callbacks->get_socket(req->conn);
         h2o_iovec_t identifier;
         if (sock != NULL && (identifier = h2o_socket_ssl_get_replay_identifier(sock)).len != 0) {
-            RESERVE(sizeof("tls13-replay-id: ") - 1 + identifier.len * 2);
-            APPEND_STRLIT("tls13-replay-id: ");
+            RESERVE(sizeof("tls-replay-id: ") - 1 + identifier.len * 2);
+            APPEND_STRLIT("tls-replay-id: ");
             h2o_hex_encode(buf.base + offset, identifier.base, identifier.len);
             offset += identifier.len * 2;
             buf.base[offset++] = '\r';

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -291,6 +291,18 @@ static h2o_iovec_t build_request(h2o_req_t *req, int keepalive, int is_websocket
         buf.base[offset++] = '\r';
         buf.base[offset++] = '\n';
     }
+    {
+        h2o_socket_t *sock = req->conn->callbacks->get_socket(req->conn);
+        h2o_iovec_t identifier;
+        if (sock != NULL && (identifier = h2o_socket_ssl_get_replay_identifier(sock)).len != 0) {
+            RESERVE(sizeof("tls13-replay-id: ") - 1 + identifier.len * 2);
+            APPEND_STRLIT("tls13-replay-id: ");
+            h2o_hex_encode(buf.base + offset, identifier.base, identifier.len);
+            offset += identifier.len * 2;
+            buf.base[offset++] = '\r';
+            buf.base[offset++] = '\n';
+        }
+    }
     APPEND_STRLIT("\r\n");
 
 #undef RESERVE


### PR DESCRIPTION
The implementation introduces `tls13-replay-id` header.

Does the name look fine?
* should not use the term _early_data_ since it's now about _how_ the request is sent but about _if_ the server sends the request to upstream before seeing ClientFinished
* omitting `tls13-` might make the header name too generic; OTOH `tls13-` might be too version-specific