### PR TITLE
load balancing using non-persistent backends

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -846,6 +846,9 @@
 		E9708B061E49A3130029E0A5 /* sha256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha256.c; sourceTree = "<group>"; };
 		E9708B071E49A3130029E0A5 /* tassert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tassert.h; sourceTree = "<group>"; };
 		E9708B1B1E49A3480029E0A5 /* handy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = handy.h; sourceTree = "<group>"; };
+		E9A410951F9EA2E400D9B0FB /* 50reverse-proxy-multiple-backends-with-down.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-multiple-backends-with-down.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9A410961F9EA2F100D9B0FB /* 50reverse-proxy-multiple-backends.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-multiple-backends.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9A410971F9EA2F200D9B0FB /* 50reverse-proxy-round-robin.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-round-robin.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9BC76BF1EE3D71000EB7A09 /* 40redis-session-resumption.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40redis-session-resumption.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9BC76C01EE3D8A100EB7A09 /* 40server-push-attrs.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40server-push-attrs.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9BC76C11EE3D9A900EB7A09 /* 50compress-hint.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50compress-hint.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -1681,8 +1684,11 @@
 				104C65021A6DF36B000AC190 /* 50reverse-proxy-config.t */,
 				108102151C3DB05100C024CD /* 50reverse-proxy-disconnected-keepalive.t */,
 				10DA969A1CCEF2C200679165 /* 50reverse-proxy-https.t */,
+				E9A410961F9EA2F100D9B0FB /* 50reverse-proxy-multiple-backends.t */,
+				E9A410951F9EA2E400D9B0FB /* 50reverse-proxy-multiple-backends-with-down.t */,
 				E9BC76C31EE4AA4600EB7A09 /* 50reverse-proxy-preserve-case.t */,
 				10FEF2441D6444E900E11B1D /* 50reverse-proxy-proxy-protocol.t */,
+				E9A410971F9EA2F200D9B0FB /* 50reverse-proxy-round-robin.t */,
 				E9BC76C41EE4AA9700EB7A09 /* 50reverse-proxy-session-resumption.t */,
 				10AA2EB21A9479B4004322AC /* 50reverse-proxy-upstream-down.t */,
 				104B9A2B1A4BBDA4009EEE64 /* 50server-starter.t */,

