### PR TITLE
backport MRB_INT64 usage

### DIFF
--- a/deps/mruby/include/mrbconf.h
+++ b/deps/mruby/include/mrbconf.h
@@ -34,6 +34,17 @@
 /* add -DMRB_INT64 to use 64bit integer for mrb_int; conflict with MRB_INT16 */
 //#define MRB_INT64
 
+/* if no specific integer type is chosen */
+#if !defined(MRB_INT16) && !defined(MRB_INT32) && !defined(MRB_INT64)
+# if defined(MRB_64BIT) && !defined(MRB_NAN_BOXING)
+/* Use 64bit integers on 64bit architecture (without MRB_NAN_BOXING) */
+#  define MRB_INT64
+# else
+/* Otherwise use 32bit integers */
+#  define MRB_INT32
+# endif
+#endif
+
 /* represent mrb_value in boxed double; conflict with MRB_USE_FLOAT */
 //#define MRB_NAN_BOXING
 


### PR DESCRIPTION
see https://github.com/mruby/mruby/commit/f0f4a1088a270e339407a24ffe8be748f4764fc2

(fixes https://github.com/h2o/h2o/issues/1394 )