### PR TITLE
Force cpan.metacpan.org as a CPAN mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: cpp
 compiler:
   - gcc
 
+env:
+  - PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
+
 addons:
   hosts:
     - 127.0.0.1.xip.io


### PR DESCRIPTION
For some reason, cpanm in h2o builds tend to consistently hit
search.cpan.org as a CPAN mirror, but that mirror is unfortunately
unreliable, timing out often after connection.

This commit forces the CPAN mirror to be cpan.metacpan.org, which is
backed by Fastly, and can be reached via https:
```
cpan.metacpan.org.      2418    IN      CNAME dualstack.a.ssl.global.fastly.net.
dualstack.a.ssl.global.fastly.net. 30 IN A      151.101.40.249
```