### PR TITLE
Don't call the proceed callback for a stream that has already sent a closing send-state

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1137,7 +1137,7 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
     *still_is_active = 0;
 
     h2o_http2_stream_send_pending_data(conn, stream);
-    if (h2o_http2_stream_has_pending_data(stream)) {
+    if (h2o_http2_stream_has_pending_data(stream) || stream->state == H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL) {
         if (h2o_http2_window_get_avail(&stream->output_window) <= 0) {
             /* is blocked */
         } else {


### PR DESCRIPTION
When the stream state is in SEND_BODY_IS_FINAL state and the stream gets activated (e.g. by receiving a WINDOW_UPDATE frame) and then is immediately disactivated (e.g. by another WINDOW_UPDATE frame), the stream remains in the scheduler.

In such case, we should not invoke `h2o_http2_stream_proceed` since the state means that there's pending data to sent (i.e. the DATA stream with the END_STREAM flag set). However a check was missing that caused that to happen.

This became a real issue as a side-effect of #1582.