### PR TITLE
append index file name to SCRIPT_NAME on dynamic request

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -928,7 +928,8 @@ typedef struct st_h2o_req_overrides_t {
  * additional information for extension-based dynamic content
  */
 typedef struct st_h2o_filereq_t {
-    size_t url_path_len;
+    h2o_iovec_t script_name;
+    h2o_iovec_t path_info;
     h2o_iovec_t local_path;
 } h2o_filereq_t;
 

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -232,10 +232,8 @@ static void append_params(h2o_req_t *req, iovec_vector_t *vecs, h2o_fastcgi_conf
     if (req->filereq != NULL) {
         h2o_filereq_t *filereq = req->filereq;
         append_pair(&req->pool, vecs, H2O_STRLIT("SCRIPT_FILENAME"), filereq->local_path.base, filereq->local_path.len);
-        append_pair(&req->pool, vecs, H2O_STRLIT("SCRIPT_NAME"), req->path_normalized.base, filereq->url_path_len);
-        if (req->path_normalized.len != filereq->url_path_len)
-            path_info =
-                h2o_iovec_init(req->path_normalized.base + filereq->url_path_len, req->path_normalized.len - filereq->url_path_len);
+        append_pair(&req->pool, vecs, H2O_STRLIT("SCRIPT_NAME"), filereq->script_name.base, filereq->script_name.len);
+        path_info = filereq->path_info;
     } else {
         append_pair(&req->pool, vecs, H2O_STRLIT("SCRIPT_NAME"), NULL, 0);
         path_info = req->path_normalized;

--- a/t/50file-custom-handler.t
+++ b/t/50file-custom-handler.t
@@ -102,5 +102,47 @@ EOT
     });
 };
 
+subtest 'SCRIPT_NAME and PATH_INFO for fastcgi' => sub {
+    eval q{use CGI; 1}
+        or plan skip_all => 'CGI.pm not found';
+
+    # spawn h2o
+    my $server = spawn_h2o(<< "EOT");
+file.index: ['printenv.cgi']
+file.custom-handler:
+  extension: .cgi
+  fastcgi.spawn: "exec \$H2O_ROOT/share/h2o/fastcgi-cgi"
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[DOC_ROOT]}
+      /foo:
+        file.dir: @{[DOC_ROOT]}
+EOT
+    my $doit = sub {
+        my ($path, $expected) = @_;
+        subtest $path => sub {
+            my $resp = `curl --silent http://127.0.0.1:$server->{port}$path`;
+            my $env = +{ map { split(':', $_, 2) } split(/\n/, $resp) };
+            for my $key (sort keys %$expected) {
+                is $env->{$key}, $expected->{$key}, $key;
+            }
+        };
+    };
+
+    $doit->('/printenv.cgi',
+        +{ SCRIPT_NAME => '/printenv.cgi', PATH_INFO => undef });
+    $doit->('/printenv.cgi/path/info',
+        +{ SCRIPT_NAME => '/printenv.cgi', PATH_INFO => '/path/info' });
+    $doit->('/foo/printenv.cgi/path/info',
+        +{ SCRIPT_NAME => '/foo/printenv.cgi', PATH_INFO => '/path/info' });
+    $doit->('/',
+        +{ SCRIPT_NAME => '/printenv.cgi', PATH_INFO => undef });
+    $doit->('/foo/',
+        +{ SCRIPT_NAME => '/foo/printenv.cgi', PATH_INFO => undef });
+
+};
+
 done_testing;
 


### PR DESCRIPTION
As mentioned in https://github.com/h2o/h2o/issues/1630, index file name is missing from SCRIPT_NAME. This PR fixes it.