### PR TITLE
forbid empty path string in configuration

### DIFF
--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -320,6 +320,10 @@ static int on_config_paths(h2o_configurator_command_t *cmd, h2o_configurator_con
             h2o_configurator_errprintf(cmd, key, "key (representing the virtual path) must be a string");
             return -1;
         }
+        if (strlen(key->data.scalar) == 0) {
+            h2o_configurator_errprintf(cmd, key, "key (representing the virtual path) must not be an empty string");
+            return -1;
+        }
     }
     qsort(node->data.mapping.elements, node->data.mapping.size, sizeof(node->data.mapping.elements[0]),
           (int (*)(const void *, const void *))sort_from_longer_paths);


### PR DESCRIPTION
In configuration, currently path string keys under `paths` directive can be empty string, but it may cause some problems (because it's not supposed be in many cases). IMHO there're no reasons to allow that, so This PR explicitly forbid that and warn in configuration phase.