### PR TITLE
Fix for ssl_setup function in some libh2o examples

### DIFF
--- a/examples/libh2o/latency-optimization.c
+++ b/examples/libh2o/latency-optimization.c
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
         OpenSSL_add_all_algorithms();
         if (mode_server) {
             ssl_ctx = SSL_CTX_new(SSLv23_server_method());
-            SSL_CTX_use_certificate_file(ssl_ctx, "examples/h2o/server.crt", SSL_FILETYPE_PEM);
+            SSL_CTX_use_certificate_chain_file(ssl_ctx, "examples/h2o/server.crt");
             SSL_CTX_use_PrivateKey_file(ssl_ctx, "examples/h2o/server.key", SSL_FILETYPE_PEM);
         } else {
             ssl_ctx = SSL_CTX_new(SSLv23_client_method());

--- a/examples/libh2o/simple.c
+++ b/examples/libh2o/simple.c
@@ -200,7 +200,7 @@ static int setup_ssl(const char *cert_file, const char *key_file, const char *ci
 #endif
 
     /* load certificate and private key */
-    if (SSL_CTX_use_certificate_file(accept_ctx.ssl_ctx, cert_file, SSL_FILETYPE_PEM) != 1) {
+    if (SSL_CTX_use_certificate_chain_file(accept_ctx.ssl_ctx, cert_file) != 1) {
         fprintf(stderr, "an error occurred while trying to load server certificate file:%s\n", cert_file);
         return -1;
     }

--- a/examples/libh2o/websocket.c
+++ b/examples/libh2o/websocket.c
@@ -66,7 +66,7 @@ static int setup_ssl(const char *cert_file, const char *key_file)
     SSL_CTX_set_options(accept_ctx.ssl_ctx, SSL_OP_NO_SSLv2);
 
     /* load certificate and private key */
-    if (SSL_CTX_use_certificate_file(accept_ctx.ssl_ctx, cert_file, SSL_FILETYPE_PEM) != 1) {
+    if (SSL_CTX_use_certificate_chain_file(accept_ctx.ssl_ctx, cert_file) != 1) {
         fprintf(stderr, "an error occurred while trying to load server certificate file:%s\n", cert_file);
         return -1;
     }


### PR DESCRIPTION
Usages of  `SSL_CTX_use_certificate_file ` function in these examples were causing silent problems when used with fullchain PEM files of letsencrypt.
Because this function adds only the first certificate in the PEM file, root certificate is ignored and causing javax.net.ssl.SSLHandshakeException: java.security.cert.CertPathValidatorException: Trust anchor for certification path not found."... error when loaded with android devices.
Even note section on [openssl documentation](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_use_certificate.html) was indicating that '`SSL_CTX_use_certificate_chain_file` should be preferred'.