### PR TITLE
better error message when preload failed

### DIFF
--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -90,12 +90,10 @@ void h2o_mruby_setup_globals(mrb_state *mrb)
     /* require core modules and include built-in libraries */
     h2o_mruby_eval_expr(mrb, "require \"#{$H2O_ROOT}/share/h2o/mruby/preloads.rb\"");
     if (mrb->exc != NULL) {
+        fprintf(stderr, "an error occurred while loading %s/%s: %s\n", root, "share/h2o/mruby/preloads.rb",
+                RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
         if (mrb_obj_is_instance_of(mrb, mrb_obj_value(mrb->exc), mrb_class_get(mrb, "LoadError"))) {
-            fprintf(stderr, "file \"%s/%s\" not found. Did you forget to run `make install`?\n", root,
-                    "share/h2o/mruby/preloads.rb");
-        } else {
-            fprintf(stderr, "an error occurred while loading %s/%s: %s\n", root, "share/h2o/mruby/preloads.rb",
-                    RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
+            fprintf(stderr, "Did you forget to run `make install`?\n");
         }
         abort();
     }


### PR DESCRIPTION
As discussed in https://github.com/h2o/h2o/issues/1552, when requiring `preloads.rb` failed with LoadError, current impl hides original exception message and only says `file "/h2o_root/share/h2o/mruby/preloads.rb" not found. Did you forget to run `make install`?`. But that makes harder to troubleshoot if nested require failed.