### PR TITLE
clear all default mimemap types on file.mime.settypes

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1605,6 +1605,10 @@ h2o_mimemap_type_t *h2o_mimemap_define_dynamic(h2o_mimemap_t *mimemap, const cha
  */
 void h2o_mimemap_remove_type(h2o_mimemap_t *mimemap, const char *ext);
 /**
+ * clears all mime-type mapping
+ */
+void h2o_mimemap_clear_types(h2o_mimemap_t *mimemap);
+/**
  * sets the default mime-type
  */
 h2o_mimemap_type_t *h2o_mimemap_get_default_type(h2o_mimemap_t *mimemap);

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -633,7 +633,7 @@ static int set_mimetypes(h2o_configurator_command_t *cmd, h2o_mimemap_t *mimemap
 static int on_config_mime_settypes(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     h2o_mimemap_t *newmap = h2o_mimemap_create();
-
+    h2o_mimemap_clear_types(newmap);
     h2o_mimemap_set_default_type(newmap, h2o_mimemap_get_default_type(*ctx->mimemap)->data.mimetype.base, NULL);
     if (set_mimetypes(cmd, newmap, node) != 0) {
         h2o_mem_release_shared(newmap);

--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -329,6 +329,22 @@ void h2o_mimemap_remove_type(h2o_mimemap_t *mimemap, const char *ext)
     }
 }
 
+void h2o_mimemap_clear_types(h2o_mimemap_t *mimemap)
+{
+    khiter_t iter;
+
+    for (iter = kh_begin(mimemap->extmap); iter != kh_end(mimemap->extmap); ++iter) {
+        if (!kh_exist(mimemap->extmap, iter)) continue;
+        const char *key = kh_key(mimemap->extmap, iter);
+        h2o_mimemap_type_t *type = kh_val(mimemap->extmap, iter);
+        on_unlink(mimemap, type);
+        h2o_mem_release_shared(type);
+        kh_del(extmap, mimemap->extmap, iter);
+        h2o_mem_release_shared((char *)key);
+    }
+    rebuild_typeset(mimemap);
+}
+
 h2o_mimemap_type_t *h2o_mimemap_get_default_type(h2o_mimemap_t *mimemap)
 {
     return mimemap->default_type;

--- a/t/50mimemap.t
+++ b/t/50mimemap.t
@@ -71,4 +71,18 @@ EOT
     is $ct, "text/plain; charset=mycharset";
 };
 
+subtest "reset mimemap to minimum" => sub {
+    my $server = spawn_h2o(<< 'EOT');
+file.mime.setdefaulttype: "application/octet-stream"
+file.mime.settypes: {}
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: t/assets/doc_root
+EOT
+    my $ct = `$CURL_CMD http://127.0.0.1:$server->{port}/index.txt`;
+    is $ct, "application/octet-stream";
+};
+
 done_testing;


### PR DESCRIPTION
[file.mime.settypes document](https://h2o.examp1e.net/configure/file_directives.html#file.mime.settypes) says that using `file.mime.settypes` with empty mapping resets default mimetype mapping, but actually that's not the case. This PR fixes it.