--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -41,22 +41,26 @@ typedef enum en_h2o_socketpool_target_type_t {
 } h2o_socketpool_target_type_t;
 
 typedef struct st_h2o_socketpool_target_t {
+    /**
+     * target URL
+     */
+    h2o_url_t url;
+    /**
+     * target type (extracted from url)
+     */
     h2o_socketpool_target_type_t type;
-    int is_ssl;
-    struct {
-        h2o_iovec_t host;
-        uint16_t port;
-        union {
-            /* used to specify servname passed to getaddrinfo */
-            h2o_iovec_t named_serv;
-            /* if type is sockaddr, the `host` is not resolved but is used for TLS SNI and hostname verification */
-            struct {
-                struct sockaddr_storage bytes;
-                socklen_t len;
-            } sockaddr;
-        };
+    /**
+     * peer address (extracted from url)
+     */
+    union {
+        /* used to specify servname passed to getaddrinfo */
+        h2o_iovec_t named_serv;
+        /* if type is sockaddr, the `host` is not resolved but is used for TLS SNI and hostname verification */
+        struct {
+            struct sockaddr_storage bytes;
+            socklen_t len;
+        } sockaddr;
     } peer;
-    h2o_url_t *url;
 
     struct {
         h2o_linklist_t sockets;

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -326,10 +326,6 @@ static int on_config_reverse_backends(h2o_configurator_command_t *cmd, h2o_confi
     case YOML_TYPE_SEQUENCE:
         sequence = 1;
         count = node->data.sequence.size;
-        if (self->vars->keepalive_timeout == 0 && count > 1) {
-            h2o_configurator_errprintf(cmd, node, "currently we do not support multiple backends with keep-alive disabled");
-            return -1;
-        }
         upstreams = alloca(count * sizeof(h2o_url_t));
         for (i = 0; i != node->data.sequence.size; ++i) {
             yoml_t *element = node->data.sequence.elements[i];
@@ -350,12 +346,6 @@ static int on_config_reverse_backends(h2o_configurator_command_t *cmd, h2o_confi
         break;
     default:
         h2o_configurator_errprintf(cmd, node, "argument to proxy.reverse.url must be either a scalar or a sequence");
-        return -1;
-    }
-
-    if (self->vars->use_proxy_protocol) {
-        h2o_configurator_errprintf(cmd, node,
-                                   "currently we do not support multiple backends with `proxy.use-proxy-protocol` enabled");
         return -1;
     }
 

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -779,7 +779,7 @@ static int on_req(h2o_handler_t *_handler, h2o_req_t *req)
     generator->timeout = (h2o_timeout_entry_t){0};
 
     set_timeout(generator, &generator->ctx->io_timeout, on_connect_timeout);
-    h2o_socketpool_connect(&generator->connect_req, &handler->sockpool, handler->sockpool.targets.entries[0]->url,
+    h2o_socketpool_connect(&generator->connect_req, &handler->sockpool, &handler->sockpool.targets.entries[0]->url,
                            req->conn->ctx->loop, &req->conn->ctx->receivers.hostinfo_getaddr, on_connect, generator);
 
     return 0;

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -25,8 +25,7 @@
 
 struct rp_handler_t {
     h2o_handler_t super;
-    h2o_url_t upstream;         /* host should be NULL-terminated */
-    h2o_socketpool_t *sockpool; /* non-NULL if config.use_keepalive == 1 */
+    h2o_socketpool_t sockpool;
     h2o_proxy_config_vars_t config;
 };
 
@@ -34,17 +33,14 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
 {
     struct rp_handler_t *self = (void *)_self;
     h2o_req_overrides_t *overrides = h2o_mem_alloc_pool(&req->pool, sizeof(*overrides));
+    h2o_url_t *upstream_url = self->sockpool.targets.entries[0]->url;
     const h2o_url_scheme_t *scheme;
     h2o_iovec_t *authority;
 
     /* setup overrides */
     *overrides = (h2o_req_overrides_t){NULL};
-    if (self->sockpool != NULL) {
-        overrides->socketpool = self->sockpool;
-    } else if (self->config.preserve_host) {
-        overrides->upstream = &self->upstream;
-    }
-    overrides->location_rewrite.match = &self->upstream;
+    overrides->socketpool = &self->sockpool;
+    overrides->location_rewrite.match = upstream_url;
     overrides->location_rewrite.path_prefix = req->pathconf->path;
     overrides->use_proxy_protocol = self->config.use_proxy_protocol;
     overrides->max_buffer_size = self->config.max_buffer_size;
@@ -57,14 +53,14 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
         authority = &req->authority;
         overrides->proxy_preserve_host = 1;
     } else {
-        scheme = self->upstream.scheme;
-        authority = &self->upstream.authority;
+        scheme = upstream_url->scheme;
+        authority = &upstream_url->authority;
         overrides->proxy_preserve_host = 0;
     }
 
     /* request reprocess */
     h2o_reprocess_request(req, req->method, scheme, *authority,
-                          h2o_build_destination(req, self->upstream.path.base, self->upstream.path.len, 0), overrides, 0);
+                          h2o_build_destination(req, upstream_url->path.base, upstream_url->path.len, 0), overrides, 0);
 
     return 0;
 }
@@ -74,8 +70,7 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
     struct rp_handler_t *self = (void *)_self;
 
     /* use the loop of first context for handling socketpool timeouts */
-    if (self->sockpool != NULL)
-        h2o_socketpool_register_loop(self->sockpool, ctx->loop);
+    h2o_socketpool_register_loop(&self->sockpool, ctx->loop);
 
     /* setup a specific client context only if we need to */
     if (ctx->globalconf->proxy.io_timeout == self->config.io_timeout &&
@@ -132,8 +127,7 @@ static void on_context_dispose(h2o_handler_t *_self, h2o_context_t *ctx)
         h2o_timeout_dispose(client_ctx->loop, client_ctx->websocket_timeout);
         free(client_ctx->websocket_timeout);
     }
-    if (self->sockpool != NULL)
-        h2o_socketpool_unregister_loop(self->sockpool, ctx->loop);
+    h2o_socketpool_unregister_loop(&self->sockpool, ctx->loop);
     free(client_ctx);
 }
 
@@ -143,41 +137,34 @@ static void on_handler_dispose(h2o_handler_t *_self)
 
     if (self->config.ssl_ctx != NULL)
         SSL_CTX_free(self->config.ssl_ctx);
-    free(self->upstream.host.base);
-    free(self->upstream.path.base);
-    if (self->sockpool != NULL) {
-        h2o_socketpool_dispose(self->sockpool);
-        free(self->sockpool);
-    }
+    h2o_socketpool_dispose(&self->sockpool);
 }
 
 void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstreams, size_t count, h2o_proxy_config_vars_t *config)
 {
-    struct sockaddr_un sa;
-    const char *to_sa_err;
     struct rp_handler_t *self = (void *)h2o_create_handler(pathconf, sizeof(*self));
+
+    assert(count != 0);
+
     self->super.on_context_init = on_context_init;
     self->super.on_context_dispose = on_context_dispose;
     self->super.dispose = on_handler_dispose;
     self->super.on_req = on_req;
     self->super.supports_request_streaming = 1;
-    if (config->keepalive_timeout != 0) {
-        size_t i;
-        self->sockpool = h2o_mem_alloc(sizeof(*self->sockpool));
-        for (i = 0; i != count; ++i) {
-            if (config->registered_as_backends && config->reverse_path.base != NULL) {
-                upstreams[i].path = config->reverse_path;
-            }
-        }
-        h2o_socketpool_init_specific(self->sockpool, SIZE_MAX /* FIXME */, upstreams, count);
-        h2o_socketpool_set_timeout(self->sockpool, config->keepalive_timeout);
-    }
-    to_sa_err = h2o_url_host_to_sun(upstreams[0].host, &sa);
-    h2o_url_copy(NULL, &self->upstream, &upstreams[0]);
-    if (to_sa_err) {
-        h2o_strtolower(self->upstream.host.base, self->upstream.host.len);
-    }
     self->config = *config;
+
+    /* FIXME who's the owner of `upstreams`? */
+    size_t i;
+    for (i = 0; i != count; ++i) {
+        struct sockaddr_un sa;
+        if (h2o_url_host_to_sun(upstreams[i].host, &sa) != NULL)
+            h2o_strtolower(upstreams[i].host.base, upstreams[i].host.len);
+        if (config->registered_as_backends && config->reverse_path.base != NULL)
+            upstreams[i].path = config->reverse_path;
+    }
+    h2o_socketpool_init_specific(&self->sockpool, SIZE_MAX /* FIXME */, upstreams, count);
+    h2o_socketpool_set_timeout(&self->sockpool, config->keepalive_timeout);
+
     if (self->config.ssl_ctx != NULL)
         SSL_CTX_up_ref(self->config.ssl_ctx);
 }

--- a/t/50reverse-proxy-multiple-backends.t
+++ b/t/50reverse-proxy-multiple-backends.t
@@ -12,7 +12,7 @@ plan skip_all => 'plackup not found'
 plan skip_all => 'Starlet not found'
     unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
 
-sub do_test_both_tcp {
+subtest "both-tcp", sub {
     my $upstream_port1 = empty_port();
     my $upstream_port2 = empty_port();
 
@@ -21,16 +21,14 @@ sub do_test_both_tcp {
         is_ready =>  sub {
             check_port($upstream_port1);
         },
-        );
+    );
 
     my $guard2 = spawn_server(
         argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port2, ASSETS_DIR . "/upstream.psgi" ],
         is_ready =>  sub {
             check_port($upstream_port2);
         },
-        );
-
-    my $unexpected = 0;
+    );
 
     my $server = spawn_h2o(<< "EOT");
 hosts:
