### PR TITLE
Fix leased socket counting in socketpool

### DIFF
--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -303,12 +303,12 @@ static void try_connect(h2o_socketpool_connect_request_t *req)
             req->selected_target = req->pool->balancer->callbacks->select_(req->pool->balancer, &req->pool->targets, req->lb.tried);
             assert(!req->lb.tried[req->selected_target]);
             req->lb.tried[req->selected_target] = 1;
-            __sync_add_and_fetch(&req->pool->targets.entries[req->selected_target]->_shared.leased_count, 1);
         } else {
             req->selected_target = 0;
         }
     }
     target = req->pool->targets.entries[req->selected_target];
+    __sync_add_and_fetch(&req->pool->targets.entries[req->selected_target]->_shared.leased_count, 1);
 
     switch (target->type) {
     case H2O_SOCKETPOOL_TYPE_NAMED:


### PR DESCRIPTION
Leased socket counting for targets becomes wrong when pooled sockets are reused or connection is cancelled, which would cause least connection load balancer not quite right. This PR fix those places.