### PR TITLE
fix abort when received invalid transfer-encoding header from upstream

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -220,7 +220,7 @@ static void on_req_chunked(h2o_socket_t *sock, const char *err)
 
 static void on_error_before_head(struct st_h2o_http1client_private_t *client, const char *errstr)
 {
-    assert(!client->_do_keepalive);
+    client->_do_keepalive = 0;
     client->_cb.on_head(&client->super, errstr, 0, 0, h2o_iovec_init(NULL, 0), NULL, 0, 0);
     close_client(client);
 }

--- a/t/50reverse-proxy-invalid-transfer-encoding.t
+++ b/t/50reverse-proxy-invalid-transfer-encoding.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $upstream_port = empty_port();
+
+my $upstream = spawn_server(
+    argv     => [ qw(plackup -s Starlet --max-keepalive-reqs 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+    is_ready =>  sub {
+        check_port($upstream_port);
+    },
+);
+
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+my $url = "http://127.0.0.1:$server->{port}/?resp:transfer-encoding=foo";
+my $resp = `curl --silent --http1.1 --dump-header /dev/stdout $url`;
+like $resp, qr{HTTP/[^ ]+ 502\s}m;
+
+done_testing();
+


### PR DESCRIPTION
Fixes https://github.com/h2o/h2o/issues/1687: on_error_before_head can be called after setting `client->_do_keepalive` to 1. This is a long standing bug.