### PR TITLE
Deprecate Next Protocol Negotiation (NPN).

### DIFF
--- a/examples/libh2o/simple.c
+++ b/examples/libh2o/simple.c
@@ -215,9 +215,6 @@ static int setup_ssl(const char *cert_file, const char *key_file, const char *ci
     }
 
 /* setup protocol negotiation methods */
-#if H2O_USE_NPN
-    h2o_ssl_register_npn_protocols(accept_ctx.ssl_ctx, h2o_http2_npn_protocols);
-#endif
 #if H2O_USE_ALPN
     h2o_ssl_register_alpn_protocols(accept_ctx.ssl_ctx, h2o_http2_alpn_protocols);
 #endif

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1262,8 +1262,6 @@ ssize_t h2o_delete_header(h2o_headers_t *headers, ssize_t cursor);
 
 /* util */
 
-extern const char *h2o_http2_npn_protocols;
-extern const char *h2o_npn_protocols;
 extern const h2o_iovec_t *h2o_http2_alpn_protocols;
 extern const h2o_iovec_t *h2o_alpn_protocols;
 

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -26,7 +26,6 @@
 extern "C" {
 #endif
 
-extern const char *h2o_http2_npn_protocols;
 extern const h2o_iovec_t *h2o_http2_alpn_protocols;
 
 extern const h2o_protocol_callbacks_t H2O_HTTP2_CALLBACKS;

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -44,13 +44,8 @@ extern "C" {
 
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L
 #define H2O_USE_ALPN 1
-#define H2O_USE_NPN 1
-#elif OPENSSL_VERSION_NUMBER >= 0x10001000L
-#define H2O_USE_ALPN 0
-#define H2O_USE_NPN 1
 #else
 #define H2O_USE_ALPN 0
-#define H2O_USE_NPN 0
 #endif
 
 typedef struct st_h2o_sliding_counter_t {
@@ -301,7 +296,7 @@ void h2o_socket_ssl_async_resumption_init(h2o_socket_ssl_resumption_get_async_cb
  */
 void h2o_socket_ssl_async_resumption_setup_ctx(SSL_CTX *ctx);
 /**
- * returns the name of the protocol selected using either NPN or ALPN (ALPN has the precedence).
+ * returns the name of the protocol selected using ALPN
  * @param sock the socket
  */
 h2o_iovec_t h2o_socket_ssl_get_selected_protocol(h2o_socket_t *sock);
@@ -333,10 +328,6 @@ void h2o_socket_ssl_destroy_session_cache_entry(h2o_iovec_t value);
  * registers the protocol list to be used for ALPN
  */
 void h2o_ssl_register_alpn_protocols(SSL_CTX *ctx, const h2o_iovec_t *protocols);
-/**
- * registers the protocol list to be used for NPN
- */
-void h2o_ssl_register_npn_protocols(SSL_CTX *ctx, const char *protocols);
 
 void h2o_socket__write_pending(h2o_socket_t *sock);
 void h2o_socket__write_on_complete(h2o_socket_t *sock, int status);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -100,7 +100,6 @@ struct st_h2o_socket_ssl_t {
 struct st_h2o_ssl_context_t {
     SSL_CTX *ctx;
     const h2o_iovec_t *protocols;
-    h2o_iovec_t _npn_list_of_protocols;
 };
 
 /* backend functions */
@@ -1352,10 +1351,6 @@ h2o_iovec_t h2o_socket_ssl_get_selected_protocol(h2o_socket_t *sock)
     if (len == 0)
         SSL_get0_alpn_selected(sock->ssl->ossl, &data, &len);
 #endif
-#if H2O_USE_NPN
-    if (len == 0)
-        SSL_get0_next_proto_negotiated(sock->ssl->ossl, &data, &len);
-#endif
 
     return h2o_iovec_init(data, len);
 }
@@ -1405,22 +1400,6 @@ Found:
 void h2o_ssl_register_alpn_protocols(SSL_CTX *ctx, const h2o_iovec_t *protocols)
 {
     SSL_CTX_set_alpn_select_cb(ctx, on_alpn_select, (void *)protocols);
-}
-
-#endif
-
-#if H2O_USE_NPN
-
-static int on_npn_advertise(SSL *ssl, const unsigned char **out, unsigned *outlen, void *protocols)
-{
-    *out = protocols;
-    *outlen = (unsigned)strlen(protocols);
-    return SSL_TLSEXT_ERR_OK;
-}
-
-void h2o_ssl_register_npn_protocols(SSL_CTX *ctx, const char *protocols)
-{
-    SSL_CTX_set_next_protos_advertised_cb(ctx, on_npn_advertise, (void *)protocols);
 }
 
 #endif

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -899,23 +899,12 @@ h2o_iovec_t h2o_build_server_timing_trailer(h2o_req_t *req, const char *prefix, 
         H2O_STRLIT(s)                                                                                                              \
     }
 #define ALPN_PROTOCOLS_CORE ALPN_ENTRY("h2"), ALPN_ENTRY("h2-16"), ALPN_ENTRY("h2-14")
-#define NPN_PROTOCOLS_CORE                                                                                                         \
-    "\x02"                                                                                                                         \
-    "h2"                                                                                                                           \
-    "\x05"                                                                                                                         \
-    "h2-16"                                                                                                                        \
-    "\x05"                                                                                                                         \
-    "h2-14"
 
 static const h2o_iovec_t http2_alpn_protocols[] = {ALPN_PROTOCOLS_CORE, {NULL}};
 const h2o_iovec_t *h2o_http2_alpn_protocols = http2_alpn_protocols;
 
 static const h2o_iovec_t alpn_protocols[] = {ALPN_PROTOCOLS_CORE, {H2O_STRLIT("http/1.1")}, {NULL}};
 const h2o_iovec_t *h2o_alpn_protocols = alpn_protocols;
-
-const char *h2o_http2_npn_protocols = NPN_PROTOCOLS_CORE;
-const char *h2o_npn_protocols = NPN_PROTOCOLS_CORE "\x08"
-                                                   "http/1.1";
 
 uint64_t h2o_connection_id = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -739,9 +739,6 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
     }
 
 /* setup protocol negotiation methods */
-#if H2O_USE_NPN
-    h2o_ssl_register_npn_protocols(ssl_ctx, h2o_npn_protocols);
-#endif
 #if H2O_USE_ALPN
     h2o_ssl_register_alpn_protocols(ssl_ctx, h2o_alpn_protocols);
 #endif


### PR DESCRIPTION
If H2O 2.3.0 is released with NPN support, we won't be able to remove it in 2.3.x for compatibility. (well, do we need to wait for 3.0.0 for the sake of Semantic Versioning?)

I am afraid that this might lead to new failures in fuzzing but I don't know.

Closes https://github.com/h2o/h2o/issues/1712