### PR TITLE
[doc] fix incorrecet example in doc

### DIFF
--- a/doc/configure/mruby.html
+++ b/doc/configure/mruby.html
@@ -109,9 +109,9 @@ The example below restricts access to requests from <code>192.168.</code> privat
     mruby.handler: |
       lambda do |env|
         if /\A192\.168\./.match(env[&quot;REMOTE_ADDR&quot;])
-          return [399, {}, []]
+          return [403, {&#39;content-type&#39; =&gt; &#39;text/plain&#39;}, [&quot;access forbidden\n&quot;]]          
         end
-        [403, {&#39;content-type&#39; =&gt; &#39;text/plain&#39;}, [&quot;access forbidden\n&quot;]]
+        return [399, {}, []]
       end
 </code></pre>
 </div>


### PR DESCRIPTION
correcting code for restricting access to 192.168. Old code did opposite.
If i correctly understand ruby code It looks like code in example did opposite than explanation for this code:
By using the 399 status code, it is possible to implement access control using mruby. The example below restricts access to requests from 192.168. private address.