### PR TITLE
fix possible offset overflow of SCRIPT_INFO and PATH_INFO

### DIFF
--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -551,8 +551,6 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
 
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SCRIPT_NAME),
                  mrb_str_new(mrb, generator->req->pathconf->path.base, confpath_len_wo_slash));
-//    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_PATH_INFO),
-//                 mrb_str_new(mrb, generator->req->path.base + path_info_offset, path_info_length));
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_PATH_INFO), construct_path_info(mrb, generator->req, confpath_len_wo_slash));
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_QUERY_STRING),
                  generator->req->query_at != SIZE_MAX ? mrb_str_new(mrb, generator->req->path.base + generator->req->query_at + 1,

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -511,24 +511,17 @@ static mrb_value build_path_info(mrb_state *mrb, h2o_req_t *req, size_t confpath
     assert(req->path_normalized.len > confpath_len_wo_slash);
 
     size_t path_info_start, path_info_end = req->query_at != SIZE_MAX ? req->query_at : req->path.len;
-    int add_leading_slash = 0;
 
     if (req->norm_indexes == NULL) {
         path_info_start = confpath_len_wo_slash;
     } else if (req->norm_indexes[0] == 0 && confpath_len_wo_slash == 0) {
         /* path without leading slash */
         path_info_start = 0;
-        add_leading_slash = 1;
     } else {
         path_info_start = req->norm_indexes[confpath_len_wo_slash] - 1;
     }
 
-    mrb_value path_info = mrb_str_new(mrb, req->path.base + path_info_start, path_info_end - path_info_start);
-    if (add_leading_slash) {
-        path_info = mrb_str_cat_str(mrb, mrb_str_new_lit(mrb, "/"), path_info);
-    }
-
-    return path_info;
+    return mrb_str_new(mrb, req->path.base + path_info_start, path_info_end - path_info_start);
 }
 
 static mrb_value build_env(h2o_mruby_generator_t *generator)

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -544,7 +544,7 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
                  mrb_str_new(mrb, generator->req->method.base, generator->req->method.len));
 
     size_t confpath_len_wo_slash = generator->req->pathconf->path.len;
-    if (generator->req->pathconf->path.len != 0 && generator->req->pathconf->path.base[generator->req->pathconf->path.len - 1] == '/')
+    if (generator->req->pathconf->path.base[generator->req->pathconf->path.len - 1] == '/')
         --confpath_len_wo_slash;
     assert(confpath_len_wo_slash <= generator->req->path_normalized.len);
 

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -503,6 +503,35 @@ static int build_env_sort_header_cb(const void *_x, const void *_y)
     return x < y ? -1 : 1;
 }
 
+static mrb_value construct_path_info(mrb_state *mrb, h2o_req_t *req, size_t confpath_len_wo_slash)
+{
+    if (req->path_normalized.len == confpath_len_wo_slash)
+        return mrb_str_new_lit(mrb, "");
+
+    assert(req->path_normalized.len > confpath_len_wo_slash);
+
+    size_t path_info_start, path_info_end = req->query_at != SIZE_MAX ? req->query_at : req->path.len;
+
+    if (req->norm_indexes == NULL) {
+        path_info_start = confpath_len_wo_slash;
+    } else if (confpath_len_wo_slash > 0) {
+        assert(req->norm_indexes[confpath_len_wo_slash] > 0);
+        path_info_start = req->norm_indexes[confpath_len_wo_slash] - 1;
+    } else if (req->norm_indexes[0] == 0) {
+        /* path without leading slash */
+        return mrb_str_cat(mrb, mrb_str_new_lit(mrb, "/"), req->path.base, path_info_end);
+    } else {
+        /*
+         * leading slash in confpath is mapped to the first character of path
+         * but we want to remove something like `/xxx/../` from PATH_INFO, so see the second character's association.
+         */
+        assert(req->norm_indexes[1] > 1); /* this case only happens when the path doesn't have a leading slash */
+        path_info_start = req->norm_indexes[1] - 2;
+    }
+
+    return mrb_str_new(mrb, req->path.base + path_info_start, path_info_end - path_info_start);
+}
+
 static mrb_value build_env(h2o_mruby_generator_t *generator)
 {
     h2o_mruby_shared_context_t *shared = generator->ctx->shared;
@@ -514,18 +543,17 @@ static mrb_value build_env(h2o_mruby_generator_t *generator)
     /* environment */
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_REQUEST_METHOD),
                  mrb_str_new(mrb, generator->req->method.base, generator->req->method.len));
