### PR TITLE
mruby sleep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,7 @@ IF (WITH_MRUBY)
         lib/handler/mruby.c
         lib/handler/mruby/chunked.c
         lib/handler/mruby/http_request.c
+        lib/handler/mruby/sleep.c
         lib/handler/configurator/mruby.c)
     SET(STANDALONE_COMPILE_FLAGS "${STANDALONE_COMPILE_FLAGS} -DH2O_USE_MRUBY=1")
 ENDIF (WITH_MRUBY)

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		10FEF24E1D6FC8E200E11B1D /* gkc.c in Sources */ = {isa = PBXBuildFile; fileRef = 10FEF24C1D6FC8E200E11B1D /* gkc.c */; };
 		10FEF24F1D6FC8E200E11B1D /* gkc.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FEF24D1D6FC8E200E11B1D /* gkc.h */; };
 		10FFEE0A1BB23A8C0087AD75 /* neverbleed.c in Sources */ = {isa = PBXBuildFile; fileRef = 10FFEE081BB23A8C0087AD75 /* neverbleed.c */; };
+		7D0285C91EF422D40094292B /* sleep.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D0285C81EF422D40094292B /* sleep.c */; };
 		E90A95F31E30795100483D6C /* headers_util.c in Sources */ = {isa = PBXBuildFile; fileRef = E90A95F21E30795100483D6C /* headers_util.c */; };
 		E90A95F51E30797D00483D6C /* headers_util.c in Sources */ = {isa = PBXBuildFile; fileRef = E90A95F41E30797D00483D6C /* headers_util.c */; };
 		E9708AE01E49A2120029E0A5 /* picotls.h in Headers */ = {isa = PBXBuildFile; fileRef = E9708ADF1E49A2120029E0A5 /* picotls.h */; };
@@ -813,6 +814,7 @@
 		10FEF24D1D6FC8E200E11B1D /* gkc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gkc.h; sourceTree = "<group>"; };
 		10FFEE081BB23A8C0087AD75 /* neverbleed.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = neverbleed.c; sourceTree = "<group>"; };
 		10FFEE091BB23A8C0087AD75 /* neverbleed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neverbleed.h; sourceTree = "<group>"; };
+		7D0285C81EF422D40094292B /* sleep.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sleep.c; sourceTree = "<group>"; };
 		E90A95F21E30795100483D6C /* headers_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = headers_util.c; sourceTree = "<group>"; };
 		E90A95F41E30797D00483D6C /* headers_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = headers_util.c; sourceTree = "<group>"; };
 		E9708AD81E499E040029E0A5 /* cifra.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cifra.c; sourceTree = "<group>"; };
@@ -950,6 +952,7 @@
 				08E9CC4D1E41F6660049DD26 /* embedded.c.h */,
 				100A55141C30C5BC00C4E3E0 /* chunked.c */,
 				100A550E1C2BB15100C4E3E0 /* http_request.c */,
+				7D0285C81EF422D40094292B /* sleep.c */,
 			);
 			path = mruby;
 			sourceTree = "<group>";
