### PR TITLE
Invalid status json with multiple status endpoints

### DIFF
--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -265,9 +265,10 @@ void h2o_status_register(h2o_pathconf_t *conf)
     self->super.on_context_init = on_context_init;
     self->super.on_context_dispose = on_context_dispose;
     self->super.on_req = on_req;
-    if (!handler_registered++) {
+    if (!handler_registered) {
+        handler_registered++;
         h2o_config_register_status_handler(conf->global, requests_status_handler);
         h2o_config_register_status_handler(conf->global, events_status_handler);
         h2o_config_register_status_handler(conf->global, durations_status_handler);
-    }   
+    }
 }

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -260,11 +260,14 @@ static void on_context_dispose(h2o_handler_t *_self, h2o_context_t *ctx)
 
 void h2o_status_register(h2o_pathconf_t *conf)
 {
+    static int handler_registered = 0;
     struct st_h2o_root_status_handler_t *self = (void *)h2o_create_handler(conf, sizeof(*self));
     self->super.on_context_init = on_context_init;
     self->super.on_context_dispose = on_context_dispose;
     self->super.on_req = on_req;
-    h2o_config_register_status_handler(conf->global, requests_status_handler);
-    h2o_config_register_status_handler(conf->global, events_status_handler);
-    h2o_config_register_status_handler(conf->global, durations_status_handler);
+    if (!handler_registered++) {
+        h2o_config_register_status_handler(conf->global, requests_status_handler);
+        h2o_config_register_status_handler(conf->global, events_status_handler);
+        h2o_config_register_status_handler(conf->global, durations_status_handler);
+    }   
 }

--- a/t/50status.t
+++ b/t/50status.t
@@ -84,6 +84,25 @@ EOT
 };
 
 
+subtest "json internal request bug (duplication of durations and events)" => sub {
+    my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        << "EOT";
+duration-stats: ON
+hosts:
+  default:
+    paths:
+      /server-status:
+        status: ON
+      /server-status2:
+        status: ON
+EOT
+    });
+
+    my $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/server-status/json?show=durations,events,main' 2>&1 > /dev/null`;
+    is scalar @{[ $resp =~ m!"status-errors.400":!g ]}, 1, "only once";
+    is scalar @{[ $resp =~ m!"connect-time-0":!g ]}, 1, "only once";
+};
 
 
 done_testing();

--- a/t/50status.t
+++ b/t/50status.t
@@ -99,9 +99,17 @@ hosts:
 EOT
     });
 
-    my $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/server-status/json?show=durations,events,main' 2>&1 > /dev/null`;
-    is scalar @{[ $resp =~ m!"status-errors.400":!g ]}, 1, "only once";
-    is scalar @{[ $resp =~ m!"connect-time-0":!g ]}, 1, "only once";
+    {
+        my $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/server-status/json?show=durations,events,main' 2>&1 > /dev/null`;
+        is scalar @{[ $resp =~ m!"status-errors.400":!g ]}, 1, "only once";
+        is scalar @{[ $resp =~ m!"connect-time-0":!g ]}, 1, "only once";
+    }
+
+    {
+        my $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/server-status2/json?show=durations,events,main' 2>&1 > /dev/null`;
+        is scalar @{[ $resp =~ m!"status-errors.400":!g ]}, 1, "only once";
+        is scalar @{[ $resp =~ m!"connect-time-0":!g ]}, 1, "only once";
+    }
 };
 
 


### PR DESCRIPTION
Following config produce invalid duplicated json:

```
hosts:
  default:
    paths:
      /server-status:
        status: ON
      /server-status2:
        status: ON
```
