### PR TITLE
send RST_STREAM when received smaller payload than content-length header

### DIFF
--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -444,20 +444,22 @@ static void do_send(struct st_fcgi_generator_t *generator)
 {
     h2o_iovec_t vecs[1];
     size_t veccnt;
-    int is_final;
+    h2o_send_state_t send_state;
 
     vecs[0] = h2o_doublebuffer_prepare(&generator->resp.sending, &generator->resp.receiving, generator->req->preferred_chunk_size);
     veccnt = vecs[0].len != 0 ? 1 : 0;
     if (generator->sock == NULL && vecs[0].len == generator->resp.sending.buf->size && generator->resp.receiving->size == 0) {
-        is_final = 1;
-        if (!(generator->leftsize == 0 || generator->leftsize == SIZE_MAX))
-            generator->req->http1_is_persistent = 0;
+        if (generator->leftsize == 0 || generator->leftsize == SIZE_MAX) {
+            send_state = H2O_SEND_STATE_FINAL;
+        } else {
+            send_state = H2O_SEND_STATE_ERROR;
+        }
     } else {
         if (veccnt == 0)
             return;
-        is_final = 0;
+        send_state = H2O_SEND_STATE_IN_PROGRESS;
     }
-    h2o_send(generator->req, vecs, veccnt, is_final ? H2O_SEND_STATE_FINAL : H2O_SEND_STATE_IN_PROGRESS);
+    h2o_send(generator->req, vecs, veccnt, send_state);
 }
 
 static void send_eos_and_close(struct st_fcgi_generator_t *generator, int can_keepalive)

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -104,9 +104,11 @@ static void on_shortcut_notify(h2o_mruby_generator_t *generator)
     int is_final;
     h2o_buffer_t **input = h2o_mruby_http_peek_content(chunked->shortcut.client, &is_final);
 
