### PR TITLE
avoid redundant registration of status handlers

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -319,14 +319,14 @@ typedef struct st_h2o_protocol_callbacks_t {
 } h2o_protocol_callbacks_t;
 
 typedef h2o_iovec_t (*final_status_handler_cb)(void *ctx, h2o_globalconf_t *gconf, h2o_req_t *req);
-typedef struct st_h2o_status_handler_t {
+typedef const struct st_h2o_status_handler_t {
     h2o_iovec_t name;
+    h2o_iovec_t (* final)(void *ctx, h2o_globalconf_t *gconf, h2o_req_t *req); /* mandatory, will be passed the optional context */
     void *(*init)(void); /* optional callback, allocates a context that will be passed to per_thread() */
     void (*per_thread)(void *priv, h2o_context_t *ctx); /* optional callback, will be called for each thread */
-    h2o_iovec_t (* final)(void *ctx, h2o_globalconf_t *gconf, h2o_req_t *req); /* mandatory, will be passed the optional context */
 } h2o_status_handler_t;
 
-typedef H2O_VECTOR(h2o_status_handler_t) h2o_status_callbacks_t;
+typedef H2O_VECTOR(h2o_status_handler_t *) h2o_status_callbacks_t;
 
 typedef enum h2o_send_informational_mode {
     H2O_SEND_INFORMATIONAL_MODE_EXCEPT_H1,
@@ -1514,8 +1514,7 @@ h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *p
 /**
  * registers an extra status handler
  */
-void h2o_config_register_status_handler(h2o_globalconf_t *config, h2o_status_handler_t);
-void h2o_config_register_simple_status_handler(h2o_globalconf_t *config, h2o_iovec_t name, final_status_handler_cb status_handler);
+void h2o_config_register_status_handler(h2o_globalconf_t *config, h2o_status_handler_t *status_handler);
 /**
  * disposes of the resources allocated for the global configuration
  */

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -213,21 +213,10 @@ h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *p
     return pathconf;
 }
 
-void h2o_config_register_status_handler(h2o_globalconf_t *config, h2o_status_handler_t status_handler)
+void h2o_config_register_status_handler(h2o_globalconf_t *config, h2o_status_handler_t *status_handler)
 {
     h2o_vector_reserve(NULL, &config->statuses, config->statuses.size + 1);
     config->statuses.entries[config->statuses.size++] = status_handler;
-}
-
-void h2o_config_register_simple_status_handler(h2o_globalconf_t *config, h2o_iovec_t name, final_status_handler_cb status_handler)
-{
-    h2o_status_handler_t *sh;
-
-    h2o_vector_reserve(NULL, &config->statuses, config->statuses.size + 1);
-    sh = &config->statuses.entries[config->statuses.size++];
-    memset(sh, 0, sizeof(*sh));
-    sh->name = h2o_strdup(NULL, name.base, name.len);
-    sh->final = status_handler;
 }
 
 h2o_hostconf_t *h2o_config_register_host(h2o_globalconf_t *config, h2o_iovec_t host, uint16_t port)

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -215,6 +215,12 @@ h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *p
 
 void h2o_config_register_status_handler(h2o_globalconf_t *config, h2o_status_handler_t *status_handler)
 {
+    /* check if the status handler is already registered */
+    size_t i;
+    for (i = 0; i != config->statuses.size; ++i)
+        if (config->statuses.entries[i] == status_handler)
+            return;
+    /* register the new handler */
     h2o_vector_reserve(NULL, &config->statuses, config->statuses.size + 1);
     config->statuses.entries[config->statuses.size++] = status_handler;
 }

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -21,9 +21,9 @@
  */
 #include "h2o.h"
 
-extern h2o_status_handler_t events_status_handler;
-extern h2o_status_handler_t requests_status_handler;
-extern h2o_status_handler_t durations_status_handler;
+extern h2o_status_handler_t h2o_events_status_handler;
+extern h2o_status_handler_t h2o_requests_status_handler;
+extern h2o_status_handler_t h2o_durations_status_handler;
 
 struct st_h2o_status_logger_t {
     h2o_logger_t super;
@@ -264,7 +264,7 @@ void h2o_status_register(h2o_pathconf_t *conf)
     self->super.on_context_init = on_context_init;
     self->super.on_context_dispose = on_context_dispose;
     self->super.on_req = on_req;
-    h2o_config_register_status_handler(conf->global, &requests_status_handler);
-    h2o_config_register_status_handler(conf->global, &events_status_handler);
-    h2o_config_register_status_handler(conf->global, &durations_status_handler);
+    h2o_config_register_status_handler(conf->global, &h2o_requests_status_handler);
+    h2o_config_register_status_handler(conf->global, &h2o_events_status_handler);
+    h2o_config_register_status_handler(conf->global, &h2o_durations_status_handler);
 }

--- a/lib/handler/status.c
+++ b/lib/handler/status.c
@@ -63,7 +63,7 @@ static void collect_reqs_of_context(struct st_h2o_status_collector_t *collector,
 
     for (i = 0; i < ctx->globalconf->statuses.size; i++) {
         struct st_status_ctx_t *sc = collector->status_ctx.entries + i;
-        h2o_status_handler_t *sh = ctx->globalconf->statuses.entries + i;
+        h2o_status_handler_t *sh = ctx->globalconf->statuses.entries[i];
         if (sc->active && sh->per_thread != NULL)
             sh->per_thread(sc->ctx, ctx);
     }
@@ -99,7 +99,7 @@ static void send_response(struct st_h2o_status_collector_t *collector)
 
     int coma_removed = 0;
     for (i = 0; i < req->conn->ctx->globalconf->statuses.size; i++) {
-        h2o_status_handler_t *sh = &req->conn->ctx->globalconf->statuses.entries[i];
+        h2o_status_handler_t *sh = req->conn->ctx->globalconf->statuses.entries[i];
         if (!collector->status_ctx.entries[i].active) {
             continue;
         }
@@ -162,7 +162,7 @@ static int on_req_json(struct st_h2o_root_status_handler_t *self, h2o_req_t *req
             h2o_status_handler_t *sh;
 
             h2o_vector_reserve(&req->pool, &collector->status_ctx, collector->status_ctx.size + 1);
-            sh = &req->conn->ctx->globalconf->statuses.entries[i];
+            sh = req->conn->ctx->globalconf->statuses.entries[i];
 
             if (status_list.base) {
                 if (!h2o_contains_token(status_list.base, status_list.len, sh->name.base, sh->name.len, ',')) {
@@ -264,7 +264,7 @@ void h2o_status_register(h2o_pathconf_t *conf)
     self->super.on_context_init = on_context_init;
     self->super.on_context_dispose = on_context_dispose;
     self->super.on_req = on_req;
-    h2o_config_register_status_handler(conf->global, requests_status_handler);
-    h2o_config_register_status_handler(conf->global, events_status_handler);
-    h2o_config_register_status_handler(conf->global, durations_status_handler);
+    h2o_config_register_status_handler(conf->global, &requests_status_handler);
+    h2o_config_register_status_handler(conf->global, &events_status_handler);
+    h2o_config_register_status_handler(conf->global, &durations_status_handler);
 }

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -203,6 +203,6 @@ void h2o_duration_stats_register(h2o_globalconf_t *conf)
     }
 }
 
-h2o_status_handler_t durations_status_handler = {
+h2o_status_handler_t h2o_durations_status_handler = {
     {H2O_STRLIT("durations")}, durations_status_final, durations_status_init, durations_status_per_thread
 };

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -204,5 +204,5 @@ void h2o_duration_stats_register(h2o_globalconf_t *conf)
 }
 
 h2o_status_handler_t durations_status_handler = {
-    {H2O_STRLIT("durations")}, durations_status_init, durations_status_per_thread, durations_status_final,
+    {H2O_STRLIT("durations")}, durations_status_final, durations_status_init, durations_status_per_thread
 };

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -108,5 +108,5 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
 }
 
 h2o_status_handler_t events_status_handler = {
-    {H2O_STRLIT("events")}, events_status_init, events_status_per_thread, events_status_final,
+    {H2O_STRLIT("events")}, events_status_final, events_status_init, events_status_per_thread
 };

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -107,6 +107,6 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
 #undef H2_AGG_ERR
 }
 
-h2o_status_handler_t events_status_handler = {
+h2o_status_handler_t h2o_events_status_handler = {
     {H2O_STRLIT("events")}, events_status_final, events_status_init, events_status_per_thread
 };

--- a/lib/handler/status/requests.c
+++ b/lib/handler/status/requests.c
@@ -147,5 +147,5 @@ static h2o_iovec_t requests_status_final(void *priv, h2o_globalconf_t *gconf, h2
 }
 
 h2o_status_handler_t requests_status_handler = {
-    {H2O_STRLIT("requests")}, requests_status_init, requests_status_per_thread, requests_status_final,
+    {H2O_STRLIT("requests")}, requests_status_final, requests_status_init, requests_status_per_thread
 };

--- a/lib/handler/status/requests.c
+++ b/lib/handler/status/requests.c
@@ -146,6 +146,6 @@ static h2o_iovec_t requests_status_final(void *priv, h2o_globalconf_t *gconf, h2
     return ret;
 }
 
-h2o_status_handler_t requests_status_handler = {
+h2o_status_handler_t h2o_requests_status_handler = {
     {H2O_STRLIT("requests")}, requests_status_final, requests_status_init, requests_status_per_thread
 };

--- a/src/main.c
+++ b/src/main.c
@@ -1948,7 +1948,8 @@ static void setup_configurators(void)
     h2o_mruby_register_configurator(&conf.globalconf);
 #endif
 
-    h2o_config_register_simple_status_handler(&conf.globalconf, (h2o_iovec_t){H2O_STRLIT("main")}, on_extra_status);
+    static h2o_status_handler_t extra_status_handler = {{H2O_STRLIT("main")}, on_extra_status};
+    h2o_config_register_status_handler(&conf.globalconf, &extra_status_handler);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR reimplements #1807 in a way that it does not cause issues when more than one globalconf is used.

Specifically, the deduplication logic is moved into `h2o_config_register_status_handler`, using the address of the handler as a tool to determine uniqueness.