### PR TITLE
respect H2O_PERL environment variable in share/h2o/setuidgid

### DIFF
--- a/share/h2o/setuidgid
+++ b/share/h2o/setuidgid
@@ -1,5 +1,5 @@
 #! /bin/sh
-exec perl -x $0 "$@"
+exec ${H2O_PERL:-perl} -x $0 "$@"
 #! perl
 
 use strict;


### PR DESCRIPTION
In #847 shebang for the perl interpreter was changed to respect the `H2O_PERL` environment variable. However, setuidgid script (only) has missed to receive the change.