### PR TITLE
queue 4 chunks for wslay's send_callback(), and merged with one h2o_socket_write() call

### DIFF
--- a/include/h2o/websocket.h
+++ b/include/h2o/websocket.h
@@ -41,7 +41,10 @@ struct st_h2o_websocket_conn_t {
     struct wslay_event_callbacks ws_callbacks;
     void *data;
     h2o_websocket_msg_callback cb;
-    void *_write_buf;
+    struct {
+        size_t cnt;
+        h2o_iovec_t bufs[4];
+    } _write_buf;
 };
 
 int h2o_is_websocket_handshake(h2o_req_t *req, const char **client_key);

--- a/include/h2o/websocket.h
+++ b/include/h2o/websocket.h
@@ -32,7 +32,7 @@ extern "C" {
 
 typedef struct st_h2o_websocket_conn_t h2o_websocket_conn_t;
 
-/* arg is NULL if the connection has been closed */
+/* if arg is NULL, the user should close connection by calling h2o_websocket_close() */
 typedef void (*h2o_websocket_msg_callback)(h2o_websocket_conn_t *conn, const struct wslay_event_on_msg_recv_arg *arg);
 
 struct st_h2o_websocket_conn_t {
@@ -48,7 +48,6 @@ struct st_h2o_websocket_conn_t {
 };
 
 int h2o_is_websocket_handshake(h2o_req_t *req, const char **client_key);
-void h2o_websocket_create_accept_key(char *dst, const char *client_key);
 h2o_websocket_conn_t *h2o_upgrade_to_websocket(h2o_req_t *req, const char *client_key, void *user_data,
                                                h2o_websocket_msg_callback msg_cb);
 void h2o_websocket_close(h2o_websocket_conn_t *conn);

--- a/lib/websocket.c
+++ b/lib/websocket.c
@@ -224,7 +224,10 @@ void h2o_websocket_proceed(h2o_websocket_conn_t *conn)
             if (wslay_event_send(conn->ws_ctx) != 0) {
                 goto Close;
             }
-            handled = 1;
+            /* avoid infinite loop when user want send more bufers count than ours in on_msg_callback() */
+            if (conn->_write_buf.cnt < sizeof(conn->_write_buf.bufs) / sizeof(conn->_write_buf.bufs[0])) {
+                handled = 1;
+            }
         }
         if (conn->sock->input->size != 0 && wslay_event_want_read(conn->ws_ctx)) {
             if (wslay_event_recv(conn->ws_ctx) != 0) {

--- a/lib/websocket.c
+++ b/lib/websocket.c
@@ -67,10 +67,10 @@ static void on_write_complete(h2o_socket_t *sock, const char *err)
     assert(conn->_write_buf.cnt == 0);
     for (i = 0; i < sizeof(conn->_write_buf.bufs) / sizeof(conn->_write_buf.bufs[0]); ++i) {
         buf = &conn->_write_buf.bufs[i];
-        if (buf->base != NULL) {
-            free(buf->base);
-            buf->base = NULL;
-        }
+        if (buf->base == NULL)
+            break;
+        free(buf->base);
+        buf->base = NULL;
     }
 
     h2o_websocket_proceed(conn);

--- a/lib/websocket.c
+++ b/lib/websocket.c
@@ -62,6 +62,7 @@ static void on_write_complete(h2o_socket_t *sock, const char *err)
         on_close(conn);
         return;
     }
+    assert(conn->_write_buf.cnt == 0);
     h2o_websocket_proceed(conn);
 }
 
@@ -85,23 +86,22 @@ static ssize_t recv_callback(wslay_event_context_ptr ctx, uint8_t *buf, size_t l
 static ssize_t send_callback(wslay_event_context_ptr ctx, const uint8_t *data, size_t len, int flags, void *_conn)
 {
     h2o_websocket_conn_t *conn = _conn;
-    h2o_iovec_t buf;
+    h2o_iovec_t *buf;
 
-    /* return WOULDBLOCK if pending (TODO: queue fixed number of chunks, instead of only one) */
-    if (h2o_socket_is_writing(conn->sock)) {
+    /* return WOULDBLOCK if pending or no buffer available */
+    if (h2o_socket_is_writing(conn->sock) ||
+        conn->_write_buf.cnt == sizeof(conn->_write_buf.bufs) / sizeof(conn->_write_buf.bufs[0])) {
         wslay_event_set_error(conn->ws_ctx, WSLAY_ERR_WOULDBLOCK);
         return -1;
     }
 
+    buf = &conn->_write_buf.bufs[conn->_write_buf.cnt];
+
     /* copy data */
-    conn->_write_buf = h2o_mem_realloc(conn->_write_buf, len);
-    memcpy(conn->_write_buf, data, len);
-
-    /* write */
-    buf.base = conn->_write_buf;
-    buf.len = len;
-    h2o_socket_write(conn->sock, &buf, 1, on_write_complete);
-
+    buf->base = h2o_mem_realloc(buf->base, len);
+    buf->len = len;
+    memcpy(buf->base, data, len);
+    ++conn->_write_buf.cnt;
     return len;
 }
 
@@ -194,9 +194,11 @@ int h2o_is_websocket_handshake(h2o_req_t *req, const char **ws_client_key)
 
 void h2o_websocket_close(h2o_websocket_conn_t *conn)
 {
+    size_t i;
     if (conn->sock != NULL)
         h2o_socket_close(conn->sock);
-    free(conn->_write_buf);
+    for (i = 0; i < sizeof(conn->_write_buf.bufs) / sizeof(conn->_write_buf.bufs[0]); ++i)
+        free(conn->_write_buf.bufs[i].base);
     wslay_event_context_free(conn->ws_ctx);
     free(conn);
 }
@@ -221,6 +223,12 @@ void h2o_websocket_proceed(h2o_websocket_conn_t *conn)
             handled = 1;
         }
     } while (handled);
+
+    if (conn->_write_buf.cnt > 0) {
+        /* write */
+        h2o_socket_write(conn->sock, conn->_write_buf.bufs, conn->_write_buf.cnt, on_write_complete);
+        conn->_write_buf.cnt = 0;
+    }
 
     if (wslay_event_want_read(conn->ws_ctx)) {
         h2o_socket_read_start(conn->sock, on_recv);


### PR DESCRIPTION
wslay_event_send() may trigger  send_callback() more than once.
so we can buffer the send request's data and merge the real send with only one h2o_socket_write() call.