### PR TITLE
fix broken memory problem on keepalived connection

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -114,12 +114,15 @@ static void init_request(struct st_h2o_http1_conn_t *conn)
 
     ++conn->_req_index;
     conn->req._ostr_top = &conn->_ostr_final.super;
-    conn->_ostr_final.super.do_send = finalostream_send;
-    conn->_ostr_final.super.start_pull = finalostream_start_pull;
-    conn->_ostr_final.super.send_informational = conn->super.ctx->globalconf->send_informational_mode == H2O_SEND_INFORMATIONAL_MODE_ALL
-                                                     ? finalostream_send_informational
-                                                     : NULL;
-    conn->_ostr_final.sent_headers = 0;
+
+    conn->_ostr_final = (struct st_h2o_http1_finalostream_t){{
+        NULL,                    /* next */
+        finalostream_send,       /* do_send */
+        NULL,                    /* stop */
+        finalostream_start_pull, /* start_pull */
+        conn->super.ctx->globalconf->send_informational_mode == H2O_SEND_INFORMATIONAL_MODE_ALL ? finalostream_send_informational
+                                                                                                : NULL, /* send_informational */
+    }};
 }
 
 static void close_connection(struct st_h2o_http1_conn_t *conn, int close_socket)

--- a/t/50reverse-proxy-informational.t
+++ b/t/50reverse-proxy-informational.t
@@ -67,6 +67,22 @@ EOT
     };
 };
 
+subtest 'broken memory issue when keepalive is used' => sub {
+    my $server = spawn_h2o(<< "EOT");
+send-informational: all
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+    my $resp;
+    my $url = "http://127.0.0.1:$server->{port}/early-hints";
+    $resp = `curl --http1.1 --silent --dump-header /dev/stdout '$url' '$url?sleep'`;
+    my @m = $resp =~ m{HTTP/1.1 200 OK}g;
+    is(scalar(@m), 2) or diag $resp;
+};
+
 done_testing();
 
 sub do_forward {

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -316,4 +316,26 @@ builder {
         );
         return sub {}; # do nothing
     };
+    mount "/early-hints" => sub {
+        my $env = shift;
+        my $fh = $env->{"psgix.io"};
+        print $fh join(
+            "\r\n",
+            "HTTP/1.1 103 Early Hints",
+            "link: </index.js>; rel=preload",
+            "",
+            "",
+        );
+        sleep 0.1 if $env->{'QUERY_STRING'} eq 'sleep';
+        print $fh join(
+            "\r\n",
+            "HTTP/1.1 200 OK",
+            "connection: close",
+            "content-type: text/plain",
+            "content-length: 11",
+            "",
+            "hello world",
+        );
+        return sub {};
+    };
 };


### PR DESCRIPTION
When h2o receives continuous multiple informational responses from upstream, and handle those on one HTTP/1.1 keep-alive downstream connection, h2o may refer broken memory (used for prior request). If it happens it causes broken response, and may causes other problems.
This bug was introduced by h2o/h2o#1727. The cause of the bug is forgetting initializing st_h2o_http1_finalostream_t.