### PR TITLE
[wip] allow different paths for load-balanced backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ matrix:
         - misc/install-perl-module.pl JSON
         - misc/install-perl-module.pl Path::Tiny
         - misc/install-perl-module.pl Test::Exception
+        - if [ "`perl -MIO::Socket::SSL -e 'print IO::Socket::SSL->can_server_sni'`" != 1 ] ; then cpanm --sudo --notest Net::SSLeay IO::Socket::SSL ; fi
           # install the `ab` command (a.k.a. ApacheBench; optionally required for running some of the tests)
         - sudo apt-get install -qq apache2-utils
           # install nghttp2 with `--enable-app` (optionally required for running HTTP/2 tests)

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1877,10 +1877,6 @@ typedef struct st_h2o_proxy_config_vars_t {
         uint64_t timeout;
     } websocket;
     h2o_headers_command_t *headers_cmds;
-    h2o_iovec_t reverse_path; /* optional */
-    /* I don't know how to detect if handler registered on same path twice, so temporarily use these switches to do so. */
-    unsigned registered_as_url : 1;
-    unsigned registered_as_backends : 1;
     SSL_CTX *ssl_ctx; /* optional */
     size_t max_buffer_size;
 } h2o_proxy_config_vars_t;

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -64,9 +64,7 @@ struct st_h2o_http1client_t {
         h2o_socketpool_t *pool;
         h2o_socketpool_connect_request_t *connect_req;
     } sockpool;
-    struct {
-        char *server_name; /* non-null if ssl is to be used */
-    } ssl;
+    char *sni_name; /* set even if SSL is not used */
     h2o_socket_t *sock;
     void *data;
     h2o_http1client_informational_cb informational_cb;
@@ -75,8 +73,18 @@ struct st_h2o_http1client_t {
 extern const char *const h2o_http1client_error_is_eos;
 
 int h2o_http1client_write_req(void *priv, h2o_iovec_t chunk, int is_end_stream);
+/**
+ * connects to a HTTP/1.1 server
+ * @param client
+ * @param data
+ * @param ctx
+ * @param socketpool
+ * @param target URL of the target to connect to (or NULL if relying on a non-global socket pool to connect and supply SNI value)
+ * @param is_chunked
+ * @param cb
+ */
 void h2o_http1client_connect(h2o_http1client_t **client, void *data, h2o_http1client_ctx_t *ctx, h2o_socketpool_t *socketpool,
-                             h2o_url_t *origin, h2o_http1client_connect_cb cb, int is_chunked);
+                             h2o_url_t *target, h2o_http1client_connect_cb cb, int is_chunked);
 void h2o_http1client_cancel(h2o_http1client_t *client);
 h2o_socket_t *h2o_http1client_steal_socket(h2o_http1client_t *client);
 void h2o_http1client_body_read_stop(h2o_http1client_t *client);

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -64,7 +64,6 @@ struct st_h2o_http1client_t {
         h2o_socketpool_t *pool;
         h2o_socketpool_connect_request_t *connect_req;
     } sockpool;
-    char *sni_name; /* set even if SSL is not used */
     h2o_socket_t *sock;
     void *data;
     h2o_http1client_informational_cb informational_cb;

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -200,6 +200,7 @@ void init_target(h2o_socketpool_target_t *target, h2o_url_t *origin)
     socklen_t salen;
 
     h2o_url_copy(NULL, &target->url, origin);