@@ -2344,6 +2347,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D0285C91EF422D40094292B /* sleep.c in Sources */,
 				E9708B7C1E52C83D0029E0A5 /* status.c in Sources */,
 				E9708B7D1E52C8430029E0A5 /* durations.c in Sources */,
 				E9708B3F1E52C7860029E0A5 /* send_text.c in Sources */,

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -122,6 +122,7 @@ typedef struct st_h2o_mruby_generator_t {
 #define H2O_MRUBY_CALLBACK_ID_SEND_CHUNKED_EOS -4
 #define H2O_MRUBY_CALLBACK_ID_HTTP_JOIN_RESPONSE -5
 #define H2O_MRUBY_CALLBACK_ID_HTTP_FETCH_CHUNK -6
+#define H2O_MRUBY_CALLBACK_ID_SLEEP -999
 
 #define h2o_mruby_assert(mrb)                                                                                                      \
     if (mrb->exc != NULL)                                                                                                          \
@@ -181,6 +182,10 @@ mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_context_t *ctx, mrb_valu
 
 h2o_mruby_http_request_context_t *h2o_mruby_http_set_shortcut(mrb_state *mrb, mrb_value obj, void (*cb)(h2o_mruby_generator_t *), h2o_mruby_generator_t *generator);
 h2o_buffer_t **h2o_mruby_http_peek_content(h2o_mruby_http_request_context_t *ctx, int *is_final);
+
+/* handler/mruby/sleep.c */
+void h2o_mruby_sleep_init_context(h2o_mruby_shared_context_t *ctx);
+mrb_value h2o_mruby_sleep_callback(h2o_mruby_context_t *mctx, mrb_value receiver, mrb_value args, int *run_again);
 
 /* handler/configurator/mruby.c */
 void h2o_mruby_register_configurator(h2o_globalconf_t *conf);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -284,11 +284,11 @@ static h2o_mruby_shared_context_t *create_shared_context(h2o_context_t *ctx)
 
     h2o_mruby_send_chunked_init_context(shared_ctx);
     h2o_mruby_http_request_init_context(shared_ctx);
+    h2o_mruby_sleep_init_context(shared_ctx);
 
     struct RClass *module = mrb_define_module(shared_ctx->mrb, "H2O");
     struct RClass *generator_klass = mrb_define_class_under(shared_ctx->mrb, module, "Generator", shared_ctx->mrb->object_class);
     mrb_ary_set(shared_ctx->mrb, shared_ctx->constants, H2O_MRUBY_GENERATOR_CLASS, mrb_obj_value(generator_klass));
-
 
     return shared_ctx;
 }
