### PR TITLE
remove duplicate date headers

### DIFF
--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -915,9 +915,6 @@ static int send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_v
                                        generator->req) != 0) {
         return -1;
     }
-    /* add date: if it's missing from the response */
-    if (h2o_find_header(&generator->req->res.headers, H2O_TOKEN_DATE, SIZE_MAX) == -1)
-        h2o_resp_add_date_header(generator->req);
 
     /* return without processing body, if status is fallthru */
     if (generator->req->res.status == STATUS_FALLTHRU) {
@@ -929,6 +926,10 @@ static int send_response(h2o_mruby_generator_t *generator, mrb_int status, mrb_v
         }
         return 0;
     }
+
+    /* add date: if it's missing from the response */
+    if (h2o_find_header(&generator->req->res.headers, H2O_TOKEN_DATE, SIZE_MAX) == -1)
+        h2o_resp_add_date_header(generator->req);
 
     /* obtain body */
     body = mrb_ary_entry(resp, 2);

--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -78,6 +78,8 @@ EOT
         ($headers, $body) = $fetch->("/fallthru/");
         like $headers, qr{^HTTP/1\.1 200 OK\r\n}is;
         is md5_hex($body), md5_file("t/50mruby/index.html");
+        my @dates = $headers =~ /^date: .+?\r$/img;
+        is scalar(@dates), 1, 'duplicate date header';
     };
     subtest "echo" => sub {
         ($headers, $body) = $fetch->("/echo/abc?def");


### PR DESCRIPTION
Fixes #1777 and #1779. This bug is happen when mruby handler returns 399  (fallthru) and then file handler serves the response.
https://github.com/h2o/h2o/pull/1495 forces lets mruby handler fill date header, but after that the file handler does it too.