### PR TITLE
suppress value conversion warnings of third party libraries

### DIFF
--- a/examples/libh2o/redis-client.c
+++ b/examples/libh2o/redis-client.c
@@ -22,7 +22,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include "h2o/redis.h"
-#include "hiredis.h"
+#include "h2o/hiredis_.h"
 
 static h2o_loop_t *loop;
 static int exit_loop;

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		10FEF24F1D6FC8E200E11B1D /* gkc.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FEF24D1D6FC8E200E11B1D /* gkc.h */; };
 		10FFEE0A1BB23A8C0087AD75 /* neverbleed.c in Sources */ = {isa = PBXBuildFile; fileRef = 10FFEE081BB23A8C0087AD75 /* neverbleed.c */; };
 		7D0285C91EF422D40094292B /* sleep.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D0285C81EF422D40094292B /* sleep.c */; };
+		7D0E5D5A20761BD800DA3E5A /* hiredis_.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DF88EF820761972005DB8D8 /* hiredis_.h */; };
 		7D9372FE202AC70F005FE6AB /* server_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D9372FD202AC70F005FE6AB /* server_timing.c */; };
 		7D9372FF202AC717005FE6AB /* server_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D9372FD202AC70F005FE6AB /* server_timing.c */; };
 		7D937300202AC717005FE6AB /* server_timing.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D9372FD202AC70F005FE6AB /* server_timing.c */; };
@@ -829,6 +830,7 @@
 		7D9372FD202AC70F005FE6AB /* server_timing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = server_timing.c; sourceTree = "<group>"; };
 		7D937301202AC7BA005FE6AB /* server_timing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = server_timing.c; sourceTree = "<group>"; };
 		7D9FA5381FC323AC00189F88 /* channel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = channel.c; sourceTree = "<group>"; };
+		7DF88EF820761972005DB8D8 /* hiredis_.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = hiredis_.h; sourceTree = "<group>"; };
 		D08137381FD400F4004679DF /* least_conn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = least_conn.c; sourceTree = "<group>"; };
 		D08137391FD400F4004679DF /* roundrobin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = roundrobin.c; sourceTree = "<group>"; };
 		D081373D1FD40431004679DF /* least_conn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = least_conn.c; sourceTree = "<group>"; };
@@ -1522,6 +1524,7 @@
 				107923A319A3215F00C52AD6 /* websocket.h */,
 				104B9A2C1A4BE029009EEE64 /* version.h */,
 				08790DE11D8275C100A04BC1 /* redis.h */,
+				7DF88EF820761972005DB8D8 /* hiredis_.h */,
 			);
 			path = h2o;
 			sourceTree = "<group>";
@@ -2151,6 +2154,7 @@
 				10A3D3D31B4CDF1200327CF9 /* memcached.h in Headers */,
 				10D0905719F102DA0043D458 /* http1client.h in Headers */,
 				08790DE01D8015A400A04BC1 /* sds.h in Headers */,
+				7D0E5D5A20761BD800DA3E5A /* hiredis_.h in Headers */,
 				106C22FA1C040F7800405689 /* tunnel.h in Headers */,
 				08790DE21D8275DE00A04BC1 /* redis.h in Headers */,
 				0812AB211D7FCFEB00004F23 /* async.h in Headers */,

--- a/include/h2o/hiredis_.h
+++ b/include/h2o/hiredis_.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018 Fastly Inc, Ichito Nagata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#include "hiredis.h"
+#include "async.h"
+#pragma GCC diagnostic pop

--- a/lib/common/redis.c
+++ b/lib/common/redis.c
@@ -20,9 +20,8 @@
  * IN THE SOFTWARE.
  */
 #include <errno.h>
-#include "async.h"
-#include "hiredis.h"
 #include "h2o/redis.h"
+#include "h2o/hiredis_.h"
 #include "h2o/socket.h"
 
 const char *const h2o_redis_error_connection = "Connection Error";

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -53,7 +53,10 @@
 #endif
 
 #define OPENSSL_HOSTNAME_VALIDATION_LINKAGE static
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #include "../../deps/ssl-conservatory/openssl/openssl_hostname_validation.c"
+#pragma clang diagnostic pop
 
 struct st_h2o_socket_ssl_t {
     SSL_CTX *ssl_ctx;

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -56,7 +56,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #include "../../deps/ssl-conservatory/openssl/openssl_hostname_validation.c"
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 struct st_h2o_socket_ssl_t {
     SSL_CTX *ssl_ctx;

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -26,10 +26,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
-#include "hiredis.h"
 #include "h2o.h"
 #include "h2o/http1.h"
 #include "h2o/http2.h"
+#include "h2o/hiredis_.h"
 
 struct st_h2o_accept_data_t {
     h2o_accept_ctx_t *ctx;

--- a/lib/handler/mruby/redis.c
+++ b/lib/handler/mruby/redis.c
@@ -28,7 +28,7 @@
 #include <mruby/variable.h>
 #include "h2o/mruby_.h"
 #include "h2o/redis.h"
-#include "hiredis.h"
+#include "h2o/hiredis_.h"
 
 struct st_h2o_mruby_redis_client_t {
     h2o_redis_client_t super;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28,7 +28,7 @@
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
-#include "hiredis.h"
+#include "h2o/hiredis_.h"
 #include "yoml-parser.h"
 #include "yrmcds.h"
 #if H2O_USE_PICOTLS


### PR DESCRIPTION
hiredis and openssl_hostname_validation have many value conversion (64-to-32) issues, which causes painful compiler warnings. This PR suppress that using diagnostic pragmas