### PR TITLE
refactor mruby callbacks

### DIFF
--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -93,6 +93,14 @@ typedef struct st_h2o_mruby_shared_context_t {
         mrb_sym sym_headers;
         mrb_sym sym_body;
         mrb_sym sym_async;
+
+        mrb_sym sym_callback_exception_raised;
+        mrb_sym sym_callback_configuring_app;
+        mrb_sym sym_callback_configured_app;
+        mrb_sym sym_callback_send_chunked_eos;
+        mrb_sym sym_callback_http_join_response;
+        mrb_sym sym_callback_http_fetch_chunk;
+        mrb_sym sym_callback_sleep;
     } symbols;
 } h2o_mruby_shared_context_t;
 
@@ -116,14 +124,6 @@ typedef struct st_h2o_mruby_generator_t {
         mrb_value generator;
     } refs;
 } h2o_mruby_generator_t;
-
-#define H2O_MRUBY_CALLBACK_ID_EXCEPTION_RAISED -1 /* used to notify exception, does not execution to mruby code */
-#define H2O_MRUBY_CALLBACK_ID_CONFIGURING_APP -2
-#define H2O_MRUBY_CALLBACK_ID_CONFIGURED_APP -3
-#define H2O_MRUBY_CALLBACK_ID_SEND_CHUNKED_EOS -4
-#define H2O_MRUBY_CALLBACK_ID_HTTP_JOIN_RESPONSE -5
-#define H2O_MRUBY_CALLBACK_ID_HTTP_FETCH_CHUNK -6
-#define H2O_MRUBY_CALLBACK_ID_SLEEP -999
 
 #define h2o_mruby_assert(mrb)                                                                                                      \
     if (mrb->exc != NULL)                                                                                                          \
@@ -153,7 +153,7 @@ typedef struct st_h2o_mruby_generator_t {
 void h2o_mruby__assert_failed(mrb_state *mrb, const char *file, int line);
 mrb_value h2o_mruby_to_str(mrb_state *mrb, mrb_value v);
 mrb_value h2o_mruby_eval_expr(mrb_state *mrb, const char *expr);
-void h2o_mruby_define_callback(mrb_state *mrb, const char *name, int id);
+void h2o_mruby_define_callback(mrb_state *mrb, const char *name, mrb_sym callback);
 mrb_value h2o_mruby_create_data_instance(mrb_state *mrb, mrb_value class_obj, void *ptr, const mrb_data_type *type);
 void h2o_mruby_setup_globals(mrb_state *mrb);
 struct RProc *h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config, char *errbuf);

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -81,6 +81,10 @@ typedef struct st_h2o_mruby_handler_t {
     h2o_mruby_config_vars_t config;
 } h2o_mruby_handler_t;
 
+typedef struct st_h2o_mruby_context_t h2o_mruby_context_t;
+typedef mrb_value (*h2o_mruby_callback)(h2o_mruby_context_t *ctx, mrb_value input, mrb_value receiver, mrb_value args, int *run_again);
+typedef H2O_VECTOR(h2o_mruby_callback) h2o_mruby_callbacks;
+
 typedef struct st_h2o_mruby_shared_context_t {
     h2o_context_t *ctx;
     mrb_state *mrb;
@@ -93,23 +97,16 @@ typedef struct st_h2o_mruby_shared_context_t {
         mrb_sym sym_headers;
         mrb_sym sym_body;
         mrb_sym sym_async;
-
-        mrb_sym sym_callback_exception_raised;
-        mrb_sym sym_callback_configuring_app;
-        mrb_sym sym_callback_configured_app;
-        mrb_sym sym_callback_send_chunked_eos;
-        mrb_sym sym_callback_http_join_response;
-        mrb_sym sym_callback_http_fetch_chunk;
-        mrb_sym sym_callback_sleep;
     } symbols;
+    h2o_mruby_callbacks callbacks;
 } h2o_mruby_shared_context_t;
 