@@ -47,13 +45,10 @@ EOT
         run_with_curl($server, sub {
             my ($proto, $port, $curl) = @_;
             my $resp = `$curl --silent $proto://127.0.0.1:$port/`;
-            if ($resp ne $upstream_port1 and $resp ne $upstream_port2) {
-                $unexpected = 1;
-            }
-            isnt $unexpected, 1, "both tcp"
+            ok $resp eq $upstream_port1 || $resp eq $upstream_port2;
         });
     }
-}
+};
 
 sub get_unix_socket {
     my ($unix_socket_file, $unix_socket_guard) = do {
@@ -63,31 +58,29 @@ sub get_unix_socket {
             $fn,
             Scope::Guard->new(sub {
                 unlink $fn;
-                              }),
-            );
+            }),
+        );
     };
     return $unix_socket_file
 }
 
-sub do_test_both_unix {
+subtest "both-unix", sub {
     my $upstream_file1 = get_unix_socket();
     my $upstream_file2 = get_unix_socket();
 
     my $guard1 = spawn_server(
         argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_file1, ASSETS_DIR . "/upstream.psgi" ],
-        is_ready =>  sub {
+        is_ready => sub {
             !! -e $upstream_file1;
         },
-        );
+    );
 
     my $guard2 = spawn_server(
         argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_file2, ASSETS_DIR . "/upstream.psgi" ],
-        is_ready =>  sub {
+        is_ready => sub {
             !! -e $upstream_file2;
         },
-        );
-
-    my $unexpected = 0;
+    );
 
     my $server = spawn_h2o(<< "EOT");
 hosts:
