### PR TITLE
Dynamic backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ SET(LIB_SOURCE_FILES
     lib/core/config.c
     lib/core/configurator.c
     lib/core/context.c
+    lib/core/dyn_backends.c
     lib/core/headers.c
     lib/core/logconf.c
     lib/core/proxy.c

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1830,6 +1830,11 @@ void h2o_headers_register_configurator(h2o_globalconf_t *conf);
 
 /* lib/proxy.c */
 
+/**
+ * A callback to be able to override the destination url on a per-request basis
+ */
+typedef int (*h2o_proxy_get_upstream)(h2o_handler_t *, h2o_req_t *, h2o_url_t **, h2o_socketpool_t **, void *ctx);
+
 typedef struct st_h2o_proxy_config_vars_t {
     uint64_t io_timeout;
     unsigned preserve_host : 1;
@@ -1845,8 +1850,13 @@ typedef struct st_h2o_proxy_config_vars_t {
     unsigned registered_as_url : 1;
     unsigned registered_as_backends : 1;
     SSL_CTX *ssl_ctx; /* optional */
+    struct {
+        h2o_proxy_get_upstream cb;
+        void *ctx;
+    } get_upstream;
 } h2o_proxy_config_vars_t;
 
+int h2o_proxy_url_get_upstream(h2o_handler_t *self, h2o_req_t *req, h2o_url_t **upstream, h2o_socketpool_t **sockpool, void *ctx);
 /**
  * registers the reverse proxy handler to the context
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -302,7 +302,7 @@ typedef struct st_h2o_status_handler_t {
     h2o_iovec_t name;
     void *(*init)(void); /* optional callback, allocates a context that will be passed to per_thread() */
     void (*per_thread)(void *priv, h2o_context_t *ctx); /* optional callback, will be called for each thread */
-    h2o_iovec_t (* final)(void *ctx, h2o_globalconf_t *gconf, h2o_req_t *req); /* mandatory, will be passed the optional context */
+    h2o_iovec_t (*final)(void *ctx, h2o_globalconf_t *gconf, h2o_req_t *req); /* mandatory, will be passed the optional context */
 } h2o_status_handler_t;
 
 typedef H2O_VECTOR(h2o_status_handler_t) h2o_status_callbacks_t;
@@ -1860,7 +1860,8 @@ int h2o_proxy_url_get_upstream(h2o_handler_t *self, h2o_req_t *req, h2o_url_t **
 /**
  * registers the reverse proxy handler to the context
  */
-void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstreams, size_t count, h2o_proxy_config_vars_t *config);
+void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstreams, size_t count,
+                                      h2o_proxy_config_vars_t *config);
 /**
  * registers the configurator
  */
@@ -2125,11 +2126,12 @@ static inline void h2o_doublebuffer_consume(h2o_doublebuffer_t *db)
     }
 
 COMPUTE_DURATION(connect_time, &req->conn->connected_at, &req->timestamps.request_begin_at);
