### PR TITLE
Fix fuzz driver (hopefully)

### DIFF
--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -165,13 +165,19 @@ void *upstream_thread(void *arg)
     char rbuf[1 * 1024 * 1024];
     snprintf(path, sizeof(path), "/%s/_.sock", dirname);
     int sd = socket(AF_UNIX, SOCK_STREAM, 0);
-    assert(sd >= 0);
+    if (sd < 0) {
+        abort();
+    }
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
     strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
-    assert(bind(sd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
-    assert(listen(sd, 100) == 0);
+    if (bind(sd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        abort();
+    }
+    if (listen(sd, 100) != 0) {
+        abort();
+    }
 
     while (1) {
         struct sockaddr_un caddr;
@@ -287,7 +293,9 @@ static int create_accepted(int sfd, char *buf, size_t len, pthread_barrier_t **b
 
     /* Create an HTTP[/2] client that will send the fuzzed request */
     fd = feeder(sfd, buf, len, barrier);
-    assert(fd >= 0);
+    if (fd < 0) {
+        abort();
+    }
 
     /* Pass the server socket to h2o and invoke request processing */
     sock = h2o_evloop_socket_create(ctx.loop, fd, H2O_SOCKET_FLAG_IS_ACCEPTED_CONNECTION);
@@ -350,8 +358,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT(unix_listener)), 65535);
         register_handler(hostconf, "/chunked-test", chunked_test);
         h2o_url_parse(unix_listener, strlen(unix_listener), &upstream);
-        void h2o_proxy_register_reverse_proxy(h2o_pathconf_t * pathconf, h2o_url_t * upstream, h2o_proxy_config_vars_t * config);
-        h2o_proxy_register_reverse_proxy(h2o_config_register_path(hostconf, "/reproxy-test", 0), &upstream, &proxy_config);
+        h2o_proxy_register_reverse_proxy(h2o_config_register_path(hostconf, "/reproxy-test", 0), &upstream, 1, &proxy_config);
         h2o_file_register(h2o_config_register_path(hostconf, "/", 0), "./examples/doc_root", NULL, NULL, 0);
 
         loop = h2o_evloop_create();
@@ -361,9 +368,15 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         accept_ctx.hosts = config.hosts;
 
         /* Create a thread to act as the HTTP client */
-        assert(socketpair(AF_UNIX, SOCK_STREAM, 0, job_queue) == 0);
-        assert(pthread_create(&twriter, NULL, writer_thread, (void *)(long)job_queue[1]) == 0);
-        assert(pthread_create(&tupstream, NULL, upstream_thread, dirname) == 0);
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, job_queue) != 0) {
+            abort();
+        }
+        if (pthread_create(&twriter, NULL, writer_thread, (void *)(long)job_queue[1]) != 0) {
+            abort();
+        }
+        if (pthread_create(&tupstream, NULL, upstream_thread, dirname) != 0) {
+            abort();
+        }
         init_done = 1;
     }
 


### PR DESCRIPTION
Hello,

The h2o fuzz drivers can't be built in the latest commit to master (issue [here](https://github.com/google/oss-fuzz/issues/704)). This PR seems to fix the problem, but I ran into some odd behavior along the way: please read on.

The fuzz integration broke because the prototype for `h2o_proxy_register_reverse_proxy` changed. I updated the function invocation in the fuzz driver to fix the compile error (assuming `1` was the proper argument in this case), but this caused the first iteration of fuzzing to fail with an `abort`. The `abort` is raised by the `write_fully` function (which writes the fuzzed input the socket passed to h2o "server") due to a socket error.

```
Using seed corpus: ./h2o-fuzzer-http2_seed_corpus.zip
/out/./h2o-fuzzer-http2 -rss_limit_mb=2048 -timeout=25 /tmp/input -close_fd_mask=3 -max_len=16384 -dict=http.dict < /dev/null
Dictionary: 126 entries
INFO: Seed: 3505464597
INFO: Loaded 1 modules (8780 guards): [0xbb5650, 0xbbdf80),
Loading corpus dir: /tmp/input
Loaded 1024/1402 files from /tmp/input
#0	READ units: 1402
=================================================================
==14==ERROR: AddressSanitizer: ABRT on unknown address 0x00000000000e (pc 0x7f7f55e6c428 bp 0x7ffd33e97eb0 sp 0x7ffd33e97cc8 T0)
SCARINESS: 10 (signal)
    #0 0x7f7f55e6c427 in gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x35427)
    #1 0x7f7f55e6e029 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x37029)
    #2 0x58456d in write_fully /src/h2o/fuzz/driver.cc:147:17
    #3 0x58456d in feeder /src/h2o/fuzz/driver.cc:284
    #4 0x58456d in create_accepted /src/h2o/fuzz/driver.cc:300
    #5 0x58456d in LLVMFuzzerTestOneInput /src/h2o/fuzz/driver.cc:388
    #6 0x680af9 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:460:13
    #7 0x68058e in fuzzer::Fuzzer::ShuffleAndMinimize(std::__1::vector<std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >, std::__1::allocator<std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > > >*) /src/libfuzzer/FuzzerLoop.cpp:377:3
    #8 0x6638e3 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:742:6
    #9 0x657878 in main /src/libfuzzer/FuzzerMain.cpp:20:10
    #10 0x7f7f55e5782f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #11 0x489dc8 in _start (/out/h2o-fuzzer-http2+0x489dc8)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: ABRT (/lib/x86_64-linux-gnu/libc.so.6+0x35427) in gsignal
==14==ABORTING
MS: 0 ; base unit: 0000000000000000000000000000000000000000


artifact_prefix='./'; Test unit written to ./crash-da39a3ee5e6b4b0d3255bfef95601890afd80709
Base64:
```

