### PR TITLE
refactor request body streaming

### DIFF
--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -40,8 +40,8 @@ static int delay_interval_ms = 0;
 static int cur_body_size;
 
 static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
-                                          int *method_is_head, h2o_http1client_write_req_chunk_done *write_req_chunk_done,
-                                          void **write_req_chunk_done_ctx, h2o_iovec_t *cur_body, h2o_url_t *location_rewrite_url);
+                                          int *method_is_head, h2o_http1client_write_req_chunk_done_cb *write_req_chunk_done,
+                                          h2o_iovec_t *cur_body, h2o_url_t *location_rewrite_url);
 static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *errstr, int minor_version, int status,
                                        h2o_iovec_t msg, h2o_header_t *headers, size_t num_headers, int rlen);
 
@@ -143,7 +143,6 @@ int fill_body(h2o_iovec_t *reqbuf)
     }
 }
 
-static void http1_write_req_chunk_done(void *sock_, size_t written, int done);
 static h2o_timeout_t post_body_timeout;
 
 struct st_timeout_ctx {
@@ -163,23 +162,21 @@ static void timeout_cb(h2o_timeout_entry_t *entry)
     return;
 }
 
-static void http1_write_req_chunk_done(void *sock_, size_t written, int done)
+static void http1_write_req_chunk_done(h2o_http1client_t *client, size_t written, int done)
 {
-    h2o_socket_t *sock = sock_;
-    h2o_http1client_t *client = (h2o_http1client_t *)sock->data;
     if (cur_body_size > 0) {
         struct st_timeout_ctx *tctx;
         tctx = h2o_mem_alloc(sizeof(*tctx));
         memset(tctx, 0, sizeof(*tctx));
-        tctx->sock = sock;
+        tctx->sock = client->sock;
         tctx->_timeout.cb = timeout_cb;
         h2o_timeout_link(client->ctx->loop, &post_body_timeout, &tctx->_timeout);
     }
 }
 
 static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