+    assert(target->url.host.base[target->url.host.len] == '\0'); /* needs to be null-terminated in order to be used in SNI */
     target->type = detect_target_type(origin, &sa, &salen);
     if (!(target->type == H2O_SOCKETPOOL_TYPE_SOCKADDR && sa.ss_family == AF_UNIX)) {
         h2o_strtolower(target->url.authority.base, target->url.authority.len);

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -608,11 +608,18 @@ static h2o_http1client_head_cb on_connect(h2o_http1client_t *client, const char 
         if (req->overrides != NULL) {
             use_proxy_protocol = req->overrides->use_proxy_protocol;
             req->overrides->location_rewrite.match = origin;
-
             if (!req->overrides->proxy_preserve_host) {
                 req->scheme = origin->scheme;
                 req->authority = origin->authority;
             }
+            h2o_iovec_t append = req->path;
+            if (origin->path.base[origin->path.len - 1] == '/' && append.base[0] == '/') {
+                append.base += 1;
+                append.len -= 1;
+            }
+            req->path = h2o_concat(&req->pool, origin->path, append);
+            req->path_normalized =
+                h2o_url_normalize_path(&req->pool, req->path.base, req->path.len, &req->query_at, &req->norm_indexes);
         }
         self->up_req.bufs[0] = build_request_line_host(req, use_proxy_protocol);
     }
@@ -682,23 +689,22 @@ void h2o__proxy_process_request(h2o_req_t *req)
 {
     h2o_req_overrides_t *overrides = req->overrides;
     h2o_http1client_ctx_t *client_ctx = get_client_ctx(req);
+    h2o_url_t target_buf, *target = &target_buf;
     int te_chunked = 0;
 
     h2o_socketpool_t *socketpool = &req->conn->ctx->globalconf->proxy.global_socketpool;
-    if (overrides != NULL && overrides->socketpool != NULL)
+    if (overrides != NULL && overrides->socketpool != NULL) {
         socketpool = overrides->socketpool;
+        if (!overrides->proxy_preserve_host)
+            target = NULL;
+    }
     int keepalive = h2o_socketpool_can_keepalive(socketpool);
     if (overrides != NULL && overrides->use_proxy_protocol)
         keepalive = 0;
+    if (target == &target_buf)
+        h2o_url_init(&target_buf, req->scheme, req->authority, h2o_iovec_init(H2O_STRLIT("/")));
 
     struct rp_generator_t *self = proxy_send_prepare(req, keepalive, &te_chunked);
-
-    h2o_url_t upstream;
-    if (overrides != NULL && overrides->upstream != NULL) {
-        upstream = *overrides->upstream;
-    } else {
-        h2o_url_init(&upstream, req->scheme, req->authority, h2o_iovec_init(H2O_STRLIT("/")));
-    }
 
     /*
       When the PROXY protocol is being used (i.e. when overrides->use_proxy_protocol is set), the client needs to establish a new
@@ -713,5 +719,5 @@ void h2o__proxy_process_request(h2o_req_t *req)
 
      So I leave this as it is for the time being.
      */
-    h2o_http1client_connect(&self->client, self, client_ctx, socketpool, &upstream, on_connect, te_chunked);
+    h2o_http1client_connect(&self->client, self, client_ctx, socketpool, target, on_connect, te_chunked);
 }

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -262,107 +262,44 @@ static int on_config_ssl_session_cache(h2o_configurator_command_t *cmd, h2o_conf
 static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    h2o_url_t parsed;
+    yoml_t **inputs;
+    size_t num_upstreams, i;
 
-    if (h2o_url_parse(node->data.scalar, SIZE_MAX, &parsed) != 0) {
-        h2o_configurator_errprintf(cmd, node, "failed to parse URL: %s\n", node->data.scalar);
+    /* parse the URL(s) */
+    switch (node->type) {
+    case YOML_TYPE_SCALAR:
+        inputs = &node;
+        num_upstreams = 1;
+        break;
+    case YOML_TYPE_SEQUENCE:
+        inputs = node->data.sequence.elements;
+        num_upstreams = node->data.sequence.size;
+        break;
+    default:
+        h2o_fatal("unexpected node type");
         return -1;
     }
+    h2o_url_t *upstreams = alloca(sizeof(*upstreams) * num_upstreams);
+    for (i = 0; i != num_upstreams; ++i) {
+        if (inputs[i]->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, inputs[i], "argument to proxy.reverse.url must be a scalar or a sequence");
+            return -1;
+        }
+        if (h2o_url_parse(inputs[i]->data.scalar, SIZE_MAX, upstreams + i) != 0) {
+            h2o_configurator_errprintf(cmd, inputs[i], "failed to parse URL: %s\n", inputs[i]->data.scalar);
+            return -1;
+        }
+    }
+
     if (self->vars->keepalive_timeout != 0 && self->vars->use_proxy_protocol) {
         h2o_configurator_errprintf(cmd, node, "please either set `proxy.use-proxy-protocol` to `OFF` or disable keep-alive by "
                                               "setting `proxy.timeout.keepalive` to zero; the features are mutually exclusive");
         return -1;
     }
-    if (self->vars->reverse_path.base != NULL || self->vars->registered_as_backends) {
-        h2o_configurator_errprintf(cmd, node,
-                                   "please either set `proxy.reverse.backends` with `proxy.reverse.path` to support "
-                                   "multiple backends or only set `proxy.reverse.url`; the features are mutually exclusive");
-        return -1;
-    }
-
     if (self->vars->headers_cmds != NULL)
         h2o_mem_addref_shared(self->vars->headers_cmds);
 
-    /* register */
-    self->vars->registered_as_url = 1;
-    h2o_proxy_register_reverse_proxy(ctx->pathconf, &parsed, 1, self->vars);
-
-    return 0;
-}
-
-static int on_config_reverse_path(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    struct proxy_configurator_t *self = (void *)cmd->configurator;
-
-    self->vars->reverse_path = h2o_strdup(NULL, node->data.scalar, strlen(node->data.scalar));
-    /* we should check if path is legal here */
-    return 0;
-}
-
-static int on_config_reverse_backends(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
-{
-    struct proxy_configurator_t *self = (void *)cmd->configurator;
-
-    h2o_url_t parsed;
-    h2o_url_t *upstreams;
-    size_t count;
-    size_t i;
-    int sequence = 0;
-
-    switch (node->type) {
-    case YOML_TYPE_SCALAR:
-        if (h2o_url_parse(node->data.scalar, SIZE_MAX, &parsed) != 0) {
-            h2o_configurator_errprintf(cmd, node, "failed to parse URL: %s\n", node->data.scalar);
-            return -1;
-        }
-        if (parsed.path.len != 1 || parsed.path.base[0] != '/') {
-            h2o_configurator_errprintf(cmd, node, "backends should have no path");
-            return -1;
-        }
-        upstreams = &parsed;
-        count = 1;
-
-        break;
-    case YOML_TYPE_SEQUENCE:
-        sequence = 1;
-        count = node->data.sequence.size;
-        upstreams = alloca(count * sizeof(h2o_url_t));
-        for (i = 0; i != node->data.sequence.size; ++i) {
-            yoml_t *element = node->data.sequence.elements[i];
-            if (element->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, element, "element of a sequence passed to proxy.reverse.backends must be a scalar");
-                return -1;
-            }
-            if (h2o_url_parse(element->data.scalar, SIZE_MAX, &upstreams[i]) != 0) {
-                h2o_configurator_errprintf(cmd, node, "failed to parse URL: %s\n", element->data.scalar);
-                return -1;
-            }
-            if (upstreams[i].path.len != 1 || upstreams[i].path.base[0] != '/') {
-                h2o_configurator_errprintf(cmd, node, "backends should have no path");
-                return -1;
-            }
-        }
-
-        break;
-    default:
-        h2o_configurator_errprintf(cmd, node, "argument to proxy.reverse.url must be either a scalar or a sequence");
-        return -1;
-    }
-
-    if (self->vars->registered_as_url) {
-        h2o_configurator_errprintf(cmd, node,
-                                   "please either set `proxy.reverse.backends` with `proxy.reverse.path` to support "
-                                   "multiple backends or only set `proxy.reverse.url`; the features are mutually exclusive");
-        return -1;
-    }
-
-    if (self->vars->headers_cmds != NULL)
-        h2o_mem_addref_shared(self->vars->headers_cmds);
-
-    /* register */
-    self->vars->registered_as_backends = 1;
-    h2o_proxy_register_reverse_proxy(ctx->pathconf, upstreams, count, self->vars);
-
+    h2o_proxy_register_reverse_proxy(ctx->pathconf, upstreams, num_upstreams, self->vars);
     return 0;
 }
 
@@ -447,9 +384,6 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
     if (self->vars->headers_cmds != NULL)
         h2o_mem_release_shared(self->vars->headers_cmds);
 
-    if (self->vars->reverse_path.base != NULL)
-        free(self->vars->reverse_path.base);
-
     --self->vars;
     return 0;
 }