As I was debugging I patched the fuzz driver to print the socket file descriptor numbers to stdout (see debug version [here](https://github.com/jfoote/h2o/blob/debug-fuzz/fuzz/driver.cc#L366-L367)). The one-time call to `socketpair` that initializes the `job_queue` socket vector is wrapped in an `assert`, but oddly in newer versions of h2o both sockets are still set to `0` after the call. This could be the culprit as the `oss-fuzz` environment is configured to close stdout and stdin for the fuzz driver, which could cause the writes to fail. 

Here is output showing the socket FDs being set to `0` (look for `job_queue={0, 0}`):

```
root@008220b13b7d:/out# echo "foo" > tt
root@008220b13b7d:/out# /out/./h2o-fuzzer-http2 -rss_limit_mb=2048 -timeout=25 ./tt -max_len=16384 -dict=http.dict < /dev/null
Dictionary: 126 entries
INFO: Seed: 1290788959
INFO: Loaded 1 modules (8780 guards): [0xbb5650, 0xbbdf80),
/out/./h2o-fuzzer-http2: Running 1 inputs 1 time(s) each.
Running: ./tt
job_queue={0, 0}
pair={6, 7}
ASAN:DEADLYSIGNAL
=================================================================
==50==ERROR: AddressSanitizer: ABRT on unknown address 0x000000000032 (pc 0x7fa3ff41a428 bp 0x7ffe78a91350 sp 0x7ffe78a91168 T0)
SCARINESS: 10 (signal)
    #0 0x7fa3ff41a427 in gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x35427)
    #1 0x7fa3ff41c029 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x37029)
    #2 0x58456d in write_fully /src/h2o/fuzz/driver.cc:147:17
    #3 0x58456d in feeder /src/h2o/fuzz/driver.cc:284
    #4 0x58456d in create_accepted /src/h2o/fuzz/driver.cc:300
    #5 0x58456d in LLVMFuzzerTestOneInput /src/h2o/fuzz/driver.cc:387
    #6 0x680af9 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:460:13
    #7 0x68132a in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:399:3
    #8 0x658266 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/libfuzzer/FuzzerDriver.cpp:268:6
    #9 0x6633d0 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:683:9
    #10 0x657878 in main /src/libfuzzer/FuzzerMain.cpp:20:10
    #11 0x7fa3ff40582f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #12 0x489dc8 in _start (/out/h2o-fuzzer-http2+0x489dc8)



AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: ABRT (/lib/x86_64-linux-gnu/libc.so.6+0x35427) in gsignal
==50==ABORTING
MS: 0 ; base unit: 0000000000000000000000000000000000000000
0x66,0x6f,0x6f,0xa,
foo\x0a
```

For comparison, here is similar output from a similarly patched fuzz driver built on an older version of the h2o (I tried this to help eliminate a change to the oss-fuzz environment as the cause):

```
root@0241acce99f5:/src/h2o# /out/h2o-fuzzer-http2
INFO: Seed: 1512827089
INFO: Loaded 1 modules (7660 guards): [0xb892d0, 0xb90a80),
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#0	READ units: 1
job_queue={6, 7}
pair={9, 10}
pair={9, 10}
#1	INITED cov: 442 ft: 156 corp: 1/1b exec/s: 0 rss: 33Mb
pair={9, 10}
pair={9, 10}
pair={9, 10}
```

After some additional tinkering, I found that when I add the `-DCMAKE_BUILD_TYPE=debug` flag to the h2o fuzzer build, the problem goes away (the `socketpair` call returns non-zero FD numbers, similar to the output directly above). So, this patch to h2o along with a pull request to [oss-fuzz](https://github.com/google/oss-fuzz) to configure a debug build of the fuzz driver should resolve the issue for now, but I am not completely satisfied with the solution because I don't understand why the `job_queue` FDs seem to be incorrect after the call to `socketpair`. Any ideas?

On a related note, I have been meaning to upgrade the h2o oss-fuzz integration st. the fuzz driver is checked as part of CI -- I will likely take this as impetus to make a PR for this soon.