### PR TITLE
Fix cmake build issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,9 +575,10 @@ ENDIF ()
 
 IF (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get/CMakeLists.txt)
     ExternalProject_Add(h2get
+                        CONFIGURE_COMMAND cmake -DH2GET_SSL_ROOT_DIR=${H2GET_SSL_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get
                         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get
                         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/h2get_bin
-                        BUILD_COMMAND cmake -DH2GET_SSL_ROOT_DIR=${H2GET_SSL_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get && make
+                        BUILD_COMMAND make
                         INSTALL_COMMAND true)
     SET_TARGET_PROPERTIES(h2get PROPERTIES EXCLUDE_FROM_ALL TRUE)
     IF (WITH_BUNDLED_SSL)


### PR DESCRIPTION
This is due to a cmake oddity: when CONFIGURE_COMMAND is not set,
`ExternalProject_Add` defaults to running cmake with no arguments.