### PR TITLE
add h2o_gettimeofday

### DIFF
--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -289,7 +289,7 @@ static int create_accepted(int sfd, char *buf, size_t len, h2o_barrier_t **barri
 {
     int fd;
     h2o_socket_t *sock;
-    struct timeval connected_at = h2o_gettimeofday(ctx->loop);
+    struct timeval connected_at = h2o_gettimeofday(ctx.loop);
 
     /* Create an HTTP[/2] client that will send the fuzzed request */
     fd = feeder(sfd, buf, len, barrier);

--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -289,7 +289,7 @@ static int create_accepted(int sfd, char *buf, size_t len, h2o_barrier_t **barri
 {
     int fd;
     h2o_socket_t *sock;
-    struct timeval connected_at = *h2o_get_timestamp(&ctx, NULL, NULL);
+    struct timeval connected_at = h2o_gettimeofday(ctx->loop);
 
     /* Create an HTTP[/2] client that will send the fuzzed request */
     fd = feeder(sfd, buf, len, barrier);

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -663,7 +663,6 @@ struct st_h2o_context_t {
     void **_module_configs;
 
     struct {
-        uint64_t uv_now_at;
         struct timeval tv_at;
         h2o_timestamp_string_t *value;
     } _timestamp_cache;
@@ -1517,6 +1516,7 @@ void h2o_context_init_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pathc
  *
  */
 void h2o_context_dispose_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pathconf);
+
 /**
  * returns current timestamp
  * @param ctx the context
@@ -2129,11 +2129,7 @@ inline void h2o_setup_next_prefilter(h2o_req_prefilter_t *self, h2o_req_t *req, 
 
 inline struct timeval *h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t *ts)
 {
-    uint64_t now = h2o_now(ctx->loop);
-
-    if (ctx->_timestamp_cache.uv_now_at != now) {
-        h2o_context_update_timestamp_cache(ctx);
-    }
+    h2o_context_update_timestamp_cache(ctx);
 
     if (ts != NULL) {
         ts->at = ctx->_timestamp_cache.tv_at;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1525,7 +1525,7 @@ void h2o_context_dispose_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pa
  * @return current time in UTC
  */
 static h2o_timestamp_t h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool);
-void h2o_context_update_timestamp_cache(h2o_context_t *ctx);
+void h2o_context_update_timestamp_string_cache(h2o_context_t *ctx);
 /**
  * returns per-module context set
  */
@@ -2129,7 +2129,10 @@ inline void h2o_setup_next_prefilter(h2o_req_prefilter_t *self, h2o_req_t *req, 
 
 inline h2o_timestamp_t h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool)
 {
-    h2o_context_update_timestamp_cache(ctx);
+    time_t prev_sec = ctx->_timestamp_cache.tv_at.tv_sec;
+    ctx->_timestamp_cache.tv_at = h2o_gettimeofday(ctx->loop);
+    if (ctx->_timestamp_cache.tv_at.tv_sec != prev_sec)
+        h2o_context_update_timestamp_string_cache(ctx);
 
     h2o_timestamp_t ts;
     ts.at = ctx->_timestamp_cache.tv_at;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1524,7 +1524,7 @@ void h2o_context_dispose_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pa
  * @param ts buffer to store the timestamp (optional)
  * @return current time in UTC
  */
-static struct timeval *h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t *ts);
+static h2o_timestamp_t h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool);
 void h2o_context_update_timestamp_cache(h2o_context_t *ctx);
 /**
  * returns per-module context set
@@ -2127,17 +2127,16 @@ inline void h2o_setup_next_prefilter(h2o_req_prefilter_t *self, h2o_req_t *req, 
         h2o_setup_next_ostream(req, slot);
 }
 
-inline struct timeval *h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool, h2o_timestamp_t *ts)
+inline h2o_timestamp_t h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool)
 {
     h2o_context_update_timestamp_cache(ctx);
 
-    if (ts != NULL) {
-        ts->at = ctx->_timestamp_cache.tv_at;
-        h2o_mem_link_shared(pool, ctx->_timestamp_cache.value);
-        ts->str = ctx->_timestamp_cache.value;
-    }
+    h2o_timestamp_t ts;
+    ts.at = ctx->_timestamp_cache.tv_at;
+    h2o_mem_link_shared(pool, ctx->_timestamp_cache.value);
+    ts.str = ctx->_timestamp_cache.value;
 
-    return &ctx->_timestamp_cache.tv_at;
+    return ts;
 }
 
 inline void *h2o_context_get_handler_context(h2o_context_t *ctx, h2o_handler_t *handler)

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -439,11 +439,11 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         else
             h2o_http2_stream_update_open_slot(stream, &conn->num_streams.pull);
         stream->state = new_state;
-        stream->req.timestamps.request_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+        stream->req.timestamps.request_begin_at = h2o_gettimeofday(conn->super.ctx->loop);
         break;
     case H2O_HTTP2_STREAM_STATE_RECV_BODY:
         stream->state = new_state;
-        stream->req.timestamps.request_body_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+        stream->req.timestamps.request_body_begin_at = h2o_gettimeofday(conn->super.ctx->loop);
         break;
     case H2O_HTTP2_STREAM_STATE_REQ_PENDING:
         stream->state = new_state;
@@ -483,7 +483,7 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
             break;
         }
         stream->state = new_state;
-        stream->req.timestamps.response_end_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+        stream->req.timestamps.response_end_at = h2o_gettimeofday(conn->super.ctx->loop);
         --stream->_num_streams_slot->open;
         stream->_num_streams_slot = NULL;
         if (stream->blocked_by_server)

--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -42,6 +42,7 @@ typedef struct st_h2o_evloop_t {
         struct st_h2o_evloop_socket_t **tail_ref;
     } _statechanged;
     uint64_t _now;
+    struct timeval _tv_at;
     h2o_linklist_t _timeouts; /* list of h2o_timeout_t */
     h2o_sliding_counter_t exec_time_counter;
 } h2o_evloop_t;
@@ -60,6 +61,11 @@ void h2o_evloop_destroy(h2o_evloop_t *loop);
 int h2o_evloop_run(h2o_evloop_t *loop, int32_t max_wait);
 
 /* inline definitions */
+
+static inline struct timeval h2o_gettimeofday(h2o_evloop_t *loop)
+{
+    return loop->_tv_at;
+}
 
 static inline uint64_t h2o_now(h2o_evloop_t *loop)
 {

--- a/include/h2o/socket/uv-binding.h
+++ b/include/h2o/socket/uv-binding.h
@@ -37,6 +37,13 @@ struct st_h2o_timeout_backend_properties_t {
 h2o_socket_t *h2o_uv_socket_create(uv_handle_t *handle, uv_close_cb close_cb);
 h2o_socket_t *h2o_uv__poll_create(h2o_loop_t *loop, int fd, uv_close_cb close_cb);
 
+static inline struct timeval h2o_gettimeofday(uv_loop_t *loop)
+{
+    struct timeval tv_at;
+    gettimeofday(&tv_at, NULL);
+    return tv_at;
+}
+
 static inline uint64_t h2o_now(uv_loop_t *loop)
 {
     return uv_now(loop);

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -474,9 +474,8 @@ h2o_evloop_t *create_evloop(size_t sz)
 
 void update_now(h2o_evloop_t *loop)
 {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    loop->_now = (uint64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+    gettimeofday(&loop->_tv_at, NULL);
+    loop->_now = (uint64_t)loop->_tv_at.tv_sec * 1000 + loop->_tv_at.tv_usec / 1000;
 }
 
 int32_t adjust_max_wait(h2o_evloop_t *loop, int32_t max_wait)

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -197,8 +197,7 @@ void h2o_context_request_shutdown(h2o_context_t *ctx)
 void h2o_context_update_timestamp_cache(h2o_context_t *ctx)
 {
     time_t prev_sec = ctx->_timestamp_cache.tv_at.tv_sec;
-    ctx->_timestamp_cache.uv_now_at = h2o_now(ctx->loop);
-    gettimeofday(&ctx->_timestamp_cache.tv_at, NULL);
+    ctx->_timestamp_cache.tv_at = h2o_gettimeofday(ctx->loop);
     if (ctx->_timestamp_cache.tv_at.tv_sec != prev_sec) {
         struct tm gmt;
         /* update the string cache */

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -194,18 +194,13 @@ void h2o_context_request_shutdown(h2o_context_t *ctx)
         ctx->globalconf->http2.callbacks.request_shutdown(ctx);
 }
 
-void h2o_context_update_timestamp_cache(h2o_context_t *ctx)
+void h2o_context_update_timestamp_string_cache(h2o_context_t *ctx)
 {
-    time_t prev_sec = ctx->_timestamp_cache.tv_at.tv_sec;
-    ctx->_timestamp_cache.tv_at = h2o_gettimeofday(ctx->loop);
-    if (ctx->_timestamp_cache.tv_at.tv_sec != prev_sec) {
-        struct tm gmt;
-        /* update the string cache */
-        if (ctx->_timestamp_cache.value != NULL)
-            h2o_mem_release_shared(ctx->_timestamp_cache.value);
-        ctx->_timestamp_cache.value = h2o_mem_alloc_shared(NULL, sizeof(h2o_timestamp_string_t), NULL);
-        gmtime_r(&ctx->_timestamp_cache.tv_at.tv_sec, &gmt);
-        h2o_time2str_rfc1123(ctx->_timestamp_cache.value->rfc1123, &gmt);
-        h2o_time2str_log(ctx->_timestamp_cache.value->log, ctx->_timestamp_cache.tv_at.tv_sec);
-    }
+    struct tm gmt;
+    if (ctx->_timestamp_cache.value != NULL)
+        h2o_mem_release_shared(ctx->_timestamp_cache.value);
+    ctx->_timestamp_cache.value = h2o_mem_alloc_shared(NULL, sizeof(h2o_timestamp_string_t), NULL);
+    gmtime_r(&ctx->_timestamp_cache.tv_at.tv_sec, &gmt);
+    h2o_time2str_rfc1123(ctx->_timestamp_cache.value->rfc1123, &gmt);
+    h2o_time2str_log(ctx->_timestamp_cache.value->log, ctx->_timestamp_cache.tv_at.tv_sec);
 }

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -116,7 +116,7 @@ h2o_hostconf_t *h2o_req_setup(h2o_req_t *req)
     h2o_context_t *ctx = req->conn->ctx;
     h2o_hostconf_t *hostconf;
 
-    h2o_get_timestamp(ctx, &req->pool, &req->processed_at);
+    req->processed_at = h2o_get_timestamp(ctx, &req->pool);
 
     /* find the host context */
     if (req->input.authority.base != NULL) {
@@ -732,7 +732,6 @@ h2o_iovec_t h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size
 
 void h2o_resp_add_date_header(h2o_req_t *req)
 {
-    h2o_timestamp_t ts;
-    h2o_get_timestamp(req->conn->ctx, &req->pool, &ts);
+    h2o_timestamp_t ts = h2o_get_timestamp(req->conn->ctx, &req->pool);
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_DATE, NULL, ts.str->rfc1123, strlen(ts.str->rfc1123));
 }

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -498,7 +498,7 @@ static void on_read_proxy_line(h2o_socket_t *sock, const char *err)
 
 void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
 {
-    struct timeval connected_at = *h2o_get_timestamp(ctx->ctx, NULL, NULL);
+    struct timeval connected_at = h2o_gettimeofday(ctx->ctx->loop);
 
     if (ctx->expect_proxy_line || ctx->ssl_ctx != NULL) {
         sock->data = accept_data_callbacks.create(ctx, sock, connected_at);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -415,7 +415,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
 
     /* need to set request_begin_at here for keep-alive connection */
     if (conn->req.timestamps.request_begin_at.tv_sec == 0)
-        conn->req.timestamps.request_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+        conn->req.timestamps.request_begin_at = h2o_gettimeofday(conn->super.ctx->loop);
 
     reqlen = phr_parse_request(conn->sock->input->bytes, inreqlen, (const char **)&conn->req.input.method.base,
                                &conn->req.input.method.len, (const char **)&conn->req.input.path.base, &conn->req.input.path.len,
@@ -426,7 +426,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
     default: // parse complete
         conn->_reqsize = reqlen;
         if ((entity_body_header_index = fixup_request(conn, headers, num_headers, minor_version, &expect)) != -1) {
-            conn->req.timestamps.request_body_begin_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+            conn->req.timestamps.request_body_begin_at = h2o_gettimeofday(conn->super.ctx->loop);
             if (expect.base != NULL) {
                 if (!h2o_lcstris(expect.base, expect.len, H2O_STRLIT("100-continue"))) {
                     set_timeout(conn, NULL, NULL);
@@ -574,7 +574,7 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
 
     assert(conn->req._ostr_top == &conn->_ostr_final.super);
 
-    conn->req.timestamps.response_end_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+    conn->req.timestamps.response_end_at = h2o_gettimeofday(conn->super.ctx->loop);
 
     if (err != NULL)
         conn->req.http1_is_persistent = 0;
@@ -702,7 +702,7 @@ static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb
     assert(conn->req._ostr_top == &conn->_ostr_final.super);
     assert(!conn->_ostr_final.sent_headers);
 
-    conn->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+    conn->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
     if (conn->req.send_server_timing)
         h2o_add_server_timing_header(&conn->req);
 
@@ -751,7 +751,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
     }
 
     if (!self->sent_headers) {
-        conn->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+        conn->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
         if (conn->req.send_server_timing)
             h2o_add_server_timing_header(&conn->req);
         /* build headers and send */

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -218,7 +218,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
         return -1;
     }
 
-    stream->req.timestamps.response_start_at = *h2o_get_timestamp(conn->super.ctx, NULL, NULL);
+    stream->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
 
     /* cancel push with an error response */
     if (h2o_http2_stream_is_push(stream->stream_id)) {


### PR DESCRIPTION
This PR adds `h2o_gettimeofday(h2o_loop_t *)` function. This function aims to decouple getting current timestamp (`struct timeval`) from h2o_context_t so that modules which don't have h2o_context_t (e.g. http1client) can get cached current timestamp too.
As a demerit of this approach, **timestamps are not cached at all if libuv is used**. But we don't address this issue at this point because we can expect VDSO in many environments. If the performance degrade becomes an actual problem in the future, we can introduce an extension point as a callback function to get cached timestamp.