-                                          int *method_is_head, h2o_http1client_write_req_chunk_done *write_req_chunk_done,
-                                          void **write_req_chunk_done_ctx, h2o_iovec_t *cur_body, h2o_url_t *dummy)
+                                          int *method_is_head, h2o_http1client_write_req_chunk_done_cb *write_req_chunk_done,
+                                          h2o_iovec_t *cur_body, h2o_url_t *dummy)
 {
     if (errstr != NULL) {
         fprintf(stderr, "%s\n", errstr);
@@ -192,7 +189,6 @@ static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char 
     *method_is_head = 0;
     if (cur_body_size > 0) {
         *write_req_chunk_done = http1_write_req_chunk_done;
-        *write_req_chunk_done_ctx = client->sock;
 
         struct st_timeout_ctx *tctx;
         tctx = h2o_mem_alloc(sizeof(*tctx));

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1101,7 +1101,6 @@ struct st_h2o_req_t {
         void *priv;
     } _write_req_chunk;
     h2o_write_req_chunk_done _write_req_chunk_done;
-    char _found_handler;
 
     /* per-request memory pool (placed at the last since the structure is large) */
     h2o_mem_pool_t pool;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -921,8 +921,8 @@ typedef struct st_h2o_req_error_log_t {
     h2o_iovec_t msg;
 } h2o_req_error_log_t;
 
-typedef void (*h2o_write_req_chunk_done)(struct st_h2o_req_t *req, size_t written, int done);
-typedef int (*h2o_write_req_chunk)(void *priv, h2o_iovec_t req_chunk, int is_end);
+typedef void (*h2o_proceed_req_cb)(h2o_req_t *req, size_t written, int is_end_stream);
+typedef int (*h2o_write_req_cb)(void *ctx, h2o_iovec_t chunk, int is_end_stream);
 
 /**
  * a HTTP request
@@ -1089,18 +1089,18 @@ struct st_h2o_req_t {
      */
     size_t preferred_chunk_size;
 
+    /* streaming request body */
+    struct {
+        h2o_write_req_cb cb;
+        void *ctx;
+    } write_req;
+    h2o_proceed_req_cb proceed_req;
+
     /* internal structure */
     h2o_generator_t *_generator;
     h2o_ostream_t *_ostr_top;
     size_t _next_filter_index;
     h2o_timeout_entry_t _timeout_entry;
-
-    /* streaming request body */
-    struct {
-        h2o_write_req_chunk cb;
-        void *priv;
-    } _write_req_chunk;
-    h2o_write_req_chunk_done _write_req_chunk_done;
 
     /* per-request memory pool (placed at the last since the structure is large) */
     h2o_mem_pool_t pool;

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -36,16 +36,15 @@ typedef struct st_h2o_http1client_t h2o_http1client_t;
 
 struct st_h2o_header_t;
 
-typedef void (*h2o_http1client_write_req_chunk_done)(void *priv, size_t written, int done);
+typedef void (*h2o_http1client_write_req_chunk_done_cb)(h2o_http1client_t *client, size_t written, int done);
 typedef int (*h2o_http1client_body_cb)(h2o_http1client_t *client, const char *errstr);
 typedef h2o_http1client_body_cb (*h2o_http1client_head_cb)(h2o_http1client_t *client, const char *errstr, int minor_version,
                                                            int status, h2o_iovec_t msg, struct st_h2o_header_t *headers,
                                                            size_t num_headers, int rlen);
 typedef h2o_http1client_head_cb (*h2o_http1client_connect_cb)(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs,
                                                               size_t *reqbufcnt, int *method_is_head,
-                                                              h2o_http1client_write_req_chunk_done *req_body_done,
-                                                              void **req_body_done_ctx, h2o_iovec_t *cur_body,
-                                                              h2o_url_t *location_rewrite_url);
+                                                              h2o_http1client_write_req_chunk_done_cb *req_body_done,
+                                                              h2o_iovec_t *cur_body, h2o_url_t *location_rewrite_url);
 typedef int (*h2o_http1client_informational_cb)(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg,
                                                 struct st_h2o_header_t *headers, size_t num_headers);
 

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -43,8 +43,8 @@ typedef h2o_http1client_body_cb (*h2o_http1client_head_cb)(h2o_http1client_t *cl
                                                            size_t num_headers, int rlen);
 typedef h2o_http1client_head_cb (*h2o_http1client_connect_cb)(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs,
                                                               size_t *reqbufcnt, int *method_is_head,
-                                                              h2o_http1client_prcoeed_req_cb *proceed_req_cb,
-                                                              h2o_iovec_t *cur_body, h2o_url_t *location_rewrite_url);
+                                                              h2o_http1client_prcoeed_req_cb *proceed_req_cb, h2o_iovec_t *cur_body,
+                                                              h2o_url_t *location_rewrite_url);
 typedef int (*h2o_http1client_informational_cb)(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg,
                                                 struct st_h2o_header_t *headers, size_t num_headers);
 

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -36,14 +36,14 @@ typedef struct st_h2o_http1client_t h2o_http1client_t;
 
 struct st_h2o_header_t;
 
-typedef void (*h2o_http1client_write_req_chunk_done_cb)(h2o_http1client_t *client, size_t written, int done);
+typedef void (*h2o_http1client_prcoeed_req_cb)(h2o_http1client_t *client, size_t written, int is_end_stream);
 typedef int (*h2o_http1client_body_cb)(h2o_http1client_t *client, const char *errstr);
 typedef h2o_http1client_body_cb (*h2o_http1client_head_cb)(h2o_http1client_t *client, const char *errstr, int minor_version,
                                                            int status, h2o_iovec_t msg, struct st_h2o_header_t *headers,
                                                            size_t num_headers, int rlen);
 typedef h2o_http1client_head_cb (*h2o_http1client_connect_cb)(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs,
                                                               size_t *reqbufcnt, int *method_is_head,
-                                                              h2o_http1client_write_req_chunk_done_cb *req_body_done,
+                                                              h2o_http1client_prcoeed_req_cb *proceed_req_cb,
                                                               h2o_iovec_t *cur_body, h2o_url_t *location_rewrite_url);
 typedef int (*h2o_http1client_informational_cb)(h2o_http1client_t *client, int minor_version, int status, h2o_iovec_t msg,
                                                 struct st_h2o_header_t *headers, size_t num_headers);
@@ -74,7 +74,7 @@ struct st_h2o_http1client_t {
 
 extern const char *const h2o_http1client_error_is_eos;
 
-int h2o_http1client_write_req_chunk(void *priv, h2o_iovec_t req_chunk, int is_end);
+int h2o_http1client_write_req(void *priv, h2o_iovec_t chunk, int is_end_stream);
 void h2o_http1client_connect(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_iovec_t host, uint16_t port,
                              int is_ssl, h2o_http1client_connect_cb cb, int is_chunked, h2o_url_t *location_rewrite_url);
 void h2o_http1client_connect_with_pool(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx,

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -210,7 +210,7 @@ struct st_h2o_http2_stream_t {
 
     struct {
         h2o_buffer_t *body; /* NULL unless request body IS expected */
-        size_t streamed_body_size;
+        size_t bytes_received;
     } _req_body;
 
     /* placed at last since it is large and has it's own ctor */
@@ -319,7 +319,6 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
 static int h2o_http2_stream_has_pending_data(h2o_http2_stream_t *stream);
 void h2o_http2_stream_proceed(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
 static void h2o_http2_stream_send_push_promise(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream);
-static size_t h2o_http2_stream_req_body_size(h2o_http2_stream_t *stream);
 
 /* misc */
 static void h2o_http2_window_init(h2o_http2_window_t *window, const h2o_http2_settings_t *peer_settings);
@@ -527,16 +526,6 @@ inline void h2o_http2_stream_send_push_promise(h2o_http2_conn_t *conn, h2o_http2
     h2o_hpack_flatten_request(&conn->_write.buf, &conn->_output_header_table, stream->stream_id, conn->peer_settings.max_frame_size,
                               &stream->req, stream->push.parent_stream_id);
     stream->push.promise_sent = 1;
-}
-
-inline size_t h2o_http2_stream_req_body_size(h2o_http2_stream_t *stream)
-{
-    if (stream->req._write_req_chunk_done != NULL)
-        return stream->_req_body.streamed_body_size;
-    else if (stream->_req_body.body != NULL)
-        return stream->_req_body.body->size;
-
-    return 0;
 }
 
 inline uint16_t h2o_http2_decode16u(const uint8_t *src)

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -136,13 +136,37 @@ typedef struct st_h2o_http2_window_t {
 } h2o_http2_window_t;
 
 typedef enum enum_h2o_http2_stream_state_t {
+    /**
+     * stream in idle state (but registered; i.e. priority stream)
+     */
     H2O_HTTP2_STREAM_STATE_IDLE,
+    /**
+     * receiving headers
+     */
     H2O_HTTP2_STREAM_STATE_RECV_HEADERS,
+    /**
+     * receiving body (or trailers), waiting for the arrival of END_STREAM
+     */
     H2O_HTTP2_STREAM_STATE_RECV_BODY,
+    /**
+     * received request but haven't been assigned a handler
+     */
     H2O_HTTP2_STREAM_STATE_REQ_PENDING,
+    /**
+     * waiting for receiving response headers from the handler
+     */
     H2O_HTTP2_STREAM_STATE_SEND_HEADERS,
+    /**
+     * sending body
+     */
     H2O_HTTP2_STREAM_STATE_SEND_BODY,
+    /**
+     * received EOS from handler but still is sending body to client
+     */
     H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL,
+    /**
+     * closed
+     */
     H2O_HTTP2_STREAM_STATE_END_STREAM
 } h2o_http2_stream_state_t;
 

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -51,7 +51,7 @@ struct st_h2o_http1client_private_t {
         } chunked;
     } _body_decoder;
     h2o_socket_cb reader;
-    h2o_http1client_write_req_chunk_done_cb _write_req_chunk_done;
+    h2o_http1client_prcoeed_req_cb proceed_req;
     char _chunk_len_str[(sizeof(H2O_UINT64_LONGEST_HEX_STR) - 1) + 2 + 1]; /* SIZE_MAX in hex + CRLF + '\0' */
     h2o_buffer_t *_body_buf;
     h2o_buffer_t *_body_buf_in_flight;
@@ -403,7 +403,7 @@ static void on_req_body_done(h2o_socket_t *sock, const char *err)
     struct st_h2o_http1client_private_t *client = sock->data;
 
     if (client->_body_buf_in_flight != NULL) {
-        client->_write_req_chunk_done(&client->super, client->_body_buf_in_flight->size, client->_body_buf_is_done);
+        client->proceed_req(&client->super, client->_body_buf_in_flight->size, client->_body_buf_is_done);
         h2o_buffer_consume(&client->_body_buf_in_flight, client->_body_buf_in_flight->size);
     }
 
@@ -413,7 +413,7 @@ static void on_req_body_done(h2o_socket_t *sock, const char *err)
     }
 
     if (client->_body_buf != NULL && client->_body_buf->size != 0)
-        h2o_http1client_write_req_chunk(client->super.sock, h2o_iovec_init(NULL, 0), client->_body_buf_is_done);
+        h2o_http1client_write_req(client->super.sock, h2o_iovec_init(NULL, 0), client->_body_buf_is_done);
     else if (client->_body_buf_is_done)
         on_send_request(client->super.sock, NULL);
 }
@@ -447,18 +447,18 @@ void write_chunk_to_socket(struct st_h2o_http1client_private_t *client, h2o_iove
     h2o_socket_write(client->super.sock, chunk_and_reqbufs, i, cb);
 }
 
-int h2o_http1client_write_req_chunk(void *priv, h2o_iovec_t req_chunk, int is_end)
+int h2o_http1client_write_req(void *priv, h2o_iovec_t chunk, int is_end_stream)
 {
     h2o_socket_t *sock = priv;
     struct st_h2o_http1client_private_t *client = sock->data;
 
-    client->_body_buf_is_done = is_end;
+    client->_body_buf_is_done = is_end_stream;
 
     if (client->_body_buf == NULL)
         h2o_buffer_init(&client->_body_buf, &h2o_socket_buffer_prototype);
 
-    if (req_chunk.len != 0) {
-        if (h2o_buffer_append(&client->_body_buf, req_chunk.base, req_chunk.len) == 0)
+    if (chunk.len != 0) {
+        if (h2o_buffer_append(&client->_body_buf, chunk.base, chunk.len) == 0)
             return -1;
     }
 
@@ -476,7 +476,7 @@ int h2o_http1client_write_req_chunk(void *priv, h2o_iovec_t req_chunk, int is_en
     }
 
     if (client->_is_chunked) {
-        if (is_end && client->_body_buf_in_flight->size == 0) {
+        if (is_end_stream && client->_body_buf_in_flight->size == 0) {
             on_send_request(sock, NULL);
             return 0;
         }
@@ -511,12 +511,12 @@ static void on_connection_ready(struct st_h2o_http1client_private_t *client)
     h2o_iovec_t cur_body = h2o_iovec_init(NULL, 0);
 
     client->_cb.on_head = client->_cb.on_connect(&client->super, NULL, &reqbufs, &reqbufcnt, &client->_method_is_head,
-                                                 &client->_write_req_chunk_done, &cur_body, client->_location_rewrite_url);
+                                                 &client->proceed_req, &cur_body, client->_location_rewrite_url);
     if (client->_cb.on_head == NULL) {
         close_client(client);
         return;
     }
-    if (client->_write_req_chunk_done != NULL) {
+    if (client->proceed_req != NULL) {
         if (cur_body.len != 0) {
             h2o_buffer_init(&client->_body_buf, &h2o_socket_buffer_prototype);
             if (h2o_buffer_append(&client->_body_buf, cur_body.base, cur_body.len) == 0) {

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -578,9 +578,9 @@ static int on_1xx(h2o_http1client_t *client, int minor_version, int status, h2o_
     return 0;
 }
 
-static void proxy_write_req_chunk_done(void *priv, size_t written, int done)
+static void proxy_write_req_chunk_done(h2o_http1client_t *client, size_t written, int done)
 {
-    struct rp_generator_t *self = priv;
+    struct rp_generator_t *self = client->data;
     self->frontend_write_req_chunk_done(self->src_req, written, done);
 }
 
@@ -595,8 +595,8 @@ static int frontend_write_req_chunk(void *priv, h2o_iovec_t payload, int is_end_
 }
 
 static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
-                                          int *method_is_head, h2o_http1client_write_req_chunk_done *write_req_chunk_done,
-                                          void **write_req_chunk_done_ctx, h2o_iovec_t *cur_body, h2o_url_t *location_rewrite_url)
+                                          int *method_is_head, h2o_http1client_write_req_chunk_done_cb *write_req_chunk_done,
+                                          h2o_iovec_t *cur_body, h2o_url_t *location_rewrite_url)
 {
     struct rp_generator_t *self = client->data;
 
@@ -634,7 +634,6 @@ static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char 
         if (self->src_req->_write_req_chunk_done != NULL) {
             *cur_body = self->src_req->entity;
             *write_req_chunk_done = proxy_write_req_chunk_done;
-            *write_req_chunk_done_ctx = self;
             self->frontend_write_req_chunk_done = self->src_req->_write_req_chunk_done;
             self->src_req->_write_req_chunk.cb = frontend_write_req_chunk;
             self->src_req->_write_req_chunk.priv = self;

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -233,7 +233,7 @@ static h2o_iovec_t build_request_rest_headers(h2o_req_t *req, int keepalive, int
 
     /* CL or TE? Depends on whether we're streaming the request body or
        not, and if CL was advertised in the original request */
-    if (req->_write_req_chunk_done == NULL) {
+    if (req->proceed_req == NULL) {
         if (req->entity.base != NULL || req_requires_content_length(req)) {
             RESERVE(sizeof("content-length: " H2O_UINT64_LONGEST_STR) - 1);
             offset += sprintf(buf.base + offset, "content-length: %zu\r\n", req->entity.len);
@@ -577,25 +577,25 @@ static int on_1xx(h2o_http1client_t *client, int minor_version, int status, h2o_
     return 0;
 }
 
-static void proxy_write_req_chunk_done(h2o_http1client_t *client, size_t written, int done)
+static void proceed_request(h2o_http1client_t *client, size_t written, int is_end_stream)
 {
     struct rp_generator_t *self = client->data;
-    if (self->src_req->_write_req_chunk_done != NULL)
-        self->src_req->_write_req_chunk_done(self->src_req, written, done);
+    if (self->src_req->proceed_req != NULL)
+        self->src_req->proceed_req(self->src_req, written, is_end_stream);
 }
 
-static int frontend_write_req_chunk(void *priv, h2o_iovec_t payload, int is_end_stream)
+static int write_req(void *ctx, h2o_iovec_t chunk, int is_end_stream)
 {
-    struct rp_generator_t *self = priv;
+    struct rp_generator_t *self = ctx;
 
     if (is_end_stream) {
-        self->src_req->_write_req_chunk.cb = NULL;
+        self->src_req->write_req.cb = NULL;
     }
-    return h2o_http1client_write_req_chunk(self->client->sock, payload, is_end_stream);
+    return h2o_http1client_write_req(self->client->sock, chunk, is_end_stream);
 }
 
 static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
-                                          int *method_is_head, h2o_http1client_write_req_chunk_done_cb *write_req_chunk_done,
+                                          int *method_is_head, h2o_http1client_prcoeed_req_cb *proceed_req_cb,
                                           h2o_iovec_t *cur_body, h2o_url_t *location_rewrite_url)
 {
     struct rp_generator_t *self = client->data;
@@ -631,11 +631,11 @@ static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char 
     *method_is_head = self->up_req.is_head;
 
     if (self->src_req->entity.base != NULL) {
-        if (self->src_req->_write_req_chunk_done != NULL) {
+        if (self->src_req->proceed_req != NULL) {
             *cur_body = self->src_req->entity;
-            *write_req_chunk_done = proxy_write_req_chunk_done;
-            self->src_req->_write_req_chunk.cb = frontend_write_req_chunk;
-            self->src_req->_write_req_chunk.priv = self;
+            *proceed_req_cb = proceed_request;
+            self->src_req->write_req.cb = write_req;
+            self->src_req->write_req.ctx = self;
         } else {
             self->up_req.bufs[2] = self->src_req->entity;
             *reqbufcnt = 3;

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -387,7 +387,6 @@ void h2o_reprocess_request(h2o_req_t *req, h2o_iovec_t method, const h2o_url_sch
 
     /* handle the response using the handlers, if hostconf exists */
     if (req->overrides == NULL && (hostconf = find_hostconf(req->conn->hosts, req->authority, req->scheme->default_port)) != NULL) {
-        req->_found_handler = 0;
         req->pathconf = NULL;
         process_hosted_request(req, hostconf);
         return;

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -282,8 +282,8 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
 }
 
 static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
-                                          int *method_is_head, h2o_http1client_write_req_chunk_done *req_body_done,
-                                          void **req_body_done_ctx, h2o_iovec_t *cur_body, h2o_url_t *dummy)
+                                          int *method_is_head, h2o_http1client_write_req_chunk_done_cb *req_body_done,
+                                          h2o_iovec_t *cur_body, h2o_url_t *dummy)
 {
     struct st_h2o_mruby_http_request_context_t *ctx = client->data;
 

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -282,7 +282,7 @@ static h2o_http1client_body_cb on_head(h2o_http1client_t *client, const char *er
 }
 
 static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char *errstr, h2o_iovec_t **reqbufs, size_t *reqbufcnt,
-                                          int *method_is_head, h2o_http1client_write_req_chunk_done_cb *req_body_done,
+                                          int *method_is_head, h2o_http1client_prcoeed_req_cb *proceed_req_cb,
                                           h2o_iovec_t *cur_body, h2o_url_t *dummy)
 {
     struct st_h2o_mruby_http_request_context_t *ctx = client->data;

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -159,7 +159,7 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
     self->super.on_context_dispose = on_context_dispose;
     self->super.dispose = on_handler_dispose;
     self->super.on_req = on_req;
-    self->super.has_body_stream = 1;
+    self->super.supports_request_streaming = 1;
     if (config->keepalive_timeout != 0) {
         size_t i;
         int is_ssl;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -66,7 +66,6 @@ static void on_read(h2o_socket_t *sock, const char *err);
 static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_len, int is_critical);
 static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata);
 static void stream_send_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum);
-static int write_req_chunk(void *req_, h2o_iovec_t payload, int is_end_stream);
 
 const h2o_protocol_callbacks_t H2O_HTTP2_CALLBACKS = {initiate_graceful_shutdown, foreach_request};
 
@@ -210,27 +209,22 @@ static void run_pending_requests(h2o_http2_conn_t *conn)
     } while (ran_one_request && !h2o_linklist_is_empty(&conn->_pending_reqs));
 }
 
-static void execute_or_enqueue_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
+static void execute_or_enqueue_request_core(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
 {
-    assert(stream->state < H2O_HTTP2_STREAM_STATE_REQ_PENDING);
-
-    if (stream->req._write_req_chunk_done == NULL && stream->_req_body.body != NULL && stream->req.content_length != SIZE_MAX &&
-        stream->_req_body.body->size != stream->req.content_length) {
-        stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
-        h2o_http2_stream_reset(conn, stream);
-        return;
-    }
-
-    if (stream->req._write_req_chunk_done == NULL) {
-        h2o_http2_stream_set_response_blocked_by_server(conn, stream, 1);
-        h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_REQ_PENDING);
-    }
-
     /* TODO schedule the pending reqs using the scheduler */
     h2o_linklist_insert(&conn->_pending_reqs, &stream->_refs.link);
 
     run_pending_requests(conn);
     update_idle_timeout(conn);
+}
+
+static void execute_or_enqueue_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
+{
+    assert(stream->state == H2O_HTTP2_STREAM_STATE_RECV_HEADERS || stream->state == H2O_HTTP2_STREAM_STATE_REQ_PENDING);
+
+    h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_REQ_PENDING);
+    h2o_http2_stream_set_response_blocked_by_server(conn, stream, 1);
+    execute_or_enqueue_request_core(conn, stream);
 }
 
 void h2o_http2_conn_register_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
@@ -371,6 +365,45 @@ static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta
     return 0;
 }
 
+static void handle_request_body_chunk(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_iovec_t payload, int is_end_stream)
+{
+    stream->_req_body.bytes_received += payload.len;
+
+    /* check size */
+    if (stream->_req_body.bytes_received > conn->super.ctx->globalconf->max_request_entity_size) {
+        stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
+        h2o_http2_stream_reset(conn, stream);
+        return;
+    }
+    if (stream->req.content_length != SIZE_MAX) {
+        size_t received = stream->_req_body.bytes_received, cl = stream->req.content_length;
+        if (is_end_stream ? (received != cl) : (received > cl)) {
+            stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
+            h2o_http2_stream_reset(conn, stream);
+            return;
+        }
+    }
+
+    /* update timer */
+    if (!stream->request_blocked_by_server) {
+        h2o_http2_stream_set_request_blocked_by_server(conn, stream, 1);
+        update_idle_timeout(conn);
+    }
+
+    /* handle input */
+    if (is_end_stream) {
+        h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_REQ_PENDING);
+        if (stream->req._write_req_chunk_done != NULL) {
+            h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_HEADERS);
+            h2o_http2_stream_set_response_blocked_by_server(conn, stream, 1);
+        }
+    }
+    if (stream->req._write_req_chunk.cb(stream->req._write_req_chunk.priv, payload, is_end_stream) != 0) {
+        stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
+        h2o_http2_stream_reset(conn, stream);
+    }
+}
+
 static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, const uint8_t *src, size_t len,
                                    const char **err_desc)
 {
@@ -427,19 +460,7 @@ static int handle_trailing_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     if ((ret = h2o_hpack_parse_headers(&stream->req, &conn->_input_header_table, src, len, NULL, &dummy_content_length, NULL,
                                        err_desc)) != 0)
         return ret;
-
-    /* this means we already had a END_STREAM on a previous frame */
-    if (!stream->req._write_req_chunk.cb)
-        return H2O_HTTP2_ERROR_PROTOCOL;
-
-    /* trailing headers for are ignored for streaming body, but
-       we still need to parse them to keep the HPACK state in sync */
-    if (!stream->req._write_req_chunk_done) {
-        assert(stream->state == H2O_HTTP2_STREAM_STATE_RECV_BODY);
-        execute_or_enqueue_request(conn, stream);
-    } else {
-        stream->req._write_req_chunk.cb(stream->req._write_req_chunk.priv, h2o_iovec_init(NULL, 0), 1);
-    }
+    handle_request_body_chunk(conn, stream, h2o_iovec_init(NULL, 0), 1);
     return 0;
 }
 
@@ -548,52 +569,56 @@ static void write_req_chunk_done(h2o_req_t *req, size_t written, int done)
     }
 
     update_input_window(conn, stream->stream_id, &stream->input_window, written);
-
-    if (done) {
-        if (stream->state == H2O_HTTP2_STREAM_STATE_RECV_BODY) {
-            h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_REQ_PENDING);
-            h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_HEADERS);
-        }
-        run_pending_requests(conn);
-    }
 }
 
-static int write_req_chunk(void *req_, h2o_iovec_t payload, int is_end_stream)
+static int write_req_chunk_non_streaming(void *_req, h2o_iovec_t payload, int is_end_stream)
 {
-    h2o_req_t *req = req_;
-    h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, req);
-    h2o_http2_conn_t *conn = (h2o_http2_conn_t *)stream->req.conn;
+    h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
+
+    if (h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len) == 0)
+        return -1;
+    write_req_chunk_done(&stream->req, payload.len, is_end_stream);
+
+    if (is_end_stream) {
+        stream->req.entity = h2o_iovec_init(stream->_req_body.body->bytes, stream->_req_body.body->size);
+        execute_or_enqueue_request((h2o_http2_conn_t *)stream->req.conn, stream);
+    }
+    return 0;
+}
+
+static int write_req_chunk_streaming_pre_dispatch(void *_req, h2o_iovec_t payload, int is_end_stream)
+{
+    h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
 
     if (h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len) == 0)
         return -1;
     stream->req.entity = h2o_iovec_init(stream->_req_body.body->bytes, stream->_req_body.body->size);
 
-    /* handle request if request body is complete */
-    if (!stream->req._write_req_chunk_done) {
-        if (is_end_stream) {
-            stream->req.entity = h2o_iovec_init(stream->_req_body.body->bytes, stream->_req_body.body->size);
-            execute_or_enqueue_request(conn, stream);
-        } else {
-            if (!stream->req._found_handler) {
-                stream->req._found_handler = 1;
-                h2o_handler_t *h = h2o_get_first_handler(&stream->req);
-                if (h != NULL && h->has_body_stream) {
-                    stream->req._write_req_chunk_done = write_req_chunk_done;
-                    stream->_req_body.streamed_body_size = stream->_req_body.body->size;
-                    execute_or_enqueue_request(conn, stream);
-                }
-            } else {
-                write_req_chunk_done(req, payload.len, is_end_stream);
-            }
-        }
-    } else {
-        if (is_end_stream) {
-            stream->req._write_req_chunk_done = NULL;
-            stream->req._write_req_chunk.cb = NULL;
-        }
-    }
+    /* mark that we have seen eos */
+    if (is_end_stream)
+        stream->req._write_req_chunk_done = NULL;
 
     return 0;
+}
+
+static int write_req_chunk_first(void *_req, h2o_iovec_t payload, int is_end_stream)
+{
+    h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
+    h2o_handler_t *first_handler;
+
+    /* if possible, switch to either streaming request body mode */
+    if (!is_end_stream && (first_handler = h2o_get_first_handler(&stream->req)) != NULL && first_handler->has_body_stream) {
+        if (h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len) == 0)
+            return -1;
+        stream->req.entity = h2o_iovec_init(stream->_req_body.body->bytes, stream->_req_body.body->size);
+        stream->req._write_req_chunk.cb = write_req_chunk_streaming_pre_dispatch;
+        stream->req._write_req_chunk_done = write_req_chunk_done;
+        execute_or_enqueue_request_core((h2o_http2_conn_t *)stream->req.conn, stream);
+        return 0;
+    }
+
+    stream->req._write_req_chunk.cb = write_req_chunk_non_streaming;
+    return write_req_chunk_non_streaming(stream->req._write_req_chunk.priv, payload, is_end_stream);
 }
 
 static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, const char **err_desc)
