### PR TITLE
Trailers are sent with the body on error

### DIFF
--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -63,6 +63,9 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     if (req->version == 0x200) {
         /* ok */
     } else if (0x101 <= req->version && req->version < 0x200) {
+        /* current chunking code disables chunking for non-200 statuses */
+        if (req->res.status != 200)
+            goto Next;
         if (self->enforce) {
             req->res.content_length = SIZE_MAX;
         } else {


### PR DESCRIPTION
The chunking code disables chunking if the status is not 200, but this
is done after the server-timing code runs. This results in sending the
trailer as part of the body for 404 errors, in `enforce` mode. For example:

```
<= Recv header, 29 bytes (0x1d)
0000: HTTP/1.1 404 File Not Found
<= Recv header, 19 bytes (0x13)
0000: Connection: close
<= Recv header, 32 bytes (0x20)
0000: Server: h2o/2.3.0-DEV@7112c45c
<= Recv header, 41 bytes (0x29)
0000: content-type: text/plain; charset=utf-8
<= Recv header, 24 bytes (0x18)
0000: trailer: server-timing
<= Recv header, 117 bytes (0x75)
0000: server-timing: connect; dur=0.091, request-header; dur=0, reques
0040: t-body; dur=0, request-total; dur=0, process; dur=0
<= Recv header, 2 bytes (0x2)
0000:
<= Recv data, 57 bytes (0x39)
0000: not foundserver-timing: response; dur=0, total; dur=0
0037:
== Info: Closing connection 0
```