### PR TITLE
fix mruby gc problem for http request context

### DIFF
--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -179,6 +179,7 @@ mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_context_t *ctx, mrb_valu
                                               int *next_action);
 
 h2o_mruby_http_request_context_t *h2o_mruby_http_set_shortcut(mrb_state *mrb, mrb_value obj, void (*cb)(h2o_mruby_generator_t *), h2o_mruby_generator_t *generator);
+void h2o_mruby_http_unset_shortcut(mrb_state *mrb, h2o_mruby_http_request_context_t *ctx, h2o_mruby_generator_t *generator);
 h2o_buffer_t **h2o_mruby_http_peek_content(h2o_mruby_http_request_context_t *ctx, int *is_final);
 
 /* handler/configurator/mruby.c */

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -698,17 +698,10 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
 
     /* use fiber in case we need to call #each */
     if (!mrb_nil_p(body)) {
-        /* check the body hasn't already consumed */
-        mrb_sym consume = mrb_intern_lit(mrb, "consume!");
-        if (mrb_respond_to(mrb, body, consume)) {
-            mrb_funcall_argv(mrb, body, consume, 0, NULL);
-            if (mrb->exc != NULL) {
-                goto GotException;
-            }
-        }
-
-        h2o_start_response(generator->req, &generator->super);
         mrb_value receiver = h2o_mruby_send_chunked_init(generator, body);
+        if (mrb->exc) {
+            goto GotException;
+        }
         if (!mrb_nil_p(receiver)) {
             mrb_value input = mrb_ary_new_capa(mrb, 2);
             mrb_ary_set(mrb, input, 0, body);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -698,6 +698,15 @@ static void send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_
 
     /* use fiber in case we need to call #each */
     if (!mrb_nil_p(body)) {
+        /* check the body hasn't already consumed */
+        mrb_sym consume = mrb_intern_lit(mrb, "consume!");
+        if (mrb_respond_to(mrb, body, consume)) {
+            mrb_funcall_argv(mrb, body, consume, 0, NULL);
+            if (mrb->exc != NULL) {
+                goto GotException;
+            }
+        }
+
         h2o_start_response(generator->req, &generator->super);
         mrb_value receiver = h2o_mruby_send_chunked_init(generator, body);
         if (!mrb_nil_p(receiver)) {

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -31,10 +31,10 @@ struct st_h2o_mruby_chunked_t {
     h2o_doublebuffer_t sending;
     size_t bytes_left; /* SIZE_MAX indicates that the number is undermined */
     enum { H2O_MRUBY_CHUNKED_TYPE_CALLBACK, H2O_MRUBY_CHUNKED_TYPE_SHORTCUT } type;
+    mrb_value body_obj; /* becomes nil on eos */
     union {
         struct {
             h2o_buffer_t *receiving;
-            mrb_value body_obj; /* becomes nil on eos */
         } callback;
         struct {
             h2o_mruby_http_request_context_t *client;
@@ -79,7 +79,7 @@ static void do_proceed(h2o_generator_t *_generator, h2o_req_t *req)
     switch (chunked->type) {
     case H2O_MRUBY_CHUNKED_TYPE_CALLBACK:
         input = &chunked->callback.receiving;
-        is_final = mrb_nil_p(chunked->callback.body_obj);
+        is_final = mrb_nil_p(chunked->body_obj);
         break;
     case H2O_MRUBY_CHUNKED_TYPE_SHORTCUT:
         if (chunked->shortcut.client != NULL) {
@@ -113,6 +113,7 @@ static void on_shortcut_notify(h2o_mruby_generator_t *generator)
         chunked->shortcut.remaining = *input;
         h2o_buffer_init(input, &h2o_socket_buffer_prototype);
         input = &chunked->shortcut.remaining;
+        h2o_mruby_http_unset_shortcut(generator->ctx->shared->mrb, chunked->shortcut.client, generator);
         chunked->shortcut.client = NULL;
     }
 
@@ -125,13 +126,13 @@ static void close_body_obj(h2o_mruby_generator_t *generator)
     h2o_mruby_chunked_t *chunked = generator->chunked;
     mrb_state *mrb = generator->ctx->shared->mrb;
 
-    if (!mrb_nil_p(chunked->callback.body_obj)) {
+    if (!mrb_nil_p(chunked->body_obj)) {
         /* call close and throw away error */
-        if (mrb_respond_to(mrb, chunked->callback.body_obj, generator->ctx->shared->symbols.sym_close))
-            mrb_funcall_argv(mrb, chunked->callback.body_obj, generator->ctx->shared->symbols.sym_close, 0, NULL);
+        if (mrb_respond_to(mrb, chunked->body_obj, generator->ctx->shared->symbols.sym_close))
+            mrb_funcall_argv(mrb, chunked->body_obj, generator->ctx->shared->symbols.sym_close, 0, NULL);
         mrb->exc = NULL;
-        mrb_gc_unregister(mrb, chunked->callback.body_obj);
-        chunked->callback.body_obj = mrb_nil_value();
+        mrb_gc_unregister(mrb, chunked->body_obj);
+        chunked->body_obj = mrb_nil_value();
     }
 }
 
@@ -144,19 +145,21 @@ mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_valu
                               : generator->req->res.content_length;
     generator->super.proceed = do_proceed;
     generator->chunked = chunked;
+    mrb_value ret;
 
     if ((chunked->shortcut.client = h2o_mruby_http_set_shortcut(generator->ctx->shared->mrb, body, on_shortcut_notify, generator)) != NULL) {
         chunked->type = H2O_MRUBY_CHUNKED_TYPE_SHORTCUT;
         chunked->shortcut.remaining = NULL;
         on_shortcut_notify(generator);
-        return mrb_nil_value();
+        ret = mrb_nil_value();
     } else {
         chunked->type = H2O_MRUBY_CHUNKED_TYPE_CALLBACK;
         h2o_buffer_init(&chunked->callback.receiving, &h2o_socket_buffer_prototype);
-        mrb_gc_register(generator->ctx->shared->mrb, body);
-        chunked->callback.body_obj = body;
-        return mrb_ary_entry(generator->ctx->shared->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER);
+        ret = mrb_ary_entry(generator->ctx->shared->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER);
     }
+    mrb_gc_register(generator->ctx->shared->mrb, body);
+    chunked->body_obj = body;
+    return ret;
 }
 
 void h2o_mruby_send_chunked_dispose(h2o_mruby_generator_t *generator)
@@ -168,7 +171,6 @@ void h2o_mruby_send_chunked_dispose(h2o_mruby_generator_t *generator)
     switch (chunked->type) {
     case H2O_MRUBY_CHUNKED_TYPE_CALLBACK:
         h2o_buffer_dispose(&chunked->callback.receiving);
-        close_body_obj(generator);
         break;
     case H2O_MRUBY_CHUNKED_TYPE_SHORTCUT:
         /* note: no need to free reference from chunked->client, since it is disposed at the same moment */
@@ -176,6 +178,10 @@ void h2o_mruby_send_chunked_dispose(h2o_mruby_generator_t *generator)
             h2o_buffer_dispose(&chunked->shortcut.remaining);
         break;
     }
+
+    if (chunked->shortcut.client != NULL)
+        h2o_mruby_http_unset_shortcut(generator->ctx->shared->mrb, chunked->shortcut.client, generator);
+    close_body_obj(generator);
 }
 
 static mrb_value check_precond(mrb_state *mrb, h2o_mruby_generator_t *generator)

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -138,6 +138,13 @@ static void close_body_obj(h2o_mruby_generator_t *generator)
 
 mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_value body)
 {
+    mrb_state *mrb = generator->ctx->shared->mrb;
+
+    h2o_mruby_http_request_context_t *client = h2o_mruby_http_set_shortcut(mrb, body, on_shortcut_notify, generator);
+    if (mrb->exc != NULL) {
+        return mrb_nil_value();
+    }
+
     h2o_mruby_chunked_t *chunked = h2o_mem_alloc_pool(&generator->req->pool, sizeof(*chunked));
     h2o_doublebuffer_init(&chunked->sending, &h2o_socket_buffer_prototype);
     chunked->bytes_left = h2o_memis(generator->req->method.base, generator->req->method.len, H2O_STRLIT("HEAD"))
@@ -147,8 +154,11 @@ mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_valu
     generator->chunked = chunked;
     mrb_value ret;
 
-    if ((chunked->shortcut.client = h2o_mruby_http_set_shortcut(generator->ctx->shared->mrb, body, on_shortcut_notify, generator)) != NULL) {
+    h2o_start_response(generator->req, &generator->super);
+
+    if (client != NULL) {
         chunked->type = H2O_MRUBY_CHUNKED_TYPE_SHORTCUT;
+        chunked->shortcut.client = client;
         chunked->shortcut.remaining = NULL;
         on_shortcut_notify(generator);
         ret = mrb_nil_value();
@@ -157,6 +167,7 @@ mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_valu
         h2o_buffer_init(&chunked->callback.receiving, &h2o_socket_buffer_prototype);
         ret = mrb_ary_entry(generator->ctx->shared->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER);
     }
+
     mrb_gc_register(generator->ctx->shared->mrb, body);
     chunked->body_obj = body;
     return ret;

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -96,7 +96,14 @@
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
     "  class HttpInputStream\n"                                                                                                    \
+    "    def consume!\n"                                                                                                           \
+    "      if @consumed\n"                                                                                                         \
+    "        raise RuntimeError.new('http response body is already consumed')\n"                                                   \
+    "      end\n"                                                                                                                  \
+    "      @consumed = true\n"                                                                                                     \
+    "    end\n"                                                                                                                    \
     "    def each\n"                                                                                                               \
+    "      consume!\n"                                                                                                             \
     "      while c = _h2o__http_fetch_chunk(self)\n"                                                                               \
     "        yield c\n"                                                                                                            \
     "      end\n"                                                                                                                  \

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -96,16 +96,11 @@
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
     "  class HttpInputStream\n"                                                                                                    \
-    "    def consume!\n"                                                                                                           \
-    "      if @consumed\n"                                                                                                         \
-    "        raise RuntimeError.new('http response body is already consumed')\n"                                                   \
-    "      end\n"                                                                                                                  \
-    "      @consumed = true\n"                                                                                                     \
-    "    end\n"                                                                                                                    \
     "    def each\n"                                                                                                               \
-    "      consume!\n"                                                                                                             \
-    "      while c = _h2o__http_fetch_chunk(self)\n"                                                                               \
+    "      first = true\n"                                                                                                         \
+    "      while c = _h2o__http_fetch_chunk(self, first)\n"                                                                        \
     "        yield c\n"                                                                                                            \
+    "        first = false\n"                                                                                                      \
     "      end\n"                                                                                                                  \
     "    end\n"                                                                                                                    \
     "    def join\n"                                                                                                               \

--- a/lib/handler/mruby/embedded/http_request.rb
+++ b/lib/handler/mruby/embedded/http_request.rb
@@ -33,7 +33,14 @@ module H2O
   end
 
   class HttpInputStream
+    def consume!
+      if @consumed
+        raise RuntimeError.new('http response body is already consumed')
+      end
+      @consumed = true
+    end
     def each
+      consume!
       while c = _h2o__http_fetch_chunk(self)
         yield c
       end

--- a/lib/handler/mruby/embedded/http_request.rb
+++ b/lib/handler/mruby/embedded/http_request.rb
@@ -33,16 +33,11 @@ module H2O
   end
 
   class HttpInputStream
-    def consume!
-      if @consumed
-        raise RuntimeError.new('http response body is already consumed')
-      end
-      @consumed = true
-    end
     def each
-      consume!
-      while c = _h2o__http_fetch_chunk(self)
+      first = true
+      while c = _h2o__http_fetch_chunk(self, first)
         yield c
+        first = false
       end
     end
     def join

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -461,6 +461,7 @@ h2o_mruby_http_request_context_t *h2o_mruby_http_set_shortcut(mrb_state *mrb, mr
 
     if ((ctx = mrb_data_check_get_ptr(mrb, obj, &input_stream_type)) == NULL)
         return NULL;
+    assert(ctx->shortcut.generator == NULL);
     ctx->shortcut.notify_cb = cb;
     ctx->shortcut.generator = generator;
     return ctx;
@@ -468,10 +469,9 @@ h2o_mruby_http_request_context_t *h2o_mruby_http_set_shortcut(mrb_state *mrb, mr
 
 void h2o_mruby_http_unset_shortcut(mrb_state *mrb, h2o_mruby_http_request_context_t *ctx, h2o_mruby_generator_t *generator)
 {
-    if (ctx->shortcut.generator == generator) {
-        ctx->shortcut.notify_cb = NULL;
-        ctx->shortcut.generator = NULL;
-    }
+    assert(ctx->shortcut.generator = generator);
+    ctx->shortcut.notify_cb = NULL;
+    ctx->shortcut.generator = NULL;
 }
 
 h2o_buffer_t **h2o_mruby_http_peek_content(h2o_mruby_http_request_context_t *ctx, int *is_final)

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -32,6 +32,7 @@ struct st_h2o_mruby_http_request_context_t {
     h2o_mruby_context_t *ctx;
     h2o_http1client_t *client;
     mrb_value receiver;
+    unsigned consumed : 1; /* flag to check that the response body is consumed only once */
     struct {
         h2o_buffer_t *buf;
         h2o_iovec_t body; /* body.base != NULL indicates that post content exists (and the length MAY be zero) */
@@ -51,7 +52,6 @@ struct st_h2o_mruby_http_request_context_t {
         h2o_mruby_generator_t *generator;
         void (*notify_cb)(h2o_mruby_generator_t *generator);
     } shortcut;
-
 };
 
 static void attach_receiver(struct st_h2o_mruby_http_request_context_t *ctx, mrb_value receiver)
@@ -432,6 +432,11 @@ mrb_value h2o_mruby_http_join_response_callback(h2o_mruby_context_t *mctx, mrb_v
     return mrb_nil_value();
 }
 
+static mrb_value create_already_consumed_error(mrb_state *mrb)
+{
+    return mrb_exc_new_str_lit(mrb, E_RUNTIME_ERROR, "http response body is already consumed");
+}
+
 mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_context_t *mctx, mrb_value receiver, mrb_value args,
                                               int *run_again)
 {
@@ -442,6 +447,16 @@ mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_context_t *mctx, mrb_val
     if ((ctx = mrb_data_check_get_ptr(mrb, mrb_ary_entry(args, 0), &input_stream_type)) == NULL) {
         *run_again = 1;
         return mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "_HttpInputStream#each wrong self");
+    }
+
+    mrb_value first = mrb_ary_entry(args, 1);
+    if (mrb_bool(first)) {
+        /* check the body hasn't already consumed */
+        if (ctx->consumed) {
+            *run_again = 1;
+            return create_already_consumed_error(mrb);
+        }
+        ctx->consumed = 1;
     }
 
     if (ctx->resp.has_content) {
@@ -457,10 +472,18 @@ mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_context_t *mctx, mrb_val
 
 h2o_mruby_http_request_context_t *h2o_mruby_http_set_shortcut(mrb_state *mrb, mrb_value obj, void (*cb)(h2o_mruby_generator_t *), h2o_mruby_generator_t *generator)
 {
+    assert(mrb->exc == NULL);
     struct st_h2o_mruby_http_request_context_t *ctx;
 
     if ((ctx = mrb_data_check_get_ptr(mrb, obj, &input_stream_type)) == NULL)
         return NULL;
+
+    if (ctx->consumed) {
+        mrb->exc = mrb_ptr(create_already_consumed_error(mrb));
+        return NULL;
+    }
+    ctx->consumed = 1;
+
     assert(ctx->shortcut.generator == NULL);
     ctx->shortcut.notify_cb = cb;
     ctx->shortcut.generator = generator;

--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -110,14 +110,25 @@ hosts:
             resp[2] = ESIResponse.new(resp[2].join)
             resp
           end
-      /fast-path-partial:
+      /partial:
         mruby.handler: |
+          class PartialBody
+            def initialize(body)
+              \@body = body
+            end
+            def each
+             \@body.each {|buf|
+               if \@first_received
+                 yield buf
+               else
+                 \@first_received = true
+               end
+             }
+            end
+          end
           Proc.new do |env|
             resp = http_request("http://$upstream_hostport/streaming-body").join
-            resp[2].each do |x|
-              break
-            end
-            resp
+            [resp[0], resp[1], PartialBody.new(resp[2])]
           end
       /async-delegate:
         mruby.handler: |
@@ -204,8 +215,8 @@ run_with_curl($server, sub {
         like $headers, qr{HTTP/[^ ]+ 200\s}is;
         is $body, "Hello to the world, from H2O!\n";
     };
-    subtest "fast-path-partial" => sub {
-        my ($headers, $body) = run_prog("$curl_cmd $proto://127.0.0.1:$port/fast-path-partial/");
+    subtest "partial" => sub {
+        my ($headers, $body) = run_prog("$curl_cmd $proto://127.0.0.1:$port/partial/");
         like $headers, qr{HTTP/[^ ]+ 200\s}is;
         is $body, join "", 2..30;
     };
@@ -251,6 +262,80 @@ EOT
             is $body, "hello\n";
         };
     });
+};
+
+subtest 'double consume' => sub {
+    my $upstream = create_upstream();
+    my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        return << "EOT";
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /check-alive:
+        mruby.handler: proc { [200, {}, []] }
+      /join-join:
+        mruby.handler: |
+          Proc.new do |env|
+            resp = http_request("http://$upstream_hostport/index.txt").join
+            resp[2].join
+            resp[2].join
+            [200, {}, []]
+          end
+      /join-chunked:
+        mruby.handler: |
+          Proc.new do |env|
+            resp = http_request("http://$upstream_hostport/index.txt").join
+            resp[2].join
+            [200, {}, resp[2]]
+          end
+      /chunked-join:
+        mruby.handler: |
+          resp = nil
+          Proc.new do |env|
+            if resp
+              resp[2].join
+            else
+              resp = http_request("http://$upstream_hostport/index.txt").join
+            end
+            [200, {}, resp[2]]
+          end
+      /chunked-chunked:
+        mruby.handler: |
+          resp = nil
+          Proc.new do |env|
+            resp ||= http_request("http://$upstream_hostport/index.txt").join
+            [200, {}, resp[2]]
+          end
+EOT
+    });
+
+    my $tester = sub {
+        local $Test::Builder::Level = $Test::Builder::Level + 1;
+        my ($path, $expected) = @_;
+        my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:@{[$server->{port}]}$path");
+        like $headers, qr{HTTP/[^ ]+ $expected\s}is;
+    };
+
+    subtest "join-join" => sub {
+        $tester->('/join-join', 500);
+        $tester->('/check-alive', 200);
+    };
+    subtest "join-chunked" => sub {
+        $tester->('/join-chunked', 500);
+        $tester->('/check-alive', 200);
+    };
+    subtest "chunked-join" => sub {
+        $tester->('/chunked-join', 200);
+        $tester->('/chunked-join', 500);
+        $tester->('/check-alive', 200);
+    };
+    subtest "chunked-chunked" => sub {
+        $tester->('/chunked-chunked', 200);
+        $tester->('/chunked-chunked', 500);
+        $tester->('/check-alive', 200);
+    };
 };
 
 done_testing();


### PR DESCRIPTION
This PR contains 2 fixes of mruby related bugs.

The first is, `h2o_mruby_http_request_context_t` (req-ctx) gets released unexpectedly when fast-path body streaming is used. After https://github.com/h2o/h2o/pull/1173, the lifecycle of req-ctx is not bound to the request lifetime, so we have to keep the HttpInputStream object from gc (as [slow-path does](https://github.com/h2o/h2o/blob/master/lib/handler/mruby/chunked.c#L156)). But it was forgotten, so as a result, occasionally req-ctx and http1client_t is freed and badaccess crashes happen when chunked body streaming is processed. To fix this issue I retained the body obj until generator->chunked is disposed, and added an additional assertion in
req-ctx disposal. The newly added `h2o_mruby_http_unset_shortcut` function is for clearing the reference to the generator for shortcut, that is for assertion and preventing non-alive reference.

The second, a bit related to the first one, is if the body streaming (both of fast and slow path) gets started while another request is already streaming it, the first request doesn't receive remained response anymore and wait it forever. Basically the streaming shouldn't be invoked multiple times, so I added additional checking and marking method `consume!`, which raises a RuntimeError when it has already started body streaming once.