### PR TITLE
Commented out debug mode for performance gain

### DIFF
--- a/deps/mruby/build_config.rb
+++ b/deps/mruby/build_config.rb
@@ -8,7 +8,8 @@ MRuby::Build.new do |conf|
     toolchain :gcc
   end
 
-  enable_debug
+  # Uncomment enable_debug for development
+  # enable_debug
 
   # Use mrbgems
   # conf.gem 'examples/mrbgems/ruby_extension_example'
@@ -94,7 +95,8 @@ MRuby::Build.new('host-debug') do |conf|
     toolchain :gcc
   end
 
-  enable_debug
+  # Uncomment enable_debug for development
+  # enable_debug
 
   # include the default GEMs
   conf.gembox 'default'
@@ -117,7 +119,8 @@ MRuby::Build.new('test') do |conf|
     toolchain :gcc
   end
 
-  enable_debug
+  # Uncomment enable_debug for development
+  # enable_debug
   conf.enable_bintest
   conf.enable_test
 


### PR DESCRIPTION
Should we comment out as discussed by this finding?
https://github.com/mruby/mruby/issues/4045

Or should we have a better approach to notify user about MRuby will be compile in debug or production mode during H2O CMake?

Love to know how much impact in benchmark in plaintext and json test between the 2 modes.