### PR TITLE
keep mruby's PATH_INFO undecoded

### DIFF
--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -454,7 +454,7 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
         --confpath_len_wo_slash;
 
     assert(confpath_len_wo_slash <= generator->req->path_normalized.len);
-    size_t path_info_offset = generator->req->norm_indexes != NULL ? generator->req->norm_indexes[confpath_len_wo_slash] - 1 : confpath_len_wo_slash;
+    size_t path_info_offset = generator->req->norm_indexes != NULL ? generator->req->norm_indexes[confpath_len_wo_slash - 1] : confpath_len_wo_slash;
     size_t path_info_length = (generator->req->query_at != SIZE_MAX ? generator->req->query_at : generator->req->path.len) - path_info_offset;
 
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SCRIPT_NAME),

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -452,11 +452,15 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
     size_t confpath_len_wo_slash = generator->req->pathconf->path.len;
     if (generator->req->pathconf->path.base[generator->req->pathconf->path.len - 1] == '/')
         --confpath_len_wo_slash;
+
+    assert(confpath_len_wo_slash <= generator->req->path_normalized.len);
+    size_t path_info_offset = generator->req->norm_indexes != NULL ? generator->req->norm_indexes[confpath_len_wo_slash] - 1 : confpath_len_wo_slash;
+    size_t path_info_length = (generator->req->query_at != SIZE_MAX ? generator->req->query_at : generator->req->path.len) - path_info_offset;
+
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SCRIPT_NAME),
                  mrb_str_new(mrb, generator->req->pathconf->path.base, confpath_len_wo_slash));
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_PATH_INFO),
-                 mrb_str_new(mrb, generator->req->path_normalized.base + confpath_len_wo_slash,
-                             generator->req->path_normalized.len - confpath_len_wo_slash));
+                 mrb_str_new(mrb, generator->req->path.base + path_info_offset, path_info_length));
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_QUERY_STRING),
                  generator->req->query_at != SIZE_MAX ? mrb_str_new(mrb, generator->req->path.base + generator->req->query_at + 1,
                                                                     generator->req->path.len - (generator->req->query_at + 1))

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -525,4 +525,20 @@ EOT
     unlike $headers, qr{^content-length:}im;
 };
 
+subtest 'PATH_INFO should be kept undecoded' => sub {
+    my $server = spawn_h2o(<< "EOT");
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /foo:
+        mruby.handler: |
+          proc {|env|
+            [200, {}, [env['PATH_INFO']]]
+          }
+EOT
+    (undef, my $body) = run_prog("curl --silent http://127.0.0.1:$server->{port}/foo/bar%20baz");
+    is $body, '/bar%20baz';
+};
+
 done_testing();

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -525,20 +525,34 @@ EOT
     unlike $headers, qr{^content-length:}im;
 };
 
-subtest 'PATH_INFO should be kept undecoded' => sub {
+subtest 'PATH_INFO' => sub {
+    plan skip_all => "nc not found"
+        unless prog_exists("nc");
+
     my $server = spawn_h2o(<< "EOT");
 num-threads: 1
 hosts:
   default:
     paths:
-      /foo:
+      /abc:
         mruby.handler: |
           proc {|env|
             [200, {}, [env['PATH_INFO']]]
           }
 EOT
-    (undef, my $body) = run_prog("curl --silent http://127.0.0.1:$server->{port}/foo/bar%20baz");
-    is $body, '/bar%20baz';
+    my $nc = sub {
+        my $path = shift;
+        my $cmd = "echo 'GET $path HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r' | nc 127.0.0.1 $server->{port}";
+        (undef, my $r) = run_prog($cmd);
+        split(/\r\n\r\n/, $r, 2);
+    };
+    my $body;
+    (undef, $body) = $nc->('/abc/def%20ghi');
+    is $body, '/def%20ghi', 'should be kept undecoded';
+    (undef, $body) = $nc->('/abc/def/../ghi/../jhk');
+    is $body, '/def/../ghi/../jhk', 'https://github.com/h2o/h2o/pull/1480#issuecomment-339614160';
+    (undef, $body) = $nc->('/123/../abc/def/../ghi');
+    is $body, '/def/../ghi', 'https://github.com/h2o/h2o/pull/1480#issuecomment-339658134';
 };
 
 done_testing();


### PR DESCRIPTION
Currently mruby env's `PATH_INFO` value is url-decoded. For example, if we access to `/foo%20bar`, `env['PATH_INFO']` will be `/foo bar` .

Facts:
- Popular Ruby application servers keeps it undecoded
  - unicorn / thin / puma / webrick
- Rack specification is very ambiguous (says `This value may be percent-encoded`)
  - https://github.com/rack/rack/blob/master/SPEC#L37-L39
- WSGI specification doesn't say anything about it
  - https://www.python.org/dev/peps/pep-0333/#id19
- CGI specification defines 'Unlike a URI path, the PATH_INFO is not URL-encoded'
  - https://tools.ietf.org/html/rfc3875#section-4.1.5

Considering mruby in h2o, the compatibility to other servers is important for portability and "least surprise". So I think it's best if we can change it undecoded, but it may break backward compatibility if the users already use and depend on decoded one.

Dear users: if you have any thoughts or suggestions on this, please share them with me by adding comments!
