### PR TITLE
run h2spec as part of  CI

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -921,13 +921,14 @@
 		E9BC76E41F00E70700EB7A09 /* salsa20.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = salsa20.h; sourceTree = "<group>"; };
 		E9BC76E61F00E72D00EB7A09 /* chacha20.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha20.c; sourceTree = "<group>"; };
 		E9BC76E91F00E74C00EB7A09 /* poly1305.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = poly1305.c; sourceTree = "<group>"; };
-		E9BCE6921FF344D4003CEA11 /* 40http2-request-window-size.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40http2-request-window-size.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9BCE6911FF326AC003CEA11 /* 80no-handler-vs-h2-post.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "80no-handler-vs-h2-post.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9BCE6921FF344D4003CEA11 /* 40http2-request-window-size.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40http2-request-window-size.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9BCE6931FF35502003CEA11 /* 50mruby-channel.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50mruby-channel.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9CD04271F8F1D5D00524877 /* Changes */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Changes; sourceTree = "<group>"; };
 		E9CD04281F8F1D7500524877 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		E9CD04291F8F1D7F00524877 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E9CD042A1F8F1D8A00524877 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		E9F677CA1FF47BD0006476D3 /* 40http2-h2spec.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40http2-h2spec.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1687,6 +1688,7 @@
 				105534F41A460EF600627ECB /* 10http1client.t */,
 				10FEF2481D6EC30800E11B1D /* 40bad-request.t */,
 				104CD5021CC465AF0057C62F /* 40env.t */,
+				E9F677CA1FF47BD0006476D3 /* 40http2-h2spec.t */,
 				E9BCE6921FF344D4003CEA11 /* 40http2-request-window-size.t */,
 				104B9A301A58F55E009EEE64 /* 40max-connections.t */,
 				10A3D3D71B4F4D0900327CF9 /* 40memcached-session-resumption.t */,

--- a/misc/docker-ci/Dockerfile
+++ b/misc/docker-ci/Dockerfile
@@ -23,6 +23,11 @@ RUN apt-get install --yes libfcgi-perl libfcgi-procmanager-perl libipc-signal-pe
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
 RUN sudo cpanm --notest Starlet Test::TCP
 
+# h2get
+RUN apt-get install --yes golang && mkdir -p /golang && ln -sf /usr/local/bin /golang/bin
+ENV GOPATH=/golang
+RUN (go get github.com/summerwind/h2spec && cd /golang/src/github.com/summerwind/h2spec/cmd/h2spec && git checkout v2.0.0^ && go install)
+
 # create user
 RUN useradd --create-home ci
 RUN echo 'ci ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/t/40http2-h2spec.t
+++ b/t/40http2-h2spec.t
@@ -14,6 +14,7 @@ hosts:
         file.dir: @{[DOC_ROOT]}
 EOT
 
-is system(qw(h2spec -t -k -p), $server->{tls_port}), 0;
+my $output = `h2spec -t -k -p $server->{tls_port} 2>&1`;
+like $output, qr/All tests passed/;
 
 done_testing();

--- a/t/40http2-h2spec.t
+++ b/t/40http2-h2spec.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+plan skip_all => 'h2spec not found'
+    unless prog_exists('h2spec');
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        file.dir: @{[DOC_ROOT]}
+EOT
+
+is system(qw(h2spec -t -k -p), $server->{tls_port}), 0;
+
+done_testing();


### PR DESCRIPTION
Currently uses h2spec pre-v2.0.0. We need to address the failures caused by v2.0.x on either of the two sides.