### PR TITLE
refactor YOML attribute parsing

### DIFF
--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -170,7 +170,7 @@ ssize_t h2o_configurator_get_one_of(h2o_configurator_command_t *cmd, yoml_t *nod
  * @param node the mapping to parse
  * @param keys_required comma-separated list of required keys (or NULL)
  * @param keys_optional comma-separated list of optional keys (or NULL)
- * @param ... pointers to `yoml_t *` for receiving the results; they should appear in the order they appear in the key names
+ * @param ... pointers to `yoml_t **` for receiving the results; they should appear in the order they appear in the key names
  * @return 0 if successful, -1 if not
  */
 #define h2o_configurator_parse_mapping(cmd, node, keys_required, keys_optional, ...)                                               \

--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -175,7 +175,7 @@ ssize_t h2o_configurator_get_one_of(h2o_configurator_command_t *cmd, yoml_t *nod
  */
 #define h2o_configurator_parse_mapping(cmd, node, keys_required, keys_optional, ...)                                               \
     h2o_configurator__do_parse_mapping((cmd), (node), (keys_required), (keys_optional), (yoml_t * **[]){__VA_ARGS__},              \
-                                       sizeof((yoml_t ***[]){__VA_ARGS__}) / sizeof(yoml_t **))
+                                       sizeof((yoml_t ***[]){__VA_ARGS__}) / sizeof(yoml_t ***))
 int h2o_configurator__do_parse_mapping(h2o_configurator_command_t *cmd, yoml_t *node, const char *keys_required,
                                        const char *keys_optional, yoml_t ****values, size_t num_values);
 /**

--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -165,7 +165,7 @@ int h2o_configurator_scanf(h2o_configurator_command_t *cmd, yoml_t *node, const 
  */
 ssize_t h2o_configurator_get_one_of(h2o_configurator_command_t *cmd, yoml_t *node, const char *candidates);
 /**
- * extracts keys (required and optional) from a mapping, or prints an error upon failure
+ * extracts values (required and optional) from a mapping by their keys, or prints an error upon failure
  * @param configurator configurator
  * @param node the mapping to parse
  * @param keys_required comma-separated list of required keys (or NULL)

--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -174,7 +174,7 @@ ssize_t h2o_configurator_get_one_of(h2o_configurator_command_t *cmd, yoml_t *nod
  * @return 0 if successful, -1 if not
  */
 #define h2o_configurator_parse_mapping(cmd, node, keys_required, keys_optional, ...)                                               \
-    h2o_configurator__do_parse_mapping((cmd), (node), keys_required, keys_optional, (yoml_t * **[]){__VA_ARGS__},                  \
+    h2o_configurator__do_parse_mapping((cmd), (node), (keys_required), (keys_optional), (yoml_t * **[]){__VA_ARGS__},              \
                                        sizeof((yoml_t ***[]){__VA_ARGS__}) / sizeof(yoml_t **))
 int h2o_configurator__do_parse_mapping(h2o_configurator_command_t *cmd, yoml_t *node, const char *keys_required,
                                        const char *keys_optional, yoml_t ****values, size_t num_values);

--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -165,6 +165,20 @@ int h2o_configurator_scanf(h2o_configurator_command_t *cmd, yoml_t *node, const 
  */
 ssize_t h2o_configurator_get_one_of(h2o_configurator_command_t *cmd, yoml_t *node, const char *candidates);
 /**
+ * extracts keys (required and optional) from a mapping, or prints an error upon failure
+ * @param configurator configurator
+ * @param node the mapping to parse
+ * @param keys_required comma-separated list of required keys (or NULL)
+ * @param keys_optional comma-separated list of optional keys (or NULL)
+ * @param ... pointers to `yoml_t *` for receiving the results; they should appear in the order they appear in the key names
+ * @return 0 if successful, -1 if not
+ */
+#define h2o_configurator_parse_mapping(cmd, node, keys_required, keys_optional, ...)                                               \
+    h2o_configurator__do_parse_mapping((cmd), (node), keys_required, keys_optional, (yoml_t * **[]){__VA_ARGS__},                  \
+                                       sizeof((yoml_t ***[]){__VA_ARGS__}) / sizeof(yoml_t **))
+int h2o_configurator__do_parse_mapping(h2o_configurator_command_t *cmd, yoml_t *node, const char *keys_required,
+                                       const char *keys_optional, yoml_t ****values, size_t num_values);
+/**
  * returns the absolute paths of supplementary commands
  */
 char *h2o_configurator_get_cmd_path(const char *cmd);

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -1114,7 +1114,8 @@ Error:
 static const char *get_next_key(const char *start, h2o_iovec_t *output, unsigned *type_mask)
 {
     const char *p = strchr(start, ':');
-    assert(p != NULL);
+    if (p == NULL)
+        goto Error;
 
     /* set output */
     *output = h2o_iovec_init(start, p - start);
@@ -1138,12 +1139,15 @@ static const char *get_next_key(const char *start, h2o_iovec_t *output, unsigned
             *type_mask |= (1u << YOML_TYPE_SCALAR) | (1u << YOML_TYPE_SEQUENCE) | (1u << YOML_TYPE_MAPPING);
             break;
         default:
-            h2o_fatal("unexpected attribute");
-            break;
+            goto Error;
         }
     }
 
     return NULL;
+
+Error:
+    fprintf(stderr, "%s: detected invalid or missing type specifier; input is: %s\n", __FUNCTION__, start);
+    abort();
 }
 
 int h2o_configurator__do_parse_mapping(h2o_configurator_command_t *cmd, yoml_t *node, const char *keys_required,

--- a/lib/handler/configurator/access_log.c
+++ b/lib/handler/configurator/access_log.c
@@ -33,55 +33,46 @@ struct st_h2o_access_log_configurator_t {
 static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct st_h2o_access_log_configurator_t *self = (void *)cmd->configurator;
-    const char *path, *fmt = NULL;
+    yoml_t **path, **format = NULL, **escape_node = NULL;
     int escape = H2O_LOGCONF_ESCAPE_APACHE;
     h2o_access_log_filehandle_t *fh;
 
     switch (node->type) {
     case YOML_TYPE_SCALAR:
-        path = node->data.scalar;
+        path = &node;
         break;
-    case YOML_TYPE_MAPPING: {
-        yoml_t *t;
-        /* get path */
-        if ((t = yoml_get(node, "path")) == NULL) {
-            h2o_configurator_errprintf(cmd, node, "could not find mandatory key `path`");
+    case YOML_TYPE_MAPPING:
+        if (h2o_configurator_parse_mapping(cmd, node, "path", "format,escape", &path, &format, &escape_node) != 0)
+            return -1;
+        if ((*path)->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, *path, "`path` must be scalar");
             return -1;
         }
-        if (t->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, t, "`path` must be scalar");
+        if (format != NULL && (*format)->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, *format, "`format` must be a scalar");
             return -1;
         }
-        path = t->data.scalar;
-        /* get format */
-        if ((t = yoml_get(node, "format")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, t, "`format` must be a scalar");
-                return -1;
-            }
-            fmt = t->data.scalar;
-        }
-        /* get escape */
-        if ((t = yoml_get(node, "escape")) != NULL) {
-            switch (h2o_configurator_get_one_of(cmd, t, "apache,json")) {
-            case 0:
-                escape = H2O_LOGCONF_ESCAPE_APACHE;
-                break;
-            case 1:
-                escape = H2O_LOGCONF_ESCAPE_JSON;
-                break;
-            default:
-                return -1;
-            }
-        }
-    } break;
+        break;
     default:
         h2o_configurator_errprintf(cmd, node, "node must be a scalar or a mapping");
         return -1;
     }
 
+    if (escape_node != NULL) {
+        switch (h2o_configurator_get_one_of(cmd, *escape_node, "apache,json")) {
+        case 0:
+            escape = H2O_LOGCONF_ESCAPE_APACHE;
+            break;
+        case 1:
+            escape = H2O_LOGCONF_ESCAPE_JSON;
+            break;
+        default:
+            return -1;
+        }
+    }
+
     if (!ctx->dry_run) {
-        if ((fh = h2o_access_log_open_handle(path, fmt, escape)) == NULL)
+        if ((fh = h2o_access_log_open_handle((*path)->data.scalar, format != NULL ? (*format)->data.scalar : NULL, escape)) == NULL)
             return -1;
         h2o_vector_reserve(NULL, self->handles, self->handles->size + 1);
         self->handles->entries[self->handles->size++] = fh;

--- a/lib/handler/configurator/access_log.c
+++ b/lib/handler/configurator/access_log.c
@@ -42,7 +42,7 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
         path = &node;
         break;
     case YOML_TYPE_MAPPING:
-        if (h2o_configurator_parse_mapping(cmd, node, "path:s", "format:s,escape", &path, &format, &escape_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "path:s", "format:s,escape:*", &path, &format, &escape_node) != 0)
             return -1;
         break;
     default:

--- a/lib/handler/configurator/access_log.c
+++ b/lib/handler/configurator/access_log.c
@@ -42,16 +42,8 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
         path = &node;
         break;
     case YOML_TYPE_MAPPING:
-        if (h2o_configurator_parse_mapping(cmd, node, "path", "format,escape", &path, &format, &escape_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "path:s", "format:s,escape", &path, &format, &escape_node) != 0)
             return -1;
-        if ((*path)->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, *path, "`path` must be scalar");
-            return -1;
-        }
-        if (format != NULL && (*format)->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, *format, "`format` must be a scalar");
-            return -1;
-        }
         break;
     default:
         h2o_configurator_errprintf(cmd, node, "node must be a scalar or a mapping");

--- a/lib/handler/configurator/compress.c
+++ b/lib/handler/configurator/compress.c
@@ -106,7 +106,7 @@ static int on_config_compress(h2o_configurator_command_t *cmd, h2o_configurator_
     case YOML_TYPE_MAPPING: {
         yoml_t **gzip_node, **br_node;
         *self->vars = all_off;
-        if (h2o_configurator_parse_mapping(cmd, node, NULL, "gzip,br", &gzip_node, &br_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, NULL, "gzip:*,br:*", &gzip_node, &br_node) != 0)
             return -1;
         if (gzip_node != NULL && obtain_quality(*gzip_node, 1, 9, DEFAULT_GZIP_QUALITY, &self->vars->gzip.quality) != 0) {
             h2o_configurator_errprintf(cmd, *gzip_node,

--- a/lib/handler/configurator/errordoc.c
+++ b/lib/handler/configurator/errordoc.c
@@ -35,7 +35,7 @@ static int register_errordoc(h2o_configurator_command_t *cmd, h2o_configurator_c
     size_t i, j, num_status;
 
     /* extract the nodes to handle */
-    if (h2o_configurator_parse_mapping(cmd, hash, "url:s,status", NULL, &url_node, &status_nodes) != 0)
+    if (h2o_configurator_parse_mapping(cmd, hash, "url:s,status:*", NULL, &url_node, &status_nodes) != 0)
         return -1;
     switch ((*status_nodes)->type) {
     case YOML_TYPE_SCALAR:

--- a/lib/handler/configurator/errordoc.c
+++ b/lib/handler/configurator/errordoc.c
@@ -46,84 +46,61 @@ static int scan_and_check_status(h2o_configurator_command_t *cmd, yoml_t *value,
 static int register_errordoc(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *hash)
 {
     struct errordoc_configurator_t *self = (void *)cmd->configurator;
-    int status[200];
-    size_t status_len = 0;
-    int parsed;
-    const char *url = NULL;
-    size_t i, j, k;
-    yoml_t *key, *value;
+    yoml_t **url_node, **status_nodes;
+    size_t i, j, num_status;
 
-    for (i = 0; i != hash->data.mapping.size; ++i) {
-        key = hash->data.mapping.elements[i].key;
-        value = hash->data.mapping.elements[i].value;
-        if (key->type != YOML_TYPE_SCALAR)
-            goto UnknownKeyError;
-        if (strcmp(key->data.scalar, "status") == 0) {
-            if (status_len != 0)
-                goto KeyAlreadyDefinedError;
+    /* extract the nodes to handle */
+    if (h2o_configurator_parse_mapping(cmd, hash, "url,status", NULL, &url_node, &status_nodes) != 0)
+        return -1;
+    if ((*url_node)->type != YOML_TYPE_SCALAR) {
+        h2o_configurator_errprintf(cmd, *url_node, "URL must be a scalar");
+        return -1;
+    }
+    switch ((*status_nodes)->type) {
+    case YOML_TYPE_SCALAR:
+        num_status = 1;
+        break;
+    case YOML_TYPE_SEQUENCE:
+        if ((*status_nodes)->data.sequence.size == 0) {
+            h2o_configurator_errprintf(cmd, *status_nodes, "status cannot be an empty sequence");
+            return -1;
+        }
+        num_status = (*status_nodes)->data.sequence.size;
+        status_nodes = (*status_nodes)->data.sequence.elements;
+        break;
+    default:
+        h2o_configurator_errprintf(cmd, *status_nodes, "status must be a 3-digit scalar or a sequence of 3-digit scalars");
+        return -1;
+    }
 
-            if (value->type == YOML_TYPE_SEQUENCE) {
-                if (value->data.sequence.size == 0) {
-                    h2o_configurator_errprintf(cmd, value, "status sequence must not be empty");
-                    return -1;
-                }
-                for (j = 0; j != value->data.sequence.size; ++j) {
-                    if (scan_and_check_status(cmd, value->data.sequence.elements[j], &parsed) != 0)
-                        return -1;
-                    /* check the scanned status hasn't already appeared */
-                    for (k = 0; k != status_len; ++k) {
-                        if (status[k] == parsed) {
-                            h2o_configurator_errprintf(cmd, value, "status %d appears multiple times", status[k]);
-                            return -1;
-                        }
-                    }
-                    status[status_len++] = parsed;
-                }
-            } else {
-                if (scan_and_check_status(cmd, value, &parsed) != 0)
-                    return -1;
-                status[status_len++] = parsed;
-            }
-
-        } else if (strcmp(key->data.scalar, "url") == 0) {
-            if (url != NULL)
-                goto KeyAlreadyDefinedError;
-            if (value->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, value, "URL must be a scalar");
+    /* convert list of status_nodes (in string) to list of 3-digit codes */
+    int *status_codes = alloca(sizeof(*status_codes) * num_status);
+    for (i = 0; i != num_status; ++i) {
+        if (h2o_configurator_scanf(cmd, status_nodes[i], "%d", &status_codes[i]) != 0)
+            return -1;
+        if (!(400 <= status_codes[i] && status_codes[i] <= 599)) {
+            h2o_configurator_errprintf(cmd, status_nodes[i], "status must be within range of 400 to 599");
+            return -1;
+        }
+        /* check the scanned status hasn't already appeared */
+        for (j = 0; j != i; ++j) {
+            if (status_codes[j] == status_codes[i]) {
+                h2o_configurator_errprintf(cmd, status_nodes[i], "status %d appears multiple times", status_codes[i]);
                 return -1;
             }
-            url = value->data.scalar;
-        } else {
-            goto UnknownKeyError;
         }
     }
 
-    if (status_len == 0) {
-        h2o_configurator_errprintf(cmd, hash, "mandatory key `status` is not defined");
-        return -1;
-    }
-    if (url == NULL) {
-        h2o_configurator_errprintf(cmd, hash, "mandatory key `url` is not defined");
-        return -1;
-    }
-
-    h2o_iovec_t _url = h2o_strdup(&self->pool, url, SIZE_MAX);
-    for (i = 0; i != status_len; ++i) {
+    h2o_iovec_t url = h2o_strdup(&self->pool, (*url_node)->data.scalar, SIZE_MAX);
+    for (i = 0; i != num_status; ++i) {
         /* register */
         h2o_vector_reserve(&self->pool, self->vars, self->vars->size + 1);
         h2o_errordoc_t *errordoc = self->vars->entries + self->vars->size++;
-        errordoc->status = status[i];
-        errordoc->url = _url;
+        errordoc->status = status_codes[i];
+        errordoc->url = url;
     }
 
     return 0;
-
-UnknownKeyError:
-    h2o_configurator_errprintf(cmd, key, "key must be either of: `status`, `url`");
-    return -1;
-KeyAlreadyDefinedError:
-    h2o_configurator_errprintf(cmd, key, "the key cannot be defined more than once");
-    return -1;
 }
 
 static int on_config_errordoc(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)

--- a/lib/handler/configurator/errordoc.c
+++ b/lib/handler/configurator/errordoc.c
@@ -50,12 +50,8 @@ static int register_errordoc(h2o_configurator_command_t *cmd, h2o_configurator_c
     size_t i, j, num_status;
 
     /* extract the nodes to handle */
-    if (h2o_configurator_parse_mapping(cmd, hash, "url,status", NULL, &url_node, &status_nodes) != 0)
+    if (h2o_configurator_parse_mapping(cmd, hash, "url:s,status", NULL, &url_node, &status_nodes) != 0)
         return -1;
-    if ((*url_node)->type != YOML_TYPE_SCALAR) {
-        h2o_configurator_errprintf(cmd, *url_node, "URL must be a scalar");
-        return -1;
-    }
     switch ((*status_nodes)->type) {
     case YOML_TYPE_SCALAR:
         num_status = 1;

--- a/lib/handler/configurator/errordoc.c
+++ b/lib/handler/configurator/errordoc.c
@@ -28,21 +28,6 @@ struct errordoc_configurator_t {
     H2O_VECTOR(h2o_errordoc_t) * vars, _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
 };
 
-static int scan_and_check_status(h2o_configurator_command_t *cmd, yoml_t *value, int *slot)
-{
-    if (value->type != YOML_TYPE_SCALAR) {
-        h2o_configurator_errprintf(cmd, value, "status must be must be either of: scalar, sequence of scalar");
-        return -1;
-    }
-    if (h2o_configurator_scanf(cmd, value, "%d", slot) != 0)
-        return -1;
-    if (!(400 <= *slot && *slot <= 599)) {
-        h2o_configurator_errprintf(cmd, value, "status must be within range of 400 to 599");
-        return -1;
-    }
-    return 0;
-}
-
 static int register_errordoc(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *hash)
 {
     struct errordoc_configurator_t *self = (void *)cmd->configurator;

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -90,29 +90,27 @@ static int on_config_connect(h2o_configurator_command_t *cmd, h2o_configurator_c
         servname = node->data.scalar;
         break;
     case YOML_TYPE_MAPPING: {
-        yoml_t *t;
-        if ((t = yoml_get(node, "host")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, t, "`host` is not a string");
-                return -1;
-            }
-            hostname = t->data.scalar;
-        }
-        if ((t = yoml_get(node, "port")) == NULL) {
-            h2o_configurator_errprintf(cmd, node, "cannot find mandatory property `port`");
+        yoml_t **port_node, **host_node, **type_node;
+        if (h2o_configurator_parse_mapping(cmd, node, "port", "host,type", &port_node, &host_node, &type_node) != 0)
+            return -1;
+        if ((*port_node)->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, *port_node, "`port` is not a string");
             return -1;
         }
-        if (t->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, node, "`port` is not a string");
-            return -1;
-        }
-        servname = t->data.scalar;
-        if ((t = yoml_get(node, "type")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, t, "`type` is not a string");
+        servname = (*port_node)->data.scalar;
+        if (host_node != NULL) {
+            if ((*host_node)->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, *host_node, "`host` is not a string");
                 return -1;
             }
-            type = t->data.scalar;
+            hostname = (*host_node)->data.scalar;
+        }
+        if (type_node != NULL) {
+            if ((*type_node)->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, *type_node, "`type` is not a string");
+                return -1;
+            }
+            type = (*type_node)->data.scalar;
         }
     } break;
     default:
@@ -231,7 +229,7 @@ static void spawnproc_on_dispose(h2o_fastcgi_handler_t *handler, void *data)
 static int on_config_spawn(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct fastcgi_configurator_t *self = (void *)cmd->configurator;
-    char *spawn_user = NULL, *spawn_cmd;
+    char *spawn_user = ctx->globalconf->user, *spawn_cmd;
     char *kill_on_close_cmd_path = NULL, *setuidgid_cmd_path = NULL;
     char dirname[] = "/tmp/h2o.fcgisock.XXXXXX";
     char *argv[10];
@@ -246,27 +244,23 @@ static int on_config_spawn(h2o_configurator_command_t *cmd, h2o_configurator_con
 
     switch (node->type) {
     case YOML_TYPE_SCALAR:
-        spawn_user = ctx->globalconf->user;
         spawn_cmd = node->data.scalar;
         break;
     case YOML_TYPE_MAPPING: {
-        yoml_t *t;
-        if ((t = yoml_get(node, "command")) == NULL) {
-            h2o_configurator_errprintf(cmd, node, "mandatory attribute `command` does not exist");
+        yoml_t **command_node, **user_node;
+        if (h2o_configurator_parse_mapping(cmd, node, "command", "user", &command_node, &user_node) != 0)
+            return -1;
+        if ((*command_node)->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, *command_node, "attribute `command` must be scalar");
             return -1;
         }
-        if (t->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, node, "attribute `command` must be scalar");
-            return -1;
-        }
-        spawn_cmd = t->data.scalar;
-        spawn_user = ctx->globalconf->user;
-        if ((t = yoml_get(node, "user")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, node, "attribute `user` must be scalar");
+        spawn_cmd = (*command_node)->data.scalar;
+        if (user_node != NULL) {
+            if ((*user_node)->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, *user_node, "attribute `user` must be scalar");
                 return -1;
             }
-            spawn_user = t->data.scalar;
+            spawn_user = (*user_node)->data.scalar;
         }
     } break;
     default:

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -91,27 +91,13 @@ static int on_config_connect(h2o_configurator_command_t *cmd, h2o_configurator_c
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **port_node, **host_node, **type_node;
-        if (h2o_configurator_parse_mapping(cmd, node, "port", "host,type", &port_node, &host_node, &type_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "port:s", "host:s,type:s", &port_node, &host_node, &type_node) != 0)
             return -1;
-        if ((*port_node)->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, *port_node, "`port` is not a string");
-            return -1;
-        }
         servname = (*port_node)->data.scalar;
-        if (host_node != NULL) {
-            if ((*host_node)->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, *host_node, "`host` is not a string");
-                return -1;
-            }
+        if (host_node != NULL)
             hostname = (*host_node)->data.scalar;
-        }
-        if (type_node != NULL) {
-            if ((*type_node)->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, *type_node, "`type` is not a string");
-                return -1;
-            }
+        if (type_node != NULL)
             type = (*type_node)->data.scalar;
-        }
     } break;
     default:
         h2o_configurator_errprintf(cmd, node,
@@ -248,20 +234,11 @@ static int on_config_spawn(h2o_configurator_command_t *cmd, h2o_configurator_con
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **command_node, **user_node;
-        if (h2o_configurator_parse_mapping(cmd, node, "command", "user", &command_node, &user_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "command:s", "user:s", &command_node, &user_node) != 0)
             return -1;
-        if ((*command_node)->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, *command_node, "attribute `command` must be scalar");
-            return -1;
-        }
         spawn_cmd = (*command_node)->data.scalar;
-        if (user_node != NULL) {
-            if ((*user_node)->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, *user_node, "attribute `user` must be scalar");
-                return -1;
-            }
+        if (user_node != NULL)
             spawn_user = (*user_node)->data.scalar;
-        }
     } break;
     default:
         h2o_configurator_errprintf(cmd, node, "argument must be scalar or mapping");

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -214,7 +214,7 @@ static int on_config_ssl_session_cache(h2o_configurator_command_t *cmd, h2o_conf
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **capacity_node, **lifetime_node;
-        if (h2o_configurator_parse_mapping(cmd, node, "capacity,lifetime", NULL, &capacity_node, &lifetime_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "capacity:*,lifetime:*", NULL, &capacity_node, &lifetime_node) != 0)
             return -1;
         if (h2o_configurator_scanf(cmd, *capacity_node, "%zu", &capacity) != 0)
             return -1;
@@ -261,7 +261,7 @@ static h2o_socketpool_target_t *parse_backend(h2o_configurator_command_t *cmd, y
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **weight_node;
-        if (h2o_configurator_parse_mapping(cmd, backend, "url:s", "weight", &url_node, &weight_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, backend, "url:s", "weight:*", &url_node, &weight_node) != 0)
             return NULL;
         if (weight_node != NULL) {
             unsigned weight;
@@ -307,7 +307,7 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
         num_backends = node->data.sequence.size;
         break;
     case YOML_TYPE_MAPPING:
-        if (h2o_configurator_parse_mapping(cmd, node, "backends", "balancer:s", &backends, &balancer_conf) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "backends:*", "balancer:s", &backends, &balancer_conf) != 0)
             return -1;
         switch ((*backends)->type) {
         case YOML_TYPE_SCALAR:

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -261,12 +261,8 @@ static h2o_socketpool_target_t *parse_backend(h2o_configurator_command_t *cmd, y
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **weight_node;
-        if (h2o_configurator_parse_mapping(cmd, backend, "url", "weight", &url_node, &weight_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, backend, "url:s", "weight", &url_node, &weight_node) != 0)
             return NULL;
-        if ((*url_node)->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, *url_node, "value of the `url` property must be a scalar");
-            return NULL;
-        }
         if (weight_node != NULL) {
             unsigned weight;
             if (h2o_configurator_scanf(cmd, *weight_node, "%u", &weight) != 0)
@@ -311,7 +307,7 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
         num_backends = node->data.sequence.size;
         break;
     case YOML_TYPE_MAPPING:
-        if (h2o_configurator_parse_mapping(cmd, node, "backends", "balancer", &backends, &balancer_conf) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "backends", "balancer:s", &backends, &balancer_conf) != 0)
             return -1;
         switch ((*backends)->type) {
         case YOML_TYPE_SCALAR:
@@ -337,10 +333,6 @@ static int on_config_reverse_url(h2o_configurator_command_t *cmd, h2o_configurat
 
     /* determine the balancer */
     if (balancer_conf != NULL) {
-        if ((*balancer_conf)->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, *balancer_conf, "name of the balancer must be a scalar");
-            return -1;
-        }
         if (strcmp((*balancer_conf)->data.scalar, "round-robin") == 0) {
             balancer = h2o_balancer_create_rr();
         } else if (strcmp((*balancer_conf)->data.scalar, "least-conn") == 0) {

--- a/lib/handler/configurator/redirect.c
+++ b/lib/handler/configurator/redirect.c
@@ -27,37 +27,39 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
     const char *dest;
     int status = 302; /* default is temporary redirect */
     int internal = 0; /* default is external redirect */
-    yoml_t *t;
 
     switch (node->type) {
     case YOML_TYPE_SCALAR:
         dest = node->data.scalar;
         break;
-    case YOML_TYPE_MAPPING:
-        if ((t = yoml_get(node, "url")) == NULL) {
-            h2o_configurator_errprintf(cmd, node, "mandatory property `url` is missing");
+    case YOML_TYPE_MAPPING: {
+        yoml_t **url_node, **status_node, **internal_node;
+        if (h2o_configurator_parse_mapping(cmd, node, "url,status", "internal", &url_node, &status_node, &internal_node) != 0)
+            return -1;
+        if ((*url_node)->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, *url_node, "property `url` must be a string");
             return -1;
         }
-        if (t->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, t, "property `url` must be a string");
-            return -1;
-        }
-        dest = t->data.scalar;
-        if ((t = yoml_get(node, "status")) == NULL) {
-            h2o_configurator_errprintf(cmd, node, "mandatory property `status` is missing");
-            return -1;
-        }
-        if (h2o_configurator_scanf(cmd, t, "%d", &status) != 0)
+        dest = (*url_node)->data.scalar;
+        if (h2o_configurator_scanf(cmd, *status_node, "%d", &status) != 0)
             return -1;
         if (!(300 <= status && status <= 399)) {
-            h2o_configurator_errprintf(cmd, t, "value of property `status` should be within 300 to 399");
+            h2o_configurator_errprintf(cmd, *status_node, "value of property `status` should be within 300 to 399");
             return -1;
         }
-        if ((t = yoml_get(node, "internal")) != NULL) {
-            if ((internal = (int)h2o_configurator_get_one_of(cmd, t, "NO,YES")) == -1)
+        if (internal_node != NULL) {
+            switch (h2o_configurator_get_one_of(cmd, *internal_node, "YES,NO")) {
+            case 0:
+                internal = 1;
+                break;
+            case 1:
+                internal = 0;
+                break;
+            default:
                 return -1;
+            }
         }
-        break;
+    } break;
     default:
         h2o_configurator_errprintf(cmd, node, "value must be a string or a mapping");
         return -1;

--- a/lib/handler/configurator/redirect.c
+++ b/lib/handler/configurator/redirect.c
@@ -34,7 +34,7 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **url_node, **status_node, **internal_node;
-        if (h2o_configurator_parse_mapping(cmd, node, "url:s,status:*", "internal", &url_node, &status_node, &internal_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "url:s,status:*", "internal:*", &url_node, &status_node, &internal_node) != 0)
             return -1;
         dest = (*url_node)->data.scalar;
         if (h2o_configurator_scanf(cmd, *status_node, "%d", &status) != 0)

--- a/lib/handler/configurator/redirect.c
+++ b/lib/handler/configurator/redirect.c
@@ -34,7 +34,7 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **url_node, **status_node, **internal_node;
-        if (h2o_configurator_parse_mapping(cmd, node, "url:s,status", "internal", &url_node, &status_node, &internal_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "url:s,status:*", "internal", &url_node, &status_node, &internal_node) != 0)
             return -1;
         dest = (*url_node)->data.scalar;
         if (h2o_configurator_scanf(cmd, *status_node, "%d", &status) != 0)

--- a/lib/handler/configurator/redirect.c
+++ b/lib/handler/configurator/redirect.c
@@ -34,12 +34,8 @@ static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **url_node, **status_node, **internal_node;
-        if (h2o_configurator_parse_mapping(cmd, node, "url,status", "internal", &url_node, &status_node, &internal_node) != 0)
+        if (h2o_configurator_parse_mapping(cmd, node, "url:s,status", "internal", &url_node, &status_node, &internal_node) != 0)
             return -1;
-        if ((*url_node)->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, *url_node, "property `url` must be a string");
-            return -1;
-        }
         dest = (*url_node)->data.scalar;
         if (h2o_configurator_scanf(cmd, *status_node, "%d", &status) != 0)
             return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -548,16 +548,12 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
 
     if (ssl_node == NULL)
         return 0;
-    if ((*ssl_node)->type != YOML_TYPE_MAPPING) {
-        h2o_configurator_errprintf(cmd, *ssl_node, "`ssl` is not a mapping");
-        return -1;
-    }
 
     /* parse */
     if (h2o_configurator_parse_mapping(
-            cmd, *ssl_node, "certificate-file:s,key-file:s",
-            "min-version:s,minimum-version:s,max-version:s,maximum-version:s,cipher-suite:s,ocsp-update-cmd:s,ocsp-update-interval,"
-            "ocsp-max-failures,dh-file:s,cipher-preference,neverbleed",
+            cmd, *ssl_node, "certificate-file:s,key-file:s", "min-version:s,minimum-version:s,max-version:s,maximum-version:s,"
+                                                             "cipher-suite:s,ocsp-update-cmd:s,ocsp-update-interval:*,"
+                                                             "ocsp-max-failures:*,dh-file:s,cipher-preference:*,neverbleed:*",
             &certificate_file, &key_file, &min_version, &min_version, &max_version, &max_version, &cipher_suite, &ocsp_update_cmd,
             &ocsp_update_interval_node, &ocsp_max_failures_node, &dh_file, &cipher_preference_node, &neverbleed_node) != 0)
         return -1;
@@ -973,8 +969,8 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
         break;
     case YOML_TYPE_MAPPING: {
         yoml_t **port_node, **host_node, **type_node, **proxy_protocol_node;
-        if (h2o_configurator_parse_mapping(cmd, node, "port:s", "host:s,type:s,owner:s,permission,ssl,proxy-protocol", &port_node,
-                                           &host_node, &type_node, &owner_node, &permission_node, &ssl_node,
+        if (h2o_configurator_parse_mapping(cmd, node, "port:s", "host:s,type:s,owner:s,permission:*,ssl:m,proxy-protocol:*",
+                                           &port_node, &host_node, &type_node, &owner_node, &permission_node, &ssl_node,
                                            &proxy_protocol_node) != 0)
             return -1;
         servname = (*port_node)->data.scalar;

--- a/src/main.c
+++ b/src/main.c
@@ -525,11 +525,11 @@ static void listener_setup_ssl_add_host(struct listener_ssl_config_t *ssl_config
 }
 
 static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *listen_node,
-                              yoml_t *ssl_node, struct listener_config_t *listener, int listener_is_new)
+                              yoml_t **ssl_node, struct listener_config_t *listener, int listener_is_new)
 {
     SSL_CTX *ssl_ctx = NULL;
-    yoml_t *certificate_file = NULL, *key_file = NULL, *dh_file = NULL, *min_version = NULL, *max_version = NULL,
-           *cipher_suite = NULL, *ocsp_update_cmd = NULL, *ocsp_update_interval_node = NULL, *ocsp_max_failures_node = NULL;
+    yoml_t **certificate_file, **key_file, **dh_file, **min_version, **max_version, **cipher_suite, **ocsp_update_cmd,
+        **ocsp_update_interval_node, **ocsp_max_failures_node, **cipher_preference_node, **neverbleed_node;
     long ssl_options = SSL_OP_ALL;
     uint64_t ocsp_update_interval = 4 * 60 * 60; /* defaults to 4 hours */
     unsigned ocsp_max_failures = 3;              /* defaults to 3; permit 3 failures before temporary disabling OCSP stapling */
@@ -541,117 +541,87 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
             return -1;
         }
         if (listener->ssl.size == 0 && ssl_node != NULL) {
-            h2o_configurator_errprintf(cmd, ssl_node, "cannot accept HTTPS; already defined to accept HTTP");
+            h2o_configurator_errprintf(cmd, *ssl_node, "cannot accept HTTPS; already defined to accept HTTP");
             return -1;
         }
     }
 
     if (ssl_node == NULL)
         return 0;
-    if (ssl_node->type != YOML_TYPE_MAPPING) {
-        h2o_configurator_errprintf(cmd, ssl_node, "`ssl` is not a mapping");
+    if ((*ssl_node)->type != YOML_TYPE_MAPPING) {
+        h2o_configurator_errprintf(cmd, *ssl_node, "`ssl` is not a mapping");
         return -1;
     }
 
-    { /* parse */
-        size_t i;
-        for (i = 0; i != ssl_node->data.sequence.size; ++i) {
-            yoml_t *key = ssl_node->data.mapping.elements[i].key, *value = ssl_node->data.mapping.elements[i].value;
-            /* obtain the target command */
-            if (key->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(NULL, key, "command must be a string");
-                return -1;
-            }
-#define FETCH_PROPERTY(n, p)                                                                                                       \
-    if (strcmp(key->data.scalar, n) == 0) {                                                                                        \
-        if (value->type != YOML_TYPE_SCALAR) {                                                                                     \
-            h2o_configurator_errprintf(cmd, value, "property of `" n "` must be a string");                                        \
-            return -1;                                                                                                             \
-        }                                                                                                                          \
-        p = value;                                                                                                                 \
-        continue;                                                                                                                  \
+    /* parse */
+    if (h2o_configurator_parse_mapping(cmd, *ssl_node, "certificate-file,key-file",
+                                       "min-version,minimum-version,max-version,maximum-version,cipher-suite,ocsp-update-cmd,ocsp-"
+                                       "update-interval,ocsp-max-failures,dh-file,cipher-preference,neverbleed",
+                                       &certificate_file, &key_file, &min_version, &min_version, &max_version, &max_version,
+                                       &cipher_suite, &ocsp_update_cmd, &ocsp_update_interval_node, &ocsp_max_failures_node,
+                                       &dh_file, &cipher_preference_node, &neverbleed_node) != 0)
+        return -1;
+#define ASSERT_SCALAR(n, p)                                                                                                        \
+    if (p != NULL && (*p)->type != YOML_TYPE_SCALAR) {                                                                             \
+        h2o_configurator_errprintf(cmd, (*p), "`" n "` must be a string");                                                         \
+        return -1;                                                                                                                 \
     }
-            FETCH_PROPERTY("certificate-file", certificate_file);
-            FETCH_PROPERTY("key-file", key_file);
-            FETCH_PROPERTY("min-version", min_version);
-            FETCH_PROPERTY("minimum-version", min_version);
-            FETCH_PROPERTY("max-version", max_version);
-            FETCH_PROPERTY("maximum-version", max_version);
-            FETCH_PROPERTY("cipher-suite", cipher_suite);
-            FETCH_PROPERTY("ocsp-update-cmd", ocsp_update_cmd);
-            FETCH_PROPERTY("ocsp-update-interval", ocsp_update_interval_node);
-            FETCH_PROPERTY("ocsp-max-failures", ocsp_max_failures_node);
-            FETCH_PROPERTY("dh-file", dh_file);
-            if (strcmp(key->data.scalar, "cipher-preference") == 0) {
-                if (value->type == YOML_TYPE_SCALAR && strcasecmp(value->data.scalar, "client") == 0) {
-                    ssl_options &= ~SSL_OP_CIPHER_SERVER_PREFERENCE;
-                } else if (value->type == YOML_TYPE_SCALAR && strcasecmp(value->data.scalar, "server") == 0) {
-                    ssl_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
-                } else {
-                    h2o_configurator_errprintf(cmd, value, "property of `cipher-preference` must be either of: `client`, `server`");
-                    return -1;
-                }
-                continue;
-            }
-            if (strcmp(key->data.scalar, "neverbleed") == 0) {
-                if (value->type == YOML_TYPE_SCALAR && strcasecmp(value->data.scalar, "ON") == 0) {
-                    /* no need to enable neverbleed for daemon / master */
-                    use_neverbleed = 1;
-                } else if (value->type == YOML_TYPE_SCALAR && strcasecmp(value->data.scalar, "OFF") == 0) {
-                    use_neverbleed = 0;
-                } else {
-                    h2o_configurator_errprintf(cmd, value, "property of `neverbleed` must be either of: `ON`, `OFF");
-                    return -1;
-                }
-                continue;
-            }
-            h2o_configurator_errprintf(cmd, key, "unknown property: %s", key->data.scalar);
-            return -1;
-#undef FETCH_PROPERTY
-        }
-        if (certificate_file == NULL) {
-            h2o_configurator_errprintf(cmd, ssl_node, "could not find mandatory property `certificate-file`");
+    ASSERT_SCALAR("certificate-file", certificate_file);
+    ASSERT_SCALAR("key-file", key_file);
+    ASSERT_SCALAR("min-version", min_version);
+    ASSERT_SCALAR("max-version", max_version);
+    ASSERT_SCALAR("cipher-suite", cipher_suite);
+    ASSERT_SCALAR("ocsp-update-cmd", ocsp_update_cmd);
+    ASSERT_SCALAR("dh-file", dh_file);
+#undef ASSERT_SCALAR
+    if (cipher_preference_node != NULL) {
+        switch (h2o_configurator_get_one_of(cmd, *cipher_preference_node, "client,server")) {
+        case 0:
+            ssl_options &= ~SSL_OP_CIPHER_SERVER_PREFERENCE;
+            break;
+        case 1:
+            ssl_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+            break;
+        default:
             return -1;
         }
-        if (key_file == NULL) {
-            h2o_configurator_errprintf(cmd, ssl_node, "could not find mandatory property `key-file`");
-            return -1;
-        }
-        if (min_version != NULL) {
+    }
+    if (neverbleed_node != NULL && (use_neverbleed = (int)h2o_configurator_get_one_of(cmd, *neverbleed_node, "off,on")) == -1)
+        return -1;
+    if (min_version != NULL) {
 #define MAP(tok, op)                                                                                                               \
-    if (strcasecmp(min_version->data.scalar, tok) == 0) {                                                                          \
+    if (strcasecmp((*min_version)->data.scalar, tok) == 0) {                                                                       \
         ssl_options |= (op);                                                                                                       \
         goto VersionFound;                                                                                                         \
     }
-            MAP("sslv2", 0);
-            MAP("sslv3", SSL_OP_NO_SSLv2);
-            MAP("tlsv1", SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
-            MAP("tlsv1.1", SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1);
+        MAP("sslv2", 0);
+        MAP("sslv3", SSL_OP_NO_SSLv2);
+        MAP("tlsv1", SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+        MAP("tlsv1.1", SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1);
 #ifdef SSL_OP_NO_TLSv1_1
-            MAP("tlsv1.2", SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
+        MAP("tlsv1.2", SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
 #endif
 #ifdef SSL_OP_NO_TLSv1_2
-            MAP("tlsv1.3", SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2);
+        MAP("tlsv1.3", SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2);
 #endif
 #undef MAP
-            h2o_configurator_errprintf(cmd, min_version, "unknown protocol version: %s", min_version->data.scalar);
-        VersionFound:;
-        } else {
-            /* default is >= TLSv1 */
-            ssl_options |= SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
-        }
-        if (max_version != NULL) {
-            if (strcasecmp(max_version->data.scalar, "tlsv1.3") < 0)
-                use_picotls = 0;
-        }
-        if (ocsp_update_interval_node != NULL) {
-            if (h2o_configurator_scanf(cmd, ocsp_update_interval_node, "%" PRIu64, &ocsp_update_interval) != 0)
-                goto Error;
-        }
-        if (ocsp_max_failures_node != NULL) {
-            if (h2o_configurator_scanf(cmd, ocsp_max_failures_node, "%u", &ocsp_max_failures) != 0)
-                goto Error;
-        }
+        h2o_configurator_errprintf(cmd, *min_version, "unknown protocol version: %s", (*min_version)->data.scalar);
+    VersionFound:;
+    } else {
+        /* default is >= TLSv1 */
+        ssl_options |= SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
+    }
+    if (max_version != NULL) {
+        if (strcasecmp((*max_version)->data.scalar, "tlsv1.3") < 0)
+            use_picotls = 0;
+    }
+    if (ocsp_update_interval_node != NULL) {
+        if (h2o_configurator_scanf(cmd, *ocsp_update_interval_node, "%" PRIu64, &ocsp_update_interval) != 0)
+            goto Error;
+    }
+    if (ocsp_max_failures_node != NULL) {
+        if (h2o_configurator_scanf(cmd, *ocsp_max_failures_node, "%u", &ocsp_max_failures) != 0)
+            goto Error;
     }
 
     /* add the host to the existing SSL config, if the certificate file is already registered */
@@ -659,7 +629,7 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
         size_t i;
         for (i = 0; i != listener->ssl.size; ++i) {
             struct listener_ssl_config_t *ssl_config = listener->ssl.entries[i];
-            if (strcmp(ssl_config->certificate_file, certificate_file->data.scalar) == 0) {
+            if (strcmp(ssl_config->certificate_file, (*certificate_file)->data.scalar) == 0) {
                 listener_setup_ssl_add_host(ssl_config, ctx->hostconf->authority.hostport);
                 return 0;
             }
@@ -676,8 +646,9 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
     SSL_CTX_set_options(ssl_ctx, ssl_options);
 
     setup_ecc_key(ssl_ctx);
-    if (SSL_CTX_use_certificate_chain_file(ssl_ctx, certificate_file->data.scalar) != 1) {
-        h2o_configurator_errprintf(cmd, certificate_file, "failed to load certificate file:%s\n", certificate_file->data.scalar);
+    if (SSL_CTX_use_certificate_chain_file(ssl_ctx, (*certificate_file)->data.scalar) != 1) {
+        h2o_configurator_errprintf(cmd, *certificate_file, "failed to load certificate file:%s\n",
+                                   (*certificate_file)->data.scalar);
         ERR_print_errors_cb(on_openssl_print_errors, stderr);
         goto Error;
     }
@@ -701,33 +672,33 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
                 abort();
             }
         }
-        if (neverbleed_load_private_key_file(neverbleed, ssl_ctx, key_file->data.scalar, errbuf) != 1) {
-            h2o_configurator_errprintf(cmd, key_file, "failed to load private key file:%s:%s\n", key_file->data.scalar, errbuf);
+        if (neverbleed_load_private_key_file(neverbleed, ssl_ctx, (*key_file)->data.scalar, errbuf) != 1) {
+            h2o_configurator_errprintf(cmd, *key_file, "failed to load private key file:%s:%s\n", (*key_file)->data.scalar, errbuf);
             goto Error;
         }
     } else {
-        if (SSL_CTX_use_PrivateKey_file(ssl_ctx, key_file->data.scalar, SSL_FILETYPE_PEM) != 1) {
-            h2o_configurator_errprintf(cmd, key_file, "failed to load private key file:%s\n", key_file->data.scalar);
+        if (SSL_CTX_use_PrivateKey_file(ssl_ctx, (*key_file)->data.scalar, SSL_FILETYPE_PEM) != 1) {
+            h2o_configurator_errprintf(cmd, *key_file, "failed to load private key file:%s\n", (*key_file)->data.scalar);
             ERR_print_errors_cb(on_openssl_print_errors, stderr);
             goto Error;
         }
     }
-    if (cipher_suite != NULL && SSL_CTX_set_cipher_list(ssl_ctx, cipher_suite->data.scalar) != 1) {
-        h2o_configurator_errprintf(cmd, cipher_suite, "failed to setup SSL cipher suite\n");
+    if (cipher_suite != NULL && SSL_CTX_set_cipher_list(ssl_ctx, (*cipher_suite)->data.scalar) != 1) {
+        h2o_configurator_errprintf(cmd, *cipher_suite, "failed to setup SSL cipher suite\n");
         ERR_print_errors_cb(on_openssl_print_errors, stderr);
         goto Error;
     }
     if (dh_file != NULL) {
-        BIO *bio = BIO_new_file(dh_file->data.scalar, "r");
+        BIO *bio = BIO_new_file((*dh_file)->data.scalar, "r");
         if (bio == NULL) {
-            h2o_configurator_errprintf(cmd, dh_file, "failed to load dhparam file:%s\n", dh_file->data.scalar);
+            h2o_configurator_errprintf(cmd, *dh_file, "failed to load dhparam file:%s\n", (*dh_file)->data.scalar);
             ERR_print_errors_cb(on_openssl_print_errors, stderr);
             goto Error;
         }
         DH *dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
         BIO_free(bio);
         if (dh == NULL) {
-            h2o_configurator_errprintf(cmd, dh_file, "failed to load dhparam file:%s\n", dh_file->data.scalar);
+            h2o_configurator_errprintf(cmd, *dh_file, "failed to load dhparam file:%s\n", (*dh_file)->data.scalar);
             ERR_print_errors_cb(on_openssl_print_errors, stderr);
             goto Error;
         }
@@ -759,7 +730,7 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
         listener_setup_ssl_add_host(ssl_config, ctx->hostconf->authority.hostport);
     }
     ssl_config->ctx = ssl_ctx;
-    ssl_config->certificate_file = h2o_strdup(NULL, certificate_file->data.scalar, SIZE_MAX).base;
+    ssl_config->certificate_file = h2o_strdup(NULL, (*certificate_file)->data.scalar, SIZE_MAX).base;
 
 #if !H2O_USE_OCSP
     if (ocsp_update_interval != 0)
@@ -770,8 +741,8 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
     SSL_CTX_set_tlsext_status_arg(ssl_ctx, ssl_config);
 #endif
     pthread_mutex_init(&ssl_config->ocsp_stapling.response.mutex, NULL);
-    ssl_config->ocsp_stapling.cmd =
-        ocsp_update_cmd != NULL ? h2o_strdup(NULL, ocsp_update_cmd->data.scalar, SIZE_MAX).base : "share/h2o/fetch-ocsp-response";
+    ssl_config->ocsp_stapling.cmd = ocsp_update_cmd != NULL ? h2o_strdup(NULL, (*ocsp_update_cmd)->data.scalar, SIZE_MAX).base
+                                                            : "share/h2o/fetch-ocsp-response";
     if (ocsp_update_interval != 0) {
         switch (conf.run_mode) {
         case RUN_MODE_WORKER:
@@ -786,19 +757,19 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
             break;
         case RUN_MODE_TEST: {
             h2o_buffer_t *respbuf;
-            fprintf(stderr, "[OCSP Stapling] testing for certificate file:%s\n", certificate_file->data.scalar);
-            switch (get_ocsp_response(certificate_file->data.scalar, ssl_config->ocsp_stapling.cmd, &respbuf)) {
+            fprintf(stderr, "[OCSP Stapling] testing for certificate file:%s\n", (*certificate_file)->data.scalar);
+            switch (get_ocsp_response((*certificate_file)->data.scalar, ssl_config->ocsp_stapling.cmd, &respbuf)) {
             case 0:
                 h2o_buffer_dispose(&respbuf);
-                fprintf(stderr, "[OCSP Stapling] stapling works for file:%s\n", certificate_file->data.scalar);
+                fprintf(stderr, "[OCSP Stapling] stapling works for file:%s\n", (*certificate_file)->data.scalar);
                 break;
             case EX_TEMPFAIL:
-                h2o_configurator_errprintf(cmd, certificate_file, "[OCSP Stapling] temporary failed for file:%s\n",
-                                           certificate_file->data.scalar);
+                h2o_configurator_errprintf(cmd, *certificate_file, "[OCSP Stapling] temporary failed for file:%s\n",
+                                           (*certificate_file)->data.scalar);
                 break;
             default:
-                h2o_configurator_errprintf(cmd, certificate_file, "[OCSP Stapling] does not work, will be disabled for file:%s\n",
-                                           certificate_file->data.scalar);
+                h2o_configurator_errprintf(cmd, *certificate_file, "[OCSP Stapling] does not work, will be disabled for file:%s\n",
+                                           (*certificate_file)->data.scalar);
                 break;
             }
         } break;
@@ -810,7 +781,7 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
     if (use_picotls) {
         const char *errstr = listener_setup_ssl_picotls(listener, ssl_config, ssl_ctx);
         if (errstr != NULL)
-            h2o_configurator_errprintf(cmd, ssl_node, "%s; TLS 1.3 will be disabled\n", errstr);
+            h2o_configurator_errprintf(cmd, *ssl_node, "%s; TLS 1.3 will be disabled\n", errstr);
     }
 #endif
 
@@ -1008,56 +979,43 @@ Error:
 
 static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
-    const char *hostname = NULL, *servname = NULL, *type = "tcp";
-    yoml_t *ssl_node = NULL;
+    const char *hostname = NULL, *servname, *type = "tcp";
+    yoml_t **ssl_node;
     int proxy_protocol = 0;
 
     /* fetch servname (and hostname) */
     switch (node->type) {
     case YOML_TYPE_SCALAR:
         servname = node->data.scalar;
+        ssl_node = NULL;
         break;
     case YOML_TYPE_MAPPING: {
-        yoml_t *t;
-        if ((t = yoml_get(node, "host")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, t, "`host` is not a string");
-                return -1;
-            }
-            hostname = t->data.scalar;
-        }
-        if ((t = yoml_get(node, "port")) == NULL) {
-            h2o_configurator_errprintf(cmd, node, "cannot find mandatory property `port`");
+        yoml_t **port_node, **host_node, **type_node, **proxy_protocol_node;
+        if (h2o_configurator_parse_mapping(cmd, node, "port", "host,type,ssl,proxy-protocol", &port_node, &host_node, &type_node,
+                                           &ssl_node, &proxy_protocol_node) != 0)
+            return -1;
+        if ((*port_node)->type != YOML_TYPE_SCALAR) {
+            h2o_configurator_errprintf(cmd, *port_node, "`port` is not a string");
             return -1;
         }
-        if (t->type != YOML_TYPE_SCALAR) {
-            h2o_configurator_errprintf(cmd, node, "`port` is not a string");
+        servname = (*port_node)->data.scalar;
+        if (host_node != NULL) {
+            if ((*host_node)->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, *host_node, "`host` is not a string");
+                return -1;
+            }
+            hostname = (*host_node)->data.scalar;
+        }
+        if (type_node != NULL) {
+            if ((*type_node)->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, *type_node, "`type` is not a string");
+                return -1;
+            }
+            type = (*type_node)->data.scalar;
+        }
+        if (proxy_protocol_node != NULL &&
+            (proxy_protocol = (int)h2o_configurator_get_one_of(cmd, *proxy_protocol_node, "OFF,ON")) == -1)
             return -1;
-        }
-        servname = t->data.scalar;
-        if ((t = yoml_get(node, "type")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, t, "`type` is not a string");
-                return -1;
-            }
-            type = t->data.scalar;
-        }
-        if ((t = yoml_get(node, "ssl")) != NULL)
-            ssl_node = t;
-        if ((t = yoml_get(node, "proxy-protocol")) != NULL) {
-            if (t->type != YOML_TYPE_SCALAR) {
-                h2o_configurator_errprintf(cmd, node, "`proxy-protocol` must be a string");
-                return -1;
-            }
-            if (strcasecmp(t->data.scalar, "ON") == 0) {
-                proxy_protocol = 1;
-            } else if (strcasecmp(t->data.scalar, "OFF") == 0) {
-                proxy_protocol = 0;
-            } else {
-                h2o_configurator_errprintf(cmd, node, "value of `proxy-protocol` must be either of: ON,OFF");
-                return -1;
-            }
-        }
     } break;
     default:
         h2o_configurator_errprintf(cmd, node, "value must be a string or a mapping (with keys: `port` and optionally `host`)");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -779,13 +779,13 @@ int ssl_session_resumption_on_config(h2o_configurator_command_t *cmd, h2o_config
         **ticket_store, **ticket_cipher, **ticket_hash, **ticket_memcached_prefix, **ticket_redis_prefix, **ticket_file,
         **memcached_node, **redis_node, **lifetime;
 
-    if (h2o_configurator_parse_mapping(cmd, node, "mode",
-                                       "cache-store,cache-memcached-num-threads,cache-memcached-prefix:s,cache-redis-prefix:s,"
-                                       "ticket-store,ticket-cipher:s,ticket-hash:s,ticket-memcached-prefix:s,ticket-redis-prefix:s,"
-                                       "ticket-file:s,memcached,redis,lifetime",
-                                       &mode_node, &cache_store, &cache_memcached_num_threads, &cache_memcached_prefix,
-                                       &cache_redis_prefix, &ticket_store, &ticket_cipher, &ticket_hash, &ticket_memcached_prefix,
-                                       &ticket_redis_prefix, &ticket_file, &memcached_node, &redis_node, &lifetime) != 0)
+    if (h2o_configurator_parse_mapping(
+            cmd, node, "mode:*", "cache-store:*,cache-memcached-num-threads:*,cache-memcached-prefix:s,cache-redis-prefix:s,"
+                                 "ticket-store:*,ticket-cipher:s,ticket-hash:s,ticket-memcached-prefix:s,ticket-redis-prefix:s,"
+                                 "ticket-file:s,memcached:m,redis:m,lifetime:*",
+            &mode_node, &cache_store, &cache_memcached_num_threads, &cache_memcached_prefix, &cache_redis_prefix, &ticket_store,
+            &ticket_cipher, &ticket_hash, &ticket_memcached_prefix, &ticket_redis_prefix, &ticket_file, &memcached_node,
+            &redis_node, &lifetime) != 0)
         return -1;
 
     switch (h2o_configurator_get_one_of(cmd, *mode_node, "off,cache,ticket,all")) {
@@ -909,12 +909,8 @@ int ssl_session_resumption_on_config(h2o_configurator_command_t *cmd, h2o_config
     }
 
     if (memcached_node != NULL) {
-        if ((*memcached_node)->type != YOML_TYPE_MAPPING) {
-            h2o_configurator_errprintf(cmd, *memcached_node, "`memcached` attribute must be a mapping");
-            return -1;
-        }
         yoml_t **host, **port, **protocol;
-        if (h2o_configurator_parse_mapping(cmd, *memcached_node, "host:s", "port,protocol", &host, &port, &protocol) != 0)
+        if (h2o_configurator_parse_mapping(cmd, *memcached_node, "host:s", "port:*,protocol:*", &host, &port, &protocol) != 0)
             return -1;
         conf.store.memcached.host = h2o_strdup(NULL, (*host)->data.scalar, SIZE_MAX).base;
         conf.store.memcached.port = 11211;
@@ -927,12 +923,8 @@ int ssl_session_resumption_on_config(h2o_configurator_command_t *cmd, h2o_config
     }
 
     if (redis_node != NULL) {
-        if ((*redis_node)->type != YOML_TYPE_MAPPING) {
-            h2o_configurator_errprintf(cmd, *redis_node, "`redis` attribute must be a mapping");
-            return -1;
-        }
         yoml_t **host, **port;
-        if (h2o_configurator_parse_mapping(cmd, *redis_node, "host:s", "port", &host, &port) != 0)
+        if (h2o_configurator_parse_mapping(cmd, *redis_node, "host:s", "port:*", &host, &port) != 0)
             return -1;
         conf.store.redis.host = h2o_strdup(NULL, (*host)->data.scalar, SIZE_MAX).base;
         conf.store.redis.port = 6379;


### PR DESCRIPTION
Until now, every configuration directive that (optionally) takes a YOML mapping has written it's own attribute parser.

The fact has not only made the code-base unnecessary complex but also has caused inconsistency between the parsers in how they deal with unknown or duplicate key.

This PR aims to resolve the issue by introducing a function to be used for fetching named values from a YOML mapping.

rework of #1068