@@ -466,31 +400,21 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
 
     /* set default vars */
     c->vars = c->_vars_stack;
-    c->vars->reverse_path.base = NULL;
-    c->vars->reverse_path.len = 0;
     c->vars->io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
     c->vars->connect_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
     c->vars->first_byte_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
     c->vars->keepalive_timeout = h2o_socketpool_get_timeout(&conf->proxy.global_socketpool);
     c->vars->websocket.enabled = 0; /* have websocket proxying disabled by default; until it becomes non-experimental */
     c->vars->websocket.timeout = H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT;
-    c->vars->registered_as_url = 0;
-    c->vars->registered_as_backends = 0;
     c->vars->max_buffer_size = SIZE_MAX;
 
     /* setup handlers */
     c->super.enter = on_config_enter;
     c->super.exit = on_config_exit;
-    h2o_configurator_define_command(
-        &c->super, "proxy.reverse.url",
-        H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR | H2O_CONFIGURATOR_FLAG_DEFERRED, on_config_reverse_url);
-    /* if reverse proxy with multiple backends, they should be equivalent. then use backends & path instead of url. */
-    h2o_configurator_define_command(&c->super, "proxy.reverse.backends",
+    h2o_configurator_define_command(&c->super, "proxy.reverse.url",
                                     H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR |
                                         H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE | H2O_CONFIGURATOR_FLAG_DEFERRED,
-                                    on_config_reverse_backends);
-    h2o_configurator_define_command(&c->super, "proxy.reverse.path",
-                                    H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_reverse_path);
+                                    on_config_reverse_url);
     h2o_configurator_define_command(&c->super, "proxy.preserve-host",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_preserve_host);

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -141,15 +141,6 @@ void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstr
     self->config = *config;
 
     /* init socket pool */
