### PR TITLE
add clang-format-diff make command

### DIFF
--- a/misc/clang-format-diff.sh
+++ b/misc/clang-format-diff.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+git diff -U0 --no-color master -- '*.c' '*.h' | clang-format-diff.py -i -p1
+exit $?

--- a/misc/regen.mk
+++ b/misc/regen.mk
@@ -28,6 +28,9 @@ lib/handler/file/templates.c.h: misc/picotemplate-conf.pl lib/handler/file/_temp
 clang-format-all:
 	misc/clang-format-all.sh
 
+clang-format-diff:
+	misc/clang-format-diff.sh
+
 share/h2o/start_server: FORCE
 	cd misc/p5-Server-Starter; \
 	fatpack-simple --shebang "$$FATPACK_SHEBANG" -o ../../$@ script/start_server


### PR DESCRIPTION
[clang-format-diff.py](https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py) makes our life easier by allowing us to re-format only changes. This requires clang-format-diff.py is installed in accessible path.