-COMPUTE_DURATION(header_time, &req->timestamps.request_begin_at, h2o_timeval_is_null(&req->timestamps.request_body_begin_at)
-                                                                     ? &req->processed_at.at
-                                                                     : &req->timestamps.request_body_begin_at);
-COMPUTE_DURATION(body_time, h2o_timeval_is_null(&req->timestamps.request_body_begin_at) ? &req->processed_at.at
-                                                                                        : &req->timestamps.request_body_begin_at,
+COMPUTE_DURATION(header_time, &req->timestamps.request_begin_at,
+                 h2o_timeval_is_null(&req->timestamps.request_body_begin_at) ? &req->processed_at.at
+                                                                             : &req->timestamps.request_body_begin_at);
+COMPUTE_DURATION(body_time,
+                 h2o_timeval_is_null(&req->timestamps.request_body_begin_at) ? &req->processed_at.at
+                                                                             : &req->timestamps.request_body_begin_at,
                  &req->processed_at.at);
 COMPUTE_DURATION(request_total_time, &req->timestamps.request_begin_at, &req->processed_at.at);
 COMPUTE_DURATION(process_time, &req->processed_at.at, &req->timestamps.response_start_at);

--- a/include/h2o/dyn_backends.h
+++ b/include/h2o/dyn_backends.h
@@ -1,0 +1,13 @@
+#ifndef FASTLY_BACKENDS_H_
+#define FASTLY_BACKENDS_H_
+
+#include "h2o/url.h"
+#include "h2o/socketpool.h"
+
+typedef struct st_h2o_dyn_backend_config_t {
+    h2o_url_t upstream;
+} h2o_dyn_backend_config_t;
+const char *h2o_dyn_backend_add(const char *id, h2o_dyn_backend_config_t *config);
+int h2o_dyn_backend_get_upstream(h2o_handler_t *h, h2o_req_t *req, h2o_url_t **upstream, h2o_socketpool_t **pool, void *ctx);
+
+#endif /* FASTLY_BACKENDS_H_ */

--- a/lib/core/dyn_backends.c
+++ b/lib/core/dyn_backends.c
@@ -1,0 +1,101 @@
+#include "h2o.h"
+#include "h2o/dyn_backends.h"
+
+#include "khash.h"
+
+
+KHASH_MAP_INIT_STR(backends, h2o_socketpool_t *);
+
+struct st_backend_t {
+    char id[64];
+    int timeout_set;
+    struct sockaddr_storage ss;
+    socklen_t sslen;
+    h2o_url_t upstream;
+    h2o_socketpool_t sockpool;
+};
+static khash_t(backends) *backends;
+
+const char *h2o_dyn_backend_add(const char *id, h2o_dyn_backend_config_t *config)
+{
+    khint_t k;
+    struct st_backend_t *backend = h2o_mem_alloc(sizeof(*backend));
+    struct sockaddr_in sin;
+    struct sockaddr_un sa;
+    const char *to_sa_err;
+    int is_ssl;
+
+    if (!backends) {
+        backends = kh_init(backends);
+    }
+    memset(&sin, 0, sizeof(sin));
+    memset(backend, 0, sizeof(*backend));
+
+    is_ssl = config->upstream.scheme == &H2O_URL_SCHEME_HTTPS;
+    to_sa_err = h2o_url_host_to_sun(config->upstream.host, &sa);
+    if (to_sa_err == h2o_url_host_to_sun_err_is_not_unix_socket) {
+        h2o_socketpool_init_by_hostport(&backend->sockpool, config->upstream.host, h2o_url_get_port(&config->upstream), is_ssl,
+                SIZE_MAX /* FIXME */);
+    } else {
+        assert(to_sa_err == NULL);
+        h2o_socketpool_init_by_address(&backend->sockpool, (void *)&sa, sizeof(sa), is_ssl, SIZE_MAX /* FIXME */);
+    }
+
+    if (strlen(id) + 1 > sizeof(backend->id)) {
+        goto err;
+    }
+
+    memcpy(backend->id, id, strlen(id));
+    k = kh_get(backends, backends, backend->id);
+    if (k != kh_end(backends)) {
+        goto err;
+    }
+
+    h2o_url_copy(NULL, &backend->upstream, &config->upstream);
+    int ret;
+    k = kh_put(backends, backends, backend->id, &ret);
+    kh_val(backends, k) = &backend->sockpool;
+    return backend->id;
+
+err:
+    h2o_socketpool_dispose(&backend->sockpool);
+    free(backend);
+    return NULL;
+}
+
+int h2o_dyn_backend_get_upstream(h2o_handler_t *h, h2o_req_t *req, h2o_url_t **upstream, h2o_socketpool_t **pool, void *ctx)
+{
+    khint_t k;
+    struct st_backend_t *backend;
+    h2o_iovec_t *bid_header = ctx;
+    h2o_iovec_t id = {};
+    char *p;
+    ssize_t bid;
+
+    if (!bid_header->base)
+        return -1;
+
+    if ((bid = h2o_find_header_by_str(&req->headers, bid_header->base, bid_header->len, -1)) != -1) {
+        if (req->headers.entries[bid].value.base)
+            id = h2o_strdup(&req->pool, req->headers.entries[bid].value.base, req->headers.entries[bid].value.len);
+    }
+    if (!id.base)
+        return -1;
+
+    p = memchr(id.base, '\r', id.len);
+    if (p)
+        *p = '\0';
+
+    k = kh_get(backends, backends, id.base);
+    if (k == kh_end(backends))
+        return -1;
+
+    backend = H2O_STRUCT_FROM_MEMBER(struct st_backend_t, sockpool, kh_val(backends, k));
+    *upstream = &backend->upstream;
+    *pool = &backend->sockpool;
+
+    if (backend->sockpool._interval_cb.loop == NULL)
+        h2o_socketpool_set_timeout(&backend->sockpool, req->conn->ctx->loop, 5000);
+
+    return 0;
+}

--- a/lib/core/dyn_backends.c
+++ b/lib/core/dyn_backends.c
@@ -3,7 +3,6 @@
 
 #include "khash.h"
 
-
 KHASH_MAP_INIT_STR(backends, h2o_socketpool_t *);
 
 struct st_backend_t {
@@ -14,7 +13,7 @@ struct st_backend_t {
     h2o_url_t upstream;
     h2o_socketpool_t sockpool;
 };
-static khash_t(backends) *backends;
+static khash_t(backends) * backends;
 
 const char *h2o_dyn_backend_add(const char *id, h2o_dyn_backend_config_t *config)
 {
@@ -35,7 +34,7 @@ const char *h2o_dyn_backend_add(const char *id, h2o_dyn_backend_config_t *config
     to_sa_err = h2o_url_host_to_sun(config->upstream.host, &sa);
     if (to_sa_err == h2o_url_host_to_sun_err_is_not_unix_socket) {
         h2o_socketpool_init_by_hostport(&backend->sockpool, config->upstream.host, h2o_url_get_port(&config->upstream), is_ssl,
-                SIZE_MAX /* FIXME */);
+                                        SIZE_MAX /* FIXME */);
     } else {
         assert(to_sa_err == NULL);
         h2o_socketpool_init_by_address(&backend->sockpool, (void *)&sa, sizeof(sa), is_ssl, SIZE_MAX /* FIXME */);

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -281,11 +281,12 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
 
     if (self->vars->keepalive_timeout != 0 && self->vars->use_proxy_protocol) {
         h2o_configurator_errprintf(cmd, node, "please either set `proxy.use-proxy-protocol` to `OFF` or disable keep-alive by "
-                                   "setting `proxy.timeout.keepalive` to zero; the features are mutually exclusive");
+                                              "setting `proxy.timeout.keepalive` to zero; the features are mutually exclusive");
         return -1;
     }
     if (self->vars->reverse_path.base != NULL || self->vars->registered_as_backends) {
-        h2o_configurator_errprintf(cmd, node, "please either set `proxy.reverse.backends` with `proxy.reverse.path` to support "
+        h2o_configurator_errprintf(cmd, node,
+                                   "please either set `proxy.reverse.backends` with `proxy.reverse.path` to support "
                                    "multiple backends or only set `proxy.reverse.url`; the features are mutually exclusive");
         return -1;
     }
@@ -363,12 +364,14 @@ static int on_config_reverse_backends(h2o_configurator_command_t *cmd, h2o_confi
     }
 
     if (self->vars->use_proxy_protocol) {
-        h2o_configurator_errprintf(cmd, node, "currently we do not support multiple backends with `proxy.use-proxy-protocol` enabled");
+        h2o_configurator_errprintf(cmd, node,
+                                   "currently we do not support multiple backends with `proxy.use-proxy-protocol` enabled");
         return -1;
     }
-    
+
     if (self->vars->registered_as_url) {
-        h2o_configurator_errprintf(cmd, node, "please either set `proxy.reverse.backends` with `proxy.reverse.path` to support "
+        h2o_configurator_errprintf(cmd, node,
+                                   "please either set `proxy.reverse.backends` with `proxy.reverse.path` to support "
                                    "multiple backends or only set `proxy.reverse.url`; the features are mutually exclusive");
         return -1;
     }
@@ -453,7 +456,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 
     if (self->vars->headers_cmds != NULL)
         h2o_mem_release_shared(self->vars->headers_cmds);
-    
+
     if (self->vars->reverse_path.base != NULL)
         free(self->vars->reverse_path.base);
 
@@ -478,17 +481,17 @@ static int on_config_backend(h2o_configurator_command_t *cmd, h2o_configurator_c
         return -1;
     }
 
-    if ((turl = yoml_get(node, "url")) == NULL) {                                                                                  \
+    if ((turl = yoml_get(node, "url")) == NULL) {
         fprintf(stderr, "%s: missing mandatory attribute `url`\n", __func__);
         return -1;
     }
-    if ((tid = yoml_get(node, "id")) == NULL) {                                                                                  \
+    if ((tid = yoml_get(node, "id")) == NULL) {
         fprintf(stderr, "%s: missing mandatory attribute `id`\n", __func__);
         return -1;
     }
 
     h2o_dyn_backend_config_t bconfig;
-    ret = h2o_url_parse(turl->data.scalar,strlen(turl->data.scalar), &bconfig.upstream);
+    ret = h2o_url_parse(turl->data.scalar, strlen(turl->data.scalar), &bconfig.upstream);
     if (ret < 0) {
         fprintf(stderr, "%s: failed to parse url\n", __func__);
         return -1;
@@ -516,14 +519,15 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
     /* setup handlers */
     c->super.enter = on_config_enter;
     c->super.exit = on_config_exit;
-    h2o_configurator_define_command(
-        &c->super, "proxy.reverse.url",
-        H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR | H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING | H2O_CONFIGURATOR_FLAG_DEFERRED, on_config_reverse_url);
+    h2o_configurator_define_command(&c->super, "proxy.reverse.url",
+                                    H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR |
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING | H2O_CONFIGURATOR_FLAG_DEFERRED,
+                                    on_config_reverse_url);
     /* if reverse proxy with multiple backends, they should be equivalent. then use backends & path instead of url. */
-    h2o_configurator_define_command(
-        &c->super, "proxy.reverse.backends",
-        H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR | H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE
-                                    | H2O_CONFIGURATOR_FLAG_DEFERRED, on_config_reverse_backends);
+    h2o_configurator_define_command(&c->super, "proxy.reverse.backends",
+                                    H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR |
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE | H2O_CONFIGURATOR_FLAG_DEFERRED,
+                                    on_config_reverse_backends);
     h2o_configurator_define_command(&c->super, "proxy.reverse.path",
                                     H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_reverse_path);
     h2o_configurator_define_command(&c->super, "proxy.preserve-host",
@@ -556,10 +560,8 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_emit_x_forwarded_headers);
     h2o_configurator_define_command(&c->super, "proxy.emit-via-header",
-                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
-                                    on_config_emit_via_header);
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_emit_via_header);
     h2o_configurator_define_headers_commands(conf, &c->super, "proxy.header", get_headers_commands);
-    h2o_configurator_define_command(&c->super, "backend",
-                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,
+    h2o_configurator_define_command(&c->super, "backend", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,
                                     on_config_backend);
 }

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -27,6 +27,7 @@
 #include <openssl/ssl.h>
 #include "h2o.h"
 #include "h2o/configurator.h"
+#include "h2o/dyn_backends.h"
 
 struct proxy_configurator_t {
     h2o_configurator_t super;
@@ -238,12 +239,46 @@ static int on_config_ssl_session_cache(h2o_configurator_command_t *cmd, h2o_conf
 static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    h2o_url_t parsed;
-    
-    if (h2o_url_parse(node->data.scalar, SIZE_MAX, &parsed) != 0) {
-        h2o_configurator_errprintf(cmd, node, "failed to parse URL: %s\n", node->data.scalar);
+    h2o_url_t parsed, *reg = NULL;
+
+    switch (node->type) {
+    case YOML_TYPE_SCALAR:
+        self->vars->get_upstream.cb = h2o_proxy_url_get_upstream;
+        if (h2o_url_parse(node->data.scalar, SIZE_MAX, &parsed) != 0) {
+            h2o_configurator_errprintf(cmd, node, "failed to parse URL: %s\n", node->data.scalar);
+            return -1;
+        }
+        reg = &parsed;
+        break;
+    case YOML_TYPE_MAPPING: {
+        size_t i;
+        for (i = 0; i != node->data.mapping.size; ++i) {
+            yoml_t *key = node->data.mapping.elements[i].key;
+            yoml_t *value = node->data.mapping.elements[i].value;
+            if (key->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, key, "key must be a scalar");
+                return -1;
+            }
+            if (strcasecmp(key->data.scalar, "header") == 0) {
+                h2o_iovec_t *hn = h2o_mem_alloc(sizeof(*hn));
+                *hn = h2o_strdup(NULL, value->data.scalar, strlen(value->data.scalar));
+                self->vars->get_upstream.ctx = hn;
+            } else {
+                h2o_configurator_errprintf(cmd, key, "key must be `header`");
+                return -1;
+            }
+        }
+        if (!self->vars->get_upstream.ctx) {
+            h2o_configurator_errprintf(cmd, node, "`header` is required");
+            return -1;
+        }
+        self->vars->get_upstream.cb = h2o_dyn_backend_get_upstream;
+    } break;
+    default:
+        h2o_configurator_errprintf(cmd, node, "argument to proxy.reverse.url must be either a scalar or a mapping");
         return -1;
     }
+
     if (self->vars->keepalive_timeout != 0 && self->vars->use_proxy_protocol) {
         h2o_configurator_errprintf(cmd, node, "please either set `proxy.use-proxy-protocol` to `OFF` or disable keep-alive by "
                                    "setting `proxy.timeout.keepalive` to zero; the features are mutually exclusive");
@@ -254,21 +289,20 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
                                    "multiple backends or only set `proxy.reverse.url`; the features are mutually exclusive");
         return -1;
     }
-    
+
     if (self->vars->headers_cmds != NULL)
         h2o_mem_addref_shared(self->vars->headers_cmds);
-    
+
     /* register */
     self->vars->registered_as_url = 1;
-    h2o_proxy_register_reverse_proxy(ctx->pathconf, &parsed, 1, self->vars);
-    
+    h2o_proxy_register_reverse_proxy(ctx->pathconf, reg, reg ? 1 : 0, self->vars);
     return 0;
 }
 
 static int on_config_reverse_path(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    
+
     self->vars->reverse_path = h2o_strdup(NULL, node->data.scalar, strlen(node->data.scalar));
     /* we should check if path is legal here */
     return 0;
@@ -324,7 +358,7 @@ static int on_config_reverse_backends(h2o_configurator_command_t *cmd, h2o_confi
 
         break;
     default:
-        h2o_configurator_errprintf(cmd, node, "argument to proxy.reverse.url must be either a scalar or a sequence");
+        h2o_configurator_errprintf(cmd, node, "argument to proxy.reverse.backends must be either a scalar or a sequence");
         return -1;
     }
 
@@ -343,6 +377,7 @@ static int on_config_reverse_backends(h2o_configurator_command_t *cmd, h2o_confi
         h2o_mem_addref_shared(self->vars->headers_cmds);
 
     /* register */
+    self->vars->get_upstream.cb = h2o_proxy_url_get_upstream;
     self->vars->registered_as_backends = 1;
     h2o_proxy_register_reverse_proxy(ctx->pathconf, upstreams, count, self->vars);
 
@@ -432,6 +467,37 @@ static h2o_headers_command_t **get_headers_commands(h2o_configurator_t *_self)
     return &self->vars->headers_cmds;
 }
 
+static int on_config_backend(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    int ret;
+    yoml_t *turl, *tid;
+    const char *id;
+
+    if (node->type != YOML_TYPE_MAPPING) {
+        fprintf(stderr, "%s: exected a node backend\n", __func__);
+        return -1;
+    }
+
+    if ((turl = yoml_get(node, "url")) == NULL) {                                                                                  \
+        fprintf(stderr, "%s: missing mandatory attribute `url`\n", __func__);
+        return -1;
+    }
+    if ((tid = yoml_get(node, "id")) == NULL) {                                                                                  \
+        fprintf(stderr, "%s: missing mandatory attribute `id`\n", __func__);
+        return -1;
+    }
+
+    h2o_dyn_backend_config_t bconfig;
+    ret = h2o_url_parse(turl->data.scalar,strlen(turl->data.scalar), &bconfig.upstream);
+    if (ret < 0) {
+        fprintf(stderr, "%s: failed to parse url\n", __func__);
+        return -1;
+    }
+
+    id = h2o_dyn_backend_add(tid->data.scalar, &bconfig);
+    return 0;
+}
+
 void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
 {
     struct proxy_configurator_t *c = (void *)h2o_configurator_create(conf, sizeof(*c));
@@ -452,7 +518,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
     c->super.exit = on_config_exit;
     h2o_configurator_define_command(
         &c->super, "proxy.reverse.url",
-        H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR | H2O_CONFIGURATOR_FLAG_DEFERRED, on_config_reverse_url);
+        H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR | H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING | H2O_CONFIGURATOR_FLAG_DEFERRED, on_config_reverse_url);
     /* if reverse proxy with multiple backends, they should be equivalent. then use backends & path instead of url. */
     h2o_configurator_define_command(
         &c->super, "proxy.reverse.backends",
@@ -493,4 +559,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
                                     H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_emit_via_header);
     h2o_configurator_define_headers_commands(conf, &c->super, "proxy.header", get_headers_commands);
+    h2o_configurator_define_command(&c->super, "backend",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,
+                                    on_config_backend);
 }

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -190,7 +190,8 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
                 to_sa_err = h2o_url_host_to_sun(upstreams[i].host, &sa);
                 is_ssl = upstreams[i].scheme == &H2O_URL_SCHEME_HTTPS;
                 if (to_sa_err == h2o_url_host_to_sun_err_is_not_unix_socket) {
-                    h2o_socketpool_init_target_by_hostport(&targets.entries[i], upstreams[i].host, h2o_url_get_port(&upstreams[i]), is_ssl, &upstreams[i]);
+                    h2o_socketpool_init_target_by_hostport(&targets.entries[i], upstreams[i].host, h2o_url_get_port(&upstreams[i]),
+                                                           is_ssl, &upstreams[i]);
                 } else {
                     assert(to_sa_err == NULL);
                     h2o_socketpool_init_target_by_address(&targets.entries[i], (void *)&sa, sizeof(sa), is_ssl, &upstreams[i]);
@@ -202,7 +203,6 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
         h2o_url_copy(NULL, &self->upstream, &upstreams[0]);
         if (to_sa_err)
             h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
-
     }
     self->config = *config;
     if (self->config.ssl_ctx != NULL)

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -23,29 +23,56 @@
 #include "h2o.h"
 #include "h2o/socketpool.h"
 
+#include "h2o/dyn_backends.h"
+
+struct rp_handler_t;
+
 struct rp_handler_t {
     h2o_handler_t super;
     h2o_url_t upstream;         /* host should be NULL-terminated */
     h2o_socketpool_t *sockpool; /* non-NULL if config.use_keepalive == 1 */
     h2o_proxy_config_vars_t config;
+    struct {
+        h2o_proxy_get_upstream cb;
+        void *ctx;
+    } get_upstream;
 };
+
+int h2o_proxy_url_get_upstream(h2o_handler_t *_self, h2o_req_t *req, h2o_url_t **upstream, h2o_socketpool_t **sockpool, void *ctx)
+{
+    struct rp_handler_t *self = (void *)_self;
+
+    *sockpool = self->sockpool;
+    *upstream = &self->upstream;
+    return 0;
+}
 
 static int on_req(h2o_handler_t *_self, h2o_req_t *req)
 {
+    int ret;
     struct rp_handler_t *self = (void *)_self;
     h2o_req_overrides_t *overrides = h2o_mem_alloc_pool(&req->pool, sizeof(*overrides));
     const h2o_url_scheme_t *scheme;
     h2o_iovec_t *authority;
-   
+
+    h2o_url_t *upstream;
+    h2o_socketpool_t *sockpool;
+
+    ret = self->get_upstream.cb(&self->super, req, &upstream, &sockpool, self->get_upstream.ctx);
+    if (ret < 0) {
+        h2o_send_error_502(req, "Gateway Error", "No available upstream", 0);
+        return 0;
+    }
+
     /* setup overrides */
     *overrides = (h2o_req_overrides_t){NULL};
-    if (self->sockpool != NULL) {
-        overrides->socketpool = self->sockpool;
+    if (sockpool != NULL) {
+        overrides->socketpool = sockpool;
     } else if (self->config.preserve_host) {
-        overrides->hostport.host = self->upstream.host;
-        overrides->hostport.port = h2o_url_get_port(&self->upstream);
+        overrides->hostport.host = upstream->host;
+        overrides->hostport.port = h2o_url_get_port(upstream);
     }
-    overrides->location_rewrite.match = &self->upstream;
+    overrides->location_rewrite.match = upstream;
     overrides->location_rewrite.path_prefix = req->pathconf->path;
     overrides->use_proxy_protocol = self->config.use_proxy_protocol;
     overrides->client_ctx = h2o_context_get_handler_context(req->conn->ctx, &self->super);
@@ -57,14 +84,15 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
         authority = &req->authority;
         overrides->proxy_preserve_host = 1;
     } else {
-        scheme = self->upstream.scheme;
-        authority = &self->upstream.authority;
+        scheme = req->scheme;
+        scheme = upstream->scheme;
+        authority = &upstream->authority;
         overrides->proxy_preserve_host = 0;
     }
 
     /* request reprocess */
     h2o_reprocess_request(req, req->method, scheme, *authority,
-                          h2o_build_destination(req, self->upstream.path.base, self->upstream.path.len, 0), overrides, 0);
+                          h2o_build_destination(req, upstream->path.base, upstream->path.len, 0), overrides, 0);
 
     return 0;
 }
@@ -139,39 +167,42 @@ static void on_handler_dispose(h2o_handler_t *_self)
 void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstreams, size_t count, h2o_proxy_config_vars_t *config)
 {
     struct sockaddr_un sa;
-    const char *to_sa_err;
+    const char *to_sa_err = NULL;
     struct rp_handler_t *self = (void *)h2o_create_handler(pathconf, sizeof(*self));
     self->super.on_context_init = on_context_init;
     self->super.on_context_dispose = on_context_dispose;
     self->super.dispose = on_handler_dispose;
     self->super.on_req = on_req;
     self->super.has_body_stream = 1;
-    if (config->keepalive_timeout != 0) {
-        size_t i;
-        int is_ssl;
-        h2o_socketpool_target_vector_t targets = {};
-        h2o_vector_reserve(NULL, &targets, count);
-        self->sockpool = h2o_mem_alloc(sizeof(*self->sockpool));
-        for (i = 0; i != count; ++i) {
-            if (config->registered_as_backends && config->reverse_path.base != NULL) {
-                upstreams[i].path = config->reverse_path;
+    self->get_upstream.cb = config->get_upstream.cb;
+    self->get_upstream.ctx = config->get_upstream.ctx;
+    if (upstreams != NULL) {
+        if (config->keepalive_timeout != 0) {
+            size_t i;
+            int is_ssl;
+            h2o_socketpool_target_vector_t targets = {};
+            h2o_vector_reserve(NULL, &targets, count);
+            self->sockpool = h2o_mem_alloc(sizeof(*self->sockpool));
+            for (i = 0; i != count; ++i) {
+                if (config->registered_as_backends && config->reverse_path.base != NULL) {
+                    upstreams[i].path = config->reverse_path;
+                }
+                to_sa_err = h2o_url_host_to_sun(upstreams[i].host, &sa);
+                is_ssl = upstreams[i].scheme == &H2O_URL_SCHEME_HTTPS;
+                if (to_sa_err == h2o_url_host_to_sun_err_is_not_unix_socket) {
+                    h2o_socketpool_init_target_by_hostport(&targets.entries[i], upstreams[i].host, h2o_url_get_port(&upstreams[i]), is_ssl, &upstreams[i]);
+                } else {
+                    assert(to_sa_err == NULL);
+                    h2o_socketpool_init_target_by_address(&targets.entries[i], (void *)&sa, sizeof(sa), is_ssl, &upstreams[i]);
+                }
+                targets.size++;
             }
-            to_sa_err = h2o_url_host_to_sun(upstreams[i].host, &sa);
-            is_ssl = upstreams[i].scheme == &H2O_URL_SCHEME_HTTPS;
-            if (to_sa_err == h2o_url_host_to_sun_err_is_not_unix_socket) {
-                h2o_socketpool_init_target_by_hostport(&targets.entries[i], upstreams[i].host, h2o_url_get_port(&upstreams[i]), is_ssl, &upstreams[i]);
-            } else {
-                assert(to_sa_err == NULL);
-                h2o_socketpool_init_target_by_address(&targets.entries[i], (void *)&sa, sizeof(sa), is_ssl, &upstreams[i]);
-            }
-            targets.size++;
+            h2o_socketpool_init_by_targets(self->sockpool, targets, SIZE_MAX /* FIXME */);
         }
-        h2o_socketpool_init_by_targets(self->sockpool, targets, SIZE_MAX /* FIXME */);
-    }
-    to_sa_err = h2o_url_host_to_sun(upstreams[0].host, &sa);
-    h2o_url_copy(NULL, &self->upstream, &upstreams[0]);
-    if (to_sa_err) {
-        h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
+        h2o_url_copy(NULL, &self->upstream, &upstreams[0]);
+        if (to_sa_err)
+            h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
+
     }
     self->config = *config;
     if (self->config.ssl_ctx != NULL)

--- a/t/50reverse-proxy-dynamic-backends.t
+++ b/t/50reverse-proxy-dynamic-backends.t
@@ -1,0 +1,82 @@
+use strict;
+use warnings;
+use File::Temp qw(tempfile);
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+sub create_upstream {
+    my $upstream_port = shift;
+    spawn_server(
+        argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+        is_ready =>  sub {
+            if ($upstream_port =~ /^\//) {
+                !! -e $upstream_port;
+            } else {
+                check_port($upstream_port);
+            }
+        },
+    );
+}
+
+my $upstream_port1 = empty_port();
+my $upstream_port2 = empty_port();
+my ($unix_socket_file, $unix_socket_guard) = do {
+    (undef, my $fn) = tempfile(UNLINK => 0);
+    unlink $fn;
+    +(
+        $fn,
+        Scope::Guard->new(sub {
+                unlink $fn;
+            }),
+    );
+};
+my $up1 = create_upstream($upstream_port1);
+my $up2 = create_upstream($upstream_port2);
+my $up3 = create_upstream($unix_socket_file);
+
+my $server = spawn_h2o(<< "EOT");
+backend:
+    id: a
+    url: http://127.0.0.1:$upstream_port1
+backend:
+    id: b
+    url: http://127.0.0.1.xip.io:$upstream_port2
+backend:
+    id: c
+    url: http://[unix:$unix_socket_file]
+hosts:
+    default:
+        paths:
+            /:
+                proxy.reverse.url:
+                    header: backend-id
+EOT
+
+run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my $resp = `$curl -Hbackend-id:a --silent $proto://127.0.0.1:$port/echo-headers`;
+        like $resp, qr{^host:.*:(\d+)}m, "Found port in hostname";
+        $resp =~ qr{^host:.*:(\d+)}m;
+        ok $1 == $upstream_port1, "ok $1";
+
+        $resp = `$curl -Hbackend-id:b --silent $proto://127.0.0.1:$port/echo-headers`;
+        like $resp, qr{^host:.*:(\d+)}m, "Found port in hostname";
+        $resp =~ qr{^host:.*:(\d+)}m;
+        ok $1 == $upstream_port2, "ok $1";
+
+        $resp = `$curl -Hbackend-id:c --silent $proto://127.0.0.1:$port/echo-headers`;
+        like $resp, qr{^host:.*unix:(\S+)\]}m, "Found unix path";
+        $resp =~ qr{^host:.*unix:(\S+)\]}m;
+        ok $1 eq $unix_socket_file, "ok $1";
+    }
+);
+
+done_testing();


### PR DESCRIPTION
This PR adds infrastructure to make it possible to dynamically chose
a backend destination on a per request basis. We then take advantage of
this by allowing `proxy.reverse.url` to take a mapping, in which case we
can add customizable routing policies. This commit adds the `header`
policy, if this is set, H2O will look for a given header name in order
to chose the backend destination.

Having dynamic backends also supposes that backends can defined on their
own right, indenpendently of `proxy.reverse.url`.  To that end, this
commit defines a `backend` directive that allows to declare a backend to
H2O, which can then be used for routing.