### PR TITLE
Mark `*/*+json` MIME types as compressible.

### DIFF
--- a/lib/handler/mimemap.c
+++ b/lib/handler/mimemap.c
@@ -432,6 +432,7 @@ void h2o_mimemap_get_default_attributes(const char *_mime, h2o_mime_attributes_t
         attr->is_compressible = 1;
         attr->priority = H2O_MIME_ATTRIBUTE_PRIORITY_HIGHEST;
     } else if (h2o_memis(mime, type_end_at - mime, H2O_STRLIT("application/json")) || strncmp(mime, "text/", 5) == 0 ||
+               h2o_strstr(mime, type_end_at - mime, H2O_STRLIT("+json")) != SIZE_MAX ||
                h2o_strstr(mime, type_end_at - mime, H2O_STRLIT("+xml")) != SIZE_MAX) {
         attr->is_compressible = 1;
     }


### PR DESCRIPTION
Unsurprisingly, we have plenty of formats encoded as JSON nowadays and some of them have `+json` media types. [ActivityPub](https://www.w3.org/TR/activitypub/), [GeoJSON](https://tools.ietf.org/html/rfc7946) and [JSON-LD](https://json-ld.org/spec/latest/json-ld/) are such examples.