### PR TITLE
trivial changes

### DIFF
--- a/include/h2o/balancer.h
+++ b/include/h2o/balancer.h
@@ -30,8 +30,6 @@ extern "C" {
 #include "h2o/socketpool.h"
 #include "yoml.h"
 
-typedef struct st_h2o_balancer_t h2o_balancer_t;
-
 typedef size_t (*h2o_balancer_selector)(h2o_balancer_t *balancer, h2o_socketpool_target_vector_t *targets, char *tried);
 
 typedef void (*h2o_balancer_destroyer)(h2o_balancer_t *balancer);

--- a/lib/tunnel.c
+++ b/lib/tunnel.c
@@ -56,7 +56,7 @@ static inline void reset_timeout(struct st_h2o_tunnel_t *tunnel)
     h2o_timeout_link(tunnel->ctx->loop, tunnel->timeout, &tunnel->timeout_entry);
 }
 
-static inline void on_read(h2o_socket_t *sock, const char *err)
+static void on_read(h2o_socket_t *sock, const char *err)
 {
     struct st_h2o_tunnel_t *tunnel = sock->data;
     h2o_socket_t *dst;


### PR DESCRIPTION
"h2o_balancer_t" type defined twice
"__builtin_expect" under clang
remove "inline"