### PR TITLE
fix miscellaneous test issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,7 +566,7 @@ ELSE ()
     ENDIF ()
 ENDIF ()
 
-ADD_CUSTOM_TARGET(check env H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -v t/*.t
+ADD_CUSTOM_TARGET(check env H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -I. -v t/*.t
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS h2o t-00unit-evloop.t)
 IF (LIBUV_FOUND)
@@ -590,7 +590,7 @@ IF (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get/CMakeLists.txt)
     ADD_DEPENDENCIES(check h2get)
 ENDIF ()
 
-ADD_CUSTOM_TARGET(check-valgrind env H2O_VALGRIND=./misc/h2o_valgrind/ H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -v t/*.t
+ADD_CUSTOM_TARGET(check-valgrind env H2O_VALGRIND=./misc/h2o_valgrind/ H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -I. -v t/*.t
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS h2o t-00unit-evloop.t)
 IF (LIBUV_FOUND)
@@ -600,10 +600,10 @@ IF (LIBUV_FOUND)
     ENDIF ()
 ENDIF ()
 
-ADD_CUSTOM_TARGET(check-as-root env H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -v t/90root-*.t
+ADD_CUSTOM_TARGET(check-as-root env H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -I. -v t/90root-*.t
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-ADD_CUSTOM_TARGET(check-as-root-valgrind env H2O_VALGRIND=./misc/h2o_valgrind/ H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -v t/90root-*.t
+ADD_CUSTOM_TARGET(check-as-root-valgrind env H2O_VALGRIND=./misc/h2o_valgrind/ H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -I. -v t/90root-*.t
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 

--- a/t/40proxy-protocol.t
+++ b/t/40proxy-protocol.t
@@ -10,7 +10,7 @@ use t::Util;
 my $tempdir = tempdir(CLEANUP => 1);
 my $port = empty_port();
 
-sub spawn_h2o {
+sub _spawn_h2o {
     my ($proxy_protocol, $ssl) = @_;
 
     open my $fh, ">", "$tempdir/h2o.conf"
@@ -99,7 +99,7 @@ sub test_timeout {
 }
 
 subtest "http" => sub {
-    my $guard = spawn_h2o(1, 0);
+    my $guard = _spawn_h2o(1, 0);
     subtest "with proxy" => sub {
         my $resp = fetch("PROXY TCP4 1.2.3.4 5.6.7.8 1234 9999\r\nGET / HTTP/1.0\r\n\r\n");
         like $resp, qr{^HTTP/1.1 200 OK\r\n}s;
@@ -116,7 +116,7 @@ subtest "http" => sub {
 };
 
 subtest "https" => sub {
-    my $guard = spawn_h2o(1, 1);
+    my $guard = _spawn_h2o(1, 1);
     subtest "with proxy" => sub {
         my $resp = fetch_ssl("PROXY TCP4 1.2.3.4 5.6.7.8 1234 9999\r\n", "GET / HTTP/1.0\r\n\r\n");
         like $resp, qr{^HTTP/1.1 200 OK\r\n}s;
@@ -133,7 +133,7 @@ subtest "https" => sub {
 };
 
 subtest "off" => sub {
-    my $guard = spawn_h2o(0, 0);
+    my $guard = _spawn_h2o(0, 0);
     subtest "with proxy" => sub {
         my $resp = fetch("PROXY TCP4 1.2.3.4 5.6.7.8 1234 9999\r\nGET / HTTP/1.0\r\n\r\n");
         unlike $resp, qr{^HTTP/1.1 200 OK\r\n}s;
@@ -146,7 +146,7 @@ subtest "off" => sub {
 
 subtest "https handshake timeout" => sub {
     # timeout test for PROXY:OFF over HTTPS is implemented here since it is easier to do so
-    my $guard = spawn_h2o(0, 1);
+    my $guard = _spawn_h2o(0, 1);
     test_timeout();
 };
 

--- a/t/50reverse-proxy-chunk-sizes.t
+++ b/t/50reverse-proxy-chunk-sizes.t
@@ -32,10 +32,11 @@ sub test {
     my $file = create_data_file($size);
     my $file_md5 = md5_file($file);
     note("$size, cl:'$cl', trailer:'$trailer', h2c");
-    my $resp = `nghttp $cl $trailer -d $file -u http://127.0.0.1:$server->{port}/echo`;
+    my $resp;
+    $resp = `nghttp $cl $trailer -d $file -u http://127.0.0.1:$server->{port}/echo`;
     is md5_hex($resp), $file_md5, "body matches";
     note("$size, cl:'$cl', trailer:'$trailer', h2");
-    my $resp = `nghttp $cl $trailer -d $file https://127.0.0.1:$server->{tls_port}/echo`;
+    $resp = `nghttp $cl $trailer -d $file https://127.0.0.1:$server->{tls_port}/echo`;
     is md5_hex($resp), $file_md5, "body matches";
 }
 my @sizes = ( 1000, 65535, 1000000 );

--- a/t/50reverse-proxy-chunk-timeout-1.t
+++ b/t/50reverse-proxy-chunk-timeout-1.t
@@ -11,7 +11,7 @@ plan skip_all => "nc not found"
 my $upstream_port = empty_port();
 $| = 1;
 
-open(my $nc_out, "nc -q -1 -dl $upstream_port |");
+open(my $nc_out, "nc -dl $upstream_port |");
 
 my $server = spawn_h2o(<< "EOT");
 http2-idle-timeout: 2

--- a/t/50reverse-proxy-chunk-timeout-1.t
+++ b/t/50reverse-proxy-chunk-timeout-1.t
@@ -5,6 +5,9 @@ use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 
+plan skip_all => "nc not found"
+    unless prog_exists("nc");
+
 my $upstream_port = empty_port();
 $| = 1;
 

--- a/t/50reverse-proxy-serialize-posts-3.t
+++ b/t/50reverse-proxy-serialize-posts-3.t
@@ -60,7 +60,7 @@ my $output = run_with_h2get($server, <<"EOR");
     sleep 5;
 EOR
 
-my $resp;
+my $resp = '';
 while (<$nc_out>) {
     $resp = $resp . $_;
 }
@@ -77,7 +77,7 @@ ok($chunked_header_found == 1, "TE:chunked header found");
 my @chunks = split /\r\n/, $body;
 
 my $chunk_len = 0;
-for (my $i = 0; $i < length(@chunks); $i+=3) {
+for (my $i = 0; $i < scalar(@chunks); $i+=3) {
     $chunk_len += hex($chunks[$i]);
 }
 

--- a/t/50reverse-proxy-serialize-posts-3.t
+++ b/t/50reverse-proxy-serialize-posts-3.t
@@ -11,7 +11,7 @@ plan skip_all => "nc not found"
 my $upstream_port = empty_port();
 $| = 1;
 
-open(my $nc_out, "nc -q -1 -dl $upstream_port |");
+open(my $nc_out, "nc -dl $upstream_port |");
 
 my $server = spawn_h2o(<< "EOT");
 http2-idle-timeout: 2

--- a/t/50reverse-proxy-serialize-posts-3.t
+++ b/t/50reverse-proxy-serialize-posts-3.t
@@ -5,6 +5,9 @@ use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 
+plan skip_all => "nc not found"
+    unless prog_exists("nc");
+
 my $upstream_port = empty_port();
 $| = 1;
 

--- a/t/50status.t
+++ b/t/50status.t
@@ -53,8 +53,9 @@ hosts:
       /s:
         status: ON
 EOT
-    my $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/beeb98fcf148317be5fe5d763c658bc9ea9c087a' 2>&1 > /dev/null`;
-    my $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/s/json?show=events' 2>&1 > /dev/null`;
+    my $resp;
+    $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/beeb98fcf148317be5fe5d763c658bc9ea9c087a' 2>&1 > /dev/null`;
+    $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/s/json?show=events' 2>&1 > /dev/null`;
     my $jresp = decode_json("$resp");
     is $jresp->{'connections'}, undef, "Connections not present";
     is $jresp->{'requests'}, undef, "Requests not present";

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -285,11 +285,11 @@ sub run_with_curl {
 sub run_with_h2get {
     my ($server, $script) = @_;
     plan skip_all => "h2get not found"
-        unless prog_exists($ENV{"H2O_ROOT"}."/h2get_bin/h2get");
+        unless prog_exists(bindir()."/h2get_bin/h2get");
     my ($scriptfh, $scriptfn) = tempfile(UNLINK => 1);
     print $scriptfh $script;
     close($scriptfh);
-    return run_prog($ENV{"H2O_ROOT"}."/h2get_bin/h2get $scriptfn https://127.0.0.1:$server->{tls_port}");
+    return run_prog(bindir()."/h2get_bin/h2get $scriptfn https://127.0.0.1:$server->{tls_port}");
 }
 
 1;


### PR DESCRIPTION
- https://github.com/h2o/h2o/commit/6d551af1a44897253c1f14bb5d1dd893e8645982
  - As of Perl 5.26, `.` isn't contained in @INC in default. To workaround to this, add `-I.` option
- https://github.com/h2o/h2o/commit/990b7af47a85a054eea4c5f0b76d5d920d490a90
  - nc's  `-q` option doesn't exist in some environments and seems to be not really necessary to run the test, am I correct? @deweerdt 
- https://github.com/h2o/h2o/commit/e17d0655ecf43e72120b0c7333fbe88e1f92950b
  - h2get binary may not be placed in H2O_ROOT?