### PR TITLE
specify relative paths required by preloads.rb and others

### DIFF
--- a/share/h2o/mruby/acl.rb
+++ b/share/h2o/mruby/acl.rb
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-require "bootstrap.rb"
+require File.expand_path(File.dirname(__FILE__)) + "/bootstrap.rb"
 
 module H2O
 

--- a/share/h2o/mruby/dos_detector.rb
+++ b/share/h2o/mruby/dos_detector.rb
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-require "lru_cache.rb"
+require File.expand_path(File.dirname(__FILE__)) + "/lru_cache.rb"
 
 class DoSDetector
 

--- a/share/h2o/mruby/preloads.rb
+++ b/share/h2o/mruby/preloads.rb
@@ -1,3 +1,3 @@
-require "bootstrap.rb"
-require "acl.rb"
+require File.expand_path(File.dirname(__FILE__)) + "/bootstrap.rb"
+require File.expand_path(File.dirname(__FILE__)) + "/acl.rb"
 include H2O::ACL


### PR DESCRIPTION
This fixes the issue Reported in https://github.com/h2o/h2o/issues/1660, by specifying relative paths