### PR TITLE
SSL_CTX as part of socket pool

### DIFF
--- a/examples/libh2o/http1client.c
+++ b/examples/libh2o/http1client.c
@@ -74,6 +74,12 @@ static void start_request(h2o_http1client_ctx_t *ctx)
         h2o_socketpool_init_specific(sockpool, 10, &url_parsed, 1);
         h2o_socketpool_set_timeout(sockpool, 5000 /* in msec */);
         h2o_socketpool_register_loop(sockpool, ctx->loop);
+
+        SSL_CTX *ssl_ctx = SSL_CTX_new(TLSv1_client_method());
+        SSL_CTX_load_verify_locations(ssl_ctx, H2O_TO_STR(H2O_ROOT) "/share/h2o/ca-bundle.crt", NULL);
+        SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+        h2o_socketpool_set_ssl_ctx(sockpool, ssl_ctx);
+        SSL_CTX_free(ssl_ctx);
     }
     h2o_http1client_connect(NULL, req, ctx, sockpool, &url_parsed, on_connect, 0);
 }
@@ -213,9 +219,6 @@ int main(int argc, char **argv)
     SSL_load_error_strings();
     SSL_library_init();
     OpenSSL_add_all_algorithms();
-    ctx.ssl_ctx = SSL_CTX_new(TLSv1_client_method());
-    SSL_CTX_load_verify_locations(ctx.ssl_ctx, H2O_TO_STR(H2O_ROOT) "/share/h2o/ca-bundle.crt", NULL);
-    SSL_CTX_set_verify(ctx.ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
 
     while ((opt = getopt(argc, argv, "t:m:b:c:i:")) != -1) {
         switch (opt) {

--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -358,7 +358,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT(unix_listener)), 65535);
         register_handler(hostconf, "/chunked-test", chunked_test);
         h2o_url_parse(unix_listener, strlen(unix_listener), &upstream);
-        h2o_proxy_register_reverse_proxy(h2o_config_register_path(hostconf, "/reproxy-test", 0), &upstream, 1, &proxy_config);
+        h2o_proxy_register_reverse_proxy(h2o_config_register_path(hostconf, "/reproxy-test", 0), &upstream, 1, 2000, NULL,
+                                         &proxy_config);
         h2o_file_register(h2o_config_register_path(hostconf, "/", 0), "./examples/doc_root", NULL, NULL, 0);
 
         loop = h2o_evloop_create();

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -405,10 +405,6 @@ struct st_h2o_globalconf_t {
          */
         uint64_t first_byte_timeout;
         /**
-         * SSL context for connections initiated by the proxy (optional, governed by the application)
-         */
-        SSL_CTX *ssl_ctx;
-        /**
          * a boolean flag if set to true, instructs the proxy to preserve the x-forwarded-proto header passed by the client
          */
         unsigned preserve_x_forwarded_proto : 1;
@@ -1871,21 +1867,19 @@ typedef struct st_h2o_proxy_config_vars_t {
     uint64_t first_byte_timeout;
     unsigned preserve_host : 1;
     unsigned use_proxy_protocol : 1;
-    uint64_t keepalive_timeout; /* in milliseconds; set to zero to disable keepalive */
     struct {
         int enabled;
         uint64_t timeout;
     } websocket;
     h2o_headers_command_t *headers_cmds;
-    SSL_CTX *ssl_ctx; /* optional */
     size_t max_buffer_size;
 } h2o_proxy_config_vars_t;
 
 /**
  * registers the reverse proxy handler to the context
  */
-void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstreams, size_t count,
-                                      h2o_proxy_config_vars_t *config);
+void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_url_t *upstreams, size_t num_upstreams,
+                                      uint64_t keepalive_timeout, SSL_CTX *ssl_ctx, h2o_proxy_config_vars_t *config);
 /**
  * registers the configurator
  */