-    size_t confpath_len_wo_slash = generator->req->pathconf->path.len;
-    if (generator->req->pathconf->path.base[generator->req->pathconf->path.len - 1] == '/')
-        --confpath_len_wo_slash;
 
+    size_t confpath_len_wo_slash = generator->req->pathconf->path.len;
+    if (generator->req->pathconf->path.len != 0 && generator->req->pathconf->path.base[generator->req->pathconf->path.len - 1] == '/')
+        --confpath_len_wo_slash;
     assert(confpath_len_wo_slash <= generator->req->path_normalized.len);
-    size_t path_info_offset = generator->req->norm_indexes != NULL ? generator->req->norm_indexes[confpath_len_wo_slash - 1] : confpath_len_wo_slash;
-    size_t path_info_length = (generator->req->query_at != SIZE_MAX ? generator->req->query_at : generator->req->path.len) - path_info_offset;
 
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_SCRIPT_NAME),
                  mrb_str_new(mrb, generator->req->pathconf->path.base, confpath_len_wo_slash));
-    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_PATH_INFO),
-                 mrb_str_new(mrb, generator->req->path.base + path_info_offset, path_info_length));
+//    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_PATH_INFO),
+//                 mrb_str_new(mrb, generator->req->path.base + path_info_offset, path_info_length));
+    mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_PATH_INFO), construct_path_info(mrb, generator->req, confpath_len_wo_slash));
     mrb_hash_set(mrb, env, mrb_ary_entry(shared->constants, H2O_MRUBY_LIT_QUERY_STRING),
                  generator->req->query_at != SIZE_MAX ? mrb_str_new(mrb, generator->req->path.base + generator->req->query_at + 1,
                                                                     generator->req->path.len - (generator->req->query_at + 1))

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -586,7 +586,7 @@ EOT
     is $body, 'handler2, /abc, /def/../ghi', 'no leading slash 3';
 
     (undef, $body) = $nc->('xyz');
-    is $body, 'handler1, , /xyz', 'no leading slash 4';
+    is $body, 'handler1, , xyz', 'no leading slash 4';
 
     (undef, $body) = $nc->('');
     is $body, 'handler1, , ', 'empty path';

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -571,7 +571,7 @@ EOT
     is $body, 'handler3, /foo bar, /baz', 'paths should be decoded';
 
     (undef, $body) = $nc->('/xxx/../hoge');
-    is $body, 'handler1, , /hoge', 'string size is too big issue 1';
+    is $body, 'handler1, , /xxx/../hoge', 'string size is too big issue 1';
 
     (undef, $body) = $nc->('/../abc');
     is $body, 'handler2, /abc, ', 'string size is too big issue 2';


### PR DESCRIPTION
There are several bugs in calculating PATH_INFO and SCRIPT_NAME in mruby handlers.

1. `PATH_INFO` gets broken when `confpath_len_wo_slash` is zero and path normalization happens . This is caused by https://github.com/h2o/h2o/pull/1480
2. also `SCRIPT_NAME` can be broken when `req->pathconf->path.len` is zero and index overflow happens ([here](https://github.com/h2o/h2o/blob/4581462079ac140f8a32b37588f54495af7039f6/lib/handler/mruby.c#L453)). This is a long standing bug, maybe
3. both of them can be broken when req->path doesn't have a leading slash. This is caused by https://github.com/h2o/h2o/pull/1480

Especially 1. and 2. may leeds `ArgumentError: string size is too big` error in mruby layer. This PR fixes these issues.

Thank you for finding and reporting the bug @ykzts 