### PR TITLE
fuzzer: fix init time race

### DIFF
--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -157,6 +157,7 @@ static void write_fully(int fd, char *buf, size_t len, int abort_on_err)
     "Connection: Close\r\n\r\nOk"
 #define OK_RESP_LEN (sizeof(OK_RESP) - 1)
 
+static h2o_barrier_t init_barrier;
 void *upstream_thread(void *arg)
 {
     char *dirname = (char *)arg;
@@ -178,6 +179,7 @@ void *upstream_thread(void *arg)
         abort();
     }
 
+    h2o_barrier_wait(&init_barrier);
     while (1) {
         struct sockaddr_un caddr;
         socklen_t slen = 0;
@@ -339,6 +341,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         static char tmpname[] = "/tmp/h2o-fuzz-XXXXXX";
         char *dirname;
         h2o_url_t upstream;
+        h2o_barrier_init(&init_barrier, 2);
         signal(SIGPIPE, SIG_IGN);
 
         dirname = mkdtemp(tmpname);
@@ -382,6 +385,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         if (pthread_create(&tupstream, NULL, upstream_thread, dirname) != 0) {
             abort();
         }
+        h2o_barrier_wait(&init_barrier);
         init_done = 1;
     }
 


### PR DESCRIPTION
This fixes a race between upstream_thread and sending a request.
It's possible that a request is injected via `created_accepted` before
the socket pair in `upstream_thread` is created.
If that request causes h2o to close the connection, and the socketpair
is created in the interm, it's possible that the socketpair gets the
same fd number as the closed request.
This means that the `is_valid_fd` test down the line doesn't fail,
resulting in a timeout.

This should address the issue reported by oss-fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=8208