### PR TITLE
Add a helper to provide a prometheus endpoint

### DIFF
--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -110,10 +110,15 @@ static h2o_iovec_t durations_status_final(void *priv, h2o_globalconf_t *gconf, h
 #define BUFSIZE 16384
 #define DURATION_FMT(x)                                                                                                            \
     " \"" x "-0\": %lu,\n"                                                                                                         \
+    " \"" x "-0-type\": \"gauge\",\n"                                                                                                         \
     " \"" x "-25\": %lu,\n"                                                                                                        \
+    " \"" x "-25-type\": \"gauge\",\n"                                                                                                         \
     " \"" x "-50\": %lu,\n"                                                                                                        \
+    " \"" x "-50-type\": \"gauge\",\n"                                                                                                         \
     " \"" x "-75\": %lu,\n"                                                                                                        \
-    " \"" x "-99\": %lu\n"
+    " \"" x "-75-type\": \"gauge\",\n"                                                                                                         \
+    " \"" x "-99\": %lu,\n" \
+    " \"" x "-99-type\": \"gauge\"\n"
 #define DURATION_VALS(x)                                                                                                           \
     gkc_query(agg_stats->stats.x, 0), gkc_query(agg_stats->stats.x, 0.25), gkc_query(agg_stats->stats.x, 0.5),                     \
         gkc_query(agg_stats->stats.x, 0.75), gkc_query(agg_stats->stats.x, 0.99)

--- a/share/h2o/mruby/prometheus_helper.rb
+++ b/share/h2o/mruby/prometheus_helper.rb
@@ -1,0 +1,51 @@
+# Copyright (c) 2018 Fastly, Frederik Deweerdt
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+
+class PrometheusHelper
+    def self.run(url)
+        resp = http_request(url)
+        status, headers, body = resp.join
+        stats = JSON.parse(body.join)
+        s = ""
+        version = ""
+        keys = {}
+        stats.each { |k,v|
+            next if v.kind_of?(Array)
+            next if k =~ "-time$"
+            if k == "server-version" then
+                version = v 
+                next
+            end
+            keys[k] = v
+        }
+        keys.each { |k,v|
+            next if k =~ "-type$"
+
+            type = keys["#{k}-type"]
+            type = "counter" unless type
+
+            s += "#HELP #{k}\n"
+            s += "#TYPE #{k} #{type}\n"
+            s += "#{k}{version=\"#{version}\"} #{v}\n"
+        }
+        [status, headers, [s]]
+    end
+end

--- a/src/main.c
+++ b/src/main.c
@@ -1839,11 +1839,14 @@ static h2o_iovec_t on_extra_status(void *unused, h2o_globalconf_t *_conf, h2o_re
                                           " \"current-time\": \"%s\",\n"
                                           " \"restart-time\": \"%s\",\n"
                                           " \"uptime\": %" PRIu64 ",\n"
+                                          " \"uptime-type\": \"gauge\",\n"
                                           " \"generation\": %s,\n"
                                           " \"connections\": %d,\n"
+                                          " \"connections-type\": \"gauge\",\n"
                                           " \"max-connections\": %d,\n"
                                           " \"listeners\": %zu,\n"
                                           " \"worker-threads\": %zu,\n"
+                                          " \"num-sessions-type\": \"gauge\",\n"
                                           " \"num-sessions\": %lu",
                        SSLeay_version(SSLEAY_VERSION), current_time, restart_time, (uint64_t)(now - conf.launch_time), generation,
                        num_connections(0), conf.max_connections, conf.num_listeners, conf.num_threads, num_sessions(0));

--- a/srcdoc/configure/prometheus.mt
+++ b/srcdoc/configure/prometheus.mt
@@ -1,0 +1,34 @@
+? my $ctx = $main::context;
+? $_mt->wrapper_file("wrapper.mt", "Configure", "Using the Prometheus exporter")->(sub {
+
+<p>
+Starting from version 2.3, H2O comes with a mruby script named <a href="https://github.com/h2o/h2o/blob/master/share/h2o/mruby/prometheus_helper.rb">prometheus_helper.rb</a> that allows to export stats in a way compatible with the Prometheus stats aggregator.
+</p>
+
+<h3 id="basic-usage">Basic Usage</h3>
+
+<p>
+Below example uses the mruby script export a Prometheus endpoint:
+</p>
+
+<?= $ctx->{example}->('Prometheus exporter', <<'EOT');
+listen: 8080
+hosts:
+  "*":
+    paths:
+      /:
+        file.dir: examples/doc_root
+      /status:
+        status: ON
+      /metrics:
+        mruby.handler: |
+          Proc.new do |env|
+            require "prometheus_helper.rb"
+            PrometheusHelper.run("http://127.0.0.1:8080/status/json")
+          end
+    access-log: /dev/stdout
+EOT
+?>
+
+
+? })


### PR DESCRIPTION
There are two parts to this PR:
- we annotate existing stats as 'gauge', so that we can default all
  other stats as 'counter'
- we add an mruby helper and associated doc that consumes a status
  hander to produce stats in a Prometheus format