### PR TITLE
changes to build for Android

### DIFF
--- a/deps/brotli/enc/fast_log.h
+++ b/deps/brotli/enc/fast_log.h
@@ -124,7 +124,7 @@ static inline double FastLog2(size_t v) {
   if (v < sizeof(kLog2Table) / sizeof(kLog2Table[0])) {
     return kLog2Table[v];
   }
-#if defined(_MSC_VER) && _MSC_VER <= 1600
+#if (defined(_MSC_VER) && _MSC_VER <= 1600) || (defined(__ANDROID__) && __ANDROID_API__ < 21)
   // Visual Studio 2010 does not have the log2() function defined, so we use
   // log() and a multiplication instead.
   static const double kLog2Inv = 1.4426950408889634f;

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -32,7 +32,11 @@
 #include "h2o/memory.h"
 
 #if defined(__linux__)
+#if defined(__ANDROID__) && (__ANDROID_API__ < 21)
+#define USE_POSIX_FALLOCATE 0
+#else
 #define USE_POSIX_FALLOCATE 1
+#endif
 #elif __FreeBSD__ >= 9
 #define USE_POSIX_FALLOCATE 1
 #elif __NetBSD__ >= 7

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -25,7 +25,9 @@
 #include <pthread.h>
 #include <pwd.h>
 #include <signal.h>
+#ifndef __ANDROID__
 #include <spawn.h>
+#endif
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -25,7 +25,7 @@
 #include <pthread.h>
 #include <pwd.h>
 #include <signal.h>
-#ifndef __ANDROID__
+#ifndef __linux__
 #include <spawn.h>
 #endif
 #include <stdint.h>

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -31,7 +31,11 @@
 
 #if !defined(H2O_USE_ACCEPT4)
 #ifdef __linux__
+#if defined(__ANDROID__) && __ANDROID_API__ < 21
+#define H2O_USE_ACCEPT4 0
+#else
 #define H2O_USE_ACCEPT4 1
+#endif
 #elif __FreeBSD__ >= 10
 #define H2O_USE_ACCEPT4 1
 #else

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -24,9 +24,6 @@
 #include <inttypes.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#ifndef __ANDROID__
-#include <spawn.h>
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -24,7 +24,9 @@
 #include <inttypes.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#ifndef __ANDROID__
 #include <spawn.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>

--- a/src/main.c
+++ b/src/main.c
@@ -35,9 +35,6 @@
 #include <pthread.h>
 #include <pwd.h>
 #include <signal.h>
-#ifndef __ANDROID__
-#include <spawn.h>
-#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/resource.h>

--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,9 @@
 #include <pthread.h>
 #include <pwd.h>
 #include <signal.h>
+#ifndef __ANDROID__
 #include <spawn.h>
+#endif
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/resource.h>


### PR DESCRIPTION
Hello,

This PR enables building H2O for Android NDK r16 (Clang 5.0).  Validated on devices in the range of 15 - 26 (armeabi-v7a, arm64-v8a, x86, x86_64).

Regards,
Joel