### PR TITLE
add /usr/lib/llvm-4.0/bin to PATH to successfully run llvm-symbolize

### DIFF
--- a/misc/docker-ci/Dockerfile
+++ b/misc/docker-ci/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get install --yes libev-dev libc-ares-dev libnghttp2-dev libssl-dev libu
 
 # clang-4.0 for fuzzing
 RUN apt-get install -y clang-4.0
+ENV PATH=/usr/lib/llvm-4.0/bin:$PATH
 
 # curl with http2 support
 RUN wget --no-verbose -O - https://curl.haxx.se/download/curl-7.57.0.tar.gz | tar xzf -

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -22,8 +22,6 @@ _do-check:
 	sudo make check-as-root
 
 _fuzz:
-	sudo ln -sf /usr/bin/clang-4.0 /usr/bin/clang
-	sudo ln -sf /usr/bin/clang++-4.0 /usr/bin/clang++
 	$(FUZZ_ASAN) CC=clang CXX=clang++ $(MAKE) -f $(CHECK_MK) _check CMAKE_ARGS=-DBUILD_FUZZER=ON
 	$(FUZZ_ASAN) $(MAKE) -f $(CHECK_MK) -C build _do-fuzz-extra
 


### PR DESCRIPTION
address sanitizer requires `llvm-symbolize` binary to locate file:line, and it's located in `/usr/lib/llvm-4.0/bin`.