### PR TITLE
[brotli] Ensure there's a minimal good buffer size

### DIFF
--- a/lib/handler/compress/brotli.c
+++ b/lib/handler/compress/brotli.c
@@ -120,6 +120,8 @@ h2o_compress_context_t *h2o_compress_brotli_open(h2o_mem_pool_t *pool, int quali
         self->buf_capacity = estimated_content_length;
     if (self->buf_capacity > 65536)
         self->buf_capacity = 65536;
+    if (self->buf_capacity < BUFSIZ)
+        self->buf_capacity = BUFSIZ;
     expand_buf(self);
 
     BrotliEncoderSetParameter(self->state, BROTLI_PARAM_QUALITY, quality);


### PR DESCRIPTION
Make sure that a misconfigured or malicious downstream with a very small
content-length doesn't lead to many allocated buffers.
This also fixes the issue of CL:0 leading to a crash due to memory
exhaustion.