@@ -610,50 +635,23 @@ static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, c
 
     update_input_window(conn, 0, &conn->_input_window, payload.length);
 
-    stream = h2o_http2_conn_get_stream(conn, frame->stream_id);
-
     /* save the input in the request body buffer, or send error (and close the stream) */
-    if (stream == NULL) {
+    if ((stream = h2o_http2_conn_get_stream(conn, frame->stream_id)) == NULL) {
         if (frame->stream_id <= conn->pull_stream_ids.max_open) {
             stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
-            stream = NULL;
+            return 0;
         } else {
             *err_desc = "invalid DATA frame";
             return H2O_HTTP2_ERROR_PROTOCOL;
         }
-    } else if (stream->state != H2O_HTTP2_STREAM_STATE_RECV_BODY || !stream->req._write_req_chunk.cb) {
+    }
+    if (stream->state != H2O_HTTP2_STREAM_STATE_RECV_BODY) {
         stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
         h2o_http2_stream_reset(conn, stream);
-        stream = NULL;
-    } else if (h2o_http2_stream_req_body_size(stream) + payload.length > conn->super.ctx->globalconf->max_request_entity_size) {
-        stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
-        h2o_http2_stream_reset(conn, stream);
-        stream = NULL;
-    } else {
-        int ret;
-
-        if (!stream->request_blocked_by_server) {
-            h2o_http2_stream_set_request_blocked_by_server(conn, stream, 1);
-            update_idle_timeout(conn);
-        }
-
-        ret = stream->req._write_req_chunk.cb(stream->req._write_req_chunk.priv, h2o_iovec_init(payload.data, payload.length),
-                                              frame->flags & H2O_HTTP2_FRAME_FLAG_END_STREAM);
-        if (ret < 0) {
-            stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
-            h2o_http2_stream_reset(conn, stream);
-            stream = NULL;
-            goto UpdateWindow;
-        }
         return 0;
     }
-
-UpdateWindow:
-    /* consume buffer (and set window_update) */
-    update_input_window(conn, 0, &conn->_input_window, frame->length);
-    if (stream != NULL)
-        update_input_window(conn, stream->stream_id, &stream->input_window, frame->length);
-
+    handle_request_body_chunk(conn, stream, h2o_iovec_init(payload.data, payload.length),
+                              (frame->flags & H2O_HTTP2_FRAME_FLAG_END_STREAM) != 0);
     return 0;
 }
 
