### PR TITLE
Fix integer wrapping in initail window size update

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -804,7 +804,7 @@ static int handle_settings_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *fram
         }
         /* apply the change to window size (to all the streams but not the connection, see 6.9.2 of draft-15) */
         if (prev_initial_window_size != conn->peer_settings.initial_window_size) {
-            ssize_t delta = conn->peer_settings.initial_window_size - prev_initial_window_size;
+            ssize_t delta = (ssize_t) conn->peer_settings.initial_window_size - prev_initial_window_size;
             h2o_http2_stream_t *stream;
             kh_foreach_value(conn->streams, stream, { update_stream_output_window(stream, delta); });
             resume_send(conn);


### PR DESCRIPTION
`initial_window_size` and `prev_initial_window_size` are both defined
as `uint32_t` whereas `delta` is `ssize_t`, unsigned integer wrapping can occur
in the subtraction which can lead to failures in each stream window size update.