@@ -104,15 +97,12 @@ EOT
         run_with_curl($server, sub {
             my ($proto, $port, $curl) = @_;
             my $resp = `$curl --silent $proto://127.0.0.1:$port/`;
-            if ($resp ne $upstream_file1 and $resp ne $upstream_file2) {
-                $unexpected = 1;
-            }
-            isnt $unexpected, 1, "both unix socket"
+            ok $resp eq $upstream_file1 || $resp eq $upstream_file2;
         });
     }
-}
+};
 
-sub do_test_tcp_unix {
+subtest "tcp-unix", sub {
     my $upstream_port = empty_port();
     my $upstream_file = get_unix_socket();
 
@@ -121,16 +111,14 @@ sub do_test_tcp_unix {
         is_ready =>  sub {
             check_port($upstream_port);
         },
-        );
+    );
 
     my $guard2 = spawn_server(
         argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_file, ASSETS_DIR . "/upstream.psgi" ],
         is_ready =>  sub {
             !! -e $upstream_file;
         },
-        );
-
-    my $unexpected = 0;
+    );
 
     my $server = spawn_h2o(<< "EOT");
 hosts:
@@ -147,15 +135,9 @@ EOT
         run_with_curl($server, sub {
             my ($proto, $port, $curl) = @_;
             my $resp = `$curl --silent $proto://127.0.0.1:$port/`;
-            if ($resp ne $upstream_port and $resp ne $upstream_file) {
-                $unexpected = 1;
-            }
-            isnt $unexpected, 1, "tcp & unix socket"
+            ok $resp eq $upstream_port || $resp eq $upstream_file;
         });
     }
-}
+};
 
-do_test_both_tcp();
-do_test_both_unix();
-do_test_tcp_unix();
 done_testing();

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -120,6 +120,7 @@ builder {
             200,
             [
                 'x-server' => $env->{"SERVER_PORT"},
+                'req-connection' => $env->{"HTTP_CONNECTION"} || '',
             ],
             [$env->{"SERVER_PORT"}],
         ];


### PR DESCRIPTION
Amends #1277, utilizing the fact that with #1434 socket pool can be used for non-persistent connections.

Also refactors the members of `h2o_socketpool_t` for simplicity.