@@ -707,7 +705,7 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
         set_priority(conn, stream, &payload.priority, 0);
     }
     h2o_http2_stream_prepare_for_request(conn, stream);
-    stream->req._write_req_chunk.cb = write_req_chunk;
+    stream->req._write_req_chunk.cb = write_req_chunk_first;
     stream->req._write_req_chunk.priv = &stream->req;
 
     /* setup container for request body if it is expected to arrive */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -603,7 +603,8 @@ static int write_req_first(void *_req, h2o_iovec_t payload, int is_end_stream)
     h2o_handler_t *first_handler;
 
     /* if possible, switch to either streaming request body mode */
-    if (!is_end_stream && (first_handler = h2o_get_first_handler(&stream->req)) != NULL && first_handler->has_body_stream) {
+    if (!is_end_stream && (first_handler = h2o_get_first_handler(&stream->req)) != NULL &&
+        first_handler->supports_request_streaming) {
         if (h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len) == 0)
             return -1;
         stream->req.entity = h2o_iovec_init(stream->_req_body.body->bytes, stream->_req_body.body->size);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -183,7 +183,7 @@ static void run_pending_requests(h2o_http2_conn_t *conn)
 
             lnext = link->next;
 
-            if (stream->req._write_req_chunk_done != NULL) {
+            if (stream->req.proceed_req != NULL) {
                 if (conn->num_streams._request_body_in_progress) {
                     continue;
                 }
@@ -391,10 +391,10 @@ static void handle_request_body_chunk(h2o_http2_conn_t *conn, h2o_http2_stream_t
     /* handle input */
     if (is_end_stream) {
         h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_REQ_PENDING);
-        if (stream->req._write_req_chunk_done != NULL)
+        if (stream->req.proceed_req != NULL)
             h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_HEADERS);
     }
-    if (stream->req._write_req_chunk.cb(stream->req._write_req_chunk.priv, payload, is_end_stream) != 0) {
+    if (stream->req.write_req.cb(stream->req.write_req.ctx, payload, is_end_stream) != 0) {
         stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
         h2o_http2_stream_reset(conn, stream);
     }
@@ -554,7 +554,7 @@ static void set_priority(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, con
     }
 }
 
-static void write_req_chunk_done(h2o_req_t *req, size_t written, int is_end_stream)
+static void proceed_request(h2o_req_t *req, size_t written, int is_end_stream)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, req);
     h2o_http2_conn_t *conn = (h2o_http2_conn_t *)stream->req.conn;
@@ -567,13 +567,13 @@ static void write_req_chunk_done(h2o_req_t *req, size_t written, int is_end_stre
     update_input_window(conn, stream->stream_id, &stream->input_window, written);
 }
 
-static int write_req_chunk_non_streaming(void *_req, h2o_iovec_t payload, int is_end_stream)
+static int write_req_non_streaming(void *_req, h2o_iovec_t payload, int is_end_stream)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
 
     if (h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len) == 0)
         return -1;
