### PR TITLE
clean up buildchain linuxisms & update FreeBSD URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,7 +636,7 @@ IF(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/deps/theft/Makefile)
                         SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/deps/theft"
                         BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/theft"
                         CONFIGURE_COMMAND "true"
-                        BUILD_COMMAND cd "${CMAKE_CURRENT_SOURCE_DIR}/deps/theft" && make "BUILD=${CMAKE_CURRENT_BINARY_DIR}/theft"
+                        BUILD_COMMAND cd "${CMAKE_CURRENT_SOURCE_DIR}/deps/theft" && ${CMAKE_MAKE_PROGRAM} "BUILD=${CMAKE_CURRENT_BINARY_DIR}/theft"
                         INSTALL_COMMAND "true")
     SET_TARGET_PROPERTIES(build-theft PROPERTIES EXCLUDE_FROM_ALL TRUE)
     LINK_DIRECTORIES("${CMAKE_CURRENT_BINARY_DIR}/theft")
@@ -669,12 +669,12 @@ IF (LIBUV_FOUND)
     ADD_DEPENDENCIES(check t-00unit-libuv.t lib-examples)
 ENDIF ()
 
-ADD_CUSTOM_TARGET(doc make -f ../misc/doc.mk all BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
+ADD_CUSTOM_TARGET(doc ${CMAKE_MAKE_PROGRAM} -f ../misc/doc.mk all BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc
     DEPENDS h2o)
-ADD_CUSTOM_TARGET(doc-clean make -f ../misc/doc.mk clean
+ADD_CUSTOM_TARGET(doc-clean ${CMAKE_MAKE_PROGRAM} -f ../misc/doc.mk clean
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc)
-ADD_CUSTOM_TARGET(doc-publish make -f ../misc/doc.mk publish BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
+ADD_CUSTOM_TARGET(doc-publish ${CMAKE_MAKE_PROGRAM} -f ../misc/doc.mk publish BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc
     DEPENDS h2o)
 
@@ -685,7 +685,7 @@ IF (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get/CMakeLists.txt)
                         CONFIGURE_COMMAND ${CMAKE_COMMAND} -DH2GET_SSL_ROOT_DIR=${EXTERNALPROJECT_SSL_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get
                         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get
                         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/h2get_bin
-                        BUILD_COMMAND make
+                        BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
                         INSTALL_COMMAND true)
     SET_TARGET_PROPERTIES(h2get PROPERTIES EXCLUDE_FROM_ALL TRUE)
     ADD_DEPENDENCIES(check h2get)
@@ -695,7 +695,7 @@ ExternalProject_Add(picotls-cli
                     CONFIGURE_COMMAND ${CMAKE_COMMAND} -DOPENSSL_ROOT_DIR=${EXTERNALPROJECT_SSL_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/deps/picotls
                     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/deps/picotls
                     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/picotls
-                    BUILD_COMMAND make cli
+                    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} cli
                     INSTALL_COMMAND true)
 SET_TARGET_PROPERTIES(picotls-cli PROPERTIES EXCLUDE_FROM_ALL TRUE)
 ADD_DEPENDENCIES(check picotls-cli)

--- a/misc/cli2man.pl
+++ b/misc/cli2man.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/srcdoc/install.mt
+++ b/srcdoc/install.mt
@@ -11,7 +11,7 @@ Therefore you may try to at first install the software using your favorite packa
 <p>
 At the time being, following packages are known to be actively maintained<?= $ctx->{note}->(q{Please open a new issue on <a href="https://github.com/h2o/h2o">Github</a> if you want a new package to get added.}) ?>:
 <ul>
-<li><a href="http://portsmon.freebsd.org/portoverview.py?category=www&portname=h2o">FreeBSD</a></li>
+<li><a href="https://www.freshports.org/www/h2o">FreeBSD h2o release</a> and <a href="https://www.freshports.org/www/h2o-devel">h2o betas</a></li>
 <li><a href="http://brewformulas.org/H2o">Homebrew (OS X)</a></li>
 <li><a href="https://github.com/tatsushid/h2o-rpm">RPM (Fedora, RHEL/CentOS, OpenSUSE)</a></li>
 <li><a href="https://hub.docker.com/r/lkwg82/h2o-http2-server/">Docker Image</a></li>


### PR DESCRIPTION
minor changes

- fix the url for port status as it's defunct since months
- mention the additional beta port link maybe this could go somewhere else?

Also, I'm unable to generate the docs locally using the instructions in source, to check my changes. I'll commit a fix if somebody can clarify how that works today. Here's what I'm trying on FreeBSD:

```
git clone ...
cd h2o
git submodule update --recursive
mkdir _build
cd _build
cmake ..  -DCMAKE_INSTALL_PREFIX:PATH=/tmp/usr/local
...
[100%] Linking C executable h2o
[100%] Built target h2o
Scanning dependencies of target doc
mkdir -p doc/configure
../misc/oktavia/bin/oktavia-mkindex  -m html -u h2 -c 10 -t js -s english
Search Engine Oktavia - Index Generator

usage: oktavia_mkindex [options]

Common Options:
 -i, --input [input folder/file ] : Target files to search. .html, .csv, .txt are available.
...
make[4]: stopped in /repos/h2o/doc
*** Error code 2
```

If I append `-i .` and run oktavia manually, then we get further:

```
...

Source text size: 229714 bytes
Serializing FM-index
    Wavelet Matrix: 70586 bytes (70%)
    Dictionary Cache: 183792 bytes
Char Code Map: 198 bytes
Stemmed Word Table: 7519 bytes (53%)
Meta Data section: 5030 bytes (21%)
Meta Data tag: 4280 bytes (23%)
generated: /repos/h2o/doc/search/searchindex.js
make[4]: don't know how to make workdir/configure/quick_start.man. Stop

make[4]: stopped in /repos/h2o/doc
*** Error code 2
```
