### PR TITLE
fix keepalive problem related to mruby's http_request shortcut

### DIFF
--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -104,9 +104,11 @@ static void on_shortcut_notify(h2o_mruby_generator_t *generator)
     int is_final;
     h2o_buffer_t **input = h2o_mruby_http_peek_content(chunked->shortcut.client, &is_final);
 
-    /* trim data too long */
-    if (chunked->bytes_left != SIZE_MAX && chunked->bytes_left < (*input)->size)
-        (*input)->size = chunked->bytes_left;
+    if (chunked->bytes_left != SIZE_MAX) {
+        if (chunked->bytes_left < (*input)->size)
+            (*input)->size = chunked->bytes_left; /* trim data too long */
+        chunked->bytes_left -= (*input)->size;
+    }
 
     /* if final, steal socket input buffer to shortcut.remaining, and reset pointer to client */
     if (is_final) {


### PR DESCRIPTION
This PR fixes the bug that h2o cannot persists the connections with clients when mruby's http_request is used and the response body of it is directory returned (so called `shortcut`).

The problem was caused by the fact that `chunked->bytes_left` had never been decremented when shortcut is used and so [this condition](https://github.com/h2o/h2o/blob/master/lib/handler/mruby/chunked.c#L59-L60) may accidentaly fall truthy. Thus, it only happens when the header hash of rack response contains `content-length` header.