### PR TITLE
Don't die if the git command fails

### DIFF
--- a/misc/generate_gitrev.pl
+++ b/misc/generate_gitrev.pl
@@ -3,8 +3,7 @@ use strict;
 use warnings;
 
 my $gitrev = exec_git_command('git rev-parse --short HEAD') or die "failed to get current revision";
-my $gittag = exec_git_command("git tag --points-at $gitrev");
-my $content = $gittag ? '' : "#define H2O_GITREV $gitrev\n";
+my $content = "#define H2O_GITREV $gitrev\n";
 my $outpath = 'include/h2o/gitrev.h';
 
 my $current = -f $outpath ? do {

--- a/misc/generate_gitrev.pl
+++ b/misc/generate_gitrev.pl
@@ -21,9 +21,6 @@ if ($content ne $current) {
 sub exec_git_command {
     my ($cmd) = @_;
     my $out = `$cmd`;
-    if ($? != 0) {
-        die "failed to execute `$cmd`: $!";
-    }
     chomp $out;
     $out;
 }


### PR DESCRIPTION
The `git` command succeeding is optional for the mechanism to work, don't make the error fatal.