-    /* trim data too long */
-    if (chunked->bytes_left != SIZE_MAX && chunked->bytes_left < (*input)->size)
-        (*input)->size = chunked->bytes_left;
+    if (chunked->bytes_left != SIZE_MAX) {
+        if (chunked->bytes_left < (*input)->size)
+            (*input)->size = chunked->bytes_left; /* trim data too long */
+        chunked->bytes_left -= (*input)->size;
+    }
 
     /* if final, steal socket input buffer to shortcut.remaining, and reset pointer to client */
     if (is_final) {

--- a/t/50unexpected-upstream-body.t
+++ b/t/50unexpected-upstream-body.t
@@ -1,0 +1,185 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use Time::HiRes;
+use t::Util;
+
+
+sub nc_get {
+    my ($server, $path) = @_;
+    my $resp = `echo 'GET $path HTTP/1.1\\r\\n\\r\\n' | nc 127.0.0.1 $server->{port}`;
+    (undef, my $body) = split(/\r\n\r\n/, $resp, 2);
+    $body;
+}
+
+sub nghttp_get {
+    my ($server, $path) = @_; 
+    my $out = `nghttp -vn 'https://127.0.0.1:$server->{tls_port}$path'`;
+    my $payload_size = 0;
+    while ($out =~ /recv DATA frame <length=(\d+)/g) {
+        $payload_size += $1;
+    }
+    ($payload_size, $out);
+}
+
+sub create_upstream {
+    my (@plackup_opts) = @_;
+    my $port = empty_port();
+    my ($guard, $pid) = spawn_server(
+        argv => [
+            qw(plackup), @plackup_opts, qw(--access-log /dev/null --listen), "127.0.0.1:$port",
+            ASSETS_DIR . "/upstream.psgi",
+        ],
+        is_ready => sub { check_port($port) },
+    );
+    +{ guard => $guard, pid => $pid, port => $port };
+}
+
+sub doit {
+    my ($spawner, $chunked_enabled) = @_;
+
+    subtest 'http1-client' => sub {
+        plan skip_all => "nc not found"
+            unless prog_exists("nc");
+
+        subtest 'oversize body' => sub {
+            my ($server, $upstream) = $spawner->();
+            my $body = nc_get($server, '/content?size=100000&cl=80000');
+            is length($body), 80000, 'body size';
+        };
+
+        subtest 'incomplete body' => sub {
+            my ($server, $upstream) = $spawner->();
+            my $body = nc_get($server, '/content?size=100000&cl=120000');
+            is length($body), 100000, 'body size';
+        };
+
+        if ($chunked_enabled) {
+            subtest 'chunked upstream unexpectedly closed' => sub {
+                my ($server, $upstream) = $spawner->();
+                local $SIG{ALRM} = sub { kill 'KILL', $upstream->{pid} };
+                alarm(1);
+                my $body = nc_get($server, '/infinite-stream');
+                alarm(0);
+                like $body, qr/0\r\n\r\n$/is, 'chunked eos';
+            };
+        }
+    };
+
+    subtest 'http2-client' => sub {
+        plan skip_all => 'nghttp not found'
+            unless prog_exists('nghttp');
+
+        subtest 'oversize body' => sub {
+            my ($server, $upstream) = $spawner->();
+            my ($body_size, $info) = nghttp_get($server, '/content?size=100000&cl=80000');
+            unlike $info, qr/RST_STREAM/is, 'no RST_STREAM';
+            is $body_size, 80000, 'body size';
+        };
+
+        subtest 'incomplete body' => sub {
+            my ($server, $upstream) = $spawner->();
+            my ($body_size, $info) = nghttp_get($server, '/content?size=100000&cl=120000');
+            like $info, qr/RST_STREAM/is, 'RST_STREAM';
+            is $body_size, 100000, 'body size';
+        };
+
+        if ($chunked_enabled) {
+            subtest 'upstream unexpectedly closed' => sub {
+                my ($server, $upstream) = $spawner->();
+                local $SIG{ALRM} = sub { kill 'KILL', $upstream->{pid} };
+                alarm(1);
+                my ($body_size, $info) = nghttp_get($server, '/infinite-stream');
+                alarm(0);
+                unlike $info, qr/RST_STREAM/is, 'no RST_STREAM';
+            };
+        }
+    };
+}
+
+subtest 'proxy' => sub {
+    my $spawner = sub {
+        my $upstream = create_upstream(qw(-s Starlet --max-workers 0));
+        my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        - proxy.reverse.url: http://127.0.0.1:$upstream->{port}/
+EOT
+        ($server, $upstream);
+    };
+    doit($spawner, 1);
+};
+
+subtest 'fastcgi' => sub {
+    my $spawner = sub {
+        my $upstream = create_upstream(qw(-s FCGI --manager=));
+        my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        - fastcgi.connect:
+            port: $upstream->{port}
+            type: tcp
+EOT
+        ($server, $upstream);
+    };
+    doit($spawner, 0);
+};
+
+subtest 'mruby-shortcut' => sub {
+    plan skip_all => 'mruby support is off'
+        unless server_features()->{mruby};
+
+    my $spawner = sub {
+        my $upstream = create_upstream(qw(-s Starlet --max-workers 0));
+        my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        - mruby.handler: |
+            proc {|env|
+              path = "#{env['PATH_INFO']}?#{env['QUERY_STRING']}"
+              http_request("http://127.0.0.1:$upstream->{port}#{path}").join
+            }
+EOT
+        ($server, $upstream);
+    };
+    doit($spawner, 1);
+};
+
+subtest 'mruby-no-shortcut' => sub {
+    plan skip_all => 'mruby support is off'
+        unless server_features()->{mruby};
+
+    my $spawner = sub {
+        my $upstream = create_upstream(qw(-s Starlet --max-workers 0));
+        my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        - mruby.handler: |
+            proc {|env|
+              path = "#{env['PATH_INFO']}?#{env['QUERY_STRING']}"
+              status, headers, body = http_request("http://127.0.0.1:$upstream->{port}#{path}").join
+              [status, headers, Class.new do
+                def initialize(body)
+                  \@body = body
+                end
+                def each
+                  \@body.each {|buf| yield buf }
+                end
+              end.new(body)]
+            }
+EOT
+        ($server, $upstream);
+    };
+    doit($spawner, 1);
+};
+
+done_testing;

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -257,4 +257,15 @@ builder {
             [],
         ];
     };
+    mount "/content" => sub {
+        my $env = shift;
+        my $query = Plack::Request->new($env)->query_parameters;
+        return [
+            200,
+            [
+                ($query->{cl} ? ( 'content-length' => $query->{cl}) : ())
+            ],
+            [ 'a' x ($query->{size} || 0) ],
+        ];
+    };
 };


### PR DESCRIPTION
When the upstreams (via fastcgi and mruby's http_request) respond a payload which length is smaller than content-length header value, the current implementation doesn't send RST_STREAM frame. This PR makes those handlers send RST_STREAM.

NOTE1: This PR depends on https://github.com/h2o/h2o/pull/1489 to make some tests pass

NOTE2: Desirable h2o behaviours

|Upstream Payload | h2o Payload | RST_STREAM (H2) | chunked (H1) |
| ----- | ----- | ----- | ----- |
| smaller than C-L | send all received body | YES | - |
| bigger than C-L | send body upto C-L | NO | - |
| TE:chunked ending in mid-of-chunk | send all received body | YES | append a broken chunk (`1\r\n`) |
| TE:chunked ending on chunk boundary but no eos | send all received body | NO | append an eos (`0\r\n`) |

SEE ALSO: https://github.com/h2o/h2o/pull/1031

