### PR TITLE
Clear OpenSSL's error queue before using it

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -277,6 +277,7 @@ const char *decode_ssl_input(h2o_socket_t *sock)
         { /* call SSL_read (while detecting SSL renegotiation and reporting it as error) */
             int did_write_in_read = 0;
             sock->ssl->did_write_in_read = &did_write_in_read;
+            ERR_clear_error();
             rlen = SSL_read(sock->ssl->ossl, buf.base, (int)buf.len);
             sock->ssl->did_write_in_read = NULL;
             if (did_write_in_read)
@@ -379,7 +380,8 @@ static void shutdown_ssl(h2o_socket_t *sock, const char *err)
         ret = 1; /* close the socket after sending close_notify */
     } else
 #endif
-        if (sock->ssl->ossl != NULL) {
+    if (sock->ssl->ossl != NULL) {
+        ERR_clear_error();
         if ((ret = SSL_shutdown(sock->ssl->ossl)) == -1)
             goto Close;
     } else {
@@ -1091,6 +1093,7 @@ static void proceed_handshake(h2o_socket_t *sock, const char *err)
     }
 
 Redo:
+    ERR_clear_error();
     if (SSL_is_server(sock->ssl->ossl)) {
         ret = SSL_accept(sock->ssl->ossl);
     } else {


### PR DESCRIPTION
Hi,

_TL;DR: H2O's use of `SSL_get_error()` is not safe and may cause error propagation between different connections_

This came up while debugging abnormal connection terminations that happened sporadically during a POST request. We also had reports about connection terminations from browsers, but could not pinpoint the exact cause. The connections in question appeared to complete the SSL handshake normally and then H2O returned an encrypted alert as soon as the client sent a couple of application data TLS packets. Note that the failures were not logged by H2O at all, we only heard about them from the client side. Furthermore, it turned out the failures had some kind of correlation with a third client hammering us with SSLv3 handshakes, which were refused by our OpenSSL version; as soon as we DROPd the misbehaving client from the firewall, the failures in the other connections decreased significantly. The proposed patch seems to fix these failures.

From `SSL_get_error(3ssl)`:

> The current thread's error queue must be empty before the TLS/SSL I/O operation is attempted, or SSL_get_error() will not work reliably.

There are a couple of locations where H2O relies on `SSL_get_error()`, mostly to check if a read operation would block. [As of OpenSSL 1.1](https://github.com/openssl/openssl/blob/OpenSSL_1_1_0f/ssl/ssl_lib.c#L2914), if there is _any_ error in the current thread's error queue, `SSL_get_error()` will return either `SSL_ERROR_SYSCALL` or `SSL_ERROR_SSL`, and never `SSL_ERROR_WANT_READ`/`SSL_ERROR_WANT_WRITE`. IOW, if an error occurs e.g. during an `SSL_write()` call, an `SSL_get_error()` call after a subsequent would-block `SSL_read()` call will return the former error instead of `SSL_ERROR_WANT_READ`. As this is happening inside a tight event loop, these `SSL_write()` and `SSL_read()` calls could refer to different connections, propagating errors from one connection to the other one.

Fix this by making sure the error queue is cleared right before the I/O call whose result we want to check.