-    if (config->registered_as_backends && config->reverse_path.base != NULL) {
-        /* create shallow copy of upstreams so that we can modify them */
-        h2o_url_t *p = alloca(sizeof(*upstreams) * num_upstreams);
-        memcpy(p, upstreams, sizeof(*upstreams) * num_upstreams);
-        upstreams = p;
-        size_t i;
-        for (i = 0; i != num_upstreams; ++i)
-            upstreams[i].path = config->reverse_path;
-    }
     h2o_socketpool_init_specific(&self->sockpool, SIZE_MAX /* FIXME */, upstreams, num_upstreams);
     h2o_socketpool_set_timeout(&self->sockpool, config->keepalive_timeout);
 

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -37,7 +37,6 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     /* setup overrides */
     *overrides = (h2o_req_overrides_t){NULL};
     overrides->socketpool = &self->sockpool;
-    overrides->location_rewrite.match = &self->sockpool.targets.entries[0]->url; /* FIXME do we need to set this here? */
     overrides->location_rewrite.path_prefix = req->pathconf->path;
     overrides->use_proxy_protocol = self->config.use_proxy_protocol;
     overrides->max_buffer_size = self->config.max_buffer_size;

--- a/t/50reverse-proxy-https.t
+++ b/t/50reverse-proxy-https.t
@@ -83,7 +83,7 @@ EOT
         run_with_curl($server, sub {
             my ($proto, $port, $curl) = @_;
             my $resp = `$curl --silent $proto://2130706433:$port/sni-name`;
-            is $resp, $flag ? "2130706433" : "127.0.0.1";
+            is $resp, "127.0.0.1";
         });
     };
     subtest "off" => sub {

--- a/t/50reverse-proxy-https.t
+++ b/t/50reverse-proxy-https.t
@@ -67,4 +67,31 @@ EOT
     });
 };
 
