### PR TITLE
fix proposal for OpenSSL/LibreSSL handling macro detection.

### DIFF
--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -45,7 +45,11 @@
 #endif
 #include "neverbleed.h"
 
-#define OPENSSL_1_1_API (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
+#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
+#define OPENSSL_1_1_API 1
+#else
+#define OPENSSL_1_1_API 0
+#endif
 
 enum neverbleed_type { NEVERBLEED_TYPE_ERROR, NEVERBLEED_TYPE_RSA, NEVERBLEED_TYPE_ECDSA };
 

--- a/deps/picotls/lib/openssl.c
+++ b/deps/picotls/lib/openssl.c
@@ -41,7 +41,11 @@
 #include "picotls.h"
 #include "picotls/openssl.h"
 
-#define OPENSSL_1_0_API (OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER))
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER))
+#define OPENSSL_1_0_API 1
+#else
+#define OPENSSL_1_0_API 0
+#endif
 
 #if OPENSSL_1_0_API
 


### PR DESCRIPTION
Triggered by clang 5.0