-typedef struct st_h2o_mruby_context_t {
+struct st_h2o_mruby_context_t {
     h2o_mruby_handler_t *handler;
     mrb_value proc;
     h2o_mruby_shared_context_t *shared;
     mrb_value pendings;
-} h2o_mruby_context_t;
+};
 
 typedef struct st_h2o_mruby_chunked_t h2o_mruby_chunked_t;
 typedef struct st_h2o_mruby_http_request_context_t h2o_mruby_http_request_context_t;
@@ -153,7 +150,7 @@ typedef struct st_h2o_mruby_generator_t {
 void h2o_mruby__assert_failed(mrb_state *mrb, const char *file, int line);
 mrb_value h2o_mruby_to_str(mrb_state *mrb, mrb_value v);
 mrb_value h2o_mruby_eval_expr(mrb_state *mrb, const char *expr);
-void h2o_mruby_define_callback(mrb_state *mrb, const char *name, mrb_sym callback);
+void h2o_mruby_define_callback(mrb_state *mrb, const char *name, h2o_mruby_callback callback);
 mrb_value h2o_mruby_create_data_instance(mrb_state *mrb, mrb_value class_obj, void *ptr, const mrb_data_type *type);
 void h2o_mruby_setup_globals(mrb_state *mrb);
 struct RProc *h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config, char *errbuf);
@@ -170,13 +167,8 @@ void h2o_mruby_send_chunked_close(h2o_mruby_generator_t *generator);
 mrb_value h2o_mruby_send_chunked_init(h2o_mruby_generator_t *generator, mrb_value body);
 void h2o_mruby_send_chunked_dispose(h2o_mruby_generator_t *generator);
 
-mrb_value h2o_mruby_send_chunked_eos_callback(h2o_mruby_context_t *ctx, mrb_value receiver, mrb_value input, int *next_action);
-
 /* handler/mruby/http_request.c */
 void h2o_mruby_http_request_init_context(h2o_mruby_shared_context_t *ctx);
-
-mrb_value h2o_mruby_http_join_response_callback(h2o_mruby_context_t *ctx, mrb_value receiver, mrb_value args, int *next_action);
-mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_context_t *ctx, mrb_value receiver, mrb_value input, int *next_action);
 
 h2o_mruby_http_request_context_t *h2o_mruby_http_set_shortcut(mrb_state *mrb, mrb_value obj, void (*cb)(h2o_mruby_generator_t *),
                                                               h2o_mruby_generator_t *generator);
