### PR TITLE
fix ; check ssl->ossl before access

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -970,7 +970,7 @@ static void on_handshake_complete(h2o_socket_t *sock, const char *err)
             sock->ssl->record_overhead = ptls_get_record_overhead(sock->ssl->ptls);
         } else
 #endif
-        {
+        if (sock->ssl->ossl != NULL) {
             const SSL_CIPHER *cipher = SSL_get_current_cipher(sock->ssl->ossl);
             switch (SSL_CIPHER_get_id(cipher)) {
             case TLS1_CK_RSA_WITH_AES_128_GCM_SHA256:


### PR DESCRIPTION
I could not be sure if the check of `sock->ssl->ossl` is necessary, but it was verified at the 1001st line in the same function, and the other https://github.com/h2o/h2o/blob/master/lib/common/socket.c#L320 etc.
```
if (sock->ssl->handshake.client.session_cache != NULL && sock->ssl->ossl != NULL) {
```