### PR TITLE
ssl: avoid spurious ticket renewals

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -292,7 +292,11 @@ static int ticket_key_callback(unsigned char *key_name, unsigned char *iv, EVP_C
     Found:
         EVP_DecryptInit_ex(ctx, ticket->cipher.cipher, NULL, ticket->cipher.key, iv);
         HMAC_Init_ex(hctx, ticket->hmac.key, EVP_MD_block_size(ticket->hmac.md), ticket->hmac.md, NULL);
-        ret = i == 0 ? 1 : 2; /* request renew if the key is not the newest one */
+        /* Request renewal if the youngest key is active */
+        if (i != 0 && session_tickets.tickets.entries[0]->not_before <= time(NULL))
+            ret = 2;
+        else
+            ret = 1;
     }
 
 Exit:


### PR DESCRIPTION
H2O currently signals OpenSSL to unconditionally renew a ticket if it was not encrypted using the latest key available. While this generally works, it assumes that the latest key is always valid for encryption,
which however may not be the case. When encryption keys are rotated, the newly-generated key's `not_before` is set to 60 seconds in the future, so the most recent key is not yet valid for a whole minute. This in turn leads to unnecessary ticket renewals, where a ticket will be re-issued using the same (active) encryption key.

We fix this by checking that if there is a newer key, it is indeed suitable for encryption, before requesting renewal.