### PR TITLE
http2-allow-cross-origin-push

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -303,6 +303,10 @@ struct st_h2o_hostconf_t {
          */
         unsigned push_preload : 1;
         /**
+         * if cross origin pushes should be authorized
+         */
+        unsigned allow_cross_origin_push : 1;
+        /**
          * casper settings
          */
         h2o_casper_conf_t casper;
@@ -1306,7 +1310,7 @@ void h2o_extract_push_path_from_link_header(h2o_mem_pool_t *pool, const char *va
                                             const h2o_url_scheme_t *input_scheme, h2o_iovec_t input_authority,
                                             const h2o_url_scheme_t *base_scheme, h2o_iovec_t *base_authority,
                                             void (*cb)(void *ctx, const char *path, size_t path_len, int is_critical), void *cb_ctx,
-                                            h2o_iovec_t *filtered_value);
+                                            h2o_iovec_t *filtered_value, int allow_cross_origin_push);
 /**
  * return a bitmap of compressible types, by parsing the `accept-encoding` header
  */

--- a/include/h2o/socket/uv-binding.h
+++ b/include/h2o/socket/uv-binding.h
@@ -23,6 +23,7 @@
 #define h2o__uv_binding_h
 
 #include <uv.h>
+#include <sys/time.h>
 
 #if !(defined(UV_VERSION_MAJOR) && UV_VERSION_MAJOR == 1)
 #error "libh2o (libuv binding) requires libuv version 1.x.y"

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -30,6 +30,7 @@ struct st_core_config_vars_t {
     struct {
         unsigned reprioritize_blocking_assets : 1;
         unsigned push_preload : 1;
+        unsigned allow_cross_origin_push : 1;
         h2o_casper_conf_t casper;
     } http2;
     struct {
@@ -84,6 +85,7 @@ static int on_core_exit(h2o_configurator_t *_self, h2o_configurator_context_t *c
         /* exitting from host-level configuration */
         ctx->hostconf->http2.reprioritize_blocking_assets = self->vars->http2.reprioritize_blocking_assets;
         ctx->hostconf->http2.push_preload = self->vars->http2.push_preload;
+        ctx->hostconf->http2.allow_cross_origin_push = self->vars->http2.allow_cross_origin_push;
         ctx->hostconf->http2.casper = self->vars->http2.casper;
     } else if (ctx->pathconf != NULL) {
         /* exitting from path or extension-level configuration */
@@ -497,6 +499,18 @@ static int on_config_http2_push_preload(h2o_configurator_command_t *cmd, h2o_con
     if ((on = h2o_configurator_get_one_of(cmd, node, "OFF,ON")) == -1)
         return -1;
     self->vars->http2.push_preload = (int)on;
+
+    return 0;
+}
+
+static int on_config_http2_allow_cross_origin_push(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct st_core_configurator_t *self = (void *)cmd->configurator;
+    ssize_t on;
+
+    if ((on = h2o_configurator_get_one_of(cmd, node, "OFF,ON")) == -1)
+        return -1;
+    self->vars->http2.allow_cross_origin_push = (int)on;
 
     return 0;
 }
@@ -964,6 +978,10 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_push_preload);
+        h2o_configurator_define_command(&c->super, "http2-allow-cross-origin-push",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST |
+                                            H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http2_allow_cross_origin_push);
         h2o_configurator_define_command(&c->super, "http2-casper", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST,
                                         on_config_http2_casper);
         h2o_configurator_define_command(&c->super, "file.mime.settypes",

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -979,7 +979,7 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
                                             H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_push_preload);
         h2o_configurator_define_command(&c->super, "http2-allow-cross-origin-push",
-                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST |
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_PATH |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http2_allow_cross_origin_push);
         h2o_configurator_define_command(&c->super, "http2-casper", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST,

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -751,7 +751,8 @@ h2o_iovec_t h2o_push_path_in_link_header(h2o_req_t *req, const char *value, size
 
     h2o_extract_push_path_from_link_header(&req->pool, value, value_len, req->path_normalized, req->input.scheme,
                                            req->input.authority, req->res_is_delegated ? req->scheme : NULL,
-                                           req->res_is_delegated ? &req->authority : NULL, do_push_path, req, &ret);
+                                           req->res_is_delegated ? &req->authority : NULL, do_push_path, req, &ret,
+                                           req->hostconf->http2.allow_cross_origin_push);
 
     return ret;
 }

--- a/srcdoc/configure/http2_directives.mt
+++ b/srcdoc/configure/http2_directives.mt
@@ -369,6 +369,19 @@ EOT
 )->(sub {});
 ?>
 
+<?
+$ctx->{directive}->(
+    name    => "http2-allow-cross-origin-push",
+    levels  => [ qw(global host) ],
+    since   => '2.3',
+    default => 'http2-allow-cross-origin-push: OFF',
+    desc    => << 'EOT',
+A boolean flag (<code>ON</code> or <code>OFF</code>) indicating whether if the server should push resources belonging to a different authority.
+EOT
+)->(sub {
+?>
+? })
+
 ? })
 
 ? })

--- a/srcdoc/configure/http2_directives.mt
+++ b/srcdoc/configure/http2_directives.mt
@@ -372,7 +372,7 @@ EOT
 <?
 $ctx->{directive}->(
     name    => "http2-allow-cross-origin-push",
-    levels  => [ qw(global host) ],
+    levels  => [ qw(global path) ],
     since   => '2.3',
     default => 'http2-allow-cross-origin-push: OFF',
     desc    => << 'EOT',

--- a/t/00unit/lib/core/util.c
+++ b/t/00unit/lib/core/util.c
@@ -93,7 +93,7 @@ static void test_extract_push_path_from_link_header(void)
         h2o_iovec_t input = h2o_iovec_init(_input, strlen(_input)), filtered;                                                      \
         struct expected_t expected[] = {__VA_ARGS__, {NULL}}, *e = expected;                                                       \
         h2o_extract_push_path_from_link_header(&pool, input.base, input.len, base_path, &H2O_URL_SCHEME_HTTP, input_authority,     \
-                                               _base_scheme, _base_authority, check_path, &e, &filtered);                          \
+                                               _base_scheme, _base_authority, check_path, &e, &filtered, 0);                       \
         ok(e->path == NULL);                                                                                                       \
         if (_filtered_expected != NULL) {                                                                                          \
             ok(h2o_memis(filtered.base, filtered.len, _filtered_expected, strlen(_filtered_expected)));                            \


### PR DESCRIPTION
This toggle allows H2O to push resources even if the authority doesn't
match the one in the pushed stream. It's up to the administrator to
determine whether this is a safe setting or not.