-    write_req_chunk_done(&stream->req, payload.len, is_end_stream);
+    proceed_request(&stream->req, payload.len, is_end_stream);
 
     if (is_end_stream) {
         stream->req.entity = h2o_iovec_init(stream->_req_body.body->bytes, stream->_req_body.body->size);
@@ -582,7 +582,7 @@ static int write_req_chunk_non_streaming(void *_req, h2o_iovec_t payload, int is
     return 0;
 }
 
-static int write_req_chunk_streaming_pre_dispatch(void *_req, h2o_iovec_t payload, int is_end_stream)
+static int write_req_streaming_pre_dispatch(void *_req, h2o_iovec_t payload, int is_end_stream)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
 
@@ -592,12 +592,12 @@ static int write_req_chunk_streaming_pre_dispatch(void *_req, h2o_iovec_t payloa
 
     /* mark that we have seen eos */
     if (is_end_stream)
-        stream->req._write_req_chunk_done = NULL;
+        stream->req.proceed_req = NULL;
 
     return 0;
 }
 
-static int write_req_chunk_first(void *_req, h2o_iovec_t payload, int is_end_stream)
+static int write_req_first(void *_req, h2o_iovec_t payload, int is_end_stream)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
     h2o_handler_t *first_handler;
@@ -607,14 +607,14 @@ static int write_req_chunk_first(void *_req, h2o_iovec_t payload, int is_end_str
         if (h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len) == 0)
             return -1;
         stream->req.entity = h2o_iovec_init(stream->_req_body.body->bytes, stream->_req_body.body->size);
-        stream->req._write_req_chunk.cb = write_req_chunk_streaming_pre_dispatch;
-        stream->req._write_req_chunk_done = write_req_chunk_done;
+        stream->req.write_req.cb = write_req_streaming_pre_dispatch;
+        stream->req.proceed_req = proceed_request;
         execute_or_enqueue_request_core((h2o_http2_conn_t *)stream->req.conn, stream);
         return 0;
     }
 