@@ -801,6 +801,9 @@ void h2o_mruby_run_fiber(h2o_mruby_context_t *ctx, mrb_value receiver, mrb_value
                 break;
             case H2O_MRUBY_CALLBACK_ID_HTTP_FETCH_CHUNK:
                 input = h2o_mruby_http_fetch_chunk_callback(ctx, receiver, args, &run_again);
+                break;
+            case H2O_MRUBY_CALLBACK_ID_SLEEP:
+                input = h2o_mruby_sleep_callback(ctx, receiver, args, &run_again);
                 break;
             default:
                 input = mrb_exc_new_str_lit(mrb, E_RUNTIME_ERROR, "unexpected callback id sent from rack app");

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -79,6 +79,9 @@
     "    end\n"                                                                                                                    \
     "    [runner, configurator]\n"                                                                                                 \
     "  end\n"                                                                                                                      \
+    "  def sleep(*sec)\n"                                                                                                          \
+    "    _h2o__sleep(*sec)\n"                                                                                                      \
+    "  end\n"                                                                                                                      \
     "end\n"
 
 /* lib/handler/mruby/embedded/http_request.rb */

--- a/lib/handler/mruby/embedded/core.rb
+++ b/lib/handler/mruby/embedded/core.rb
@@ -102,4 +102,8 @@ module Kernel
     [runner, configurator]
   end
 
+  def sleep(*sec)
+    _h2o__sleep(*sec)
+  end
+
 end

--- a/lib/handler/mruby/sleep.c
+++ b/lib/handler/mruby/sleep.c
@@ -79,7 +79,6 @@ mrb_value h2o_mruby_sleep_callback(h2o_mruby_context_t *mctx, mrb_value receiver
     ctx->ctx = mctx;
     ctx->receiver = receiver;
     h2o_timeout_init(ctx->ctx->shared->ctx->loop, &ctx->timeout, msec);
-    ctx->timeout_entry = (h2o_timeout_entry_t){0};
     ctx->timeout_entry.cb = on_sleep_timeout;
     h2o_timeout_link(ctx->ctx->shared->ctx->loop, &ctx->timeout, &ctx->timeout_entry);
     ctx->started_at = ctx->timeout_entry.registered_at;

--- a/lib/handler/mruby/sleep.c
+++ b/lib/handler/mruby/sleep.c
@@ -66,14 +66,16 @@ mrb_value h2o_mruby_sleep_callback(h2o_mruby_context_t *mctx, mrb_value receiver
     mrb_value arg_sec = mrb_ary_entry(args, 0);
 
     /* convert the argument using to_f */
-    if (! mrb_respond_to(mrb, arg_sec, mrb_intern_lit(mrb, "to_f"))) {
-        *run_again = 1;
-        return mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "the argument of the sleep function must respond to 'to_f' method");
-    }
     arg_sec = mrb_funcall(mrb, arg_sec, "to_f", 0);
+
     if (mrb->exc) {
         *run_again = 1;
-        return mrb_obj_value(mrb->exc);
+        mrb_value exc = mrb_obj_value(mrb->exc);
+        if (mrb_obj_is_kind_of(mrb, exc, E_NOMETHOD_ERROR)) {
+            exc = mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "the argument of the sleep function must respond to 'to_f' method");
+        }
+        mrb->exc = NULL;
+        return exc;
     }
     uint64_t msec = mrb_float(arg_sec) * 1000;
 

--- a/lib/handler/mruby/sleep.c
+++ b/lib/handler/mruby/sleep.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017 Ichito Nagata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/error.h>
+#include "h2o/mruby_.h"
+
+struct st_h2o_mruby_sleep_context_t {
+    h2o_mruby_context_t *ctx;
+    mrb_value receiver;
+    h2o_timeout_t timeout;
+    h2o_timeout_entry_t timeout_entry;
+    uint64_t started_at;
+};
+
+static void on_deferred_timeout(h2o_timeout_entry_t *entry)
+{
+    struct st_h2o_mruby_sleep_context_t *ctx = H2O_STRUCT_FROM_MEMBER(struct st_h2o_mruby_sleep_context_t, timeout_entry, entry);
+    h2o_timeout_dispose(ctx->ctx->shared->ctx->loop, &ctx->timeout);
+    free(ctx);
+}
+
+static void on_sleep_timeout(h2o_timeout_entry_t *entry)
+{
+    struct st_h2o_mruby_sleep_context_t *ctx = H2O_STRUCT_FROM_MEMBER(struct st_h2o_mruby_sleep_context_t, timeout_entry, entry);
+    assert(! mrb_nil_p(ctx->receiver));
+    h2o_mruby_shared_context_t *shared = ctx->ctx->shared;
+    mrb_int sleep_sec = (mrb_int)(h2o_now(shared->ctx->loop) - ctx->started_at) / 1000;
+
+    h2o_mruby_run_fiber(ctx->ctx, ctx->receiver, mrb_fixnum_value(sleep_sec), NULL);
+
+    mrb_gc_unregister(shared->mrb, ctx->receiver);
+    h2o_timeout_unlink(entry);
+
+    /* defer freeing to avoid concurrent modification onf timeout linklist */
+    entry->cb = on_deferred_timeout;
+    h2o_timeout_link(shared->ctx->loop, &shared->ctx->zero_timeout, entry);
+}
+
+mrb_value h2o_mruby_sleep_callback(h2o_mruby_context_t *mctx, mrb_value receiver, mrb_value args, int *run_again)
+{
+    mrb_state *mrb = mctx->shared->mrb;
+
+    if (mrb_ary_len(mrb, args) == 0) {
+        return mrb_nil_value(); /* sleep forever */
+    }
+    mrb_value arg_sec = mrb_ary_entry(args, 0);
+    uint64_t msec;
+    if (mrb_fixnum_p(arg_sec)) {
+        msec = mrb_int(mrb, arg_sec) * 1000;
+    } else if (mrb_float_p(arg_sec)) {
+        msec = mrb_float(arg_sec) * 1000;
+    } else {
+        *run_again = 1;
+        return mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "argument must be either Fixnum or Float");
+    }
+
+    struct st_h2o_mruby_sleep_context_t *ctx = h2o_mem_alloc(sizeof(*ctx));
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->ctx = mctx;
+    ctx->receiver = receiver;
+    h2o_timeout_init(ctx->ctx->shared->ctx->loop, &ctx->timeout, msec);
+    ctx->timeout_entry = (h2o_timeout_entry_t){0};
+    ctx->timeout_entry.cb = on_sleep_timeout;
+    h2o_timeout_link(ctx->ctx->shared->ctx->loop, &ctx->timeout, &ctx->timeout_entry);
+    ctx->started_at = ctx->timeout_entry.registered_at;
+
+    mrb_gc_register(mrb, receiver);
+
+    return mrb_nil_value();
+}
+
+void h2o_mruby_sleep_init_context(h2o_mruby_shared_context_t *ctx)
+{
+    mrb_state *mrb = ctx->mrb;
+
+    h2o_mruby_define_callback(mrb, "_h2o__sleep", H2O_MRUBY_CALLBACK_ID_SLEEP);
+}

