### PR TITLE
Fix deadlock in setup_bio()

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -220,6 +220,7 @@ static void setup_bio(h2o_socket_t *sock)
             __sync_synchronize();
             bio_methods = biom;
         }
+	pthread_mutex_unlock(&init_lock);
     }
 
     BIO *bio = BIO_new(bio_methods);


### PR DESCRIPTION
`setup_bio()` uses a mutex to guard the initialization of `bio_methods`, but the mutex is never released. As a consequence, if two threads find `bio_methods` to be `NULL` at the same time, or if one of them is in the critical section while the other one tries to acquire the mutex, one thread will go on and initialize bio_methods and the other one will wait for the mutex to be released indefinitely.

We have been able to reproduce this, bringing h2o to the following state:

```
(gdb) thread apply all bt

Thread 6 (Thread 0x7fdea534e700 (LWP 12695)):
#0  0x00007fdea8c7b0b3 in epoll_wait () at ../sysdeps/unix/syscall-template.S:84
#1  0x0000562180218fc7 in evloop_do_proceed (_loop=_loop@entry=0x7fde880008c0, max_wait=<optimized out>)
    at ./lib/common/socket/evloop/epoll.c.h:115
#2  0x000056218021bbd2 in h2o_evloop_run (loop=0x7fde880008c0, max_wait=<optimized out>)
    at ./lib/common/socket/evloop.c.h:574
#3  0x0000562180281c3f in run_loop (_thread_index=0x3) at ./src/main.c:1648
#4  0x00007fdea99d4494 in start_thread (arg=0x7fdea534e700) at pthread_create.c:333
#5  0x00007fdea8c7aabf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

Thread 5 (Thread 0x7fdea5b4f700 (LWP 12694)):
#0  __lll_lock_wait () at ../sysdeps/unix/sysv/linux/x86_64/lowlevellock.S:135
#1  0x00007fdea99d6b95 in __GI___pthread_mutex_lock (mutex=mutex@entry=0x5621806828c0 <init_lock>)
    at ../nptl/pthread_mutex_lock.c:80
#2  0x00005621802186ec in setup_bio (sock=0x7fde9400aed0) at ./lib/common/socket.c:213
#3  0x0000562180218988 in create_ossl (sock=<optimized out>) at ./lib/common/socket.c:916
#4  0x0000562180219f34 in proceed_handshake (sock=0x7fde9400aed0, err=0x0) at ./lib/common/socket.c:1077
#5  0x0000562180219658 in read_on_ready (sock=0x7fde9400aed0) at ./lib/common/socket/evloop.c.h:235
#6  run_socket (sock=0x7fde9400aed0) at ./lib/common/socket/evloop.c.h:495
#7  0x000056218021979a in run_pending (loop=<optimized out>, loop=<optimized out>) at ./lib/common/socket/evloop.c.h:533
#8  0x000056218021bbed in h2o_evloop_run (loop=0x7fde940008c0, max_wait=<optimized out>)
    at ./lib/common/socket/evloop.c.h:578
---Type <return> to continue, or q <return> to quit---
#9  0x0000562180281c3f in run_loop (_thread_index=0x2) at ./src/main.c:1648
#10 0x00007fdea99d4494 in start_thread (arg=0x7fdea5b4f700) at pthread_create.c:333
#11 0x00007fdea8c7aabf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

Thread 4 (Thread 0x7fdea6350700 (LWP 12693)):
#0  0x00007fdea8c7b0b3 in epoll_wait () at ../sysdeps/unix/syscall-template.S:84
#1  0x0000562180218fc7 in evloop_do_proceed (_loop=_loop@entry=0x7fde900008c0, max_wait=<optimized out>)
    at ./lib/common/socket/evloop/epoll.c.h:115
#2  0x000056218021bbd2 in h2o_evloop_run (loop=0x7fde900008c0, max_wait=<optimized out>)
    at ./lib/common/socket/evloop.c.h:574
#3  0x0000562180281c3f in run_loop (_thread_index=0x1) at ./src/main.c:1648
#4  0x00007fdea99d4494 in start_thread (arg=0x7fdea6350700) at pthread_create.c:333
#5  0x00007fdea8c7aabf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

Thread 3 (Thread 0x7fdea6b51700 (LWP 12692)):
#0  0x00007fdea8c4a27d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
#1  0x00007fdea8c4a1ca in __sleep (seconds=0) at ../sysdeps/posix/sleep.c:55
#2  0x000056218028e241 in ticket_internal_updater (unused=<optimized out>) at ./src/ssl.c:338
#3  0x00007fdea99d4494 in start_thread (arg=0x7fdea6b51700) at pthread_create.c:333
#4  0x00007fdea8c7aabf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

Thread 2 (Thread 0x7fdea7352700 (LWP 12691)):
#0  0x00007fdea8c4a27d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
#1  0x00007fdea8c4a1ca in __sleep (seconds=0) at ../sysdeps/posix/sleep.c:55
#2  0x000056218028e53b in cache_cleanup_thread (_contexts=0x562180b25180) at ./src/ssl.c:88
#3  0x00007fdea99d4494 in start_thread (arg=0x7fdea7352700) at pthread_create.c:333
#4  0x00007fdea8c7aabf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

Thread 1 (Thread 0x7fdeaa8fb840 (LWP 12670)):
#0  0x00007fdea8c7b0b3 in epoll_wait () at ../sysdeps/unix/syscall-template.S:84
#1  0x0000562180218fc7 in evloop_do_proceed (_loop=_loop@entry=0x562180b35f40, max_wait=<optimized out>)
    at ./lib/common/socket/evloop/epoll.c.h:115
#2  0x000056218021bbd2 in h2o_evloop_run (loop=0x562180b35f40, max_wait=<optimized out>)
    at ./lib/common/socket/evloop.c.h:574
#3  0x0000562180281c3f in run_loop (_thread_index=0x0) at ./src/main.c:1648
#4  0x000056218020d285 in main (argc=<optimized out>, argv=<optimized out>) at ./src/main.c:2283
```

Note that thread 5 is stuck at `pthread_mutex_lock`, while the mutex is owned by thread 6 (which left `setup_bio` a long time ago):
```
(gdb) p init_lock
$9 = {__data = {__lock = 2, __count = 0, __owner = 12695, __nusers = 1, __kind = 0, __spins = 0, __elision = 0, __list = {
      __prev = 0x0, __next = 0x0}},
  __size = "\002\000\000\000\000\000\000\000\227\061\000\000\001", '\000' <repeats 26 times>, __align = 2}
```
Fix this by releasing the mutex after bio_methods is initialized.