### PR TITLE
move "struct timeval" releated parameter passed as pointer

### DIFF
--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -301,9 +301,9 @@ static int create_accepted(int sfd, char *buf, size_t len, h2o_barrier_t **barri
     sock = h2o_evloop_socket_create(ctx.loop, fd, H2O_SOCKET_FLAG_IS_ACCEPTED_CONNECTION);
 
 #if defined(HTTP1)
-    h2o_http1_accept(&accept_ctx, sock, connected_at);
+    h2o_http1_accept(&accept_ctx, sock, &connected_at);
 #else
-    h2o_http2_accept(&accept_ctx, sock, connected_at);
+    h2o_http2_accept(&accept_ctx, sock, &connected_at);
 #endif
 
     return fd;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1233,7 +1233,7 @@ void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
 /**
  * creates a new connection
  */
-static h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval connected_at,
+static h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval *connected_at,
                                          const h2o_conn_callbacks_t *callbacks);
 /**
  * setups accept context for memcached SSL resumption
@@ -1992,14 +1992,14 @@ inline int h2o_header_name_is_equal(const h2o_header_t *x, const h2o_header_t *y
     }
 }
 
-inline h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval connected_at,
+inline h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval *connected_at,
                                          const h2o_conn_callbacks_t *callbacks)
 {
     h2o_conn_t *conn = (h2o_conn_t *)h2o_mem_alloc(sz);
 
     conn->ctx = ctx;
     conn->hosts = hosts;
-    conn->connected_at = connected_at;
+    conn->connected_at = *connected_at;
 #ifdef H2O_NO_64BIT_ATOMICS
     pthread_mutex_lock(&h2o_conn_id_mutex);
     conn->id = ++h2o_connection_id;

--- a/include/h2o/http1.h
+++ b/include/h2o/http1.h
@@ -30,7 +30,7 @@ typedef void (*h2o_http1_upgrade_cb)(void *user_data, h2o_socket_t *sock, size_t
 
 extern const h2o_protocol_callbacks_t H2O_HTTP1_CALLBACKS;
 
-void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at);
+void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval *connected_at);
 void h2o_http1_upgrade(h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_http1_upgrade_cb on_complete, void *user_data);
 
 #ifdef __cplusplus

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -64,8 +64,8 @@ typedef struct st_h2o_http2_priority_t {
 
 extern const h2o_http2_priority_t h2o_http2_default_priority;
 
-void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at);
-int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval connected_at);
+void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval *connected_at);
+int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval *connected_at);
 
 #ifdef __cplusplus
 }

--- a/include/h2o/timeout.h
+++ b/include/h2o/timeout.h
@@ -80,13 +80,16 @@ static int h2o_timeout_is_linked(h2o_timeout_entry_t *entry);
 
 void h2o_timeout_run(h2o_loop_t *loop, h2o_timeout_t *timeout, uint64_t now);
 uint64_t h2o_timeout_get_wake_at(h2o_linklist_t *timeouts);
+
+
+/* these function are provided by event loop, currently h2o-evloop or uv-binding */
 void h2o_timeout__do_init(h2o_loop_t *loop, h2o_timeout_t *timeout);
 void h2o_timeout__do_dispose(h2o_loop_t *loop, h2o_timeout_t *timeout);
 void h2o_timeout__do_link(h2o_loop_t *loop, h2o_timeout_t *timeout, h2o_timeout_entry_t *entry);
 void h2o_timeout__do_post_callback(h2o_loop_t *loop);
 
-/* inline defs */
 
+/* inline defs */
 inline int h2o_timeout_is_linked(h2o_timeout_entry_t *entry)
 {
     return h2o_linklist_is_linked(&entry->_link);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1298,7 +1298,7 @@ static h2o_iovec_t log_priority_actual_weight(h2o_req_t *req)
     return h2o_iovec_init(s, len);
 }
 
-static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock, struct timeval connected_at)
+static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts, h2o_socket_t *sock, struct timeval *connected_at)
 {
     static const h2o_conn_callbacks_t callbacks = {
         get_sockname,              /* stringify address */
@@ -1455,7 +1455,7 @@ static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *c
     return 0;
 }
 
-void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at)
+void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval *connected_at)
 {
     h2o_http2_conn_t *conn = create_conn(ctx->ctx, ctx->hosts, sock, connected_at);
     sock->data = conn;
@@ -1465,7 +1465,7 @@ void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
         on_read(sock, 0);
 }
 
-int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval connected_at)
+int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval *connected_at)
 {
     h2o_http2_conn_t *http2conn = create_conn(req->conn->ctx, req->conn->hosts, NULL, connected_at);
     h2o_http2_stream_t *stream;

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -62,9 +62,11 @@ static socklen_t get_peername(h2o_conn_t *conn, struct sockaddr *sa)
 h2o_loopback_conn_t *h2o_loopback_create(h2o_context_t *ctx, h2o_hostconf_t **hosts)
 {
     static const h2o_conn_callbacks_t callbacks = {get_sockname, get_peername};
-    h2o_loopback_conn_t *conn = (void *)h2o_create_connection(sizeof(*conn), ctx, hosts, (struct timeval){0}, &callbacks);
+    struct timeval connected_at = {0};
+    h2o_loopback_conn_t *conn = (void *)h2o_create_connection(sizeof(*conn), ctx, hosts, &connected_at, &callbacks);
 
     memset((char *)conn + sizeof(conn->super), 0, offsetof(struct st_h2o_loopback_conn_t, req) - sizeof(conn->super));
+    /* FIXME: remove the following 3 lines */
     conn->super.ctx = ctx;
     conn->super.hosts = hosts;
     conn->super.callbacks = &callbacks;


### PR DESCRIPTION
lots of functions like h2o_http1_accept() using struct timeval.
but passed by value, not by address.
this patch fix this.

can we do this?