### PR TITLE
fix a proxy test degration caused by commit aa43cbd

### DIFF
--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -86,8 +86,8 @@ hosts:
         gzip: ON
       /files:
         file.dir: @{[ DOC_ROOT ]}
-@{[ $h2o_keepalive ? "" : "        proxy.timeout.keepalive: 0" ]}
 reproxy: ON
+@{[ $h2o_keepalive ? "" : "proxy.timeout.keepalive: 0" ]}
 EOT
 
 run_with_curl($server, sub {


### PR DESCRIPTION
Before aa43cbd, `proxy.timeout.keepalive: 0` is meant to be applied to `/`, but by adding new path, that configuration unexpectedly gets disappeared from `/` and other paths.
I believe that the intension of this line was to switch keepalive ON/OFF **globally**, so.. just remove leading white spaces!