### PR TITLE
send 100-continue after creating the entity reader

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -435,13 +435,13 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
                                        H2O_SEND_ERROR_HTTP1_CLOSE_CONNECTION);
                     return;
                 }
-                static const h2o_iovec_t res = {H2O_STRLIT("HTTP/1.1 100 Continue\r\n\r\n")};
-                h2o_socket_write(conn->sock, (void *)&res, 1, on_continue_sent);
             }
             if (create_entity_reader(conn, headers + entity_body_header_index) != 0) {
                 return;
             }
             if (expect.base != NULL) {
+                static const h2o_iovec_t res = {H2O_STRLIT("HTTP/1.1 100 Continue\r\n\r\n")};
+                h2o_socket_write(conn->sock, (void *)&res, 1, on_continue_sent);
                 /* processing of the incoming entity is postponed until the 100 response is sent */
                 h2o_socket_read_stop(conn->sock);
                 return;


### PR DESCRIPTION
otherwise results in an assertion failure.

fixes #1441 #1447