### PR TITLE
fix broken trailers issue

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1128,9 +1128,13 @@ struct st_h2o_req_t {
      */
     unsigned char reprocess_if_too_early : 1;
     /**
-     * whether if the response should include server-timing
+     * whether if the response should include server-timing header
      */
-    unsigned char send_server_timing : 1;
+    unsigned char send_server_timing_header : 1;
+    /**
+     * whether if the response should include server-timing trailer
+     */
+    unsigned char send_server_timing_trailer : 1;
     /**
      * whether the request is a subrequest
      */

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -89,13 +89,11 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
         goto NextWithoutTrailer;
     else if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
         goto NextWithoutTrailer;
+
     /* we cannot handle certain responses (like 101 switching protocols) */
     if (req->res.status != 200) {
         req->http1_is_persistent = 0;
     }
-    /* skip if content-encoding header is being set */
-    if (h2o_find_header(&req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, -1) != -1)
-        goto NextWithoutTrailer;
 
     /* set content-encoding header */
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, NULL, H2O_STRLIT("chunked"));

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -89,7 +89,6 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
     /* we cannot handle certain responses (like 101 switching protocols) */
     if (req->res.status != 200) {
         req->http1_is_persistent = 0;
-        goto Next;
     }
     /* skip if content-encoding header is being set */
     if (h2o_find_header(&req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, -1) != -1)

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -78,9 +78,12 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
     if (req->is_subrequest)
         goto Next;
 
-    /* do nothing if not HTTP/1.1 */
-    if (req->version != 0x101)
+    /* do nothing with HTTP/2 */
+    if (req->version >= 0x200)
         goto Next;
+    /* do nothing with HTTP/1.0, but drop trailer flag */
+    if (req->version != 0x101)
+        goto NextWithoutTrailer;
     /* do nothing if content-length is known */
     if (req->res.content_length != SIZE_MAX)
         goto NextWithoutTrailer;

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -51,12 +51,12 @@ static void send_chunk(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         outbufcnt += inbufcnt;
         if (state != H2O_SEND_STATE_ERROR) {
             outbufs[outbufcnt].base = "\r\n0\r\n\r\n";
-            outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? (req->send_server_timing ? 5 : 7) : 2;
+            outbufs[outbufcnt].len = state == H2O_SEND_STATE_FINAL ? (req->send_server_timing_trailer ? 5 : 7) : 2;
             outbufcnt++;
         }
     } else if (state == H2O_SEND_STATE_FINAL) {
         outbufs[outbufcnt].base = "0\r\n\r\n";
-        outbufs[outbufcnt].len = req->send_server_timing ? 3 : 5;
+        outbufs[outbufcnt].len = req->send_server_timing_trailer ? 3 : 5;
         outbufcnt++;
     }
 
@@ -78,21 +78,24 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
     if (req->is_subrequest)
         goto Next;
 
-    /* do nothing if not HTTP/1.1 or content-length is known */
-    if (req->res.content_length != SIZE_MAX || req->version != 0x101)
+    /* do nothing if not HTTP/1.1 */
+    if (req->version != 0x101)
         goto Next;
+    /* do nothing if content-length is known */
+    if (req->res.content_length != SIZE_MAX)
+        goto NextWithoutTrailer;
     /* RFC 2616 4.4 states that the following status codes (and response to a HEAD method) should not include message body */
     if ((100 <= req->res.status && req->res.status <= 199) || req->res.status == 204 || req->res.status == 304)
-        goto Next;
+        goto NextWithoutTrailer;
     else if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
-        goto Next;
+        goto NextWithoutTrailer;
     /* we cannot handle certain responses (like 101 switching protocols) */
     if (req->res.status != 200) {
         req->http1_is_persistent = 0;
     }
     /* skip if content-encoding header is being set */
     if (h2o_find_header(&req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, -1) != -1)
-        goto Next;
+        goto NextWithoutTrailer;
 
     /* set content-encoding header */
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, NULL, H2O_STRLIT("chunked"));
@@ -104,7 +107,10 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
     encoder = (void *)h2o_add_ostream(req, H2O_ALIGNOF(*encoder), sizeof(*encoder), slot);
     encoder->super.do_send = send_chunk;
     slot = &encoder->super.next;
