### PR TITLE
Fix epoll-related crashes on OCSP updates

### DIFF
--- a/lib/common/socket/evloop/epoll.c.h
+++ b/lib/common/socket/evloop/epoll.c.h
@@ -189,7 +189,11 @@ h2o_evloop_t *h2o_evloop_create(void)
 {
     struct st_h2o_evloop_epoll_t *loop = (struct st_h2o_evloop_epoll_t *)create_evloop(sizeof(*loop));
 
+#ifdef EPOLL_CLOEXEC
+    loop->ep = epoll_create1(EPOLL_CLOEXEC);
+#else
     loop->ep = epoll_create(10);
+#endif
 
     return &loop->super;
 }


### PR DESCRIPTION
Hi,

We can reliably reproduce a crash of h2o when running with multiple OCSP updater threads under heavy request load. We've seen this happen sporadically in production, always following OCSP status update messages:

```
[OCSP Stapling] successfully updated the response for certificate file:ssl/certs/example.com.pem
ignoring epoll event (fd:-1,event:1)
received fatal signal 11
```

with the relevant backtrace usually being:
```
(gdb) bt
#0  0x000055555558dc0e in link_to_pending (sock=sock@entry=0x555555aee170) at ./lib/common/socket/evloop.c.h:98
#1  0x000055555558e299 in link_to_pending (sock=0x555555aee170) at ./lib/common/socket/evloop.c.h:95
#2  evloop_do_proceed (_loop=_loop@entry=0x555555a5c3b0, max_wait=<optimized out>)
    at ./lib/common/socket/evloop/epoll.c.h:130
#3  0x0000555555590be2 in h2o_evloop_run (loop=0x555555a5c3b0, max_wait=<optimized out>)
    at ./lib/common/socket/evloop.c.h:574
#4  0x00005555555f6c4f in run_loop (_thread_index=0x0) at ./src/main.c:1648
#5  0x0000555555582285 in main (argc=<optimized out>, argv=<optimized out>) at ./src/main.c:2283
```

Adding several debug print statements in the code, it is clear that the socket referred to by `sock` has been `free()`d already previously, as the socket itself was closed.

It turns out this is due to the epoll(7)-based event loop receiving events from already-closed file descriptors that are stil open in the forked OCSP children in the short time window between `fork()` and `exec()`. This issue is easy enough to reproduce in a testing environment using e.g. `h2load` with a high request load and a couple OCSP update threads doing updates every 5 seconds.

In the end, it always comes down to the epoll loop assuming that once `epoll_wait(2)` returns an event, its data pointer is always relevant and there is no way to tell if the affected socket has been closed. To avoid this issue, we explicitly remove all registered FDs from the loop on close.

This PR also includes a slightly related change to avoid leaking the `epoll(7)` fds to child processes.