### PR TITLE
don't add trailing slash to upstream request

### DIFF
--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -713,11 +713,15 @@ h2o_iovec_t h2o_build_destination(h2o_req_t *req, const char *prefix, size_t pre
 {
     h2o_iovec_t parts[4];
     size_t num_parts = 0;
-    int conf_ends_with_slash = req->pathconf->path.base[req->pathconf->path.len - 1] == '/';
-    int prefix_ends_with_slash = prefix[prefix_len - 1] == '/';
+    int conf_ends_with_slash = req->pathconf->path.base[req->pathconf->path.len - 1] == '/', prefix_ends_with_slash;
 
-    /* destination starts with given prefix */
-    parts[num_parts++] = h2o_iovec_init(prefix, prefix_len);
+    /* destination starts with given prefix, if any */
+    if (prefix_len != 0) {
+        parts[num_parts++] = h2o_iovec_init(prefix, prefix_len);
+        prefix_ends_with_slash = prefix[prefix_len - 1] == '/';
+    } else {
+        prefix_ends_with_slash = 0;
+    }
 
     /* make adjustments depending on the trailing slashes */
     if (conf_ends_with_slash != prefix_ends_with_slash) {

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -44,9 +44,10 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     overrides->headers_cmds = self->config.headers_cmds;
     overrides->proxy_preserve_host = self->config.preserve_host;
 
-    /* request reprocess */
-    h2o_reprocess_request(req, req->method, req->scheme, req->authority, h2o_build_destination(req, H2O_STRLIT("/"), 0), overrides,
-                          0);
+    /* request reprocess (note: path may become an empty string, to which one of the target URL within the socketpool will be
+     * right-padded when lib/core/proxy connects to upstream; see #1563) */
+    h2o_iovec_t path = h2o_build_destination(req, NULL, 0, 0);
+    h2o_reprocess_request(req, req->method, req->scheme, req->authority, path, overrides, 0);
 
     return 0;
 }

--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -84,10 +84,10 @@ hosts:
       /gzip:
         proxy.reverse.url: http://$upstream
         gzip: ON
-      /test-request-uri0:
+      /test-request-uri-noslash:
         proxy.reverse.url: http://$upstream/echo-request-uri
         gzip: ON
-      /test-request-uri1:
+      /test-request-uri-withslash:
         proxy.reverse.url: http://$upstream/echo-request-uri/
         gzip: ON
       /files:
@@ -198,10 +198,18 @@ run_with_curl($server, sub {
         is md5_hex($resp), md5_file("@{[DOC_ROOT]}/alice.txt");
     };
     subtest 'request uri' => sub {
-        my $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri0`;
-        like $resp, qr/^\/echo-request-uri$/mi, "request path";
-        $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri1`;
-        like $resp, qr/^\/echo-request-uri\/$/mi, "request path";
+        my $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri-noslash`;
+        like $resp, qr{^/echo-request-uri$}mi;
+        $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri-withslash`;
+        like $resp, qr{^/echo-request-uri/$}mi;
+        $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri-noslash?abc=def`;
+        like $resp, qr{^/echo-request-uri\?abc=def$}mi;
+        $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri-withslash?abc=def`;
+        like $resp, qr{^/echo-request-uri/\?abc=def$}mi;
+        $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri-noslash/abc`;
+        like $resp, qr{^/echo-request-uri/abc$}mi;
+        $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri-withslash/abc`;
+        like $resp, qr{^/echo-request-uri/abc$}mi;
     };
 });
 

--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -84,6 +84,12 @@ hosts:
       /gzip:
         proxy.reverse.url: http://$upstream
         gzip: ON
+      /test-request-uri0:
+        proxy.reverse.url: http://$upstream/echo-request-uri
+        gzip: ON
+      /test-request-uri1:
+        proxy.reverse.url: http://$upstream/echo-request-uri/
+        gzip: ON
       /files:
         file.dir: @{[ DOC_ROOT ]}
 reproxy: ON
@@ -190,6 +196,12 @@ run_with_curl($server, sub {
             if $curl =~ /--http2/;
         my $resp = `$curl --silent -H Accept-Encoding:gzip $proto://127.0.0.1:$port/gzip/alice.txt | gzip -cd`;
         is md5_hex($resp), md5_file("@{[DOC_ROOT]}/alice.txt");
+    };
+    subtest 'request uri' => sub {
+        my $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri0`;
+        like $resp, qr/^\/echo-request-uri$/mi, "request path";
+        $resp = `$curl --silent $proto://127.0.0.1:$port/test-request-uri1`;
+        like $resp, qr/^\/echo-request-uri\/$/mi, "request path";
     };
 });
 

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -114,6 +114,15 @@ builder {
             200, @resph, [ "Ok" ]
         ];
     };
+    mount "/echo-request-uri" => sub {
+        my $env = shift;
+        return [
+            200,
+            [
+            ],
+            [$env->{"REQUEST_URI"} || ''],
+        ];
+    };
     mount "/echo-server-port" => sub {
         my $env = shift;
         return [


### PR DESCRIPTION
fixes #1560

It seems that this is a regression in master branch. When backported to 2.2.x, the test runs fine (see eaaf1af).