### PR TITLE
Add CMake option to disable filebacked-buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,8 @@ IF(OPENSSL_VERSION VERSION_EQUAL "1.1.0" AND OPENSSL_VERSION STRLESS "1.1.0g")
                 "   *************************************************************************\n")
 ENDIF(OPENSSL_VERSION VERSION_EQUAL "1.1.0" AND OPENSSL_VERSION STRLESS "1.1.0g")
 
+OPTION(FILEBACKED_BUFFER "if needed, resort to a file-backed buffer for large memory allocations" ON)
+
 INCLUDE_DIRECTORIES(
     include
     deps/cloexec
@@ -730,6 +732,13 @@ ENDIF ()
 IF (NOT OSS_FUZZ)
     SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
 ENDIF (NOT OSS_FUZZ)
+
+# If enabled (which is the default), allows h2o to resort to a file-backed buffer (mmap)
+# in order to satisfy a large memory allocation for processing a request.  For more details,
+# see https://github.com/h2o/h2o/issues/1585.
+IF (FILEBACKED_BUFFER)
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFILEBACKED_BUFFER")
+ENDIF (FILEBACKED_BUFFER)
 
 IF ("${VERSION_PRERELEASE}" STREQUAL "-DEV" AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
     ADD_DEFINITIONS("-DH2O_HAS_GITREV_H")

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -129,7 +129,11 @@ h2o_buffer_mmap_settings_t h2o_socket_buffer_mmap_settings = {
 __thread h2o_buffer_prototype_t h2o_socket_buffer_prototype = {
     {16},                                       /* keep 16 recently used chunks */
     {H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE * 2}, /* minimum initial capacity */
+#if FILEBACKED_BUFFER
     &h2o_socket_buffer_mmap_settings};
+#else
+    NULL}; /* disallow the use of a file-backed buffer for large memory allocations */
+#endif
 
 const char *h2o_socket_error_out_of_memory = "out of memory";
 const char *h2o_socket_error_io = "I/O error";


### PR DESCRIPTION
In production, we noticed undesired allocations to the VFS for large chunks (32 MiB) that would linger apparently indefinitely (probably malicious requests; when testing these were short-lived buffers).  As we have enough RAM and do not want to induce additional I/O to the VFS for temporary buffers, we're proposing a CMake option for the user to indicate what should be done, if desired.

The default is to leave h2o as it is, resorting to an mmapped buffer if it sees fit.  However, if the user prefers not to hit the VFS with this kind of buffers, they can pass `-DFILEBACKED_BUFFER=off` during `cmake`, which will simply use a NULL instead of the current mmap template, `&h2o_socket_buffer_mmap_settings`.

During `h2o_buffer_reserve`, if h2o is going to try an mmapped buffer, it will test whether there is such a template and, if so, proceed with creating a temporary file and mmapping it.  With this behavior disabled/disallowed, the template will not have an mmap option (_i.e._, it will be `NULL`) and execution will resume on the else branch, allocating the buffer from memory.

This is what it looks like with the patch:

    (gdb) t a a p h2o_socket_buffer_prototype
    
    Thread 2 (Thread 0x7ffff6380700 (LWP 18157)):
    $1 = {allocator = {max = 16, cnt = 0, _link = 0x0}, _initial_buf = {capacity = 8192, size = 0, bytes = 0x0, _prototype = 0x0, _fd = 0, 
        _buf = ""}, mmap_settings = 0x0}

    Thread 1 (Thread 0x7ffff7fbe340 (LWP 18152)):
    $2 = {allocator = {max = 16, cnt = 0, _link = 0x0}, _initial_buf = {capacity = 8192, size = 0, bytes = 0x0, _prototype = 0x0, _fd = 0, 
        _buf = ""}, mmap_settings = 0x0}

We used h2spec for conformance testing, and the same behavior was observed with and without the proposed patch.