### PR TITLE
Docker CI Optimizations

### DIFF
--- a/misc/docker-ci/Dockerfile
+++ b/misc/docker-ci/Dockerfile
@@ -28,8 +28,14 @@ RUN apt-get install --yes golang && mkdir -p /golang && ln -sf /usr/local/bin /g
 ENV GOPATH=/golang
 RUN (go get github.com/summerwind/h2spec && cd /golang/src/github.com/summerwind/h2spec/cmd/h2spec && git checkout v2.0.0^ && go install)
 
+# use dumb-init
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 \
+ && chmod +x /usr/local/bin/dumb-init
+
 # create user
 RUN useradd --create-home ci
 RUN echo 'ci ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 WORKDIR /home/ci
 USER ci
+
+ENTRYPOINT ["/usr/local/bin/dumb-init"]

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -3,7 +3,7 @@ SRC_DIR=/h2o
 CHECK_MK=$(SRC_DIR)/misc/docker-ci/check.mk
 CMAKE_ARGS=
 FUZZ_ASAN=ASAN_OPTIONS=detect_leaks=0
-DOCKER_RUN_OPTS=-v `pwd`:$(SRC_DIR) --add-host=127.0.0.1.xip.io:127.0.0.1
+DOCKER_RUN_OPTS=-v `pwd`:$(SRC_DIR) --add-host=127.0.0.1.xip.io:127.0.0.1 -t
 
 ALL:
 	docker run $(DOCKER_RUN_OPTS) $(CONTAINER_NAME) make -f /h2o/misc/docker-ci/check.mk _check


### PR DESCRIPTION
This PR introduces several optimizations for docker ci:

* Introduces [dumb-init](https://github.com/Yelp/dumb-init) as entrypoint for the building process, so that singals like `^C` a.k.a `SIGINT` could be used for canceling current build.
* Introduces `-t` argument for `docker run` so output could be colored, helping locating the failed tests (maybe?)

Docker image `zlm2012/h2o-ci` could be tested with.