### PR TITLE
fix heap-use-after-free when upstream response stops unexpectly

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -630,6 +630,7 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
 {
     size_t i, prev_bytes_written = sock->bytes_written;
 
+    assert(bufcnt > 0);
     for (i = 0; i != bufcnt; ++i) {
         sock->bytes_written += bufs[i].len;
 #if H2O_SOCKET_DUMP_WRITE

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -414,14 +414,14 @@ static int on_body(h2o_http1client_t *client, const char *errstr)
             self->had_body_error = 1;
         }
     }
-    if (!self->sending.inflight)
-        do_send(self);
-
     if (self->client && self->client->sock && overrides && self->client->sock->input->size > overrides->max_buffer_size) {
         self->await_send = await_send;
         h2o_http1client_body_read_stop(self->client);
     }
 
+    if (!self->sending.inflight)
+        do_send(self);
+    
     return 0;
 }
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -414,14 +414,14 @@ static int on_body(h2o_http1client_t *client, const char *errstr)
             self->had_body_error = 1;
         }
     }
+    if (!self->sending.inflight)
+    do_send(self);
+
     if (self->client && self->client->sock && overrides && self->client->sock->input->size > overrides->max_buffer_size) {
         self->await_send = await_send;
         h2o_http1client_body_read_stop(self->client);
     }
 
-    if (!self->sending.inflight)
-        do_send(self);
-    
     return 0;
 }
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -415,7 +415,7 @@ static int on_body(h2o_http1client_t *client, const char *errstr)
         }
     }
     if (!self->sending.inflight)
-    do_send(self);
+        do_send(self);
 
     if (self->client && self->client->sock && overrides && self->client->sock->input->size > overrides->max_buffer_size) {
         self->await_send = await_send;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -698,6 +698,12 @@ static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb
     proceed_pull(conn, headers_len);
 }
 
+static void on_delayed_send_complete(h2o_timeout_entry_t *entry)
+{
+    struct st_h2o_http1_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1_conn_t, _timeout_entry, entry);
+    on_send_complete(conn->sock, 0);
+}
+
 void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t send_state)
 {
     struct st_h2o_http1_finalostream_t *self = (void *)_self;
@@ -732,8 +738,12 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         conn->req.http1_is_persistent = 0;
     }
 
-    h2o_socket_write(conn->sock, bufs, bufcnt,
-                     h2o_send_state_is_in_progress(send_state) ? on_send_next_push : on_send_complete);
+    if (bufcnt != 0) {
+        h2o_socket_write(conn->sock, bufs, bufcnt,
+                         h2o_send_state_is_in_progress(send_state) ? on_send_next_push : on_send_complete);
+    } else {
+        set_timeout(conn, &conn->super.ctx->zero_timeout, on_delayed_send_complete);
+    }
 }
 
 static socklen_t get_sockname(h2o_conn_t *_conn, struct sockaddr *sa)

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -732,12 +732,8 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         conn->req.http1_is_persistent = 0;
     }
 
-    if (bufcnt != 0) {
-        h2o_socket_write(conn->sock, bufs, bufcnt,
-                         h2o_send_state_is_in_progress(send_state) ? on_send_next_push : on_send_complete);
-    } else {
-        on_send_complete(conn->sock, 0);
-    }
+    h2o_socket_write(conn->sock, bufs, bufcnt,
+                     h2o_send_state_is_in_progress(send_state) ? on_send_next_push : on_send_complete);
 }
 
 static socklen_t get_sockname(h2o_conn_t *_conn, struct sockaddr *sa)


### PR DESCRIPTION
`t/50unexpected-upstream-body.t` would trigger an AddressSanitizer heap-use-after-free error though the test still passes. It is caused by `http1.c` where memory pool is released when last chunck of data is sent, but we still do some check on `struct rp_generator_t` which is already freed. This PR fix the problem by switching the order of the check mentioned above and `do_send`.