-    stream->req._write_req_chunk.cb = write_req_chunk_non_streaming;
-    return write_req_chunk_non_streaming(stream->req._write_req_chunk.priv, payload, is_end_stream);
+    stream->req.write_req.cb = write_req_non_streaming;
+    return write_req_non_streaming(stream->req.write_req.ctx, payload, is_end_stream);
 }
 
 static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, const char **err_desc)
@@ -701,8 +701,8 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
         set_priority(conn, stream, &payload.priority, 0);
     }
     h2o_http2_stream_prepare_for_request(conn, stream);
-    stream->req._write_req_chunk.cb = write_req_chunk_first;
-    stream->req._write_req_chunk.priv = &stream->req;
+    stream->req.write_req.cb = write_req_first;
+    stream->req.write_req.ctx = &stream->req;
 
     /* setup container for request body if it is expected to arrive */
     if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_STREAM) == 0)

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -385,10 +385,8 @@ static void handle_request_body_chunk(h2o_http2_conn_t *conn, h2o_http2_stream_t
     }
 
     /* update timer */
-    if (!stream->blocked_by_server) {
+    if (!stream->blocked_by_server)
         h2o_http2_stream_set_blocked_by_server(conn, stream, 1);
-        update_idle_timeout(conn);
-    }
 
     /* handle input */
     if (is_end_stream) {
@@ -1003,9 +1001,9 @@ static void on_read(h2o_socket_t *sock, const char *err)
         return;
     }
 