--- a/t/50mruby-sleep.t
+++ b/t/50mruby-sleep.t
@@ -1,0 +1,143 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use File::Temp qw(tempdir);
+use Test::More;
+use Time::HiRes;
+use t::Util;
+
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+subtest 'fixnum' => sub {
+    my $server = spawn_h2o(<< "EOT");
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          proc {|env|
+            ret = sleep(1)
+            [200, {}, [ret]]
+          }
+EOT
+    my $st = Time::HiRes::time;
+    (undef, my $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+    my $rtt = Time::HiRes::time - $st;
+    is $body, "1";
+    cmp_ok $rtt, '>=', 1
+};
+
+subtest 'float' => sub {
+    my $server = spawn_h2o(<< "EOT");
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          proc {|env|
+            ret = sleep(0.5)
+            [200, {}, [ret]]
+          }
+EOT
+    my $st = Time::HiRes::time;
+    (undef, my $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+    my $rtt = Time::HiRes::time - $st;
+    is $body, "0";
+    cmp_ok $rtt, '>=', 0.5 
+};
+
+subtest 'configuration phase' => sub {
+    my $server = spawn_h2o(<< "EOT");
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          ret = sleep(0.2)
+          proc {|env|
+            [200, {}, [ret]]
+          }
+EOT
+    (undef, my $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+    is $body, "0";
+};
+
+subtest 'parallel' => sub {
+    my $server = spawn_h2o(<< "EOT");
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          proc {|env|
+            sleep(1)
+            [200, {}, ["hello"]]
+          }
+EOT
+    my $pid = fork or do {
+        (undef, my $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+        is $body, 'hello';
+        exit;
+    };
+    (undef, my $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+    is $body, 'hello';
+    waitpid($pid, 0);
+};
+
+subtest 'is it really non-blocking?' => sub {
+    my $server = spawn_h2o(<< "EOT");
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /foo:
+        mruby.handler: |
+          proc {|env|
+            sleep(1)
+            [200, {}, ["hello"]]
+          }
+      /bar:
+        mruby.handler: |
+          proc {|env|
+            [200, {}, ["hello"]]
+          }
+EOT
+    my $pid = fork or do {
+        run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/foo");
+        exit;
+    };
+    Time::HiRes::sleep(0.5);
+    my $st = Time::HiRes::time;
+    (undef, my $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/bar");
+    my $rtt = Time::HiRes::time - $st;
+    is $body, 'hello';
+    cmp_ok $rtt, '<=', 0.5;
+    waitpid($pid, 0);
+};
+
+subtest 'argument error' => sub {
+    my $server = spawn_h2o(<< "EOT");
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mruby.handler: |
+          proc {|env|
+            ret = sleep(Object.new)
+            [200, {}, [ret]]
+          }
+EOT
+    my ($headers) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+    like $headers, qr{HTTP/[^ ]+ 500\s}is;
+};
+
+done_testing;

--- a/t/50mruby-sleep.t
+++ b/t/50mruby-sleep.t
@@ -132,12 +132,17 @@ hosts:
       /:
         mruby.handler: |
           proc {|env|
-            ret = sleep(Object.new)
-            [200, {}, [ret]]
+            begin
+              ret = sleep(Object.new)
+              [200, {}, [ret]]
+            rescue => e
+              [500, {}, [e.message]]
+            end
           }
 EOT
-    my ($headers) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
+    my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
     like $headers, qr{HTTP/[^ ]+ 500\s}is;
+    like $body, qr{the argument of the sleep function must respond to 'to_f' method}is;
 };
 
 done_testing;


### PR DESCRIPTION
Add `sleep` function to the Kernel.
What drove me to implement this is mainly H2O::Redis reconnect loop, but this can be useful for various situations as pointed out in https://github.com/h2o/h2o/issues/1283

NOTE: This PR is toward https://github.com/h2o/h2o/pull/1173. 