### PR TITLE
:path pseudo header field cannot be empty

### DIFF
--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -523,6 +523,8 @@ int h2o_hpack_parse_headers(h2o_req_t *req, h2o_hpack_header_table_t *header_tab
                 } else if (r.name == &H2O_TOKEN_PATH->buf) {
                     if (req->input.path.base != NULL)
                         return H2O_HTTP2_ERROR_PROTOCOL;
+                    if (r.value->len == 0)
+                        return H2O_HTTP2_ERROR_PROTOCOL;
                     req->input.path = *r.value;
                     *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_PATH_EXISTS;
                 } else if (r.name == &H2O_TOKEN_SCHEME->buf) {


### PR DESCRIPTION
[RFC7540 8.1.2.3](https://tools.ietf.org/html/rfc7540#section-8.1.2.3) states:
`This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'.`
but currently h2o recognize empty `:path` as `/`.