### PR TITLE
fix test issues

### DIFF
--- a/t/50reverse-proxy-chunk-timeout-2.t
+++ b/t/50reverse-proxy-chunk-timeout-2.t
@@ -7,6 +7,9 @@ use Socket qw(SOMAXCONN);
 use Test::More;
 use t::Util;
 
+plan skip_all => 'nghttp not found'
+    unless prog_exists('nghttp');
+
 my $upstream_port = empty_port();
 
 # we can establish SOMAXCONN sockets without actually accepting them

--- a/t/50reverse-proxy-serialize-posts.t
+++ b/t/50reverse-proxy-serialize-posts.t
@@ -31,8 +31,9 @@ my $huge_file = create_data_file($huge_file_size);
 my $doit = sub {
     my ($proto, $opt, $port) = @_;
     my $posts = 10;
-    my $out = `nghttp -t 60 $opt -nv -d $huge_file -m $posts $proto://127.0.0.1:$port/echo 2>&1 | grep 'recv WINDOW_UPDATE' | grep -v stream_id=0 | grep -oP stream_id=.. | uniq -c | wc -l`;
+    my $out = `nghttp -t 60 $opt -nv -d $huge_file -m $posts $proto://127.0.0.1:$port/echo 2>&1 | grep 'recv WINDOW_UPDATE' | grep -v stream_id=0 | grep -o stream_id=.. | uniq -c | wc -l`;
     chomp($out);
+    $out =~ s/\A\s*|\s*\z//;
     is $out, $posts, "No interleaving";
 };
 


### PR DESCRIPTION
- `t/50reverse-proxy-chunk-timeout-2.t` uses nghttp without precondition check
- in `t/50reverse-proxy-serialize-posts.t`:
  - grep command in OSX no longer supports `P` option
  - `wc` command possibly outputs leading white spaces

This PR fixes above issues