### PR TITLE
Fix uninitialized return

### DIFF
--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -317,7 +317,8 @@ static socklen_t parse_hostport(h2o_mem_pool_t *pool, h2o_iovec_t host, h2o_iove
                 4 &&
             parsed_len == host.len && d1 <= UCHAR_MAX && d2 <= UCHAR_MAX && d3 <= UCHAR_MAX && d4 <= UCHAR_MAX) {
             if (sscanf(port.base, "%" SCNd32 "%n", &_port, &parsed_len) == 1 && parsed_len == port.len && _port <= USHRT_MAX) {
-                struct sockaddr_in sin = {};
+                struct sockaddr_in sin;
+                memset(&sin, 0, sizeof(sin));
                 sin.sin_family = AF_INET;
                 sin.sin_port = htons(_port);
                 sin.sin_addr.s_addr = ntohl((d1 << 24) + (d2 << 16) + (d3 << 8) + d4);

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -317,7 +317,7 @@ static socklen_t parse_hostport(h2o_mem_pool_t *pool, h2o_iovec_t host, h2o_iove
                 4 &&
             parsed_len == host.len && d1 <= UCHAR_MAX && d2 <= UCHAR_MAX && d3 <= UCHAR_MAX && d4 <= UCHAR_MAX) {
             if (sscanf(port.base, "%" SCNd32 "%n", &_port, &parsed_len) == 1 && parsed_len == port.len && _port <= USHRT_MAX) {
-                struct sockaddr_in sin;
+                struct sockaddr_in sin = {};
                 sin.sin_family = AF_INET;
                 sin.sin_port = htons(_port);
                 sin.sin_addr.s_addr = ntohl((d1 << 24) + (d2 << 16) + (d3 << 8) + d4);


### PR DESCRIPTION
`struct sockaddr_in` also has a `sin_zero` member that needs to be
initialized

Coverity CID 1469824