+subtest "preserve.host" => sub {
+    my $doit = sub {
+        my $flag = shift;
+        my $server = spawn_h2o(<< "EOT");
+proxy.ssl.verify-peer: OFF
+proxy.preserve-host: @{[ $flag ? "ON" : "OFF" ]}
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: https://127.0.0.1:$upstream_port
+EOT
+
+        run_with_curl($server, sub {
+            my ($proto, $port, $curl) = @_;
+            my $resp = `$curl --silent $proto://2130706433:$port/sni-name`;
+            is $resp, $flag ? "2130706433" : "127.0.0.1";
+        });
+    };
+    subtest "off" => sub {
+        $doit->(0);
+    };
+    subtest "on" => sub {
+        $doit->(1);
+    };
+};
+
 done_testing();

--- a/t/50reverse-proxy-multiple-backends-with-down.t
+++ b/t/50reverse-proxy-multiple-backends-with-down.t
@@ -28,10 +28,9 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.backends:
-          - http://127.0.0.1.XIP.IO:$unused_port
-          - http://127.0.0.1.XIP.IO:$upstream_port
-        proxy.reverse.path: /echo-server-port
+        proxy.reverse.url:
+          - http://127.0.0.1.XIP.IO:$unused_port/echo-server-port
+          - http://127.0.0.1.XIP.IO:$upstream_port/echo-server-port
 EOT
 
 for my $i (1..50) {

--- a/t/50reverse-proxy-multiple-backends.t
+++ b/t/50reverse-proxy-multiple-backends.t
@@ -73,10 +73,9 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.backends:
-          - http://127.0.0.1.XIP.IO:$upstream_port1
-          - http://127.0.0.1.XIP.IO:$upstream_port2
-        proxy.reverse.path: /echo-server-port
+        proxy.reverse.url:
+          - http://127.0.0.1.XIP.IO:$upstream_port1/echo-server-port
+          - http://127.0.0.1.XIP.IO:$upstream_port2/echo-server-port
 EOT
 };
 
@@ -103,10 +102,9 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.backends:
-          - http://[unix:$upstream_file1]
-          - http://[unix:$upstream_file2]
-        proxy.reverse.path: /echo-server-port
+        proxy.reverse.url:
+          - http://[unix:$upstream_file1]/echo-server-port
+          - http://[unix:$upstream_file2]/echo-server-port
 EOT
 };
 
@@ -133,10 +131,9 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.backends:
-          - http://127.0.0.1.XIP.IO:$upstream_port
-          - http://[unix:$upstream_file]
-        proxy.reverse.path: /echo-server-port
+        proxy.reverse.url:
+          - http://127.0.0.1.XIP.IO:$upstream_port/echo-server-port
+          - http://[unix:$upstream_file]/echo-server-port
 EOT
 };
 