--- a/include/h2o/http1client.h
+++ b/include/h2o/http1client.h
@@ -55,7 +55,6 @@ typedef struct st_h2o_http1client_ctx_t {
     h2o_timeout_t *connect_timeout;
     h2o_timeout_t *first_byte_timeout;
     h2o_timeout_t *websocket_timeout; /* NULL if upgrade to websocket is not allowed */
-    SSL_CTX *ssl_ctx;
 } h2o_http1client_ctx_t;
 
 struct st_h2o_http1client_t {

--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -87,6 +87,7 @@ typedef struct st_h2o_socketpool_t {
         h2o_timeout_t timeout;
         h2o_timeout_entry_t entry;
     } _interval_cb;
+    SSL_CTX *_ssl_ctx;
 
     /* vars that are modified by multiple threads */
     struct {
@@ -126,6 +127,10 @@ static uint64_t h2o_socketpool_get_timeout(h2o_socketpool_t *pool);
  *
  */
 static void h2o_socketpool_set_timeout(h2o_socketpool_t *pool, uint64_t msec);
+/**
+ *
+ */
+void h2o_socketpool_set_ssl_ctx(h2o_socketpool_t *pool, SSL_CTX *ssl_ctx);
 /**
  * associates a loop
  */

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -540,7 +540,7 @@ static void on_handshake_complete(h2o_socket_t *sock, const char *err)
     if (err == NULL) {
         /* success */
     } else if (err == h2o_socket_error_ssl_cert_name_mismatch &&
-               (SSL_CTX_get_verify_mode(client->super.ctx->ssl_ctx) & SSL_VERIFY_PEER) == 0) {
+               (SSL_CTX_get_verify_mode(client->super.sockpool.pool->_ssl_ctx) & SSL_VERIFY_PEER) == 0) {
         /* peer verification skipped */
     } else {
         on_connect_error(client, err);
@@ -569,7 +569,8 @@ static void on_pool_connect(h2o_socket_t *sock, const char *errstr, void *data, 
 
     /* perform TLS handshake if necessary */
     if (client->_origin->scheme->is_ssl && sock->ssl == NULL) {
-        h2o_socket_ssl_handshake(client->super.sock, client->super.ctx->ssl_ctx, client->_origin->host.base, on_handshake_complete);
+        h2o_socket_ssl_handshake(client->super.sock, client->super.sockpool.pool->_ssl_ctx, client->_origin->host.base,
+                                 on_handshake_complete);
         return;
     }
 

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -532,24 +532,6 @@ static void on_connection_ready(struct st_h2o_http1client_private_t *client)
     h2o_timeout_link(client->super.ctx->loop, client->super.ctx->io_timeout, &client->_timeout);
 }
 
-static void on_handshake_complete(h2o_socket_t *sock, const char *err)
-{
-    struct st_h2o_http1client_private_t *client = sock->data;
-    h2o_timeout_unlink(&client->_timeout);
-
-    if (err == NULL) {
-        /* success */
-    } else if (err == h2o_socket_error_ssl_cert_name_mismatch &&
-               (SSL_CTX_get_verify_mode(client->super.sockpool.pool->_ssl_ctx) & SSL_VERIFY_PEER) == 0) {
-        /* peer verification skipped */
-    } else {
-        on_connect_error(client, err);
-        return;
-    }
-
-    on_connection_ready(client);
-}
-
 static void on_pool_connect(h2o_socket_t *sock, const char *errstr, void *data, h2o_url_t *origin)
 {
     struct st_h2o_http1client_private_t *client = data;
@@ -566,14 +548,6 @@ static void on_pool_connect(h2o_socket_t *sock, const char *errstr, void *data, 
     client->super.sock = sock;
     sock->data = client;
     client->_origin = origin;
-
-    /* perform TLS handshake if necessary */
-    if (client->_origin->scheme->is_ssl && sock->ssl == NULL) {
-        h2o_socket_ssl_handshake(client->super.sock, client->super.sockpool.pool->_ssl_ctx, client->_origin->host.base,
-                                 on_handshake_complete);
-        return;
-    }
-
     h2o_timeout_unlink(&client->_timeout);
 
     on_connection_ready(client);

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -305,7 +305,8 @@ void h2o_socketpool_set_ssl_ctx(h2o_socketpool_t *pool, SSL_CTX *ssl_ctx)
 {
     if (pool->_ssl_ctx != NULL)
         SSL_CTX_free(pool->_ssl_ctx);
-    SSL_CTX_up_ref(ssl_ctx);
+    if (ssl_ctx != NULL)
+        SSL_CTX_up_ref(ssl_ctx);
     pool->_ssl_ctx = ssl_ctx;
 }
 

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -289,6 +289,9 @@ void h2o_socketpool_dispose(h2o_socketpool_t *pool)
     if (pool->_lb.dispose != NULL)
         pool->_lb.dispose(pool->_lb.data);
 
+    if (pool->_ssl_ctx != NULL)
+        SSL_CTX_free(pool->_ssl_ctx);
+
     if (pool->_interval_cb.loop != NULL)
         h2o_socketpool_unregister_loop(pool, pool->_interval_cb.loop);
 

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -402,6 +402,7 @@ static void on_connect(h2o_socket_t *sock, const char *err)
     } else {
         h2o_url_t *target_url = &req->pool->targets.entries[req->selected_target]->url;
         if (target_url->scheme->is_ssl) {
+            assert(req->pool->_ssl_ctx != NULL && "h2o_socketpool_set_ssl_ctx must be called for a pool that contains SSL target");
             h2o_socket_ssl_handshake(sock, req->pool->_ssl_ctx, target_url->host.base, on_handshake_complete);
             return;
         }

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -298,6 +298,14 @@ void h2o_socketpool_dispose(h2o_socketpool_t *pool)
     free(pool->targets.entries);
 }
 
+void h2o_socketpool_set_ssl_ctx(h2o_socketpool_t *pool, SSL_CTX *ssl_ctx)
+{
+    if (pool->_ssl_ctx != NULL)
+        SSL_CTX_free(pool->_ssl_ctx);
+    SSL_CTX_up_ref(ssl_ctx);
+    pool->_ssl_ctx = ssl_ctx;
+}
+
 void h2o_socketpool_register_loop(h2o_socketpool_t *pool, h2o_loop_t *loop)
 {
     if (pool->_interval_cb.loop != NULL)

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -193,7 +193,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http2.latency_optimization.max_cwnd = 65535;
     config->http2.callbacks = H2O_HTTP2_CALLBACKS;
     config->mimemap = h2o_mimemap_create();
-    h2o_socketpool_init_global(&config->proxy.global_socketpool, SIZE_MAX /* FIXME */);
+    h2o_socketpool_init_global(&config->proxy.global_socketpool, SIZE_MAX);
 
     h2o_configurator__init_core(config);
 }

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -110,7 +110,6 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     ctx->proxy.client_ctx.io_timeout = &ctx->proxy.io_timeout;
     ctx->proxy.client_ctx.connect_timeout = &ctx->proxy.connect_timeout;
     ctx->proxy.client_ctx.first_byte_timeout = &ctx->proxy.first_byte_timeout;
-    ctx->proxy.client_ctx.ssl_ctx = config->proxy.ssl_ctx;
 
     ctx->_module_configs = h2o_mem_alloc(sizeof(*ctx->_module_configs) * config->_num_config_slots);
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -28,25 +28,31 @@
 #include "h2o.h"
 #include "h2o/configurator.h"
 
+struct proxy_config_wars_t {
+    h2o_proxy_config_vars_t conf;
+    uint64_t keepalive_timeout; /* in milliseconds; set to zero to disable keepalive */
+    SSL_CTX *ssl_ctx;
+};
+
 struct proxy_configurator_t {
     h2o_configurator_t super;
     unsigned connect_timeout_set : 1;
     unsigned first_byte_timeout_set : 1;
-    h2o_proxy_config_vars_t *vars;
-    h2o_proxy_config_vars_t _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
+    struct proxy_config_wars_t *vars;
+    struct proxy_config_wars_t _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
 };
 
 static int on_config_timeout_io(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     int ret;
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    ret = h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->io_timeout);
+    ret = h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->conf.io_timeout);
     if (ret < 0)
         return ret;
     if (!self->connect_timeout_set)
-        self->vars->connect_timeout = self->vars->io_timeout;
+        self->vars->conf.connect_timeout = self->vars->conf.io_timeout;
     if (!self->first_byte_timeout_set)
-        self->vars->first_byte_timeout = self->vars->io_timeout;
+        self->vars->conf.first_byte_timeout = self->vars->conf.io_timeout;
     return ret;
 }
 
@@ -54,14 +60,14 @@ static int on_config_timeout_connect(h2o_configurator_command_t *cmd, h2o_config
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
     self->connect_timeout_set = 1;
-    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->connect_timeout);
+    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->conf.connect_timeout);
 }
 
 static int on_config_timeout_first_byte(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
     self->first_byte_timeout_set = 1;
-    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->first_byte_timeout);
+    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->conf.first_byte_timeout);
 }
 
 static int on_config_timeout_keepalive(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
@@ -76,7 +82,7 @@ static int on_config_preserve_host(h2o_configurator_command_t *cmd, h2o_configur
     ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
     if (ret == -1)
         return -1;
-    self->vars->preserve_host = (int)ret;
+    self->vars->conf.preserve_host = (int)ret;
     return 0;
 }
 
@@ -86,14 +92,14 @@ static int on_config_proxy_protocol(h2o_configurator_command_t *cmd, h2o_configu
     ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
     if (ret == -1)
         return -1;
-    self->vars->use_proxy_protocol = (int)ret;
+    self->vars->conf.use_proxy_protocol = (int)ret;
     return 0;
 }
 
 static int on_config_websocket_timeout(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->websocket.timeout);
+    return h2o_configurator_scanf(cmd, node, "%" SCNu64, &self->vars->conf.websocket.timeout);
 }
 
 static int on_config_websocket(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
@@ -102,7 +108,7 @@ static int on_config_websocket(h2o_configurator_command_t *cmd, h2o_configurator
     ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
     if (ret == -1)
         return -1;
-    self->vars->websocket.enabled = (int)ret;
+    self->vars->conf.websocket.enabled = (int)ret;
     return 0;
 }
 
@@ -291,15 +297,16 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
         }
     }
 
