### PR TITLE
implement Server Timing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/redirect.c
     lib/handler/reproxy.c
     lib/handler/throttle_resp.c
+    lib/handler/server_timing.c
     lib/handler/status.c
     lib/handler/headers_util.c
     lib/handler/status/events.c
@@ -332,6 +333,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/configurator/redirect.c
     lib/handler/configurator/reproxy.c
     lib/handler/configurator/throttle_resp.c
+    lib/handler/configurator/server_timing.c
     lib/handler/configurator/status.c
     lib/handler/configurator/http2_debug_state.c
     lib/handler/configurator/headers_util.c

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -227,6 +227,11 @@
 		10FEF24F1D6FC8E200E11B1D /* gkc.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FEF24D1D6FC8E200E11B1D /* gkc.h */; };
 		10FFEE0A1BB23A8C0087AD75 /* neverbleed.c in Sources */ = {isa = PBXBuildFile; fileRef = 10FFEE081BB23A8C0087AD75 /* neverbleed.c */; };
 		7D0285C91EF422D40094292B /* sleep.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D0285C81EF422D40094292B /* sleep.c */; };
+		7D9372FE202AC70F005FE6AB /* server_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D9372FD202AC70F005FE6AB /* server_timing.c */; };
+		7D9372FF202AC717005FE6AB /* server_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D9372FD202AC70F005FE6AB /* server_timing.c */; };
+		7D937300202AC717005FE6AB /* server_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D9372FD202AC70F005FE6AB /* server_timing.c */; };
+		7D937302202AC7BA005FE6AB /* server_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D937301202AC7BA005FE6AB /* server_timing.c */; };
+		7D937303202AC7BA005FE6AB /* server_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D937301202AC7BA005FE6AB /* server_timing.c */; };
 		7D9FA53A1FC323B200189F88 /* channel.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D9FA5381FC323AC00189F88 /* channel.c */; };
 		D081373A1FD400F4004679DF /* least_conn.c in Sources */ = {isa = PBXBuildFile; fileRef = D08137381FD400F4004679DF /* least_conn.c */; };
 		D081373B1FD400F4004679DF /* roundrobin.c in Sources */ = {isa = PBXBuildFile; fileRef = D08137391FD400F4004679DF /* roundrobin.c */; };
@@ -818,6 +823,8 @@
 		10FFEE081BB23A8C0087AD75 /* neverbleed.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = neverbleed.c; sourceTree = "<group>"; };
 		10FFEE091BB23A8C0087AD75 /* neverbleed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neverbleed.h; sourceTree = "<group>"; };
 		7D0285C81EF422D40094292B /* sleep.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sleep.c; sourceTree = "<group>"; };
+		7D9372FD202AC70F005FE6AB /* server_timing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = server_timing.c; sourceTree = "<group>"; };
+		7D937301202AC7BA005FE6AB /* server_timing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = server_timing.c; sourceTree = "<group>"; };
 		7D9FA5381FC323AC00189F88 /* channel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = channel.c; sourceTree = "<group>"; };
 		D08137381FD400F4004679DF /* least_conn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = least_conn.c; sourceTree = "<group>"; };
 		D08137391FD400F4004679DF /* roundrobin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = roundrobin.c; sourceTree = "<group>"; };
@@ -1107,6 +1114,7 @@
 				105534D91A3C7A2000627ECB /* configurator */,
 				101B670B19ADD3380084A351 /* access_log.c */,
 				107923AE19A3217300C52AD6 /* chunked.c */,
+				7D9372FD202AC70F005FE6AB /* server_timing.c */,
 				1070866B1B787D06002B8F18 /* compress.c */,
 				107E340E1C7EB10700AEF5F8 /* compress */,
 				106C22FE1C05436100405689 /* errordoc.c */,
@@ -1239,6 +1247,7 @@
 				10835E041C9B3C6200197E59 /* status.c */,
 				10C45D4E1CFD15FA0096DB06 /* throttle_resp.c */,
 				084FC7C31D54BB9200E89F66 /* http2_debug_state.c */,
+				7D937301202AC7BA005FE6AB /* server_timing.c */,
 			);
 			path = configurator;
 			sourceTree = "<group>";
@@ -2397,6 +2406,7 @@
 				1022E7C31CA8BCCE00CE2A05 /* text_mode.c in Sources */,
 				080D35EB1D5E060D0029B7E5 /* http2_debug_state.c in Sources */,
 				10835E051C9B3C6200197E59 /* status.c in Sources */,
+				7D937302202AC7BA005FE6AB /* server_timing.c in Sources */,
 				1058C87E1AA41A1F008D6180 /* headers.c in Sources */,
 				D081373B1FD400F4004679DF /* roundrobin.c in Sources */,
 				10835E031C9A860000197E59 /* status.c in Sources */,
@@ -2410,6 +2420,7 @@
 				10C45D561CFE9B300096DB06 /* requests.c in Sources */,
 				10A3D40C1B50DAB700327CF9 /* socket.c in Sources */,
 				10AA2EC21AA0402E004322AC /* reproxy.c in Sources */,
+				7D9372FF202AC717005FE6AB /* server_timing.c in Sources */,
 				10835E011C9A6C2400197E59 /* logconf.c in Sources */,
 				107923C519A3217300C52AD6 /* http1.c in Sources */,
 				10AA2EA71A8DA93C004322AC /* redirect.c in Sources */,
@@ -2532,6 +2543,7 @@
 				E987E5F71FD8C04D00DE4346 /* histogram.c in Sources */,
 				107086701B7925D5002B8F18 /* compress.c in Sources */,
 				E987E5F41FD8C04D00DE4346 /* dictionary_hash.c in Sources */,
+				7D937300202AC717005FE6AB /* server_timing.c in Sources */,
 				107D4D4C1B5880BC004A9B21 /* writer.c in Sources */,
 				E987E5EC1FD8C04D00DE4346 /* backward_references_hq.c in Sources */,
 				10E2995A1A68D03100701AA6 /* scheduler.c in Sources */,
@@ -2604,6 +2616,7 @@
 				E987E5EA1FD7EBD100DE4346 /* dictionary.c in Sources */,
 				E9708B1D1E49BABC0029E0A5 /* aes.c in Sources */,
 				E9708B8B1E52C85A0029E0A5 /* tunnel.c in Sources */,
+				7D937303202AC7BA005FE6AB /* server_timing.c in Sources */,
 				E9708B531E52C7EE0029E0A5 /* config.c in Sources */,
 				08F320E11E7A9CBF0038FA5A /* read.c in Sources */,
 				E9708B801E52C84A0029E0A5 /* throttle_resp.c in Sources */,
@@ -2639,6 +2652,7 @@
 				08F320DD1E7A9CA60038FA5A /* redis.c in Sources */,
 				10756E2A1AC126420009BF57 /* api.c in Sources */,
 				E9708B6B1E52C81D0029E0A5 /* chunked.c in Sources */,