--- a/t/50reverse-proxy-round-robin.t
+++ b/t/50reverse-proxy-round-robin.t
@@ -37,10 +37,9 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.backends:
-          - http://127.0.0.1.XIP.IO:$upstream_port1
-          - http://127.0.0.1.XIP.IO:$upstream_port2
-        proxy.reverse.path: /echo-server-port
+        proxy.reverse.url:
+          - http://127.0.0.1.XIP.IO:$upstream_port1/echo-server-port
+          - http://127.0.0.1.XIP.IO:$upstream_port2/echo-server-port
 EOT
 
 sub do_test {

--- a/t/50reverse-proxy-round-robin.t
+++ b/t/50reverse-proxy-round-robin.t
@@ -11,26 +11,13 @@ plan skip_all => 'plackup not found'
 plan skip_all => 'Starlet not found'
     unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
 
-my $upstream_port1 = empty_port();
-my $upstream_port2 = empty_port();
-
-my $guard1 = spawn_server(
-    argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port1, ASSETS_DIR . "/upstream.psgi" ],
+my $upstream_port = empty_port();
+my $guard = spawn_server(
+    argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
     is_ready =>  sub {
-        check_port($upstream_port1);
+        check_port($upstream_port);
     },
 );
-
-my $guard2 = spawn_server(
-    argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port2, ASSETS_DIR . "/upstream.psgi" ],
-    is_ready =>  sub {
-        check_port($upstream_port2);
-    },
-);
-
-my $access_count1 = 0;
-my $access_count2 = 0;
-my $unexpected = 0;
 
 my $server = spawn_h2o(<< "EOT");
 hosts:
@@ -38,32 +25,39 @@ hosts:
     paths:
       /:
         proxy.reverse.url:
-          - http://127.0.0.1.XIP.IO:$upstream_port1/echo-server-port
-          - http://127.0.0.1.XIP.IO:$upstream_port2/echo-server-port
+          - http://127.0.0.1.XIP.IO:$upstream_port/
+          - http://127.0.0.1.XIP.IO:$upstream_port/subdir/
 EOT
 
-sub do_test {
-    run_with_curl($server, sub {
-            my ($proto, $port, $curl) = @_;
-            my $resp = `$curl --silent $proto://127.0.0.1:$port/`;
-            if ($resp eq $upstream_port1) {
-                $access_count1 += 1;
-            } elsif ($resp eq $upstream_port2) {
-                $access_count2 += 1;
-            } else {
-                $unexpected = 1;
-            }
-            isnt $unexpected, 1, "no unexpected port"
-        });
-}
+my $expected1 = do {
+    open my $fh, "<", "@{[DOC_ROOT]}/index.txt"
+        or die "failed to open file:@{[DOC_ROOT]}/index.txt:$!";
+    local $/;
+    <$fh>;
+};
+my $expected2 = do {
+    open my $fh, "<", "@{[DOC_ROOT]}/subdir/index.txt"
+        or die "failed to open file:@{[DOC_ROOT]}/subdir/index.txt:$!";
+    local $/;
+    <$fh>;
+};
+my $body_re = qr/^@{[ join "|", map { quotemeta $_ } ($expected1, $expected2) ]}$/s;
+my $access_count1 = 0;
+my $access_count2 = 0;
 
 for my $i (1..50) {
-    do_test();
-    if ($unexpected == 1) {
-        last
-    }
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my $resp = `$curl --silent $proto://127.0.0.1:$port/index.txt`;
+        like $resp, $body_re;
+        if ($resp eq $expected1) {
+            $access_count1 += 1;
+        } else {
+            $access_count2 += 1;
+        }
+    });
 }
 
-isnt $unexpected, 1, "no unexpected port";
 is $access_count1, $access_count2, "load balanced";
+
 done_testing();

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -134,6 +134,10 @@ builder {
             [$env->{"REMOTE_PORT"} || ''],
         ];
     };
+    mount "/sni-name" => sub {
+        my $env = shift;
+        [200, [], [$env->{"psgix.io"}->get_servername]];
+    };
     mount "/streaming-body" => sub {
         my $env = shift;
         return sub {


### PR DESCRIPTION
This PR aims to remove the restriction that caused the introduction of `proxy.reverse.backends` and `proxy.reverse.path` in #1277.

With #1471 being merged, we can always accept the URL that h2o has connected to (including it's path) as an argument of `on_pool_connect`. It is no longer to require all the paths of the load-balanced backends to be equivalent.

Hence we can (should) switch to using `proxy.reverse.url` accepting list of URLs rather than having different configuration directives.