-    if (self->vars->keepalive_timeout != 0 && self->vars->use_proxy_protocol) {
+    if (self->vars->keepalive_timeout != 0 && self->vars->conf.use_proxy_protocol) {
         h2o_configurator_errprintf(cmd, node, "please either set `proxy.use-proxy-protocol` to `OFF` or disable keep-alive by "
                                               "setting `proxy.timeout.keepalive` to zero; the features are mutually exclusive");
         return -1;
     }
-    if (self->vars->headers_cmds != NULL)
-        h2o_mem_addref_shared(self->vars->headers_cmds);
+    if (self->vars->conf.headers_cmds != NULL)
+        h2o_mem_addref_shared(self->vars->conf.headers_cmds);
 
-    h2o_proxy_register_reverse_proxy(ctx->pathconf, upstreams, num_upstreams, self->vars);
+    h2o_proxy_register_reverse_proxy(ctx->pathconf, upstreams, num_upstreams, self->vars->keepalive_timeout, self->vars->ssl_ctx,
+                                     &self->vars->conf);
     return 0;
 }
 
@@ -333,7 +340,7 @@ static int on_config_preserve_x_forwarded_proto(h2o_configurator_command_t *cmd,
 static int on_config_max_buffer_size(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%zu", &self->vars->max_buffer_size);
+    return h2o_configurator_scanf(cmd, node, "%zu", &self->vars->conf.max_buffer_size);
 }
 
 static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
@@ -341,8 +348,8 @@ static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t
     struct proxy_configurator_t *self = (void *)_self;
 
     memcpy(self->vars + 1, self->vars, sizeof(*self->vars));
-    if (self->vars[1].headers_cmds != NULL)
-        h2o_mem_addref_shared(self->vars[1].headers_cmds);
+    if (self->vars[1].conf.headers_cmds != NULL)
+        h2o_mem_addref_shared(self->vars[1].conf.headers_cmds);
     ++self->vars;
     self->connect_timeout_set = 0;
     self->first_byte_timeout_set = 0;
@@ -372,17 +379,16 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 
     if (ctx->pathconf == NULL && ctx->hostconf == NULL) {
         /* is global conf */
-        ctx->globalconf->proxy.io_timeout = self->vars->io_timeout;
-        ctx->globalconf->proxy.connect_timeout = self->vars->connect_timeout;
-        ctx->globalconf->proxy.first_byte_timeout = self->vars->first_byte_timeout;
-        ctx->globalconf->proxy.ssl_ctx = self->vars->ssl_ctx;
+        ctx->globalconf->proxy.io_timeout = self->vars->conf.io_timeout;
+        ctx->globalconf->proxy.connect_timeout = self->vars->conf.connect_timeout;
+        ctx->globalconf->proxy.first_byte_timeout = self->vars->conf.first_byte_timeout;
+        h2o_socketpool_set_ssl_ctx(&ctx->globalconf->proxy.global_socketpool, self->vars->ssl_ctx);
         h2o_socketpool_set_timeout(&ctx->globalconf->proxy.global_socketpool, self->vars->keepalive_timeout);
-    } else {
-        SSL_CTX_free(self->vars->ssl_ctx);
     }
+    SSL_CTX_free(self->vars->ssl_ctx);
 
-    if (self->vars->headers_cmds != NULL)
-        h2o_mem_release_shared(self->vars->headers_cmds);
+    if (self->vars->conf.headers_cmds != NULL)
+        h2o_mem_release_shared(self->vars->conf.headers_cmds);
 
     --self->vars;
     return 0;
@@ -391,7 +397,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 static h2o_headers_command_t **get_headers_commands(h2o_configurator_t *_self)
 {
     struct proxy_configurator_t *self = (void *)_self;
-    return &self->vars->headers_cmds;
+    return &self->vars->conf.headers_cmds;
 }
 
 void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
@@ -400,13 +406,13 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
 
     /* set default vars */
     c->vars = c->_vars_stack;
-    c->vars->io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
-    c->vars->connect_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
-    c->vars->first_byte_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
+    c->vars->conf.io_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
+    c->vars->conf.connect_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
+    c->vars->conf.first_byte_timeout = H2O_DEFAULT_PROXY_IO_TIMEOUT;
+    c->vars->conf.websocket.enabled = 0; /* have websocket proxying disabled by default; until it becomes non-experimental */
+    c->vars->conf.websocket.timeout = H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT;
+    c->vars->conf.max_buffer_size = SIZE_MAX;
     c->vars->keepalive_timeout = h2o_socketpool_get_timeout(&conf->proxy.global_socketpool);
-    c->vars->websocket.enabled = 0; /* have websocket proxying disabled by default; until it becomes non-experimental */
-    c->vars->websocket.timeout = H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT;
-    c->vars->max_buffer_size = SIZE_MAX;
 
     /* setup handlers */
     c->super.enter = on_config_enter;


### PR DESCRIPTION
The global socket pool determines which socket can be reused by looking at the (is_ssl, host, port) tuple. The fact means that SSL connections connecting to the same host:port using different SSL_CTXs cannot be shared within the global socket.

This PR implements the restriction by making SSL_CTX part of the socket pool. The added bonus is that SSL handshake can now be completed within the socket pool.

amends #1434 #1476