### PR TITLE
update iij/mruby-require to the latest version

### DIFF
--- a/deps/mruby-require/mrbgem.rake
+++ b/deps/mruby-require/mrbgem.rake
@@ -5,7 +5,8 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
   spec.add_dependency 'mruby-array-ext'
   spec.add_dependency 'mruby-dir'
   spec.add_dependency 'mruby-io'
-  spec.add_dependency 'mruby-tempfile'
+# only used for testing?
+#  spec.add_dependency 'mruby-tempfile'
   spec.add_dependency 'mruby-time'
   spec.add_dependency 'mruby-eval'
 

--- a/deps/mruby-require/mrbgem.rake
+++ b/deps/mruby-require/mrbgem.rake
@@ -5,8 +5,7 @@ MRuby::Gem::Specification.new('mruby-require') do |spec|
   spec.add_dependency 'mruby-array-ext'
   spec.add_dependency 'mruby-dir'
   spec.add_dependency 'mruby-io'
-# only used for testing?
-#  spec.add_dependency 'mruby-tempfile'
+  spec.add_dependency 'mruby-tempfile'
   spec.add_dependency 'mruby-time'
   spec.add_dependency 'mruby-eval'
 

--- a/deps/mruby-require/mrblib/require.rb
+++ b/deps/mruby-require/mrblib/require.rb
@@ -1,17 +1,17 @@
 class LoadError < ScriptError; end
 
-module Kernel
-  begin
-    eval "1", nil
-    def _eval_load(*args)
-      self.eval(*args)
-    end
-  rescue ArgumentError
-    def _eval_load(*args)
-      self.eval(args[0])
-    end
+begin
+  eval "1", nil
+  def _require_eval_load(*args)
+    self.eval(*args)
   end
+rescue ArgumentError
+  def _require_eval_load(*args)
+    self.eval(args[0])
+  end
+end
 
+module Kernel
   def load(path)
     raise TypeError unless path.class == String
 
@@ -19,7 +19,7 @@ module Kernel
       _load_mrb_file path
     elsif File.exist?(path)
       # _load_rb_str File.open(path).read.to_s, path
-      _eval_load File.open(path).read.to_s, nil, path
+      _require_eval_load File.open(path).read.to_s, nil, path
     else
       raise LoadError.new "File not found -- #{path}"
     end

--- a/deps/mruby-require/test/d/required.rb
+++ b/deps/mruby-require/test/d/required.rb
@@ -10,3 +10,10 @@ lvar1 = 1
 def proc0
   :proc0
 end
+
+# define a new method of an existing class.
+class MrubyRequireClass
+  def foo
+    :foo
+  end
+end

--- a/deps/mruby-require/test/require.rb
+++ b/deps/mruby-require/test/require.rb
@@ -2,6 +2,7 @@ assert("Kernel.require") do
   # see d/required.rb
   $gvar1 = 0
   lvar1 = 0
+  class MrubyRequireClass; end
 
   assert_true require(File.join(File.dirname(__FILE__), "d", "required.rb"))
 
@@ -21,4 +22,7 @@ assert("Kernel.require") do
 
   # Kernel.require can define a toplevel procedure
   assert_equal :proc0, proc0
+
+  # Kernel.require can add a method to an existing class
+  assert_equal :foo, MrubyRequireClass.new.foo
 end


### PR DESCRIPTION
This PR imports the following bugfix:
https://github.com/iij/mruby-require/commit/78d37057641336cb594ad3be5a728ff6127f9119

Before this patch:
```ruby
require "hoge.rb" # this file defining Hoge class
class Fuga; end
puts Hoge # => Kernel::Hoge
puts Fuga # => Fuga
```
This behavior is a bug because `Hoge` must be defined under top_self like `Fuga`, not under the `Kernel` . This issue makes it impossible to extend existing or built-in classes (without inserting explicit `::` prefix in the class name).

After this patch:
```ruby
require "hoge.rb"
class Fuga; end
puts Hoge # => Hoge
puts Fuga # => Fuga
```

Regarding the effect, strictly speaking, this PR breaks backward compatibility. But IMHO actually problems happen on rare occasion (e.g. using stringified value of required class for something, such as `Hoge.name` or `Hoge.to_s`).