-    update_idle_timeout(conn);
     if (parse_input(conn) != 0)
         return;
+    update_idle_timeout(conn);
 
     /* write immediately, if there is no write in flight and if pending write exists */
     if (h2o_timeout_is_linked(&conn->_write.timeout_entry)) {

--- a/lib/http2/http2_debug_state.c
+++ b/lib/http2/http2_debug_state.c
@@ -152,7 +152,7 @@ h2o_http2_debug_state_t *h2o_http2_get_debug_state(h2o_req_t *req, int hpack_ena
                                                    "      \"created\": %" PRIu64 "\n"
                                                    "    },",
                          stream->stream_id, state_string, stream->input_window._avail, stream->output_window._avail,
-                         h2o_http2_stream_req_body_size(stream), stream->req.bytes_sent,
+                         stream->_req_body.bytes_received, stream->req.bytes_sent,
                          (uint64_t)stream->req.timestamps.request_begin_at.tv_sec);
         });
 

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -313,8 +313,8 @@ void finalostream_start_pull(h2o_ostream_t *self, h2o_ostream_pull_cb cb)
     assert(stream->req._ostr_top == &stream->_ostr_final);
     assert(stream->state == H2O_HTTP2_STREAM_STATE_SEND_HEADERS);
 
-    assert(stream->response_blocked_by_server);
-    h2o_http2_stream_set_response_blocked_by_server(conn, stream, 0);
+    assert(stream->blocked_by_server);
+    h2o_http2_stream_set_blocked_by_server(conn, stream, 0);
 
     /* register the pull callback */
     stream->_pull_cb = cb;
@@ -339,8 +339,8 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, s
 
     assert(stream->_data.size == 0);
 
-    if (stream->response_blocked_by_server)
-        h2o_http2_stream_set_response_blocked_by_server(conn, stream, 0);
+    if (stream->blocked_by_server)
+        h2o_http2_stream_set_blocked_by_server(conn, stream, 0);
 
     stream->send_state = state;
 
@@ -415,8 +415,8 @@ void h2o_http2_stream_proceed(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream
     if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM) {
         h2o_http2_stream_close(conn, stream);
     } else {
-        if (!conn->num_streams.response_blocked_by_server)
-            h2o_http2_stream_set_response_blocked_by_server(conn, stream, 1);
+        if (!conn->num_streams.blocked_by_server)
+            h2o_http2_stream_set_blocked_by_server(conn, stream, 1);
         h2o_proceed_response(&stream->req);
     }
 }


### PR DESCRIPTION
Refactors the code to always rely on stream state to determine what can be received (or not). Also fixes following issues in streaming mode:
* set response_blocked_by_server when receiving end_stream
* check that the actual size of the body received matches content-length
* remove superfluous connection-level window update (was done twice at the top and bottom of handle_data_frame)