### PR TITLE
Add support for logging to unix sockets

### DIFF
--- a/include/h2o/socket/uv-binding.h
+++ b/include/h2o/socket/uv-binding.h
@@ -23,6 +23,7 @@
 #define h2o__uv_binding_h
 
 #include <uv.h>
+#include <sys/time.h>
 
 #if !(defined(UV_VERSION_MAJOR) && UV_VERSION_MAJOR == 1)
 #error "libh2o (libuv binding) requires libuv version 1.x.y"

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -96,9 +96,34 @@ int h2o_access_log_open_log(const char *path)
         close(pipefds[0]);
         fd = pipefds[1];
     } else {
-        if ((fd = open(path, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0644)) == -1) {
-            fprintf(stderr, "failed to open log file:%s:%s\n", path, strerror(errno));
-            return -1;
+        struct stat st;
+        int ret;
+
+        ret = stat(path, &st);
+        if (ret == 0 && (st.st_mode & S_IFMT) == S_IFSOCK) {
+            struct sockaddr_un sa;
+            if (strlen(path) >= sizeof(sa.sun_path)) {
+                fprintf(stderr, "path:%s is too long as a unix socket name", path);
+                return -1;
+            }
+            if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+                fprintf(stderr, "failed to create socket for log file:%s:%s\n", path, strerror(errno));
+                return -1;
+            }
+            memset(&sa, 0, sizeof(sa));
+            sa.sun_family = AF_UNIX;
+            strcpy(sa.sun_path, path);
+            if (connect(fd, (struct sockaddr*)&sa, sizeof(sa)) == -1) {
+                fprintf(stderr, "failed to connect socket for log file:%s:%s\n", path, strerror(errno));
+                close(fd);
+                return -1;
+            }
+
+        } else {
+            if ((fd = open(path, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0644)) == -1) {
+                fprintf(stderr, "failed to open log file:%s:%s\n", path, strerror(errno));
+                return -1;
+            }
         }
     }
 


### PR DESCRIPTION
This is useful for running H2O from within systemd as a worker (as
opposed to wrapped with start_server). In this case, /dev/stderr is a
unix socket to systemd-journal.

Minor tweak: silence warning in uv-binding about gettimeofday not being
defined.