+    goto Next;
 
+NextWithoutTrailer:
+    req->send_server_timing_trailer = 0;
 Next:
     h2o_setup_next_ostream(req, slot);
 }

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -86,10 +86,6 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
         goto Next;
     else if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
         goto Next;
-    /* we cannot handle certain responses (like 101 switching protocols) */
-    if (req->res.status != 200) {
-        req->http1_is_persistent = 0;
-    }
     /* skip if content-encoding header is being set */
     if (h2o_find_header(&req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, -1) != -1)
         goto Next;

--- a/lib/handler/chunked.c
+++ b/lib/handler/chunked.c
@@ -86,6 +86,10 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
         goto Next;
     else if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
         goto Next;
+    /* we cannot handle certain responses (like 101 switching protocols) */
+    if (req->res.status != 200) {
+        req->http1_is_persistent = 0;
+    }
     /* skip if content-encoding header is being set */
     if (h2o_find_header(&req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, -1) != -1)
         goto Next;

--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -76,7 +76,8 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     }
 
     /* indicate the protocol handler to emit server timing */
-    req->send_server_timing = 1;
+    req->send_server_timing_header = 1;
+    req->send_server_timing_trailer = 1;
 
 Next:
     h2o_setup_next_ostream(req, slot);

--- a/lib/handler/server_timing.c
+++ b/lib/handler/server_timing.c
@@ -60,6 +60,10 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
 {
     struct st_server_timing_filter_t *self = (struct st_server_timing_filter_t *)_self;
 
+    /* indicate the protocol handler to emit server timing header */
+    req->send_server_timing_header = 1;
+
+    /* some checks before adding server-timing trailer */
     if (req->version == 0x200) {
         /* ok */
     } else if (0x101 <= req->version && req->version < 0x200) {
@@ -74,9 +78,6 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     } else {
         goto Next;
     }
-
-    /* indicate the protocol handler to emit server timing */
-    req->send_server_timing_header = 1;
     req->send_server_timing_trailer = 1;
 
 Next:

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -726,8 +726,6 @@ static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb
     assert(!conn->_ostr_final.sent_headers);
 
     conn->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
-    if (conn->req.res.status != 200)
-        conn->req.http1_is_persistent = 0;
     if (conn->req.send_server_timing)
         h2o_add_server_timing_header(&conn->req);
 
@@ -785,8 +783,6 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
 
     if (!self->sent_headers) {
         conn->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
-        if (req->res.status != 200)
-            req->http1_is_persistent = 0;
         if (conn->req.send_server_timing)
             h2o_add_server_timing_header(&conn->req);
         /* build headers and send */

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -726,6 +726,8 @@ static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb
     assert(!conn->_ostr_final.sent_headers);
 
     conn->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
+    if (conn->req.res.status != 200)
+        conn->req.http1_is_persistent = 0;
     if (conn->req.send_server_timing)
         h2o_add_server_timing_header(&conn->req);
 
@@ -783,6 +785,8 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
 
     if (!self->sent_headers) {
         conn->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
+        if (req->res.status != 200)
+            req->http1_is_persistent = 0;
         if (conn->req.send_server_timing)
             h2o_add_server_timing_header(&conn->req);
         /* build headers and send */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1206,7 +1206,7 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
             *still_is_active = 1;
         }
     } else {
-        if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM && stream->req.send_server_timing) {
+        if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM && stream->req.send_server_timing_trailer) {
             h2o_header_t trailers[1];
             size_t num_trailers = 0;
             h2o_iovec_t server_timing;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -123,7 +123,7 @@ static void commit_data_header(h2o_http2_conn_t *conn, h2o_http2_stream_t *strea
     if (length || send_state == H2O_SEND_STATE_FINAL) {
         h2o_http2_encode_frame_header(
             (void *)((*outbuf)->bytes + (*outbuf)->size), length, H2O_HTTP2_FRAME_TYPE_DATA,
-            (send_state == H2O_SEND_STATE_FINAL && !stream->req.send_server_timing) ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0,
+            (send_state == H2O_SEND_STATE_FINAL && !stream->req.send_server_timing_trailer) ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0,
             stream->stream_id);
         h2o_http2_window_consume_window(&conn->_write.window, length);
         h2o_http2_window_consume_window(&stream->output_window, length);
@@ -295,7 +295,7 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     if (h2o_http2_stream_is_push(stream->stream_id))
         h2o_add_header_by_str(&stream->req.pool, &stream->req.res.headers, H2O_STRLIT("x-http2-push"), 0, NULL,
                               H2O_STRLIT("pushed"));
-    if (stream->req.send_server_timing)
+    if (stream->req.send_server_timing_header)
         h2o_add_server_timing_header(&stream->req);
     h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
                                conn->peer_settings.max_frame_size, &stream->req.res, &conn->super.ctx->globalconf->server_name,
@@ -434,7 +434,7 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
     }
 
     if (send_state == H2O_SEND_STATE_ERROR) {
-        stream->req.send_server_timing = 0;
+        stream->req.send_server_timing_trailer = 0;
     }
 }
 

--- a/t/50server-timing.t
+++ b/t/50server-timing.t
@@ -41,6 +41,8 @@ EOT
     subtest 'http1' => sub {
         my ($sts) = nc_get($server, '/', 1);
         is scalar(@$sts), 2, 'header and trailer';
+        ok defined($sts->[0]->{connect});
+        ok defined($sts->[1]->{total});
         $check->(@$sts);
     
     };
@@ -48,11 +50,13 @@ EOT
     subtest 'http2' => sub {
         my ($sts) = nghttp_get($server, '/');
         is scalar(@$sts), 2, 'header and trailer';
+        ok defined($sts->[0]->{connect});
+        ok defined($sts->[1]->{total});
         $check->(@$sts);
     };
 };
 
-subtest 'disabled' => sub {
+subtest 'disabled trailer' => sub {
     my $server = spawn_h2o(<< "EOT");
 hosts:
   default:
@@ -63,18 +67,22 @@ hosts:
 EOT
 
     subtest 'no te header' => sub {
-        my ($sts) = nc_get($server, '/');
-        is scalar(@$sts), 0, 'no server timing';
+        my ($sts) = nc_get($server, '/', 0);
+        is scalar(@$sts), 1, 'no server timing trailer';
+        ok defined($sts->[0]->{connect});
     };
 
     subtest 'not chunked encoding' => sub {
-        my ($sts) = nc_get($server, '/');
-        is scalar(@$sts), 0, 'no server timing';
+        my ($sts) = nc_get($server, '/', 1);
+        is scalar(@$sts), 1, 'no server timing trailer';
+        ok defined($sts->[0]->{connect});
     };
     
     subtest 'http2 is always ok' => sub {
         my ($sts) = nghttp_get($server, '/');
         is scalar(@$sts), 2, 'header and trailer';
+        ok defined($sts->[0]->{connect});
+        ok defined($sts->[1]->{total});
     };
 };
 
@@ -89,7 +97,7 @@ hosts:
 EOT
 
     subtest 'http1' => sub {
-        my ($sts) = nc_get($server, '/');
+        my ($sts) = nc_get($server, '/', 0);
         is scalar(@$sts), 2, 'header and trailer';
     };
     
@@ -117,6 +125,8 @@ hosts:
 EOT
     my ($sts, $raw) = nc_get($server, '/', 1);
     is scalar(@$sts), 2;
+    ok defined($sts->[0]->{connect});
+    ok defined($sts->[1]->{total});
     unlike $raw, qr{not foundserver-timing}i;
 };
 


### PR DESCRIPTION
Regarding https://github.com/h2o/h2o/pull/1790, I thought that the source of problem is rather chunked.c, not server-timing.c. I couldn't find any reasons to disable chunked encoding when the status is not 200, so this PR removes that behavior. Additionally I moved some code from chunked.c to http1.c.

@deweerdt Can this PR solve your issue?