### PR TITLE
fix test stall when h2get is missing

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -929,6 +929,14 @@
 		E9CD04291F8F1D7F00524877 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E9CD042A1F8F1D8A00524877 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		E9F677CA1FF47BD0006476D3 /* 40http2-h2spec.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40http2-h2spec.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9F677CB1FF62216006476D3 /* 50reverse-proxy-chunk-trailing-headers.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-chunk-trailing-headers.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9F677CC1FF62216006476D3 /* 50reverse-proxy-chunk-timeout-2.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-chunk-timeout-2.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9F677CD1FF62216006476D3 /* 50reverse-proxy-drop-headers.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-drop-headers.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9F677CE1FF62217006476D3 /* 50reverse-proxy-chunk-sizes.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-chunk-sizes.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9F677CF1FF62217006476D3 /* 50reverse-proxy-chunk-timeout-1.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-chunk-timeout-1.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9F677D01FF62228006476D3 /* 50reverse-proxy-serialize-posts-3.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-serialize-posts-3.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9F677D11FF62228006476D3 /* 50reverse-proxy-serialize-posts.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-serialize-posts.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9F677D21FF62228006476D3 /* 50reverse-proxy-serialize-posts-2.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-serialize-posts-2.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1732,14 +1740,22 @@
 				108215061AAD41A000D27E66 /* 50reverse-proxy */,
 				108214FE1AAD34DD00D27E66 /* 50reverse-proxy-0.t */,
 				E9BC76C21EE3DAA900EB7A09 /* 50reverse-proxy-added-headers.t */,
+				E9F677CE1FF62217006476D3 /* 50reverse-proxy-chunk-sizes.t */,
+				E9F677CF1FF62217006476D3 /* 50reverse-proxy-chunk-timeout-1.t */,
+				E9F677CC1FF62216006476D3 /* 50reverse-proxy-chunk-timeout-2.t */,
+				E9F677CB1FF62216006476D3 /* 50reverse-proxy-chunk-trailing-headers.t */,
 				104C65021A6DF36B000AC190 /* 50reverse-proxy-config.t */,
 				108102151C3DB05100C024CD /* 50reverse-proxy-disconnected-keepalive.t */,
+				E9F677CD1FF62216006476D3 /* 50reverse-proxy-drop-headers.t */,
 				10DA969A1CCEF2C200679165 /* 50reverse-proxy-https.t */,
 				E9A410961F9EA2F100D9B0FB /* 50reverse-proxy-multiple-backends.t */,
 				E9A410951F9EA2E400D9B0FB /* 50reverse-proxy-multiple-backends-with-down.t */,
 				E9BC76C31EE4AA4600EB7A09 /* 50reverse-proxy-preserve-case.t */,
 				10FEF2441D6444E900E11B1D /* 50reverse-proxy-proxy-protocol.t */,
 				E9A410971F9EA2F200D9B0FB /* 50reverse-proxy-round-robin.t */,
+				E9F677D11FF62228006476D3 /* 50reverse-proxy-serialize-posts.t */,
+				E9F677D21FF62228006476D3 /* 50reverse-proxy-serialize-posts-2.t */,
+				E9F677D01FF62228006476D3 /* 50reverse-proxy-serialize-posts-3.t */,
 				E9BC76C41EE4AA9700EB7A09 /* 50reverse-proxy-session-resumption.t */,
 				10AA2EB21A9479B4004322AC /* 50reverse-proxy-upstream-down.t */,
 				104B9A2B1A4BBDA4009EEE64 /* 50server-starter.t */,

--- a/t/50reverse-proxy-chunk-timeout-1.t
+++ b/t/50reverse-proxy-chunk-timeout-1.t
@@ -7,6 +7,8 @@ use t::Util;
 
 plan skip_all => "nc not found"
     unless prog_exists("nc");
+plan skip_all => "h2get not found"
+    unless h2get_exists();
 
 my $upstream_port = empty_port();
 $| = 1;

--- a/t/50reverse-proxy-serialize-posts-3.t
+++ b/t/50reverse-proxy-serialize-posts-3.t
@@ -7,6 +7,8 @@ use t::Util;
 
 plan skip_all => "nc not found"
     unless prog_exists("nc");
+plan skip_all => "h2get not found"
+    unless h2get_exists();
 
 my $upstream_port = empty_port();
 $| = 1;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -13,7 +13,7 @@ use Test::More;
 use Time::HiRes qw(sleep);
 
 use base qw(Exporter);
-our @EXPORT = qw(ASSETS_DIR DOC_ROOT bindir server_features exec_unittest exec_mruby_unittest spawn_server spawn_h2o empty_ports create_data_file md5_file prog_exists run_prog openssl_can_negotiate curl_supports_http2 run_with_curl run_with_h2get run_with_h2get_simple one_shot_http_upstream);
+our @EXPORT = qw(ASSETS_DIR DOC_ROOT bindir server_features exec_unittest exec_mruby_unittest spawn_server spawn_h2o empty_ports create_data_file md5_file prog_exists run_prog openssl_can_negotiate curl_supports_http2 run_with_curl h2get_exists run_with_h2get run_with_h2get_simple one_shot_http_upstream);
 
 use constant ASSETS_DIR => 't/assets';
 use constant DOC_ROOT   => ASSETS_DIR . "/doc_root";
@@ -285,10 +285,14 @@ sub run_with_curl {
     };
 }
 
+sub h2get_exists {
+    prog_exists(bindir() . "/h2get_bin/h2get");
+}
+
 sub run_with_h2get {
     my ($server, $script) = @_;
     plan skip_all => "h2get not found"
-        unless prog_exists(bindir()."/h2get_bin/h2get");
+        unless h2get_exists();
     my ($scriptfh, $scriptfn) = tempfile(UNLINK => 1);
     print $scriptfh $script;
     close($scriptfh);


### PR DESCRIPTION
We need to check the existence of `h2get` before spawning the server that accepts request indirectly.