### PR TITLE
add modern default ciphers to example configs

### DIFF
--- a/examples/h2o/h2o.conf
+++ b/examples/h2o/h2o.conf
@@ -6,6 +6,11 @@ listen:
   ssl:
     certificate-file: examples/h2o/server.crt
     key-file: examples/h2o/server.key
+    minimum-version: TLSv1.2
+    cipher-preference: server
+    cipher-suite: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+    # Oldest compatible clients: Firefox 27, Chrome 30, IE 11 on Windows 7, Edge, Opera 17, Safari 9, Android 5.0, and Java 8
+    # see: https://wiki.mozilla.org/Security/Server_Side_TLS
 hosts:
   "127.0.0.1.xip.io:8080":
     paths:

--- a/examples/h2o_mruby/h2o.conf
+++ b/examples/h2o_mruby/h2o.conf
@@ -6,6 +6,11 @@ listen:
   ssl:
     certificate-file: examples/h2o/server.crt
     key-file: examples/h2o/server.key
+    minimum-version: TLSv1.2
+    cipher-preference: server
+    cipher-suite: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+    # Oldest compatible clients: Firefox 27, Chrome 30, IE 11 on Windows 7, Edge, Opera 17, Safari 9, Android 5.0, and Java 8
+    # see: https://wiki.mozilla.org/Security/Server_Side_TLS
 hosts:
   "127.0.0.1.xip.io:8080":
     paths:

--- a/srcdoc/configure/base_directives.mt
+++ b/srcdoc/configure/base_directives.mt
@@ -170,7 +170,7 @@ The <code style="font-weight: bold;">ssl</code> attribute must be defined as a m
 minimum protocol version, should be one of: <code>SSLv2</code>, <code>SSLv3</code>, <code>TLSv1</code>, <code>TLSv1.1</code>, <code>TLSv1.2</code>.
 Default is <code>TLSv1</code>
 </dd>
-<dt id="min-version">min-verison:</dt>
+<dt id="min-version">min-version:</dt>
 <dd>
 synonym of <code>minimum-version</code> (introduced in version 2.2)
 </dd>


### PR DESCRIPTION
since https://github.com/h2o/h2o/pull/1334 hasn't found an agreement we should at least encourage people to take modern defaults.