### PR TITLE
fix access log body size

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1077,12 +1077,17 @@ struct st_h2o_req_t {
      * whether or not the connection is persistent.
      * Applications should set this flag to zero in case the connection cannot be kept keep-alive (due to an error etc.)
      */
-    char http1_is_persistent;
+    unsigned char http1_is_persistent : 1;
     /**
      * whether if the response has been delegated (i.e. reproxied).
      * For delegated responses, redirect responses would be handled internally.
      */
-    char res_is_delegated;
+    unsigned char res_is_delegated : 1;
+    /**
+     * whether if the bytes sent is counted by ostreams other than final ostream
+     */
+    unsigned char bytes_counted_by_ostream : 1;
+
     /**
      * Whether the producer of the response has explicitely disabled or
      * enabled compression. One of H2O_COMPRESS_HINT_*

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -2029,7 +2029,6 @@ inline h2o_send_state_t h2o_pull(h2o_req_t *req, h2o_ostream_pull_cb cb, h2o_iov
     h2o_send_state_t send_state;
     assert(req->_generator != NULL);
     send_state = cb(req->_generator, req, buf);
-    req->bytes_sent += buf->len;
     if (!h2o_send_state_is_in_progress(send_state))
         req->_generator = NULL;
     return send_state;

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -435,15 +435,10 @@ void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)
 
 void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
 {
-    size_t i;
-
     assert(req->_generator != NULL);
 
     if (!h2o_send_state_is_in_progress(state))
         req->_generator = NULL;
-
-    for (i = 0; i != bufcnt; ++i)
-        req->bytes_sent += bufs[i].len;
 
     req->_ostr_top->do_send(req->_ostr_top, req, bufs, bufcnt, state);
 }

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -39,6 +39,7 @@ static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
     chunk_size = 0;
     for (i = 0; i != inbufcnt; ++i)
         chunk_size += inbufs[i].len;
+    req->bytes_sent += chunk_size;
 
     /* create chunk header and output data */
     if (chunk_size != 0) {

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -94,6 +94,9 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
     /* set content-encoding header */
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, NULL, H2O_STRLIT("chunked"));
 
+    /* set the flag that tells finalostream that req->bytes_sent is already counted */
+    req->bytes_counted_by_ostream = 1;
+
     /* setup filter */
     encoder = (void *)h2o_add_ostream(req, sizeof(chunked_encoder_t), slot);
     encoder->super.do_send = send_chunk;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -662,6 +662,7 @@ static void proceed_pull(struct st_h2o_http1_conn_t *conn, size_t nfilled)
             conn->req.http1_is_persistent = 0;
         }
         buf.len += cbuf.len;
+        conn->req.bytes_sent += cbuf.len;
     } else {
         send_state = H2O_SEND_STATE_IN_PROGRESS;
     }
@@ -707,9 +708,13 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
     struct st_h2o_http1_finalostream_t *self = (void *)_self;
     struct st_h2o_http1_conn_t *conn = (struct st_h2o_http1_conn_t *)req->conn;
     h2o_iovec_t *bufs = alloca(sizeof(h2o_iovec_t) * (inbufcnt + 1));
+    int i;
     int bufcnt = 0;
 
     assert(self == &conn->_ostr_final);
+
+    for (i = 0; i != inbufcnt; ++i)
+        req->bytes_sent += inbufs[i].len;
 
     if (!self->sent_headers) {
         conn->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -34,7 +34,6 @@
 struct st_h2o_http1_finalostream_t {
     h2o_ostream_t super;
     int sent_headers;
-    int count_bytes_sent; /* whether count bytes_sent in finalostream (or it's counted in chunked ostream */
     struct {
         void *buf;
         h2o_ostream_pull_cb cb;
@@ -108,7 +107,6 @@ static void init_request(struct st_h2o_http1_conn_t *conn)
     conn->_ostr_final.super.do_send = finalostream_send;
     conn->_ostr_final.super.start_pull = finalostream_start_pull;
     conn->_ostr_final.sent_headers = 0;
-    conn->_ostr_final.count_bytes_sent = 0;
 }
 
 static void close_connection(struct st_h2o_http1_conn_t *conn, int close_socket)
@@ -716,10 +714,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
     assert(self == &conn->_ostr_final);
 
     /* count bytes_sent if other ostreams haven't counted */
-    if (inbufcnt > 0 && req->bytes_sent == 0) {
-        self->count_bytes_sent = 1;
-    }
-    if (self->count_bytes_sent) {
+    if (req->bytes_counted_by_ostream == 0) {
         for (i = 0; i != inbufcnt; ++i) {
             req->bytes_sent += inbufs[i].len;
         }

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -122,6 +122,7 @@ static void commit_data_header(h2o_http2_conn_t *conn, h2o_http2_stream_t *strea
         h2o_http2_window_consume_window(&conn->_write.window, length);
         h2o_http2_window_consume_window(&stream->output_window, length);
         (*outbuf)->size += length + H2O_HTTP2_FRAME_HEADER_SIZE;
+        stream->req.bytes_sent += length;
     }
     /* send a RST_STREAM if there's an error */
     if (send_state == H2O_SEND_STATE_ERROR) {

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -38,6 +38,9 @@ hosts:
         header.add: "set-cookie: c=d"
         header.add: "cache-control: must-revalidate"
         header.add: "cache-control: no-store"
+      /compress:
+        file.dir: @{[ DOC_ROOT ]}
+        compress: [gzip]
     access-log:
       format: "$args->{format}"
 @{[$args->{escape} ? "      escape: $args->{escape}" : ""]}
@@ -250,6 +253,30 @@ subtest "json-null" => sub {
         { format => '\\"%h\\" %l \\"%l\\" \'%l\' \'%l \' \'\\"%l\\"\'', escape => 'json' },
         qr{^"127\.0\.0\.1" null null null 'null ' '"null"'$},
     );
+};
+
+subtest 'compressed-body-size' => sub {
+    my $doit = sub {
+        my ($opts, $expected) = @_;
+        doit(
+            sub {
+                my $server = shift;
+                system("curl $opts --silent http://127.0.0.1:$server->{port}/compress/alice.txt > /dev/null");
+            },
+            '%b',
+            qr{^$expected$},
+        );
+    };
+    subtest 'http1' => sub {
+        $doit->("", 1661);
+        $doit->("-H 'Accept-Encoding: gzip'", 920); # gzip content size (908) + chunked encoding overhead (12)
+    };
+    subtest 'http2' => sub {
+        plan skip_all => "curl does not support HTTP/2"
+            unless curl_supports_http2();
+        $doit->("--http2", 1661);
+        $doit->("--http2 -H 'Accept-Encoding: gzip'", 908);
+    };
 };
 
 done_testing;

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -269,7 +269,7 @@ subtest 'compressed-body-size' => sub {
     };
     subtest 'http1' => sub {
         $doit->("", 1661);
-        $doit->("-H 'Accept-Encoding: gzip'", 920); # gzip content size (908) + chunked encoding overhead (12)
+        $doit->("-H 'Accept-Encoding: gzip'", 908); # it doesn't contain chunked encoding overhead (12)
     };
     subtest 'http2' => sub {
         plan skip_all => "curl does not support HTTP/2"


### PR DESCRIPTION
Currently, the access log `%b` specifier outputs *raw* body size ignoring compression, chunked encoding overhead, etc..
This PR fixes that issue.