### PR TITLE
Show filenames and consistent lineno of embedded mruby code

### DIFF
--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -159,6 +159,7 @@ void h2o_mruby__abort_exc(mrb_state *mrb, const char *mess, const char *file, in
 mrb_value h2o_mruby__new_str(mrb_state *mrb, const char *s, size_t len, const char *file, int line);
 mrb_value h2o_mruby_to_str(mrb_state *mrb, mrb_value v);
 mrb_value h2o_mruby_eval_expr(mrb_state *mrb, const char *expr);
+mrb_value h2o_mruby_eval_expr_location(mrb_state *mrb, const char *expr, const char *path, const int lineno);
 void h2o_mruby_define_callback(mrb_state *mrb, const char *name, h2o_mruby_callback_t callback);
 mrb_value h2o_mruby_create_data_instance(mrb_state *mrb, mrb_value class_obj, void *ptr, const mrb_data_type *type);
 void h2o_mruby_setup_globals(mrb_state *mrb);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -112,6 +112,12 @@ mrb_value h2o_mruby_eval_expr(mrb_state *mrb, const char *expr)
     return mrb_funcall(mrb, mrb_top_self(mrb), "eval", 1, mrb_str_new_cstr(mrb, expr));
 }
 
+mrb_value h2o_mruby_eval_expr_location(mrb_state *mrb, const char *expr, const char *path, const int lineno)
+{
+    return mrb_funcall(mrb, mrb_top_self(mrb), "eval", 4, mrb_str_new_cstr(mrb, expr),
+                       mrb_nil_value(), mrb_str_new_cstr(mrb, path), mrb_fixnum_value(lineno));
+}
+
 void h2o_mruby_define_callback(mrb_state *mrb, const char *name, h2o_mruby_callback_t callback)
 {
     h2o_mruby_shared_context_t *shared_ctx = mrb->ud;

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -270,7 +270,7 @@ static mrb_value build_constants(mrb_state *mrb, const char *server_name, size_t
 #undef SET_LITERAL
 #undef SET_STRING
 
-    h2o_mruby_eval_expr(mrb, H2O_MRUBY_CODE_CORE);
+    h2o_mruby_eval_expr_location(mrb, H2O_MRUBY_CODE_CORE, "(h2o)lib/handler/mruby/embedded/core.rb", 1);
     h2o_mruby_assert(mrb);
 
     mrb_ary_set(mrb, ary, H2O_MRUBY_PROC_EACH_TO_ARRAY,

--- a/lib/handler/mruby/channel.c
+++ b/lib/handler/mruby/channel.c
@@ -98,7 +98,7 @@ void h2o_mruby_channel_init_context(h2o_mruby_shared_context_t *shared_ctx)
 {
     mrb_state *mrb = shared_ctx->mrb;
 
-    h2o_mruby_eval_expr(mrb, H2O_MRUBY_CODE_CHANNEL);
+    h2o_mruby_eval_expr_location(mrb, H2O_MRUBY_CODE_CHANNEL, "(h2o)lib/handler/mruby/embedded/channel.rb", 1);
     h2o_mruby_assert(mrb);
 
     struct RClass *module, *klass;

--- a/lib/handler/mruby/chunked.c
+++ b/lib/handler/mruby/chunked.c
@@ -283,7 +283,7 @@ void h2o_mruby_send_chunked_init_context(h2o_mruby_shared_context_t *shared_ctx)
 {
     mrb_state *mrb = shared_ctx->mrb;
 
-    h2o_mruby_eval_expr(mrb, H2O_MRUBY_CODE_CHUNKED);
+    h2o_mruby_eval_expr_location(mrb, H2O_MRUBY_CODE_CHUNKED, "(h2o)lib/handler/mruby/embedded/chunked.rb", 1);
     h2o_mruby_assert(mrb);
 
     mrb_define_method(mrb, mrb->kernel_module, "_h2o_send_chunk", send_chunked_method, MRB_ARGS_ARG(1, 0));

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -5,11 +5,34 @@
 
 /* lib/handler/mruby/embedded/core.rb */
 #define H2O_MRUBY_CODE_CORE                                                                                                        \
+    "# Copyright (c) 2014-2016 DeNA Co., Ltd., Kazuho Oku, Ryosuke Matsumoto,\n"                                                   \
+    "#                         Masayoshi Takahashi\n"                                                                              \
+    "# \n"                                                                                                                         \
+    "# Permission is hereby granted, free of charge, to any person obtaining a copy\n"                                             \
+    "# of this software and associated documentation files (the \"Software\"), to\n"                                               \
+    "# deal in the Software without restriction, including without limitation the\n"                                               \
+    "# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or\n"                                              \
+    "# sell copies of the Software, and to permit persons to whom the Software is\n"                                               \
+    "# furnished to do so, subject to the following conditions:\n"                                                                 \
+    "# \n"                                                                                                                         \
+    "# The above copyright notice and this permission notice shall be included in\n"                                               \
+    "# all copies or substantial portions of the Software.\n"                                                                      \
+    "# \n"                                                                                                                         \
+    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n"                                             \
+    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n"                                                 \
+    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n"                                              \
+    "# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n"                                                   \
+    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n"                                                  \
+    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS\n"                                             \
+    "# IN THE SOFTWARE.\n"                                                                                                         \
+    "\n"                                                                                                                           \
     "$__TOP_SELF__ = self\n"                                                                                                       \
     "def _h2o_eval_conf(__h2o_conf)\n"                                                                                             \
     "  $__TOP_SELF__.eval(__h2o_conf[:code], nil, __h2o_conf[:file], __h2o_conf[:line])\n"                                         \
     "end\n"                                                                                                                        \
+    "\n"                                                                                                                           \
     "module Kernel\n"                                                                                                              \
+    "\n"                                                                                                                           \
     "  def _h2o_define_callback(name, callback_id)\n"                                                                              \
     "    Kernel.define_method(name) do |*args|\n"                                                                                  \
     "      ret = Fiber.yield([ callback_id, _h2o_create_resumer(), args ])\n"                                                      \
@@ -19,12 +42,14 @@
     "      ret\n"                                                                                                                  \
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "  def _h2o_create_resumer()\n"                                                                                                \
     "    me = Fiber.current\n"                                                                                                     \
     "    Proc.new do |v|\n"                                                                                                        \
     "      me.resume(v)\n"                                                                                                         \
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "  def _h2o_proc_each_to_array()\n"                                                                                            \
     "    Proc.new do |o|\n"                                                                                                        \
     "      a = []\n"                                                                                                               \
@@ -34,10 +59,12 @@
     "      a\n"                                                                                                                    \
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "  def _h2o_prepare_app(conf)\n"                                                                                               \
     "    app = Proc.new do |req|\n"                                                                                                \
     "      _h2o__block_request(req)\n"                                                                                             \
     "    end\n"                                                                                                                    \
+    "\n"                                                                                                                           \
     "    cached = nil\n"                                                                                                           \
     "    runner = Proc.new do |args|\n"                                                                                            \
     "      fiber = cached || Fiber.new do |req, generator|\n"                                                                      \
@@ -58,6 +85,7 @@
     "      cached = nil\n"                                                                                                         \
     "      fiber.resume(*args)\n"                                                                                                  \
     "    end\n"                                                                                                                    \
+    "\n"                                                                                                                           \
     "    configurator = Proc.new do\n"                                                                                             \
     "      fiber = Fiber.new do\n"                                                                                                 \
     "        begin\n"                                                                                                              \
@@ -74,11 +102,14 @@
     "      end\n"                                                                                                                  \
     "      fiber.resume\n"                                                                                                         \
     "    end\n"                                                                                                                    \
+    "\n"                                                                                                                           \
     "    [runner, configurator]\n"                                                                                                 \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "  def sleep(*sec)\n"                                                                                                          \
     "    _h2o__sleep(*sec)\n"                                                                                                      \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "  def task(&block)\n"                                                                                                         \
     "    fiber = Fiber.new do\n"                                                                                                   \
     "      begin\n"                                                                                                                \
@@ -90,11 +121,33 @@
     "    end\n"                                                                                                                    \
     "    _h2o__run_child_fiber(proc { fiber.resume })\n"                                                                           \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "end\n"
 
 /* lib/handler/mruby/embedded/http_request.rb */
 #define H2O_MRUBY_CODE_HTTP_REQUEST                                                                                                \
+    "# Copyright (c) 2015-2016 DeNA Co., Ltd., Kazuho Oku\n"                                                                       \
+    "# \n"                                                                                                                         \
+    "# Permission is hereby granted, free of charge, to any person obtaining a copy\n"                                             \
+    "# of this software and associated documentation files (the \"Software\"), to\n"                                               \
+    "# deal in the Software without restriction, including without limitation the\n"                                               \
+    "# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or\n"                                              \
+    "# sell copies of the Software, and to permit persons to whom the Software is\n"                                               \
+    "# furnished to do so, subject to the following conditions:\n"                                                                 \
+    "# \n"                                                                                                                         \
+    "# The above copyright notice and this permission notice shall be included in\n"                                               \
+    "# all copies or substantial portions of the Software.\n"                                                                      \
+    "# \n"                                                                                                                         \
+    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n"                                             \
+    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n"                                                 \
+    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n"                                              \
+    "# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n"                                                   \
+    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n"                                                  \
+    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS\n"                                             \
+    "# IN THE SOFTWARE.\n"                                                                                                         \
+    "\n"                                                                                                                           \
     "module H2O\n"                                                                                                                 \
+    "\n"                                                                                                                           \
     "  class HttpRequest\n"                                                                                                        \
     "    def join\n"                                                                                                               \
     "      if !@resp\n"                                                                                                            \
@@ -106,6 +159,7 @@
     "      @resp = resp\n"                                                                                                         \
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "  class HttpInputStream\n"                                                                                                    \
     "    def each\n"                                                                                                               \
     "      first = true\n"                                                                                                         \
@@ -121,15 +175,38 @@
     "      end\n"                                                                                                                  \
     "      s\n"                                                                                                                    \
     "    end\n"                                                                                                                    \
+    "\n"                                                                                                                           \
     "    class Empty < HttpInputStream\n"                                                                                          \
     "      def each; end\n"                                                                                                        \
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "end\n"
 
 /* lib/handler/mruby/embedded/chunked.rb */
 #define H2O_MRUBY_CODE_CHUNKED                                                                                                     \
+    "# Copyright (c) 2014 DeNA Co., Ltd.\n"                                                                                        \
+    "#\n"                                                                                                                          \
+    "# Permission is hereby granted, free of charge, to any person obtaining a copy\n"                                             \
+    "# of this software and associated documentation files (the \"Software\"), to\n"                                               \
+    "# deal in the Software without restriction, including without limitation the\n"                                               \
+    "# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or\n"                                              \
+    "# sell copies of the Software, and to permit persons to whom the Software is\n"                                               \
+    "# furnished to do so, subject to the following conditions:\n"                                                                 \
+    "#\n"                                                                                                                          \
+    "# The above copyright notice and this permission notice shall be included in\n"                                               \
+    "# all copies or substantial portions of the Software.\n"                                                                      \
+    "#\n"                                                                                                                          \
+    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n"                                             \
+    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n"                                                 \
+    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n"                                              \
+    "# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n"                                                   \
+    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n"                                                  \
+    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS\n"                                             \
+    "# IN THE SOFTWARE.\n"                                                                                                         \
+    "\n"                                                                                                                           \
     "module Kernel\n"                                                                                                              \
+    "\n"                                                                                                                           \
     "  def _h2o_chunked_proc_each_to_fiber()\n"                                                                                    \
     "    Proc.new do |args|\n"                                                                                                     \
     "      src, generator = *args\n"                                                                                               \
@@ -146,10 +223,31 @@
     "      fiber.resume\n"                                                                                                         \
     "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
     "end\n"
 
 /* lib/handler/mruby/embedded/channel.rb */
 #define H2O_MRUBY_CODE_CHANNEL                                                                                                     \
+    "# Copyright (c) 2017 Ritta Narita\n"                                                                                          \
+    "#\n"                                                                                                                          \
+    "# Permission is hereby granted, free of charge, to any person obtaining a copy\n"                                             \
+    "# of this software and associated documentation files (the \"Software\"), to\n"                                               \
+    "# deal in the Software without restriction, including without limitation the\n"                                               \
+    "# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or\n"                                              \
+    "# sell copies of the Software, and to permit persons to whom the Software is\n"                                               \
+    "# furnished to do so, subject to the following conditions:\n"                                                                 \
+    "#\n"                                                                                                                          \
+    "# The above copyright notice and this permission notice shall be included in\n"                                               \
+    "# all copies or substantial portions of the Software.\n"                                                                      \
+    "#\n"                                                                                                                          \
+    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n"                                             \
+    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n"                                                 \
+    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n"                                              \
+    "# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n"                                                   \
+    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n"                                                  \
+    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS\n"                                             \
+    "# IN THE SOFTWARE.\n"                                                                                                         \
+    "\n"                                                                                                                           \
     "module H2O\n"                                                                                                                 \
     "  class Channel\n"                                                                                                            \
     "    def push(o)\n"                                                                                                            \

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -534,7 +534,7 @@ void h2o_mruby_http_request_init_context(h2o_mruby_shared_context_t *ctx)
 {
     mrb_state *mrb = ctx->mrb;
 
-    h2o_mruby_eval_expr(mrb, H2O_MRUBY_CODE_HTTP_REQUEST);
+    h2o_mruby_eval_expr_location(mrb, H2O_MRUBY_CODE_HTTP_REQUEST, "(h2o)lib/handler/mruby/embedded/http_request.rb", 1);
     h2o_mruby_assert(mrb);
 
     struct RClass *module, *klass;

--- a/misc/embed_mruby_code.pl
+++ b/misc/embed_mruby_code.pl
@@ -37,9 +37,6 @@ EOF
 for my $path (map { path($_) } grep { $_ =~ /\.rb$/ } @mruby_files) {
     my @lines = $path->lines({ chomp => 1 });
 
-    my $in_license = 1;
-    @lines = grep { $in_license = 0 if $_ !~ /^#/; ! $in_license } @lines;
-    @lines = grep { $_ =~ /\S/ } @lines;
     @lines = map {
         s/\x5c/\\\\/g;
         s/\x22/\\"/g;


### PR DESCRIPTION
In the case of #1536, we saw just "(eval)" as the location of mruby methods.
These definitions should be eval-ed from embedded code (to help reading version-inconsistent definitions dynamically), but we can show filenames and consistent line numbers, like this:

```
FiberError:can't cross C function boundary
	(h2o)lib/handler/mruby/embedded/core.rb:31:in _h2o__run_child_fiber
	(h2o)lib/handler/mruby/embedded/core.rb:115:in task
	test/h2o/frontend.conf:11:in initialize
	test/h2o/frontend.conf:19:in eval
	(h2o)lib/handler/mruby/embedded/core.rb:68
```

This patch is to embed mruby code with file paths and consistent line numbers of these code, by using 3rd and 4th arguments of `eval`. To make it possible, this change also does a fix to embed just same mruby scripts with `lib/handler/mruby/embedded/*.rb` (by removing code to remove comments and blank lines).