@@ -185,7 +177,6 @@ h2o_buffer_t **h2o_mruby_http_peek_content(h2o_mruby_http_request_context_t *ctx
 
 /* handler/mruby/sleep.c */
 void h2o_mruby_sleep_init_context(h2o_mruby_shared_context_t *ctx);
-mrb_value h2o_mruby_sleep_callback(h2o_mruby_context_t *mctx, mrb_value receiver, mrb_value args, int *run_again);
 
 /* handler/configurator/mruby.c */
 void h2o_mruby_register_configurator(h2o_globalconf_t *conf);

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -82,8 +82,8 @@ typedef struct st_h2o_mruby_handler_t {
 } h2o_mruby_handler_t;
 
 typedef struct st_h2o_mruby_context_t h2o_mruby_context_t;
-typedef mrb_value (*h2o_mruby_callback)(h2o_mruby_context_t *ctx, mrb_value input, mrb_value receiver, mrb_value args, int *run_again);
-typedef H2O_VECTOR(h2o_mruby_callback) h2o_mruby_callbacks;
+typedef mrb_value (*h2o_mruby_callback_t)(h2o_mruby_context_t *ctx, mrb_value input, mrb_value receiver, mrb_value args, int *run_again);
+typedef H2O_VECTOR(h2o_mruby_callback_t) h2o_mruby_callbacks_t;
 
 typedef struct st_h2o_mruby_shared_context_t {
     h2o_context_t *ctx;
@@ -98,14 +98,14 @@ typedef struct st_h2o_mruby_shared_context_t {
         mrb_sym sym_body;
         mrb_sym sym_async;
     } symbols;
-    h2o_mruby_callbacks callbacks;
+    h2o_mruby_callbacks_t callbacks;
 } h2o_mruby_shared_context_t;
 
 struct st_h2o_mruby_context_t {
     h2o_mruby_handler_t *handler;
     mrb_value proc;
     h2o_mruby_shared_context_t *shared;
-    mrb_value pendings;
+    mrb_value blocking_reqs;
 };
 
 typedef struct st_h2o_mruby_chunked_t h2o_mruby_chunked_t;
@@ -150,7 +150,7 @@ typedef struct st_h2o_mruby_generator_t {
 void h2o_mruby__assert_failed(mrb_state *mrb, const char *file, int line);
 mrb_value h2o_mruby_to_str(mrb_state *mrb, mrb_value v);
 mrb_value h2o_mruby_eval_expr(mrb_state *mrb, const char *expr);
-void h2o_mruby_define_callback(mrb_state *mrb, const char *name, h2o_mruby_callback callback);
+void h2o_mruby_define_callback(mrb_state *mrb, const char *name, h2o_mruby_callback_t callback);
 mrb_value h2o_mruby_create_data_instance(mrb_state *mrb, mrb_value class_obj, void *ptr, const mrb_data_type *type);
 void h2o_mruby_setup_globals(mrb_state *mrb);
 struct RProc *h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *config, char *errbuf);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -322,7 +322,6 @@ mrb_value process_pending_requests_callback(h2o_mruby_context_t *ctx, mrb_value 
     mrb_value exc = mrb_ary_entry(args, 0);
     if (! mrb_nil_p(exc)) {
         mrb->exc = mrb_obj_ptr(exc);
-        handle_exception(ctx, NULL);
     }
     return mrb_nil_value();
 }

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -309,6 +309,13 @@ mrb_value block_request_callback(h2o_mruby_context_t *ctx, mrb_value input, mrb_
 mrb_value run_blocking_requests_callback(h2o_mruby_context_t *ctx, mrb_value input, mrb_value receiver, mrb_value args, int *run_again)
 {
     mrb_state *mrb = ctx->shared->mrb;
+
+    mrb_value exc = mrb_ary_entry(args, 0);
+    if (! mrb_nil_p(exc)) {
+        mrb->exc = mrb_obj_ptr(exc);
+        handle_exception(ctx, NULL);
+    }
+
     mrb_int i;
     mrb_int len = RARRAY_LEN(ctx->blocking_reqs);
     for (i = 0; i != len; ++i) {
@@ -319,10 +326,6 @@ mrb_value run_blocking_requests_callback(h2o_mruby_context_t *ctx, mrb_value inp
     }
     mrb_ary_clear(mrb, ctx->blocking_reqs);
 
-    mrb_value exc = mrb_ary_entry(args, 0);
-    if (! mrb_nil_p(exc)) {
-        mrb->exc = mrb_obj_ptr(exc);
-    }
     return mrb_nil_value();
 }
 

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -317,7 +317,7 @@ mrb_value process_pending_requests_callback(h2o_mruby_context_t *ctx, mrb_value 
         mrb_value pending_input = mrb_ary_entry(pending, 1);
         h2o_mruby_run_fiber(ctx, pending_resumer, pending_input, NULL);
     }
-    ctx->pendings = mrb_nil_value();
+    mrb_ary_clear(mrb, ctx->pendings);
 
     mrb_value exc = mrb_ary_entry(args, 0);
     if (! mrb_nil_p(exc)) {

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -282,7 +282,7 @@ void h2o_mruby_send_chunked_init_context(h2o_mruby_shared_context_t *shared_ctx)
     h2o_mruby_assert(mrb);
 
     mrb_define_method(mrb, mrb->kernel_module, "_h2o_send_chunk", send_chunked_method, MRB_ARGS_ARG(1, 0));
-    h2o_mruby_define_callback(mrb, "_h2o_send_chunk_eos", H2O_MRUBY_CALLBACK_ID_SEND_CHUNKED_EOS);
+    h2o_mruby_define_callback(mrb, "_h2o_send_chunk_eos", shared_ctx->symbols.sym_callback_send_chunked_eos);
 
     mrb_ary_set(mrb, shared_ctx->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER,
                 mrb_funcall(mrb, mrb_top_self(mrb), "_h2o_chunked_proc_each_to_fiber", 0));

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -243,7 +243,7 @@ static mrb_value send_chunked_method(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
 }
 
-mrb_value h2o_mruby_send_chunked_eos_callback(h2o_mruby_context_t *mctx, mrb_value receiver, mrb_value args, int *run_again)
+static mrb_value send_chunked_eos_callback(h2o_mruby_context_t *mctx, mrb_value input, mrb_value receiver, mrb_value args, int *run_again)
 {
     mrb_state *mrb = mctx->shared->mrb;
     h2o_mruby_generator_t *generator = h2o_mruby_get_generator(mrb, mrb_ary_entry(args, 0));
@@ -282,7 +282,7 @@ void h2o_mruby_send_chunked_init_context(h2o_mruby_shared_context_t *shared_ctx)
     h2o_mruby_assert(mrb);
 
     mrb_define_method(mrb, mrb->kernel_module, "_h2o_send_chunk", send_chunked_method, MRB_ARGS_ARG(1, 0));
-    h2o_mruby_define_callback(mrb, "_h2o_send_chunk_eos", shared_ctx->symbols.sym_callback_send_chunked_eos);
+    h2o_mruby_define_callback(mrb, "_h2o_send_chunk_eos", send_chunked_eos_callback);
 
     mrb_ary_set(mrb, shared_ctx->constants, H2O_MRUBY_CHUNKED_PROC_EACH_TO_FIBER,
                 mrb_funcall(mrb, mrb_top_self(mrb), "_h2o_chunked_proc_each_to_fiber", 0));

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -36,7 +36,7 @@
     "  end\n"                                                                                                                      \
     "  def _h2o_prepare_app(conf)\n"                                                                                               \
     "    app = Proc.new do |req|\n"                                                                                                \
-    "      _h2o__pend_request(req)\n"                                                                                              \
+    "      _h2o__block_request(req)\n"                                                                                             \
     "    end\n"                                                                                                                    \
     "    cached = nil\n"                                                                                                           \
     "    runner = Proc.new do |args|\n"                                                                                            \
@@ -64,12 +64,12 @@
     "          H2O::ConfigurationContext.reset\n"                                                                                  \
     "          app = _h2o_eval_conf(conf)\n"                                                                                       \
     "          H2O::ConfigurationContext.instance.call_post_handler_generation_hooks(app)\n"                                       \
-    "          _h2o__process_pending_requests()\n"                                                                                 \
+    "          _h2o__run_blocking_requests()\n"                                                                                    \
     "        rescue => e\n"                                                                                                        \
     "          app = Proc.new do |req|\n"                                                                                          \
     "            [500, {}, ['Internal Server Error']]\n"                                                                           \
     "          end\n"                                                                                                              \
-    "          _h2o__process_pending_requests(e)\n"                                                                                \
+    "          _h2o__run_blocking_requests(e)\n"                                                                                   \
     "        end\n"                                                                                                                \
     "      end\n"                                                                                                                  \
     "      fiber.resume\n"                                                                                                         \

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -10,9 +10,9 @@
     "  $__TOP_SELF__.eval(__h2o_conf[:code], nil, __h2o_conf[:file], __h2o_conf[:line])\n"                                         \
     "end\n"                                                                                                                        \
     "module Kernel\n"                                                                                                              \
-    "  def _h2o_define_callback(name, id)\n"                                                                                       \
+    "  def _h2o_define_callback(name, callback)\n"                                                                                 \
     "    Kernel.define_method(name) do |*args|\n"                                                                                  \
-    "      ret = Fiber.yield([ id, _h2o_create_resumer(), args ])\n"                                                               \
+    "      ret = Fiber.yield([ callback, _h2o_create_resumer(), args ])\n"                                                         \
     "      if ret.kind_of? Exception\n"                                                                                            \
     "        raise ret\n"                                                                                                          \
     "      end\n"                                                                                                                  \
@@ -34,12 +34,9 @@
     "      a\n"                                                                                                                    \
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
-    "  H2O_CALLBACK_ID_EXCEPTION_RAISED = -1\n"                                                                                    \
-    "  H2O_CALLBACK_ID_CONFIGURING_APP = -2\n"                                                                                     \
-    "  H2O_CALLBACK_ID_CONFIGURED_APP = -3\n"                                                                                      \
     "  def _h2o_prepare_app(conf)\n"                                                                                               \
     "    app = Proc.new do |req|\n"                                                                                                \
-    "      [H2O_CALLBACK_ID_CONFIGURING_APP]\n"                                                                                    \
+    "      [:callback_configuring_app]\n"                                                                                          \
     "    end\n"                                                                                                                    \
     "    cached = nil\n"                                                                                                           \
     "    runner = Proc.new do |args|\n"                                                                                            \
@@ -54,7 +51,7 @@
     "            end\n"                                                                                                            \
     "          rescue => e\n"                                                                                                      \
     "            cached = self_fiber\n"                                                                                            \
-    "            (req, generator) = Fiber.yield([H2O_CALLBACK_ID_EXCEPTION_RAISED, e, generator])\n"                               \
+    "            (req, generator) = Fiber.yield([:callback_exception_raised, e, generator])\n"                                     \
     "          end\n"                                                                                                              \
     "        end\n"                                                                                                                \
     "      end\n"                                                                                                                  \
@@ -67,12 +64,12 @@
     "          H2O::ConfigurationContext.reset\n"                                                                                  \
     "          app = _h2o_eval_conf(conf)\n"                                                                                       \
     "          H2O::ConfigurationContext.instance.call_post_handler_generation_hooks(app)\n"                                       \
-    "          [H2O_CALLBACK_ID_CONFIGURED_APP]\n"                                                                                 \
+    "          [:callback_configured_app]\n"                                                                                       \
     "        rescue => e\n"                                                                                                        \
     "          app = Proc.new do |req|\n"                                                                                          \
     "            [500, {}, ['Internal Server Error']]\n"                                                                           \
     "          end\n"                                                                                                              \
-    "          [H2O_CALLBACK_ID_CONFIGURED_APP, e]\n"                                                                              \
+    "          [:callback_configured_app, e]\n"                                                                                    \
     "        end\n"                                                                                                                \
     "      end\n"                                                                                                                  \
     "      fiber.resume\n"                                                                                                         \
@@ -132,7 +129,7 @@
     "          end\n"                                                                                                              \
     "          _h2o_send_chunk_eos(generator)\n"                                                                                   \
     "        rescue => e\n"                                                                                                        \
-    "          Fiber.yield([-1, e, generator])\n"                                                                                  \
+    "          Fiber.yield([:callback_exception_raised, e, generator])\n"                                                          \
     "        end\n"                                                                                                                \
     "      end\n"                                                                                                                  \
     "      fiber.resume\n"                                                                                                         \

--- a/lib/handler/mruby/embedded/chunked.rb
+++ b/lib/handler/mruby/embedded/chunked.rb
@@ -30,7 +30,7 @@ module Kernel
           end
           _h2o_send_chunk_eos(generator)
         rescue => e
-          Fiber.yield([:callback_exception_raised, e, generator])
+          _h2o__send_error(e, generator)
         end
       end
       fiber.resume

--- a/lib/handler/mruby/embedded/chunked.rb
+++ b/lib/handler/mruby/embedded/chunked.rb
@@ -30,7 +30,7 @@ module Kernel
           end
           _h2o_send_chunk_eos(generator)
         rescue => e
-          Fiber.yield([-1, e, generator])
+          Fiber.yield([:callback_exception_raised, e, generator])
         end
       end
       fiber.resume

--- a/lib/handler/mruby/embedded/core.rb
+++ b/lib/handler/mruby/embedded/core.rb
@@ -26,9 +26,9 @@ end
 
 module Kernel
 
-  def _h2o_define_callback(name, id)
+  def _h2o_define_callback(name, callback)
     Kernel.define_method(name) do |*args|
-      ret = Fiber.yield([ id, _h2o_create_resumer(), args ])
+      ret = Fiber.yield([ callback, _h2o_create_resumer(), args ])
       if ret.kind_of? Exception
         raise ret
       end
@@ -53,12 +53,9 @@ module Kernel
     end
   end
 
-  H2O_CALLBACK_ID_EXCEPTION_RAISED = -1
-  H2O_CALLBACK_ID_CONFIGURING_APP = -2
-  H2O_CALLBACK_ID_CONFIGURED_APP = -3
   def _h2o_prepare_app(conf)
     app = Proc.new do |req|
-      [H2O_CALLBACK_ID_CONFIGURING_APP]
+      [:callback_configuring_app]
     end
 
     cached = nil
@@ -74,7 +71,7 @@ module Kernel
             end
           rescue => e
             cached = self_fiber
-            (req, generator) = Fiber.yield([H2O_CALLBACK_ID_EXCEPTION_RAISED, e, generator])
+            (req, generator) = Fiber.yield([:callback_exception_raised, e, generator])
           end
         end
       end
@@ -88,12 +85,12 @@ module Kernel
           H2O::ConfigurationContext.reset
           app = _h2o_eval_conf(conf)
           H2O::ConfigurationContext.instance.call_post_handler_generation_hooks(app)
-          [H2O_CALLBACK_ID_CONFIGURED_APP]
+          [:callback_configured_app]
         rescue => e
           app = Proc.new do |req|
             [500, {}, ['Internal Server Error']]
           end
-          [H2O_CALLBACK_ID_CONFIGURED_APP, e]
+          [:callback_configured_app, e]
         end
       end
       fiber.resume

--- a/lib/handler/mruby/embedded/core.rb
+++ b/lib/handler/mruby/embedded/core.rb
@@ -55,7 +55,7 @@ module Kernel
 
   def _h2o_prepare_app(conf)
     app = Proc.new do |req|
-      _h2o__pend_request(req)
+      _h2o__block_request(req)
     end
 
     cached = nil
@@ -85,12 +85,12 @@ module Kernel
           H2O::ConfigurationContext.reset
           app = _h2o_eval_conf(conf)
           H2O::ConfigurationContext.instance.call_post_handler_generation_hooks(app)
-          _h2o__process_pending_requests()
+          _h2o__run_blocking_requests()
         rescue => e
           app = Proc.new do |req|
             [500, {}, ['Internal Server Error']]
           end
-          _h2o__process_pending_requests(e)
+          _h2o__run_blocking_requests(e)
         end
       end
       fiber.resume

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -443,7 +443,7 @@ static mrb_value http_request_method(mrb_state *mrb, mrb_value self)
     return ctx->refs.request;
 }
 
-mrb_value h2o_mruby_http_join_response_callback(h2o_mruby_context_t *mctx, mrb_value receiver, mrb_value args, int *run_again)
+static mrb_value http_join_response_callback(h2o_mruby_context_t *mctx, mrb_value input, mrb_value receiver, mrb_value args, int *run_again)
 {
     mrb_state *mrb = mctx->shared->mrb;
     struct st_h2o_mruby_http_request_context_t *ctx;
@@ -462,7 +462,7 @@ static mrb_value create_already_consumed_error(mrb_state *mrb)
     return mrb_exc_new_str_lit(mrb, E_RUNTIME_ERROR, "http response body is already consumed");
 }
 
-mrb_value h2o_mruby_http_fetch_chunk_callback(h2o_mruby_context_t *mctx, mrb_value receiver, mrb_value args, int *run_again)
+static mrb_value http_fetch_chunk_callback(h2o_mruby_context_t *mctx, mrb_value input, mrb_value receiver, mrb_value args, int *run_again)
 {
     mrb_state *mrb = mctx->shared->mrb;
     struct st_h2o_mruby_http_request_context_t *ctx;
@@ -549,6 +549,6 @@ void h2o_mruby_http_request_init_context(h2o_mruby_shared_context_t *ctx)
     klass = mrb_class_get_under(mrb, klass, "Empty");
     mrb_ary_set(mrb, ctx->constants, H2O_MRUBY_HTTP_EMPTY_INPUT_STREAM_CLASS, mrb_obj_value(klass));
 
-    h2o_mruby_define_callback(mrb, "_h2o__http_join_response", ctx->symbols.sym_callback_http_join_response);
-    h2o_mruby_define_callback(mrb, "_h2o__http_fetch_chunk", ctx->symbols.sym_callback_http_fetch_chunk);
+    h2o_mruby_define_callback(mrb, "_h2o__http_join_response", http_join_response_callback);
+    h2o_mruby_define_callback(mrb, "_h2o__http_fetch_chunk", http_fetch_chunk_callback);
 }

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -549,6 +549,6 @@ void h2o_mruby_http_request_init_context(h2o_mruby_shared_context_t *ctx)
     klass = mrb_class_get_under(mrb, klass, "Empty");
     mrb_ary_set(mrb, ctx->constants, H2O_MRUBY_HTTP_EMPTY_INPUT_STREAM_CLASS, mrb_obj_value(klass));
 
-    h2o_mruby_define_callback(mrb, "_h2o__http_join_response", H2O_MRUBY_CALLBACK_ID_HTTP_JOIN_RESPONSE);
-    h2o_mruby_define_callback(mrb, "_h2o__http_fetch_chunk", H2O_MRUBY_CALLBACK_ID_HTTP_FETCH_CHUNK);
+    h2o_mruby_define_callback(mrb, "_h2o__http_join_response", ctx->symbols.sym_callback_http_join_response);
+    h2o_mruby_define_callback(mrb, "_h2o__http_fetch_chunk", ctx->symbols.sym_callback_http_fetch_chunk);
 }

--- a/lib/handler/mruby/sleep.c
+++ b/lib/handler/mruby/sleep.c
@@ -58,7 +58,7 @@ static void on_sleep_timeout(h2o_timeout_entry_t *entry)
     h2o_timeout_link(shared->ctx->loop, &shared->ctx->zero_timeout, entry);
 }
 
-mrb_value h2o_mruby_sleep_callback(h2o_mruby_context_t *mctx, mrb_value receiver, mrb_value args, int *run_again)
+static mrb_value sleep_callback(h2o_mruby_context_t *mctx, mrb_value input, mrb_value receiver, mrb_value args, int *run_again)
 {
     mrb_state *mrb = mctx->shared->mrb;
 
@@ -100,5 +100,5 @@ void h2o_mruby_sleep_init_context(h2o_mruby_shared_context_t *ctx)
 {
     mrb_state *mrb = ctx->mrb;
 
-    h2o_mruby_define_callback(mrb, "_h2o__sleep", ctx->symbols.sym_callback_sleep);
+    h2o_mruby_define_callback(mrb, "_h2o__sleep", sleep_callback);
 }

--- a/lib/handler/mruby/sleep.c
+++ b/lib/handler/mruby/sleep.c
@@ -100,5 +100,5 @@ void h2o_mruby_sleep_init_context(h2o_mruby_shared_context_t *ctx)
 {
     mrb_state *mrb = ctx->mrb;
 
-    h2o_mruby_define_callback(mrb, "_h2o__sleep", H2O_MRUBY_CALLBACK_ID_SLEEP);
+    h2o_mruby_define_callback(mrb, "_h2o__sleep", ctx->symbols.sym_callback_sleep);
 }


### PR DESCRIPTION
The benefits:
- resolve concerns about confliction of integer ids in parallel development
- remove duplicate constant definitions of callback ids in `core.rb`
- remove difficulties of handling edge cases (like status `0`)