+				7D9372FE202AC70F005FE6AB /* server_timing.c in Sources */,
 				10756E2B1AC126420009BF57 /* dumper.c in Sources */,
 				E9708B721E52C82A0029E0A5 /* errordoc.c in Sources */,
 				7D9FA53A1FC323B200189F88 /* channel.c in Sources */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -2257,6 +2257,7 @@ COMPUTE_DURATION(request_total_time, &req->timestamps.request_begin_at, &req->pr
 COMPUTE_DURATION(process_time, &req->processed_at.at, &req->timestamps.response_start_at);
 COMPUTE_DURATION(response_time, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
 COMPUTE_DURATION(duration, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
+COMPUTE_DURATION(total, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
 
 #undef COMPUTE_DURATION
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1288,6 +1288,11 @@ int h2o_get_compressible_types(const h2o_headers_t *headers);
  */
 h2o_iovec_t h2o_build_destination(h2o_req_t *req, const char *prefix, size_t prefix_len, int use_path_normalized);
 /**
+ * encodes the value of the `server-timing` trailer header field
+ */
+size_t h2o_encode_server_timing_trailer(char *buf, int64_t duration_usec);
+#define H2O_SERVER_TIMING_TRAILER_LONGEST_STR "total; dur=" H2O_INT32_LONGEST_STR ".000"
+/**
  * release all thread-local resources used by h2o
  */
 void h2o_cleanup_thread(void);
@@ -1711,8 +1716,6 @@ void h2o_chunked_register(h2o_pathconf_t *pathconf);
 /* lib/handler/server_timing.c */
 void h2o_server_timing_register(h2o_pathconf_t *pathconf);
 void h2o_server_timing_register_configurator(h2o_globalconf_t *conf);
-#define H2O_SERVER_TIMING_TRAILER_LONGEST_STR "total; dur=" H2O_INT32_LONGEST_STR ".000"
-size_t h2o_server_timing_encode_trailer(char *buf, int64_t duration_usec);
 
 /* lib/compress.c */
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -2257,7 +2257,7 @@ COMPUTE_DURATION(request_total_time, &req->timestamps.request_begin_at, &req->pr
 COMPUTE_DURATION(process_time, &req->processed_at.at, &req->timestamps.response_start_at);
 COMPUTE_DURATION(response_time, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
 COMPUTE_DURATION(duration, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
-COMPUTE_DURATION(total, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
+COMPUTE_DURATION(total_time, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
 
 #undef COMPUTE_DURATION
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1104,8 +1104,10 @@ struct st_h2o_req_t {
      * set by the generator if the protocol handler should replay the request upon seeing 425
      */
     unsigned char reprocess_if_too_early : 1;
-
-    unsigned char send_server_timing_trailer : 1;
+    /**
+     * whether if the response should include server-timing
+     */
+    unsigned char send_server_timing : 1;
 
     /**
      * Whether the producer of the response has explicitely disabled or
@@ -1288,10 +1290,14 @@ int h2o_get_compressible_types(const h2o_headers_t *headers);
  */
 h2o_iovec_t h2o_build_destination(h2o_req_t *req, const char *prefix, size_t prefix_len, int use_path_normalized);
 /**
- * encodes the value of the `server-timing` trailer header field
+ * encodes the duration value of the `server-timing` header
  */
-size_t h2o_encode_server_timing_trailer(char *buf, int64_t duration_usec);
-#define H2O_SERVER_TIMING_TRAILER_LONGEST_STR "total; dur=" H2O_INT32_LONGEST_STR ".000"
+void h2o_add_server_timing_header(h2o_req_t *req);
+/**
+ * encodes the duration value of the `server-timing` trailer
+ */
+h2o_iovec_t h2o_build_server_timing_trailer(h2o_req_t *req, const char *prefix, size_t prefix_len, const char *suffix,
+                                            size_t suffix_len);
 /**
  * release all thread-local resources used by h2o
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1714,7 +1714,7 @@ void h2o_access_log_register_configurator(h2o_globalconf_t *conf);
 void h2o_chunked_register(h2o_pathconf_t *pathconf);
 
 /* lib/handler/server_timing.c */
-void h2o_server_timing_register(h2o_pathconf_t *pathconf);
+void h2o_server_timing_register(h2o_pathconf_t *pathconf, int enforce);
 void h2o_server_timing_register_configurator(h2o_globalconf_t *conf);
 
 /* lib/compress.c */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1711,6 +1711,7 @@ void h2o_chunked_register(h2o_pathconf_t *pathconf);
 /* lib/handler/server_timing.c */
 void h2o_server_timing_register(h2o_pathconf_t *pathconf);
 void h2o_server_timing_register_configurator(h2o_globalconf_t *conf);
+#define H2O_SERVER_TIMING_TRAILER_LONGEST_STR "total; dur=" H2O_INT32_LONGEST_STR ".000"
 size_t h2o_server_timing_encode_trailer(char *buf, int64_t duration_usec);
 
 /* lib/compress.c */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1105,6 +1105,8 @@ struct st_h2o_req_t {
      */
     unsigned char reprocess_if_too_early : 1;
 
+    unsigned char send_server_timing_trailer : 1;
+
     /**
      * Whether the producer of the response has explicitely disabled or
      * enabled compression. One of H2O_COMPRESS_HINT_*
@@ -1705,6 +1707,11 @@ void h2o_access_log_register_configurator(h2o_globalconf_t *conf);
  * registers the chunked encoding output filter (added by default)
  */
 void h2o_chunked_register(h2o_pathconf_t *pathconf);
+
+/* lib/handler/server_timing.c */
+void h2o_server_timing_register(h2o_pathconf_t *pathconf);
+void h2o_server_timing_register_configurator(h2o_globalconf_t *conf);
+size_t h2o_server_timing_encode_total(char *buf, int64_t duration_usec);
 
 /* lib/compress.c */
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -2256,7 +2256,6 @@ COMPUTE_DURATION(body_time,
 COMPUTE_DURATION(request_total_time, &req->timestamps.request_begin_at, &req->processed_at.at);
 COMPUTE_DURATION(process_time, &req->processed_at.at, &req->timestamps.response_start_at);
 COMPUTE_DURATION(response_time, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
-COMPUTE_DURATION(duration, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
 COMPUTE_DURATION(total_time, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
 
 #undef COMPUTE_DURATION

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1711,7 +1711,7 @@ void h2o_chunked_register(h2o_pathconf_t *pathconf);
 /* lib/handler/server_timing.c */
 void h2o_server_timing_register(h2o_pathconf_t *pathconf);
 void h2o_server_timing_register_configurator(h2o_globalconf_t *conf);
-size_t h2o_server_timing_encode_total(char *buf, int64_t duration_usec);
+size_t h2o_server_timing_encode_trailer(char *buf, int64_t duration_usec);
 
 /* lib/compress.c */
 

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -70,6 +70,8 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
                                size_t max_frame_size, h2o_req_t *req, uint32_t parent_stream_id);
 void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
                                 size_t max_frame_size, h2o_res_t *res, const h2o_iovec_t *server_name, size_t content_length);
+void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
+                                size_t max_frame_size, h2o_headers_t trailers);
 static h2o_hpack_header_table_entry_t *h2o_hpack_header_table_get(h2o_hpack_header_table_t *table, size_t index);
 
 /* frames */

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -457,7 +457,6 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         assert(stream->state == H2O_HTTP2_STREAM_STATE_SEND_HEADERS);
         stream->state = new_state;
         ++stream->_num_streams_slot->send_body;
-        stream->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
         break;
     case H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL:
         assert(stream->state == H2O_HTTP2_STREAM_STATE_SEND_BODY);

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -71,7 +71,7 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
 void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
                                 size_t max_frame_size, h2o_res_t *res, const h2o_iovec_t *server_name, size_t content_length);
 void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                                size_t max_frame_size, h2o_headers_t trailers);
+                                size_t max_frame_size, h2o_header_t *headers, size_t num_headers);
 static h2o_hpack_header_table_entry_t *h2o_hpack_header_table_get(h2o_hpack_header_table_t *table, size_t index);
 
 /* frames */

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -63,6 +63,7 @@ enum {
     ELEMENT_TYPE_PROCESS_TIME,                  /* %{process-time}x */
     ELEMENT_TYPE_RESPONSE_TIME,                 /* %{response-total-time}x */
     ELEMENT_TYPE_DURATION,                      /* %{duration}x */
+    ELEMENT_TYPE_TOTAL,                         /* %{total}x */
     ELEMENT_TYPE_ERROR,                         /* %{error}x */
     ELEMENT_TYPE_PROTOCOL_SPECIFIC,             /* %{protocol-specific...}x */
     NUM_ELEMENT_TYPES
@@ -246,6 +247,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_TYPE("process-time", ELEMENT_TYPE_PROCESS_TIME);
                     MAP_EXT_TO_TYPE("response-time", ELEMENT_TYPE_RESPONSE_TIME);
                     MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_DURATION);
+                    MAP_EXT_TO_TYPE("total", ELEMENT_TYPE_TOTAL);
                     MAP_EXT_TO_TYPE("error", ELEMENT_TYPE_ERROR);
                     MAP_EXT_TO_PROTO("http1.request-index", http1.request_index);
                     MAP_EXT_TO_PROTO("http2.stream-id", http2.stream_id);
@@ -739,6 +741,10 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
 
         case ELEMENT_TYPE_DURATION:
             APPEND_DURATION(pos, duration);
+            break;
+
+        case ELEMENT_TYPE_TOTAL:
+            APPEND_DURATION(pos, total);
             break;
 
         case ELEMENT_TYPE_ERROR: {

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -63,7 +63,7 @@ enum {
     ELEMENT_TYPE_PROCESS_TIME,                  /* %{process-time}x */
     ELEMENT_TYPE_RESPONSE_TIME,                 /* %{response-total-time}x */
     ELEMENT_TYPE_DURATION,                      /* %{duration}x */
-    ELEMENT_TYPE_TOTAL,                         /* %{total}x */
+    ELEMENT_TYPE_TOTAL_TIME,                    /* %{total-time}x */
     ELEMENT_TYPE_ERROR,                         /* %{error}x */
     ELEMENT_TYPE_PROTOCOL_SPECIFIC,             /* %{protocol-specific...}x */
     NUM_ELEMENT_TYPES
@@ -247,7 +247,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_TYPE("process-time", ELEMENT_TYPE_PROCESS_TIME);
                     MAP_EXT_TO_TYPE("response-time", ELEMENT_TYPE_RESPONSE_TIME);
                     MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_DURATION);
-                    MAP_EXT_TO_TYPE("total", ELEMENT_TYPE_TOTAL);
+                    MAP_EXT_TO_TYPE("total-time", ELEMENT_TYPE_TOTAL_TIME);
                     MAP_EXT_TO_TYPE("error", ELEMENT_TYPE_ERROR);
                     MAP_EXT_TO_PROTO("http1.request-index", http1.request_index);
                     MAP_EXT_TO_PROTO("http2.stream-id", http2.stream_id);
@@ -743,8 +743,8 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             APPEND_DURATION(pos, duration);
             break;
 
-        case ELEMENT_TYPE_TOTAL:
-            APPEND_DURATION(pos, total);
+        case ELEMENT_TYPE_TOTAL_TIME:
+            APPEND_DURATION(pos, total_time);
             break;
 
         case ELEMENT_TYPE_ERROR: {

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -62,7 +62,6 @@ enum {
     ELEMENT_TYPE_REQUEST_TOTAL_TIME,            /* %{request-total-time}x */
     ELEMENT_TYPE_PROCESS_TIME,                  /* %{process-time}x */
     ELEMENT_TYPE_RESPONSE_TIME,                 /* %{response-total-time}x */
-    ELEMENT_TYPE_DURATION,                      /* %{duration}x */
     ELEMENT_TYPE_TOTAL_TIME,                    /* %{total-time}x */
     ELEMENT_TYPE_ERROR,                         /* %{error}x */
     ELEMENT_TYPE_PROTOCOL_SPECIFIC,             /* %{protocol-specific...}x */
@@ -246,7 +245,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_TYPE("request-body-time", ELEMENT_TYPE_REQUEST_BODY_TIME);
                     MAP_EXT_TO_TYPE("process-time", ELEMENT_TYPE_PROCESS_TIME);
                     MAP_EXT_TO_TYPE("response-time", ELEMENT_TYPE_RESPONSE_TIME);
-                    MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_DURATION);
+                    MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_TOTAL_TIME);
                     MAP_EXT_TO_TYPE("total-time", ELEMENT_TYPE_TOTAL_TIME);
                     MAP_EXT_TO_TYPE("error", ELEMENT_TYPE_ERROR);
                     MAP_EXT_TO_PROTO("http1.request-index", http1.request_index);
@@ -737,10 +736,6 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
 
         case ELEMENT_TYPE_RESPONSE_TIME:
             APPEND_DURATION(pos, response_time);
-            break;
-
-        case ELEMENT_TYPE_DURATION:
-            APPEND_DURATION(pos, duration);
             break;
 
         case ELEMENT_TYPE_TOTAL_TIME:

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -862,7 +862,7 @@ h2o_iovec_t h2o_build_server_timing_trailer(h2o_req_t *req, const char *prefix, 
 
     h2o_iovec_t dst = h2o_iovec_init(value.base + value.len, 0);
     emit_server_timing_element(req, &dst, "response", h2o_time_compute_response_time, SIZE_MAX);
-    emit_server_timing_element(req, &dst, "total", h2o_time_compute_duration, SIZE_MAX);
+    emit_server_timing_element(req, &dst, "total", h2o_time_compute_total_time, SIZE_MAX);
     if (dst.len == 0)
         return h2o_iovec_init(NULL, 0);
     value.len += dst.len;

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -769,6 +769,26 @@ h2o_iovec_t h2o_build_destination(h2o_req_t *req, const char *prefix, size_t pre
     return h2o_concat_list(&req->pool, parts, num_parts);
 }
 
+size_t h2o_encode_server_timing_trailer(char *buf, int64_t duration_usec)
+{
+    int32_t duration_msec = (int32_t)(duration_usec / 1000);
+    duration_usec -= ((int64_t)duration_msec * 1000);
+    char *pos = buf;
+    pos += sprintf(pos, "total; dur=%" PRId32, duration_msec);
+    if (duration_usec != 0) {
+        *pos++ = '.';
+        int denom;
+        for (denom = 100; denom != 0; denom /= 10) {
+            int d = (int)duration_usec / denom;
+            *pos++ = '0' + d;
+            duration_usec -= d * denom;
+            if (duration_usec == 0)
+                break;
+        }
+    }
+    return pos - buf;
+}
+
 /* h2-14 and h2-16 are kept for backwards compatibility, as they are often used */
 #define ALPN_ENTRY(s)                                                                                                              \
     {                                                                                                                              \

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -51,12 +51,12 @@ static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         outbufcnt += inbufcnt;
         if (state != H2O_SEND_STATE_ERROR) {
             outbufs[outbufcnt].base = "\r\n0\r\n\r\n";
-            outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? 7 : 2;
+            outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? (req->send_server_timing_trailer ? 5 : 7) : 2;
             outbufcnt++;
         }
     } else if (state == H2O_SEND_STATE_FINAL) {
         outbufs[outbufcnt].base = "0\r\n\r\n";
-        outbufs[outbufcnt].len = 5;
+        outbufs[outbufcnt].len = req->send_server_timing_trailer ? 3 : 5;
         outbufcnt++;
     }
 

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -51,12 +51,12 @@ static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         outbufcnt += inbufcnt;
         if (state != H2O_SEND_STATE_ERROR) {
             outbufs[outbufcnt].base = "\r\n0\r\n\r\n";
-            outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? (req->send_server_timing_trailer ? 5 : 7) : 2;
+            outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? (req->send_server_timing ? 5 : 7) : 2;
             outbufcnt++;
         }
     } else if (state == H2O_SEND_STATE_FINAL) {
         outbufs[outbufcnt].base = "0\r\n\r\n";
-        outbufs[outbufcnt].len = req->send_server_timing_trailer ? 3 : 5;
+        outbufs[outbufcnt].len = req->send_server_timing ? 3 : 5;
         outbufcnt++;
     }
 

--- a/lib/handler/configurator/server_timing.c
+++ b/lib/handler/configurator/server_timing.c
@@ -76,6 +76,7 @@ void h2o_server_timing_register_configurator(h2o_globalconf_t *conf)
     c->super.exit = on_config_exit;
 
     /* server_timing: ON | OFF */
-    h2o_configurator_define_command(&c->super, "server-timing", H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+    h2o_configurator_define_command(&c->super, "server-timing",
+                                    H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_server_timing);
 }

--- a/lib/handler/configurator/server_timing.c
+++ b/lib/handler/configurator/server_timing.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018 Fastly, Ichito Nagata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <inttypes.h>
+#include "h2o.h"
+#include "h2o/configurator.h"
+
+struct config_t {
+    int enabled;
+};
+
+struct server_timing_configurator_t {
+    h2o_configurator_t super;
+    struct config_t *vars, _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
+};
+
+static int on_config_server_timing(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct server_timing_configurator_t *self = (void *)cmd->configurator;
+
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    self->vars->enabled = (int)ret;
+
+    return 0;
+}
+
+static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct server_timing_configurator_t *self = (void *)_self;
+
+    self->vars[1] = self->vars[0];
+    ++self->vars;
+    return 0;
+}
+
+static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct server_timing_configurator_t *self = (void *)_self;
+
+    if (ctx->pathconf != NULL && self->vars->enabled != 0)
+        h2o_server_timing_register(ctx->pathconf);
+
+    --self->vars;
+    return 0;
+}
+
+void h2o_server_timing_register_configurator(h2o_globalconf_t *conf)
+{
+    struct server_timing_configurator_t *c = (void *)h2o_configurator_create(conf, sizeof(*c));
+
+    /* set default vars */
+    c->vars = c->_vars_stack;
+
+    /* setup handlers */
+    c->super.enter = on_config_enter;
+    c->super.exit = on_config_exit;
+
+    /* server_timing: ON | OFF */
+    h2o_configurator_define_command(&c->super, "server-timing", H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_server_timing);
+}

--- a/lib/handler/configurator/server_timing.c
+++ b/lib/handler/configurator/server_timing.c
@@ -23,11 +23,7 @@
 #include "h2o.h"
 #include "h2o/configurator.h"
 
-enum {
-    SERVER_TIMING_MODE_OFF,
-    SERVER_TIMING_MODE_ON,
-    SERVER_TIMING_MODE_ENFORCE
-};
+enum { SERVER_TIMING_MODE_OFF, SERVER_TIMING_MODE_ON, SERVER_TIMING_MODE_ENFORCE };
 
 struct st_server_timing_config_t {
     int mode;

--- a/lib/handler/configurator/server_timing.c
+++ b/lib/handler/configurator/server_timing.c
@@ -23,23 +23,29 @@
 #include "h2o.h"
 #include "h2o/configurator.h"
 
-struct config_t {
-    int enabled;
+enum {
+    SERVER_TIMING_MODE_OFF,
+    SERVER_TIMING_MODE_ON,
+    SERVER_TIMING_MODE_ENFORCE
+};
+
+struct st_server_timing_config_t {
+    int mode;
 };
 
 struct server_timing_configurator_t {
     h2o_configurator_t super;
-    struct config_t *vars, _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
+    struct st_server_timing_config_t *vars, _vars_stack[H2O_CONFIGURATOR_NUM_LEVELS + 1];
 };
 
 static int on_config_server_timing(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct server_timing_configurator_t *self = (void *)cmd->configurator;
 
-    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON,ENFORCE");
     if (ret == -1)
         return -1;
-    self->vars->enabled = (int)ret;
+    self->vars->mode = (int)ret;
 
     return 0;
 }
@@ -57,8 +63,8 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 {
     struct server_timing_configurator_t *self = (void *)_self;
 
-    if (ctx->pathconf != NULL && self->vars->enabled != 0)
-        h2o_server_timing_register(ctx->pathconf);
+    if (ctx->pathconf != NULL && self->vars->mode != SERVER_TIMING_MODE_OFF)
+        h2o_server_timing_register(ctx->pathconf, self->vars->mode == SERVER_TIMING_MODE_ENFORCE);
 
     --self->vars;
     return 0;
@@ -76,7 +82,5 @@ void h2o_server_timing_register_configurator(h2o_globalconf_t *conf)
     c->super.exit = on_config_exit;
 
     /* server_timing: ON | OFF */
-    h2o_configurator_define_command(&c->super, "server-timing",
-                                    H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
-                                    on_config_server_timing);
+    h2o_configurator_define_command(&c->super, "server-timing", H2O_CONFIGURATOR_FLAG_ALL_LEVELS, on_config_server_timing);
 }

--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -46,11 +46,8 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
         goto Next;
     }
 
-    /* set content-encoding header */
-    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("trailer"), 0, NULL, H2O_STRLIT("server-timing"));
-
-    /* set the flag that tells finalostream that req->bytes_sent is already counted */
-    req->send_server_timing_trailer = 1;
+    /* indicate the protocol handler to emit server timing */
+    req->send_server_timing = 1;
 
 Next:
     h2o_setup_next_ostream(req, slot);
@@ -62,4 +59,3 @@ void h2o_server_timing_register(h2o_pathconf_t *pathconf, int enforce)
     self->super.on_setup_ostream = on_setup_ostream;
     self->enforce = enforce;
 }
-

--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -51,7 +51,7 @@ void h2o_server_timing_register(h2o_pathconf_t *pathconf)
     self->on_setup_ostream = on_setup_ostream;
 }
 
-size_t h2o_server_timing_encode_total(char *buf, int64_t duration_usec)
+size_t h2o_server_timing_encode_trailer(char *buf, int64_t duration_usec)
 {
     int32_t duration_msec = (int32_t)(duration_usec / 1000);
     duration_usec -= ((int64_t)duration_msec * 1000);

--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -56,7 +56,7 @@ size_t h2o_server_timing_encode_trailer(char *buf, int64_t duration_usec)
     int32_t duration_msec = (int32_t)(duration_usec / 1000);
     duration_usec -= ((int64_t)duration_msec * 1000);
     char *pos = buf;
-    pos += sprintf(pos, "total;dur=%" PRId32, duration_msec);
+    pos += sprintf(pos, "total; dur=%" PRId32, duration_msec);
     if (duration_usec != 0) {
         *pos++ = '.';
         int denom;

--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -30,6 +30,32 @@ struct st_server_timing_filter_t {
     unsigned enforce : 1;
 };
 
+static int has_te_trailer(const h2o_headers_t *headers)
+{
+    ssize_t te_index;
+    h2o_iovec_t iter;
+    const char *token;
+    size_t token_len;
+
+    if ((te_index = h2o_find_header(headers, H2O_TOKEN_TE, -1)) == -1)
+        return 0;
+
+    for (iter = headers->entries[te_index].value; (token = h2o_next_token(&iter, ',', &token_len, NULL)) != NULL;) {
+#define TRAILERS "trailers"
+        if (token_len >= sizeof(TRAILERS) - 1 && h2o_lcstris(token, sizeof(TRAILERS) - 1, H2O_STRLIT(TRAILERS))) {
+            /* skip trailing space and check that the next char is `;` (or if the end of the token) */
+            size_t i = sizeof(TRAILERS) - 1;
+            for (; i < token_len && (token[i] == ' ' || token[i] == '\t'); ++i)
+                ;
+            if (i >= token_len || token[i] == ';')
+                return 1;
+        }
+#undef TRAILERS
+    }
+
+    return 0;
+}
+
 static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t **slot)
 {
     struct st_server_timing_filter_t *self = (struct st_server_timing_filter_t *)_self;
@@ -37,10 +63,13 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     if (req->version == 0x200) {
         /* ok */
     } else if (0x101 <= req->version && req->version < 0x200) {
-        if (req->res.content_length != SIZE_MAX) {
-            if (!self->enforce)
-                goto Next;
+        if (self->enforce) {
             req->res.content_length = SIZE_MAX;
+        } else {
+            if (req->res.content_length != SIZE_MAX)
+                goto Next;
+            if (!has_te_trailer(&req->headers))
+                goto Next;
         }
     } else {
         goto Next;

--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018 Fastly, Ichito Nagata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "h2o.h"
+
+static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t **slot)
+{
+    if (req->version == 0x200) {
+        /* ok */
+    } else if (req->version == 0x101 && req->res.content_length == SIZE_MAX) {
+        /* ok */
+    } else {
+        goto Next;
+    }
+
+    /* set content-encoding header */
+    h2o_add_header_by_str(&req->pool, &req->res.headers, H2O_STRLIT("trailer"), 0, NULL, H2O_STRLIT("server-timing"));
+
+    /* set the flag that tells finalostream that req->bytes_sent is already counted */
+    req->send_server_timing_trailer = 1;
+
+Next:
+    h2o_setup_next_ostream(req, slot);
+}
+
+void h2o_server_timing_register(h2o_pathconf_t *pathconf)
+{
+    h2o_filter_t *self = h2o_create_filter(pathconf, sizeof(*self));
+    self->on_setup_ostream = on_setup_ostream;
+}
+
+size_t h2o_server_timing_encode_total(char *buf, int64_t duration_usec)
+{
+    int32_t duration_msec = (int32_t)(duration_usec / 1000);
+    duration_usec -= ((int64_t)duration_msec * 1000);
+    char *pos = buf;
+    pos += sprintf(pos, "total;dur=%" PRId32, duration_msec);
+    if (duration_usec != 0) {
+        *pos++ = '.';
+        int denom;
+        for (denom = 100; denom != 0; denom /= 10) {
+            int d = (int)duration_usec / denom;
+            *pos++ = '0' + d;
+            duration_usec -= d * denom;
+            if (duration_usec == 0)
+                break;
+        }
+    }
+    return pos - buf;
+}

--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -51,22 +51,3 @@ void h2o_server_timing_register(h2o_pathconf_t *pathconf)
     self->on_setup_ostream = on_setup_ostream;
 }
 
-size_t h2o_server_timing_encode_trailer(char *buf, int64_t duration_usec)
-{
-    int32_t duration_msec = (int32_t)(duration_usec / 1000);
-    duration_usec -= ((int64_t)duration_msec * 1000);
-    char *pos = buf;
-    pos += sprintf(pos, "total; dur=%" PRId32, duration_msec);
-    if (duration_usec != 0) {
-        *pos++ = '.';
-        int denom;
-        for (denom = 100; denom != 0; denom /= 10) {
-            int d = (int)duration_usec / denom;
-            *pos++ = '0' + d;
-            duration_usec -= d * denom;
-            if (duration_usec == 0)
-                break;
-        }
-    }
-    return pos - buf;
-}

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -34,7 +34,7 @@ struct st_duration_stats_t {
     struct gkc_summary *request_total_time;
     struct gkc_summary *process_time;
     struct gkc_summary *response_time;
-    struct gkc_summary *duration;
+    struct gkc_summary *total_time;
 };
 
 struct st_duration_agg_stats_t {
@@ -62,7 +62,7 @@ static void durations_status_per_thread(void *priv, h2o_context_t *ctx)
         ADD_DURATION(request_total_time);
         ADD_DURATION(process_time);
         ADD_DURATION(response_time);
-        ADD_DURATION(duration);
+        ADD_DURATION(total_time);
 #undef ADD_DURATION
         pthread_mutex_unlock(&agg_stats->mutex);
     }
@@ -76,7 +76,7 @@ static void duration_stats_init(struct st_duration_stats_t *stats)
     stats->request_total_time = gkc_summary_alloc(GK_EPSILON);
     stats->process_time = gkc_summary_alloc(GK_EPSILON);
     stats->response_time = gkc_summary_alloc(GK_EPSILON);
-    stats->duration = gkc_summary_alloc(GK_EPSILON);
+    stats->total_time = gkc_summary_alloc(GK_EPSILON);
 }
 
 static void *durations_status_init(void)
@@ -99,7 +99,7 @@ static void duration_stats_free(struct st_duration_stats_t *stats)
     gkc_summary_free(stats->request_total_time);
     gkc_summary_free(stats->process_time);
     gkc_summary_free(stats->response_time);
-    gkc_summary_free(stats->duration);
+    gkc_summary_free(stats->total_time);
 }
 
 static h2o_iovec_t durations_status_final(void *priv, h2o_globalconf_t *gconf, h2o_req_t *req)
@@ -124,7 +124,7 @@ static h2o_iovec_t durations_status_final(void *priv, h2o_globalconf_t *gconf, h
         ",\n" DURATION_FMT("connect-time") "," DURATION_FMT("header-time") "," DURATION_FMT("body-time") "," DURATION_FMT(
             "request-total-time") "," DURATION_FMT("process-time") "," DURATION_FMT("response-time") "," DURATION_FMT("duration"),
         DURATION_VALS(connect_time), DURATION_VALS(header_time), DURATION_VALS(body_time), DURATION_VALS(request_total_time),
-        DURATION_VALS(process_time), DURATION_VALS(response_time), DURATION_VALS(duration));
+        DURATION_VALS(process_time), DURATION_VALS(response_time), DURATION_VALS(total_time));
 
 #undef BUFSIZE
 #undef DURATION_FMT
@@ -159,7 +159,7 @@ static void stat_access(h2o_logger_t *_self, h2o_req_t *req)
     ADD_OBSERVATION(request_total_time, &req->timestamps.request_begin_at, &req->processed_at.at);
     ADD_OBSERVATION(process_time, &req->processed_at.at, &req->timestamps.response_start_at);
     ADD_OBSERVATION(response_time, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
-    ADD_OBSERVATION(duration, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
+    ADD_OBSERVATION(total_time, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
 #undef ADD_OBSERVATION
 }
 

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -558,7 +558,7 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
         if (h2o_time_compute_duration(&conn->req, &delta_usec)) {
             static const h2o_iovec_t name = {H2O_STRLIT("server-timing: ")};
 
-            char buf[50];
+            char buf[sizeof("server-timing: " H2O_SERVER_TIMING_TRAILER_LONGEST_STR "\r\n\r\n")];
             memcpy(buf, name.base, name.len);
             size_t len = name.len;
             len += h2o_server_timing_encode_trailer(buf + len, delta_usec);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -676,6 +676,7 @@ static void proceed_pull(struct st_h2o_http1_conn_t *conn, size_t nfilled)
         send_state = h2o_pull(&conn->req, conn->_ostr_final.pull.cb, &cbuf);
         if (send_state == H2O_SEND_STATE_ERROR) {
             conn->req.http1_is_persistent = 0;
+            conn->req.send_server_timing_trailer = 0;
         }
         buf.len += cbuf.len;
         conn->req.bytes_sent += cbuf.len;
@@ -757,6 +758,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
 
     if (send_state == H2O_SEND_STATE_ERROR) {
         conn->req.http1_is_persistent = 0;
+        conn->req.send_server_timing_trailer = 0;
     }
 
     if (bufcnt != 0) {

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -586,7 +586,7 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
             char buf[sizeof("server-timing: " H2O_SERVER_TIMING_TRAILER_LONGEST_STR "\r\n\r\n")];
             memcpy(buf, name.base, name.len);
             size_t len = name.len;
-            len += h2o_server_timing_encode_trailer(buf + len, delta_usec);
+            len += h2o_encode_server_timing_trailer(buf + len, delta_usec);
             buf[len++] = '\r';
             buf[len++] = '\n';
             buf[len++] = '\r';

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -579,7 +579,7 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
     if (err != NULL)
         conn->req.http1_is_persistent = 0;
 
-    if (conn->req.send_server_timing_trailer) {
+    if (err == NULL && conn->req.send_server_timing_trailer) {
         int64_t delta_usec;
         if (h2o_time_compute_duration(&conn->req, &delta_usec)) {
             static const h2o_iovec_t name = {H2O_STRLIT("server-timing: ")};

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -583,7 +583,8 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
         int64_t delta_usec;
         if (h2o_time_compute_duration(&conn->req, &delta_usec)) {
             static const h2o_iovec_t name = {H2O_STRLIT("server-timing: ")};
-            char buf[sizeof("server-timing: " H2O_SERVER_TIMING_TRAILER_LONGEST_STR "\r\n\r\n")];
+            char *buf = h2o_mem_alloc_pool(&conn->req.pool, *buf,
+                                           sizeof("server-timing: " H2O_SERVER_TIMING_TRAILER_LONGEST_STR "\r\n\r\n"));
             memcpy(buf, name.base, name.len);
             size_t len = name.len;
             len += h2o_encode_server_timing_trailer(buf + len, delta_usec);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -561,7 +561,7 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
             char buf[50];
             memcpy(buf, name.base, name.len);
             size_t len = name.len;
-            len += h2o_server_timing_encode_total(buf + len, delta_usec);
+            len += h2o_server_timing_encode_trailer(buf + len, delta_usec);
             buf[len++] = '\r';
             buf[len++] = '\n';
             buf[len++] = '\r';

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -576,6 +576,9 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
 
     conn->req.timestamps.response_end_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
 
+    if (err != NULL)
+        conn->req.http1_is_persistent = 0;
+
     if (conn->req.send_server_timing_trailer) {
         int64_t delta_usec;
         if (h2o_time_compute_duration(&conn->req, &delta_usec)) {

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1205,16 +1205,12 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
         if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM && stream->req.send_server_timing_trailer) {
             int64_t delta_usec;
             if (h2o_time_compute_duration(&stream->req, &delta_usec)) {
+                static const h2o_iovec_t name = {H2O_STRLIT("server-timing")};
                 char buf[sizeof(H2O_SERVER_TIMING_TRAILER_LONGEST_STR)];
                 size_t len = h2o_server_timing_encode_trailer(buf, delta_usec);
-
-                h2o_headers_t trailers = (h2o_headers_t){NULL};
-                h2o_vector_reserve(&stream->req.pool, &trailers, 1);
-                trailers.size = 1;
-                static const h2o_iovec_t name = {H2O_STRLIT("server-timing")};
-                trailers.entries[0] = (h2o_header_t){(h2o_iovec_t *)&name, NULL, h2o_iovec_init(buf, len)};
-
-                h2o_hpack_flatten_trailers(&conn->_write.buf, &conn->_output_header_table, stream->stream_id, conn->peer_settings.max_frame_size, trailers);
+                h2o_header_t trailer = {(h2o_iovec_t *)&name, NULL, h2o_iovec_init(buf, len)};
+                h2o_hpack_flatten_trailers(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
+                                           conn->peer_settings.max_frame_size, &trailer, 1);
                 h2o_http2_conn_request_write(conn);
             }
         }

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1196,8 +1196,6 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
 
     h2o_http2_stream_send_pending_data(conn, stream);
     if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM && stream->req.send_server_timing_trailer) {
-        stream->req.send_server_timing_trailer = 0;
-
         int64_t delta_usec;
         if (h2o_time_compute_duration(&stream->req, &delta_usec)) {
             char buf[sizeof(H2O_SERVER_TIMING_TRAILER_LONGEST_STR)];

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1209,7 +1209,7 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
             if (h2o_time_compute_duration(&stream->req, &delta_usec)) {
                 static const h2o_iovec_t name = {H2O_STRLIT("server-timing")};
                 char buf[sizeof(H2O_SERVER_TIMING_TRAILER_LONGEST_STR)];
-                size_t len = h2o_server_timing_encode_trailer(buf, delta_usec);
+                size_t len = h2o_encode_server_timing_trailer(buf, delta_usec);
                 trailers[num_trailers++] = (h2o_header_t){(h2o_iovec_t *)&name, NULL, h2o_iovec_init(buf, len)};
             }
             h2o_hpack_flatten_trailers(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1200,7 +1200,7 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
 
         int64_t delta_usec;
         if (h2o_time_compute_duration(&stream->req, &delta_usec)) {
-            char buf[32];
+            char buf[sizeof(H2O_SERVER_TIMING_TRAILER_LONGEST_STR)];
             size_t len = h2o_server_timing_encode_trailer(buf, delta_usec);
 
             h2o_headers_t trailers = (h2o_headers_t){NULL};

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1201,7 +1201,7 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
         int64_t delta_usec;
         if (h2o_time_compute_duration(&stream->req, &delta_usec)) {
             char buf[32];
-            size_t len = h2o_server_timing_encode_total(buf, delta_usec);
+            size_t len = h2o_server_timing_encode_trailer(buf, delta_usec);
 
             h2o_headers_t trailers = (h2o_headers_t){NULL};
             h2o_vector_reserve(&stream->req.pool, &trailers, 1);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1195,6 +1195,24 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
     *still_is_active = 0;
 
     h2o_http2_stream_send_pending_data(conn, stream);
+    if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM && stream->req.send_server_timing_trailer) {
+        stream->req.send_server_timing_trailer = 0;
+
+        int64_t delta_usec;
+        if (h2o_time_compute_duration(&stream->req, &delta_usec)) {
+            char buf[32];
+            size_t len = h2o_server_timing_encode_total(buf, delta_usec);
+
+            h2o_headers_t trailers = (h2o_headers_t){NULL};
+            h2o_vector_reserve(&stream->req.pool, &trailers, 1);
+            trailers.size = 1;
+            static const h2o_iovec_t name = {H2O_STRLIT("server-timing")};
+            trailers.entries[0] = (h2o_header_t){(h2o_iovec_t *)&name, NULL, h2o_iovec_init(buf, len)};
+
+            h2o_hpack_flatten_trailers(&conn->_write.buf, &conn->_output_header_table, stream->stream_id, conn->peer_settings.max_frame_size, trailers);
+            h2o_http2_conn_request_write(conn);
+        }
+    }
     if (h2o_http2_stream_has_pending_data(stream) || stream->state == H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL) {
         if (h2o_http2_window_get_avail(&stream->output_window) <= 0) {
             /* is blocked */

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -810,13 +810,14 @@ static size_t calc_headers_capacity(const h2o_header_t *headers, size_t num_head
     return capacity;
 }
 
-static void fixup_frame_headers(h2o_buffer_t **buf, size_t start_at, uint8_t type, uint32_t stream_id, size_t max_frame_size, int flags)
+static void fixup_frame_headers(h2o_buffer_t **buf, size_t start_at, uint8_t type, uint32_t stream_id, size_t max_frame_size,
+                                int flags)
 {
     /* try to fit all data into single frame, using the preallocated space for the frame header */
     size_t payload_size = (*buf)->size - start_at - H2O_HTTP2_FRAME_HEADER_SIZE;
     if (payload_size <= max_frame_size) {
-        h2o_http2_encode_frame_header((uint8_t *)((*buf)->bytes + start_at), payload_size, type, H2O_HTTP2_FRAME_FLAG_END_HEADERS | flags,
-                                      stream_id);
+        h2o_http2_encode_frame_header((uint8_t *)((*buf)->bytes + start_at), payload_size, type,
+                                      H2O_HTTP2_FRAME_FLAG_END_HEADERS | flags, stream_id);
         return;
     }
 

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -914,17 +914,17 @@ void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *he
 }
 
 void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                                size_t max_frame_size, h2o_headers_t trailers)
+                                size_t max_frame_size, h2o_header_t *headers, size_t num_headers)
 {
-    size_t capacity = calc_headers_capacity(trailers.entries, trailers.size);
+    size_t capacity = calc_headers_capacity(headers, num_headers);
     capacity += H2O_HTTP2_FRAME_HEADER_SIZE;
 
     size_t start_at = (*buf)->size;
     uint8_t *dst = (void *)(h2o_buffer_reserve(buf, capacity).base + H2O_HTTP2_FRAME_HEADER_SIZE); /* skip frame header */
 
     size_t i;
-    for (i = 0; i != trailers.size; ++i)
-        dst = encode_header(header_table, dst, trailers.entries[i].name, &trailers.entries[i].value);
+    for (i = 0; i != num_headers; ++i)
+        dst = encode_header(header_table, dst, headers[i].name, &headers[i].value);
     (*buf)->size = (char *)dst - (*buf)->bytes;
 
     /* setup the frame headers */

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -117,8 +117,10 @@ static void commit_data_header(h2o_http2_conn_t *conn, h2o_http2_stream_t *strea
     assert(outbuf != NULL);
     /* send a DATA frame if there's data or the END_STREAM flag to send */
     if (length || send_state == H2O_SEND_STATE_FINAL) {
-        h2o_http2_encode_frame_header((void *)((*outbuf)->bytes + (*outbuf)->size), length, H2O_HTTP2_FRAME_TYPE_DATA,
-                                      (send_state == H2O_SEND_STATE_FINAL && !stream->req.send_server_timing_trailer) ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0, stream->stream_id);
+        h2o_http2_encode_frame_header(
+            (void *)((*outbuf)->bytes + (*outbuf)->size), length, H2O_HTTP2_FRAME_TYPE_DATA,
+            (send_state == H2O_SEND_STATE_FINAL && !stream->req.send_server_timing_trailer) ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0,
+            stream->stream_id);
         h2o_http2_window_consume_window(&conn->_write.window, length);
         h2o_http2_window_consume_window(&stream->output_window, length);
         (*outbuf)->size += length + H2O_HTTP2_FRAME_HEADER_SIZE;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -119,7 +119,7 @@ static void commit_data_header(h2o_http2_conn_t *conn, h2o_http2_stream_t *strea
     if (length || send_state == H2O_SEND_STATE_FINAL) {
         h2o_http2_encode_frame_header(
             (void *)((*outbuf)->bytes + (*outbuf)->size), length, H2O_HTTP2_FRAME_TYPE_DATA,
-            (send_state == H2O_SEND_STATE_FINAL && !stream->req.send_server_timing_trailer) ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0,
+            (send_state == H2O_SEND_STATE_FINAL && !stream->req.send_server_timing) ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0,
             stream->stream_id);
         h2o_http2_window_consume_window(&conn->_write.window, length);
         h2o_http2_window_consume_window(&stream->output_window, length);
@@ -218,6 +218,8 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
         return -1;
     }
 
+    stream->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+
     /* cancel push with an error response */
     if (h2o_http2_stream_is_push(stream->stream_id)) {
         if (400 <= stream->req.res.status)
@@ -289,6 +291,8 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     if (h2o_http2_stream_is_push(stream->stream_id))
         h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, NULL,
                               H2O_STRLIT("pushed"));
+    if (stream->req.send_server_timing)
+        h2o_add_server_timing_header(&stream->req);
     h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
                                conn->peer_settings.max_frame_size, &stream->req.res, &conn->super.ctx->globalconf->server_name,
                                stream->req.res.content_length);
@@ -416,7 +420,7 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
     }
 
     if (send_state == H2O_SEND_STATE_ERROR) {
-        stream->req.send_server_timing_trailer = 0;
+        stream->req.send_server_timing = 0;
     }
 }
 

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -112,13 +112,13 @@ static size_t calc_max_payload_size(h2o_http2_conn_t *conn, h2o_http2_stream_t *
 }
 
 static void commit_data_header(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_buffer_t **outbuf, size_t length,
-                               h2o_send_state_t send_state)
+                               h2o_send_state_t send_state, int has_trailer)
 {
     assert(outbuf != NULL);
     /* send a DATA frame if there's data or the END_STREAM flag to send */
     if (length || send_state == H2O_SEND_STATE_FINAL) {
         h2o_http2_encode_frame_header((void *)((*outbuf)->bytes + (*outbuf)->size), length, H2O_HTTP2_FRAME_TYPE_DATA,
-                                      send_state == H2O_SEND_STATE_FINAL ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0, stream->stream_id);
+                                      (send_state == H2O_SEND_STATE_FINAL && !has_trailer) ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0, stream->stream_id);
         h2o_http2_window_consume_window(&conn->_write.window, length);
         h2o_http2_window_consume_window(&stream->output_window, length);
         (*outbuf)->size += length + H2O_HTTP2_FRAME_HEADER_SIZE;
@@ -145,7 +145,7 @@ static h2o_send_state_t send_data_pull(h2o_http2_conn_t *conn, h2o_http2_stream_
     cbuf.len = max_payload_size;
     send_state = h2o_pull(&stream->req, stream->_pull_cb, &cbuf);
     /* write the header */
-    commit_data_header(conn, stream, &conn->_write.buf, cbuf.len, send_state);
+    commit_data_header(conn, stream, &conn->_write.buf, cbuf.len, send_state, stream->req.send_server_timing_trailer);
 
 Exit:
     return send_state;
@@ -195,7 +195,7 @@ static h2o_iovec_t *send_data_push(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
         if (bufcnt != 0) {
             send_state = H2O_SEND_STATE_IN_PROGRESS;
         }
-        commit_data_header(conn, stream, &conn->_write.buf, payload_len, send_state);
+        commit_data_header(conn, stream, &conn->_write.buf, payload_len, send_state, stream->req.send_server_timing_trailer);
     }
 
 Exit:

--- a/src/main.c
+++ b/src/main.c
@@ -1892,6 +1892,7 @@ static void setup_configurators(void)
     h2o_redirect_register_configurator(&conf.globalconf);
     h2o_status_register_configurator(&conf.globalconf);
     h2o_http2_debug_state_register_configurator(&conf.globalconf);
+    h2o_server_timing_register_configurator(&conf.globalconf);
 #if H2O_USE_MRUBY
     h2o_mruby_register_configurator(&conf.globalconf);
 #endif

--- a/t/50server-timing.t
+++ b/t/50server-timing.t
@@ -31,8 +31,8 @@ EOT
         # durations might be less than the slept amount because h2o's timestamps are updated at each eventloop
         # so we have to introduce 100ms lower buffer (i.e. 900ms, 1900ms)
         test_element($sts[0], 'connect', undef, undef);
-        test_element($sts[0], 'header', undef, undef);
-        test_element($sts[0], 'request_total', undef, undef);
+        test_element($sts[0], 'request-header', undef, undef);
+        test_element($sts[0], 'request-total', undef, undef);
         test_element($sts[0], 'process', 900, 1100);
         test_element($sts[1], 'response', 900, 1100);
         test_element($sts[1], 'total', 1900, 2100);

--- a/t/50server-timing.t
+++ b/t/50server-timing.t
@@ -1,0 +1,131 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use Time::HiRes;
+use t::Util;
+
+
+subtest 'basic' => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        - server-timing: on
+        - mruby.handler: |
+            proc {|env|
+              sleep 1
+              [200, {}, Class.new do
+                def each
+                  yield 'hello'
+                  sleep 1
+                  yield 'world!'
+                end
+              end.new]
+            }
+EOT
+
+    subtest 'http1' => sub {
+        my @sts = nc_get($server, '/', 1);
+        is scalar(@sts), 2, 'header and trailer';
+    
+        test_element($sts[0], 'connect', undef, undef);
+        test_element($sts[0], 'header', undef, undef);
+        test_element($sts[0], 'request_total', undef, undef);
+        test_element($sts[0], 'process', 1000, 2000);
+        test_element($sts[1], 'response', 1000, 2000);
+        test_element($sts[1], 'total', 2000, 3000);
+    };
+    
+    subtest 'http2' => sub {
+        my @sts = nghttp_get($server, '/');
+        is scalar(@sts), 2, 'header and trailer';
+    
+        test_element($sts[0], 'connect', undef, undef);
+        test_element($sts[0], 'header', undef, undef);
+        test_element($sts[0], 'request_total', undef, undef);
+        test_element($sts[0], 'process', 1000, 2000);
+        test_element($sts[1], 'response', 1000, 2000);
+        test_element($sts[1], 'total', 2000, 3000);
+    };
+};
+
+subtest 'disabled' => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        - server-timing: on
+        - file.dir: t/assets/doc_root
+EOT
+
+    subtest 'no te header' => sub {
+        my @sts = nc_get($server, '/');
+        is scalar(@sts), 0, 'no server timing';
+    };
+
+    subtest 'not chunked encoding' => sub {
+        my @sts = nc_get($server, '/');
+        is scalar(@sts), 0, 'no server timing';
+    };
+    
+    subtest 'http2 is always ok' => sub {
+        my @sts = nghttp_get($server, '/');
+        is scalar(@sts), 2, 'header and trailer';
+    };
+};
+
+subtest 'enforce' => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        - server-timing: enforce
+        - file.dir: t/assets/doc_root
+EOT
+
+    subtest 'http1' => sub {
+        my @sts = nc_get($server, '/');
+        is scalar(@sts), 2, 'header and trailer';
+    };
+    
+    subtest 'http2' => sub {
+        my @sts = nghttp_get($server, '/');
+        is scalar(@sts), 2, 'header and trailer';
+    };
+};
+
+done_testing;
+
+sub nc_get {
+    my ($server, $path, $te_trailers) = @_;
+    my $req = "GET $path HTTP/1.1\\r\\n";
+    $req .= "TE: trailers\r\n" if $te_trailers;
+    $req .= "\r\n";
+    my $resp = `echo '$req' | nc 127.0.0.1 $server->{port}`;
+    map { parse_server_timing($_) } ($resp =~ /^server-timing: (.+)$/mg);
+}
+
+sub nghttp_get {
+    my ($server, $path) = @_; 
+    my $out = `nghttp -vn 'https://127.0.0.1:$server->{tls_port}$path'`;
+    map { parse_server_timing($_) } ($out =~ /recv \(stream_id=\d+\) server-timing: (.+)$/mg);
+}
+
+sub parse_server_timing {
+    my ($str) = @_;
+    +{ map { split (/; dur=/, $_, 2) } split(/, /, $str) };
+}
+
+sub test_element {
+    my ($st, $name, $lower, $upper) = @_;
+    subtest $name => sub {
+        my $value = $st->{$name};
+        ok defined $value;
+        cmp_ok $value, '>=', $lower, "lower bound" if defined $lower;
+        cmp_ok $value, '<',  $upper, "upper bound" if defined $upper;
+    };
+}


### PR DESCRIPTION
[Server Timing](https://www.w3.org/TR/server-timing/) allows the clients to get fine-grained performance metrics from the server. This PR only implement `total:dur=xxx` metrics as a trailer.

TODOs:
- [x] write tests