### PR TITLE
count sock->bytes_written correctly

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -631,7 +631,7 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
     size_t i, prev_bytes_written = sock->bytes_written;
 
     for (i = 0; i != bufcnt; ++i) {
-        sock->bytes_written = bufs[i].len;
+        sock->bytes_written += bufs[i].len;
 #if H2O_SOCKET_DUMP_WRITE
         fprintf(stderr, "writing %zu bytes to fd:%d\n", bufs[i].len, h2o_socket_get_fd(sock));
         h2o_dump_memory(stderr, bufs[i].base, bufs[i].len);


### PR DESCRIPTION
At the moment ssl record size doesn't increase as expected in some situations (connection via http1, or http2 but h2o is running in operating systems in which latency-optimization is disabled)