### PR TITLE
I/O errors with multiple 1xx responses

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -249,6 +249,7 @@ static void on_head(h2o_socket_t *sock, const char *err)
     headers = h2o_mem_alloc_pool(&pool, *headers,  MAX_HEADERS);
     header_names = h2o_mem_alloc_pool(&pool, *header_names, MAX_HEADERS);
 
+ReparseHeaders:
     {
         struct phr_header src_headers[MAX_HEADERS];
         /* parse response */
@@ -291,6 +292,9 @@ static void on_head(h2o_socket_t *sock, const char *err)
             goto Exit;
         }
         h2o_buffer_consume(&client->super.sock->input, rlen);
+        /* check if the rest of the buffer contains parsable headers */
+        if (client->super.sock->input->size > 0)
+            goto ReparseHeaders;
         h2o_timeout_link(client->super.ctx->loop, client->super.ctx->io_timeout, &client->_timeout);
         goto Exit;
     }

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -258,6 +258,13 @@ builder {
             "",
             "",
         );
+        print $fh join(
+            "\r\n",
+            "HTTP/1.1 100 Continue",
+            "link: </index.js>; rel=preload",
+            "",
+            "",
+        );
         sleep 1.1;
         [200, ["content-type" => "text/plain; charset=utf-8", "content-length" => 11], ["hello world"]];
     };


### PR DESCRIPTION
The issue happens if the responses are received in the same buffer. We
succesfully parse the first response, but we don't look at the buffer to
see if there might be another one to parse.
Sending multiple 103 responses is explicitely permitted by RFC 8297

We tweak the existing push test to send the same push twice, so that the
code path is exercised.