### PR TITLE
update mruby

### DIFF
--- a/deps/mruby/.travis.yml
+++ b/deps/mruby/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 matrix:
   include:
     - os: linux
-      sudo: 9000
+      sudo: false
     - os: osx
       osx_image: xcode7.1
 
@@ -17,4 +17,4 @@ addons:
 env:
     MRUBY_CONFIG=travis_config.rb
 env: MRUBY_CONFIG=travis_config.rb
-script: "./minirake all test"
+script: "./minirake -j4 all test"

--- a/deps/mruby/Rakefile
+++ b/deps/mruby/Rakefile
@@ -118,10 +118,21 @@ task :all => depfiles do
 end
 
 desc "run all mruby tests"
-task :test => ["all"] do
-  MRuby.each_target do
-    run_test if test_enabled?
+MRuby.each_target do
+  next unless test_enabled?
+
+  t = :"test_#{self.name}"
+  task t => ["all"] do
+    run_test
   end
+  task :test => t
+
+  next unless bintest_enabled?
+  t = :"bintest_#{self.name}"
+  task t => ["all"] do
+    run_bintest
+  end
+  task :test => t
 end
 
 desc "clean all built and in-repo installed artifacts"

--- a/deps/mruby/build_config.rb
+++ b/deps/mruby/build_config.rb
@@ -8,7 +8,8 @@ MRuby::Build.new do |conf|
     toolchain :gcc
   end
 
-  enable_debug
+  # Turn on `enable_debug` for better debugging
+  # enable_debug
 
   # Use mrbgems
   # conf.gem 'examples/mrbgems/ruby_extension_example'

--- a/deps/mruby/doc/limitations.md
+++ b/deps/mruby/doc/limitations.md
@@ -185,3 +185,23 @@ The re-defined ```+``` operator does not accept any arguments.
 
 ``` 'ab' ```
 Behavior of the operator wasn't changed.
+
+## Kernel#binding is not supported
+
+`Kernel#binding` method is not supported.
+
+#### Ruby [ruby 2.5.1p57 (2018-03-29 revision 63029)]
+
+```
+$ ruby -e 'puts Proc.new {}.binding'
+#<Binding:0x00000e9deabb9950>
+```
+
+#### mruby [1.4.1 (2018-4-27)]
+
+```
+$ ./bin/mruby -e 'puts Proc.new {}.binding'
+trace (most recent call last):
+        [0] -e:1
+-e:1: undefined method 'binding' (NoMethodError)
+```

--- a/deps/mruby/include/mruby.h
+++ b/deps/mruby/include/mruby.h
@@ -994,8 +994,8 @@ MRB_API mrb_value mrb_str_new_static(mrb_state *mrb, const char *p, size_t len);
 #define mrb_str_new_lit(mrb, lit) mrb_str_new_static(mrb, (lit), mrb_strlen_lit(lit))
 
 #ifdef _WIN32
-char* mrb_utf8_from_locale(const char *p, int len);
-char* mrb_locale_from_utf8(const char *p, int len);
+MRB_API char* mrb_utf8_from_locale(const char *p, int len);
+MRB_API char* mrb_locale_from_utf8(const char *p, int len);
 #define mrb_locale_free(p) free(p)
 #define mrb_utf8_free(p) free(p)
 #else
@@ -1235,6 +1235,7 @@ MRB_API mrb_value mrb_fiber_alive_p(mrb_state *mrb, mrb_value fib);
  * @mrbgem mruby-fiber
  */
 #define E_FIBER_ERROR (mrb_exc_get(mrb, "FiberError"))
+MRB_API void mrb_stack_extend(mrb_state*, int);
 
 /* memory pool implementation */
 typedef struct mrb_pool mrb_pool;

--- a/deps/mruby/include/mruby/class.h
+++ b/deps/mruby/include/mruby/class.h
@@ -53,19 +53,25 @@ mrb_class(mrb_state *mrb, mrb_value v)
   }
 }
 
-/* TODO: figure out where to put user flags */
-/* flags bits >= 18 is reserved */
-#define MRB_FLAG_IS_PREPENDED (1 << 19)
-#define MRB_FLAG_IS_ORIGIN (1 << 20)
+/* flags:
+   20: frozen
+   19: is_prepended
+   18: is_origin
+   17: is_inherited (used by method cache)
+   16: unused
+   0-15: instance type
+*/
+#define MRB_FL_CLASS_IS_PREPENDED (1 << 19)
+#define MRB_FL_CLASS_IS_ORIGIN (1 << 18)
 #define MRB_CLASS_ORIGIN(c) do {\
-  if (c->flags & MRB_FLAG_IS_PREPENDED) {\
+  if (c->flags & MRB_FL_CLASS_IS_PREPENDED) {\
     c = c->super;\
-    while (!(c->flags & MRB_FLAG_IS_ORIGIN)) {\
+    while (!(c->flags & MRB_FL_CLASS_IS_ORIGIN)) {\
       c = c->super;\
     }\
   }\
 } while (0)
-#define MRB_FLAG_IS_INHERITED (1 << 21)
+#define MRB_FL_CLASS_IS_INHERITED (1 << 17)
 #define MRB_INSTANCE_TT_MASK (0xFF)
 #define MRB_SET_INSTANCE_TT(c, tt) c->flags = ((c->flags & ~MRB_INSTANCE_TT_MASK) | (char)tt)
 #define MRB_INSTANCE_TT(c) (enum mrb_vtype)(c->flags & MRB_INSTANCE_TT_MASK)

--- a/deps/mruby/include/mruby/irep.h
+++ b/deps/mruby/include/mruby/irep.h
@@ -56,6 +56,7 @@ void mrb_irep_free(mrb_state*, struct mrb_irep*);
 void mrb_irep_incref(mrb_state*, struct mrb_irep*);
 void mrb_irep_decref(mrb_state*, struct mrb_irep*);
 void mrb_irep_cutref(mrb_state*, struct mrb_irep*);
+void mrb_irep_remove_lv(mrb_state *mrb, mrb_irep *irep);
 
 MRB_END_DECL
 

--- a/deps/mruby/include/mruby/object.h
+++ b/deps/mruby/include/mruby/object.h
@@ -22,11 +22,10 @@ struct RBasic {
 };
 #define mrb_basic_ptr(v) ((struct RBasic*)(mrb_ptr(v)))
 
-/* flags bits >= 18 is reserved */
-#define MRB_FLAG_IS_FROZEN (1 << 18)
-#define MRB_FROZEN_P(o) ((o)->flags & MRB_FLAG_IS_FROZEN)
-#define MRB_SET_FROZEN_FLAG(o) ((o)->flags |= MRB_FLAG_IS_FROZEN)
-#define MRB_UNSET_FROZEN_FLAG(o) ((o)->flags &= ~MRB_FLAG_IS_FROZEN)
+#define MRB_FL_OBJ_IS_FROZEN (1 << 20)
+#define MRB_FROZEN_P(o) ((o)->flags & MRB_FL_OBJ_IS_FROZEN)
+#define MRB_SET_FROZEN_FLAG(o) ((o)->flags |= MRB_FL_OBJ_IS_FROZEN)
+#define MRB_UNSET_FROZEN_FLAG(o) ((o)->flags &= ~MRB_FL_OBJ_IS_FROZEN)
 
 struct RObject {
   MRB_OBJECT_HEADER;

--- a/deps/mruby/include/mruby/opcode.h
+++ b/deps/mruby/include/mruby/opcode.h
@@ -120,7 +120,7 @@ enum {
   OP_ARYPUSH,/*   A B     ary_push(R(A),R(B))                             */
   OP_AREF,/*      A B C   R(A) := R(B)[C]                                 */
   OP_ASET,/*      A B C   R(B)[C] := R(A)                                 */
-  OP_APOST,/*     A B C   *R(A),R(A+1)..R(A+C) := R(A)                    */
+  OP_APOST,/*     A B C   *R(A),R(A+1)..R(A+C) := R(A)[B..]               */
 
   OP_STRING,/*    A Bx    R(A) := str_dup(Lit(Bx))                        */
   OP_STRCAT,/*    A B     str_cat(R(A),R(B))                              */

--- a/deps/mruby/lib/mruby/build.rb
+++ b/deps/mruby/lib/mruby/build.rb
@@ -298,7 +298,6 @@ EOS
       mrbtest = exefile("#{build_dir}/bin/mrbtest")
       sh "#{filename mrbtest.relative_path}#{$verbose ? ' -v' : ''}"
       puts
-      run_bintest if bintest_enabled?
     end
 
     def run_bintest

--- a/deps/mruby/minirake
+++ b/deps/mruby/minirake
@@ -6,6 +6,12 @@
 
 require 'getoptlong'
 require 'fileutils'
+require 'fiber'
+
+$rake_fiber_table = {}
+$rake_jobs = 1
+$rake_failed = []
+$rake_root_fiber = Fiber.current
 
 class String
   def ext(newext='')
@@ -86,14 +92,32 @@ module MiniRake
       @name.to_s
     end
 
+    def done?; @done end
+    def running?; @running end
+
     # Invoke the task if it is needed.  Prerequites are invoked first.
     def invoke
       puts "Invoke #{name} (already=[#{@already_invoked}], needed=[#{needed?}])" if $trace
       return if @already_invoked
-      @already_invoked = true
       prerequisites = @prerequisites.collect{ |n| n.is_a?(Proc) ? n.call(name) : n }.flatten
-      prerequisites.each { |n| Task[n].invoke }
-      execute if needed?
+      prerequisites.each do |n|
+        t = Task[n]
+        unless t.done?
+          return prerequisites.select{|v| v = Task[v]; v && (!v.done? || !v.running?) }
+        end
+      end
+
+      @already_invoked = true
+
+      if needed?
+        @running = true
+        return Fiber.new do
+          self.execute
+          $rake_root_fiber.transfer
+        end
+      end
+
+      @done = true
     end
 
     # Execute the actions associated with this task.
@@ -103,6 +127,8 @@ module MiniRake
       unless $dryrun
         @actions.each { |act| act.call(self) }
       end
+      @done = true
+      @running = false
     end
 
     # Is this task needed?
@@ -281,7 +307,19 @@ module MiniRake
     # Run the system command +cmd+.
     def sh(cmd)
       puts cmd if $verbose
-      system(cmd) or fail "Command Failed: [#{cmd}]"
+
+      if $rake_jobs == 1 || Fiber.current == $rake_root_fiber
+        system(cmd) or fail "Command Failed: [#{cmd}]"
+        return
+      end
+
+      pid = Process.spawn(cmd)
+      $rake_fiber_table[pid] = {
+        fiber: Fiber.current,
+        command: cmd,
+        process_waiter: Process.detach(pid)
+      }
+      $rake_root_fiber.transfer
     end
 
     def desc(text)
@@ -329,7 +367,9 @@ class RakeApp
     ['--verbose',  '-v', GetoptLong::NO_ARGUMENT,
       "Log message to standard output."],
     ['--directory', '-C', GetoptLong::REQUIRED_ARGUMENT,
-      "Change executing directory of rakefiles."]
+      "Change executing directory of rakefiles."],
+    ['--jobs', '-j', GetoptLong::REQUIRED_ARGUMENT,
+      'Execute rake with parallel jobs.']
   ]
 
   # Create a RakeApp object.
@@ -422,6 +462,8 @@ class RakeApp
       exit
     when '--directory'
       Dir.chdir value
+    when '--jobs'
+      $rake_jobs = [value.to_i, 1].max
     else
       fail "Unknown option: #{opt}"
     end
@@ -447,12 +489,12 @@ class RakeApp
         end
         here = Dir.pwd
       end
-      tasks = []
+      root_tasks = []
       ARGV.each do |task_name|
         if /^(\w+)=(.*)/.match(task_name)
           ENV[$1] = $2
         else
-          tasks << task_name
+          root_tasks << task_name
         end
       end
       puts "(in #{Dir.pwd})"
@@ -461,23 +503,94 @@ class RakeApp
       if $show_tasks
         display_tasks
       else
-        tasks.push("default") if tasks.size == 0
-        tasks.each do |task_name|
-          MiniRake::Task[task_name].invoke
+        root_tasks.push("default") if root_tasks.empty?
+        # revese tasks for popping
+        root_tasks.reverse!
+
+        tasks = []
+        until root_tasks.empty?
+          root_name = root_tasks.pop
+          tasks << root_name
+          until tasks.empty?
+            task_name = tasks.pop
+            t = MiniRake::Task[task_name]
+            f = t.invoke
+
+            # append additional tasks to task queue
+            if f.kind_of?(Array)
+              tasks.push(*f)
+              tasks.uniq!
+            end
+
+            unless f.kind_of? Fiber
+              tasks.insert 0, task_name unless t.done?
+              if root_name == task_name
+                wait_process
+              end
+              next
+            end
+
+            wait_process while $rake_fiber_table.size >= $rake_jobs
+
+            f.transfer
+          end
         end
+
+        wait_process until $rake_fiber_table.empty?
       end
-    rescue Exception => ex
-      puts "rake aborted!"
+    rescue Exception => e
+      begin
+        $rake_failed << e
+        wait_process until $rake_fiber_table.empty?
+      rescue Exception => next_e
+        e = next_e
+        retry
+      end
+    end
+
+    return if $rake_failed.empty?
+
+    puts "rake aborted!"
+    $rake_failed.each do |ex|
       puts ex.message
-      if $trace
+      if $trace || $verbose
         puts ex.backtrace.join("\n")
       else
         puts ex.backtrace.find {|str| str =~ /#{@rakefile}/ } || ""
       end
-      exit 1
     end
+    exit 1
   end
-end
+
+  def wait_process(count = 0)
+    dur = [0.0001 * (10 ** count), 1].min
+    sleep dur
+
+    exited = []
+    $rake_fiber_table.each do |pid, v|
+      exited << pid unless v[:process_waiter].alive?
+    end
+
+    exited.each do |pid|
+      ent = $rake_fiber_table.delete pid
+      st = ent[:process_waiter].value
+
+      # ignore process that isn't created by `sh` method
+      return if ent.nil?
+
+      if st.exitstatus != 0
+        raise "Command Failed: [#{ent[:command]}]"
+      end
+
+      fail 'task scheduling bug!' if $rake_fiber_table.size >= $rake_jobs
+
+      ent[:fiber].transfer
+    end
+
+    wait_process(count + 1) if !$rake_fiber_table.empty? && exited.empty?
+  end
+
+  end
 
 if __FILE__ == $0 then
   RakeApp.new.run

--- a/deps/mruby/mrbgems/mruby-bin-mirb/bintest/mirb.rb
+++ b/deps/mruby/mrbgems/mruby-bin-mirb/bintest/mirb.rb
@@ -10,3 +10,25 @@ assert('regression for #1563') do
   o, s = Open3.capture2('bin/mirb', :stdin_data => "a=1;b=2;c=3\nb\nc")
   assert_true o.include?('=> 3')
 end
+
+assert('mirb -d option') do
+  o, _ = Open3.capture2('bin/mirb', :stdin_data => "p $DEBUG\n")
+  assert_true o.include?('=> false')
+  o, _ = Open3.capture2('bin/mirb -d', :stdin_data => "p $DEBUG\n")
+  assert_true o.include?('=> true')
+end
+
+assert('mirb -r option') do
+  lib = Tempfile.new('lib.rb')
+  lib.write <<EOS
+class Hoge
+  def hoge
+    :hoge
+  end
+end
+EOS
+  lib.flush
+
+  o, _ = Open3.capture2("bin/mirb -r #{lib.path}", :stdin_data => "Hoge.new.hoge\n")
+  assert_true o.include?('=> :hoge')
+end

--- a/deps/mruby/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/deps/mruby/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -18,6 +18,7 @@ struct mrbc_args {
   const char *initname;
   mrb_bool check_syntax : 1;
   mrb_bool verbose      : 1;
+  mrb_bool remove_lv    : 1;
   unsigned int flags    : 4;
 };
 
@@ -33,6 +34,7 @@ usage(const char *name)
   "-B<symbol>   binary <symbol> output in C language format",
   "-e           generate little endian iseq data",
   "-E           generate big endian iseq data",
+  "--remove-lv  remove local variables",
   "--verbose    run at verbose mode",
   "--version    print the version",
   "--copyright  print the copyright",
@@ -142,6 +144,10 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct mrbc_args *args)
           mrb_show_copyright(mrb);
           exit(EXIT_SUCCESS);
         }
+        else if (strcmp(argv[i] + 2, "remove-lv") == 0) {
+          args->remove_lv = TRUE;
+          break;
+        }
         return -1;
       default:
         return i;
@@ -232,6 +238,9 @@ dump_file(mrb_state *mrb, FILE *wfp, const char *outfile, struct RProc *proc, st
   int n = MRB_DUMP_OK;
   mrb_irep *irep = proc->body.irep;
 
+  if (args->remove_lv) {
+    mrb_irep_remove_lv(mrb, irep);
+  }
   if (args->initname) {
     n = mrb_dump_irep_cfunc(mrb, irep, args->flags, wfp, args->initname);
     if (n == MRB_DUMP_INVALID_ARGUMENT) {

--- a/deps/mruby/mrbgems/mruby-bin-mruby-config/mrbgem.rake
+++ b/deps/mruby/mrbgems/mruby-bin-mruby-config/mrbgem.rake
@@ -19,9 +19,10 @@ MRuby.each_target do
   mruby_config_path = "#{build_dir}/bin/#{mruby_config}"
   @bins << mruby_config
 
-  file mruby_config_path => libfile("#{build_dir}/lib/libmruby") do |t|
+  make_cfg = "#{build_dir}/lib/libmruby.flags.mak"
+  file mruby_config_path => [libfile("#{build_dir}/lib/libmruby"), make_cfg] do |t|
     FileUtils.copy "#{File.dirname(__FILE__)}/#{mruby_config}", t.name
-    config = Hash[open("#{build_dir}/lib/libmruby.flags.mak").read.split("\n").map {|x| a = x.split(/\s*=\s*/, 2); [a[0], a[1].gsub('\\"', '"') ]}]
+    config = Hash[open(make_cfg).read.split("\n").map {|x| a = x.split(/\s*=\s*/, 2); [a[0], a[1].gsub('\\"', '"') ]}]
     IO.write(t.name, File.open(t.name) {|f|
       f.read.gsub (/echo (MRUBY_CFLAGS|MRUBY_LIBS|MRUBY_LDFLAGS_BEFORE_LIBS|MRUBY_LDFLAGS|MRUBY_LIBMRUBY_PATH)/) {|x| config[$1].empty? ? '' : "echo #{config[$1]}"}
     })

--- a/deps/mruby/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/deps/mruby/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -58,3 +58,33 @@ RUBY
   assert_equal "NilClass", `#{cmd('mruby')} #{script.path}`
   assert_equal 0, $?.exitstatus
 end
+
+assert('mruby -d option') do
+  o = `#{cmd('mruby')} -e #{shellquote('p $DEBUG')}`
+  assert_equal "false\n", o
+  o = `#{cmd('mruby')} -d -e #{shellquote('p $DEBUG')}`
+  assert_equal "true\n", o
+end
+
+assert('mruby -r option') do
+  lib = Tempfile.new('lib.rb')
+  lib.write <<EOS
+class Hoge
+  def hoge
+    :hoge
+  end
+end
+EOS
+  lib.flush
+
+  script = Tempfile.new('test.rb')
+  script.write <<EOS
+print Hoge.new.hoge
+EOS
+  script.flush
+  assert_equal 'hoge', `#{cmd('mruby')} -r #{lib.path} #{script.path}`
+  assert_equal 0, $?.exitstatus
+
+  assert_equal 'hogeClass', `#{cmd('mruby')} -r #{lib.path} -r #{script.path} -e #{shellquote('print Hoge.class')}`
+  assert_equal 0, $?.exitstatus
+end

--- a/deps/mruby/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
+++ b/deps/mruby/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c
@@ -27,8 +27,11 @@ struct _args {
   mrb_bool mrbfile      : 1;
   mrb_bool check_syntax : 1;
   mrb_bool verbose      : 1;
+  mrb_bool debug        : 1;
   int argc;
   char** argv;
+  int libc;
+  char **libv;
 };
 
 static void
@@ -38,7 +41,9 @@ usage(const char *name)
   "switches:",
   "-b           load and execute RiteBinary (mrb) file",
   "-c           check syntax only",
+  "-d           set debugging flags (set $DEBUG to true)"
   "-e 'command' one line of script",
+  "-r library   load the library before executing your script",
   "-v           print version number, then run in verbose mode",
   "--verbose    run in verbose mode",
   "--version    print the version",
@@ -50,6 +55,15 @@ usage(const char *name)
   printf("Usage: %s [switches] programfile\n", name);
   while (*p)
     printf("  %s\n", *p++);
+}
+
+static char *
+dup_arg_item(mrb_state *mrb, const char *item)
+{
+  size_t buflen = strlen(item) + 1;
+  char *buf = (char*)mrb_malloc(mrb, buflen);
+  memcpy(buf, item, buflen);
+  return buf;
 }
 
 static int
@@ -78,6 +92,9 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
     case 'c':
       args->check_syntax = TRUE;
       break;
+    case 'd':
+      args->debug = TRUE;
+      break;
     case 'e':
       if (item[0]) {
         goto append_cmdline;
@@ -87,13 +104,7 @@ parse_args(mrb_state *mrb, int argc, char **argv, struct _args *args)
         item = argv[0];
 append_cmdline:
         if (!args->cmdline) {
-          size_t buflen;
-          char *buf;
-
-          buflen = strlen(item) + 1;
-          buf = (char *)mrb_malloc(mrb, buflen);
-          memcpy(buf, item, buflen);
-          args->cmdline = buf;
+          args->cmdline = dup_arg_item(mrb, item);
         }
         else {
           size_t cmdlinelen;
@@ -111,6 +122,23 @@ append_cmdline:
         printf("%s: No code specified for -e\n", *origargv);
         return EXIT_SUCCESS;
       }
+      break;
+    case 'r':
+      if (!item[0]) {
+        if (argc <= 1) {
+          printf("%s: No library specified for -r\n", *origargv);
+          return EXIT_FAILURE;
+        }
+        argc--; argv++;
+        item = argv[0];
+      }
+      if (args->libc == 0) {
+        args->libv = (char**)mrb_malloc(mrb, sizeof(char*));
+      }
+      else {
+        args->libv = (char**)mrb_realloc(mrb, args->libv, sizeof(char*) * (args->libc + 1));
+      }
+      args->libv[args->libc++] = dup_arg_item(mrb, item);
       break;
     case 'v':
       if (!args->verbose) mrb_show_version(mrb);
@@ -162,6 +190,12 @@ cleanup(mrb_state *mrb, struct _args *args)
   if (!args->fname)
     mrb_free(mrb, args->cmdline);
   mrb_free(mrb, args->argv);
+  if (args->libc) {
+    while (args->libc--) {
+      mrb_free(mrb, args->libv[args->libc]);
+    }
+    mrb_free(mrb, args->libv);
+  }
   mrb_close(mrb);
 }
 
@@ -199,6 +233,7 @@ main(int argc, char **argv)
       }
     }
     mrb_define_global_const(mrb, "ARGV", ARGV);
+    mrb_gv_set(mrb, mrb_intern_lit(mrb, "$DEBUG"), mrb_bool_value(args.debug));
 
     c = mrbc_context_new(mrb);
     if (args.verbose)
@@ -217,6 +252,23 @@ main(int argc, char **argv)
     else {
       mrbc_filename(mrb, c, "-e");
       mrb_gv_set(mrb, zero_sym, mrb_str_new_lit(mrb, "-e"));
+    }
+
+    /* Load libraries */
+    for (i = 0; i < args.libc; i++) {
+      FILE *lfp = fopen(args.libv[i], args.mrbfile ? "rb" : "r");
+      if (lfp == NULL) {
+        printf("Cannot open library file. (%s)\n", args.libv[i]);
+        cleanup(mrb, &args);
+        return EXIT_FAILURE;
+      }
+      if (args.mrbfile) {
+        v = mrb_load_irep_file_cxt(mrb, lfp, c);
+      }
+      else {
+        v = mrb_load_file_cxt(mrb, lfp, c);
+      }
+      fclose(lfp);
     }
 
     /* Load program */

--- a/deps/mruby/mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.c
+++ b/deps/mruby/mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.c
@@ -12,22 +12,6 @@ struct strip_args {
   mrb_bool lvar;
 };
 
-
-static void
-irep_remove_lv(mrb_state *mrb, mrb_irep *irep)
-{
-  int i;
-
-  if (irep->lv) {
-    mrb_free(mrb, irep->lv);
-    irep->lv = NULL;
-  }
-
-  for (i = 0; i < irep->rlen; ++i) {
-    irep_remove_lv(mrb, irep->reps[i]);
-  }
-}
-
 static void
 print_usage(const char *f)
 {
@@ -99,7 +83,7 @@ strip(mrb_state *mrb, struct strip_args *args)
 
     /* clear lv if --lvar is enabled */
     if (args->lvar) {
-      irep_remove_lv(mrb, irep);
+      mrb_irep_remove_lv(mrb, irep);
     }
 
     wfile = fopen(filename, "wb");

--- a/deps/mruby/mrbgems/mruby-compiler/core/codegen.c
+++ b/deps/mruby/mrbgems/mruby-compiler/core/codegen.c
@@ -1088,8 +1088,12 @@ gen_vmassignment(codegen_scope *s, node *tree, int rhs, int val)
     t = tree->car;
     n = 0;
     while (t) {
-      genop(s, MKOP_ABC(OP_AREF, cursp(), rhs, n));
-      gen_assignment(s, t->car, cursp(), NOVAL);
+      int sp = cursp();
+
+      genop(s, MKOP_ABC(OP_AREF, sp, rhs, n));
+      push();
+      gen_assignment(s, t->car, sp, NOVAL);
+      pop();
       n++;
       t = t->cdr;
     }
@@ -1103,14 +1107,9 @@ gen_vmassignment(codegen_scope *s, node *tree, int rhs, int val)
         p = p->cdr;
       }
     }
-    if (val) {
-      genop(s, MKOP_AB(OP_MOVE, cursp(), rhs));
-    }
-    else {
-      pop();
-    }
-    push_n(post);
-    pop_n(post);
+    genop(s, MKOP_AB(OP_MOVE, cursp(), rhs));
+    push_n(post+1);
+    pop_n(post+1);
     genop(s, MKOP_ABC(OP_APOST, cursp(), n, post));
     n = 1;
     if (t->car) {               /* rest */
@@ -1124,8 +1123,8 @@ gen_vmassignment(codegen_scope *s, node *tree, int rhs, int val)
         n++;
       }
     }
-    if (!val) {
-      push();
+    if (val) {
+      genop(s, MKOP_AB(OP_MOVE, cursp(), rhs));
     }
   }
 }
@@ -3050,8 +3049,8 @@ loop_pop(codegen_scope *s, int val)
   if (val) push();
 }
 
-MRB_API struct RProc*
-mrb_generate_code(mrb_state *mrb, parser_state *p)
+static struct RProc*
+generate_code(mrb_state *mrb, parser_state *p, int val)
 {
   codegen_scope *scope = scope_new(mrb, 0, 0);
   struct RProc *proc;
@@ -3068,7 +3067,7 @@ mrb_generate_code(mrb_state *mrb, parser_state *p)
   MRB_TRY(&scope->jmp) {
     mrb->jmp = &scope->jmp; 
     /* prepare irep */
-    codegen(scope, p->tree, NOVAL);
+    codegen(scope, p->tree, val);
     proc = mrb_proc_new(mrb, scope->irep);
     mrb_irep_decref(mrb, scope->irep);
     mrb_pool_close(scope->mpool);
@@ -3086,4 +3085,25 @@ mrb_generate_code(mrb_state *mrb, parser_state *p)
     return NULL;
   }
   MRB_END_EXC(&scope->jmp);
+}
+
+MRB_API struct RProc*
+mrb_generate_code(mrb_state *mrb, parser_state *p)
+{
+  return generate_code(mrb, p, VAL);
+}
+
+void
+mrb_irep_remove_lv(mrb_state *mrb, mrb_irep *irep)
+{
+  int i;
+
+  if (irep->lv) {
+    mrb_free(mrb, irep->lv);
+    irep->lv = NULL;
+  }
+
+  for (i = 0; i < irep->rlen; ++i) {
+    mrb_irep_remove_lv(mrb, irep->reps[i]);
+  }
 }

--- a/deps/mruby/mrbgems/mruby-compiler/mrbgem.rake
+++ b/deps/mruby/mrbgems/mruby-compiler/mrbgem.rake
@@ -23,10 +23,10 @@ MRuby::Gem::Specification.new 'mruby-compiler' do |spec|
       cc.run t.name, t.prerequisites.first, [], ["#{current_dir}/core"]
     end
   end
-  file objfile("#{current_build_dir}/core/y.tab") => lex_def
 
   # Parser
-  file "#{current_build_dir}/core/y.tab.c" => ["#{current_dir}/core/parse.y"] do |t|
+  file "#{current_build_dir}/core/y.tab.c" => ["#{current_dir}/core/parse.y", lex_def] do |t|
+    FileUtils.mkdir_p File.dirname t.name
     yacc.run t.name, t.prerequisites.first
   end
 

--- a/deps/mruby/mrbgems/mruby-eval/src/eval.c
+++ b/deps/mruby/mrbgems/mruby-eval/src/eval.c
@@ -254,6 +254,7 @@ create_proc_from_string(mrb_state *mrb, char *s, mrb_int len, mrb_value binding,
       if (ci->argc < 0) bidx = 2;
       else bidx += 1;
       MRB_ENV_SET_BIDX(e, bidx);
+      ci->env = e;
     }
     proc->e.env = e;
     proc->flags |= MRB_PROC_ENVSET;
@@ -325,6 +326,7 @@ f_instance_eval(mrb_state *mrb, mrb_value self)
     proc = create_proc_from_string(mrb, s, len, mrb_nil_value(), file, line);
     MRB_PROC_SET_TARGET_CLASS(proc, mrb_class_ptr(cv));
     mrb_assert(!MRB_PROC_CFUNC_P(proc));
+    mrb->c->ci->target_class = mrb_class_ptr(cv);
     return exec_irep(mrb, self, proc);
   }
   else {

--- a/deps/mruby/mrbgems/mruby-eval/test/eval.rb
+++ b/deps/mruby/mrbgems/mruby-eval/test/eval.rb
@@ -99,3 +99,34 @@ assert('Object#instance_eval with begin-rescue-ensure execution order') do
   hell_raiser = HellRaiser.new
   assert_equal([:enter_raise_hell, :begin, :rescue, :ensure], hell_raiser.raise_hell)
 end
+
+assert('Kernel#instance_eval() to define singleton methods Issue #3141') do
+  foo_class = Class.new do
+    def bar(x)
+      instance_eval "def baz; #{x}; end"
+    end
+  end
+
+  f1 = foo_class.new
+  f2 = foo_class.new
+  f1.bar 1
+  f2.bar 2
+  assert_equal(1){f1.baz}
+  assert_equal(2){f2.baz}
+end
+
+assert('Kernel.#eval(string) Issue #4021') do
+  assert_equal('FOO') { (eval <<'EOS').call }
+foo = "FOO"
+Proc.new { foo }
+EOS
+  assert_equal('FOO') {
+    def do_eval(code)
+      eval(code)
+    end
+    do_eval(<<'EOS').call
+foo = "FOO"
+Proc.new { foo }
+EOS
+  }
+end

--- a/deps/mruby/mrbgems/mruby-fiber/src/fiber.c
+++ b/deps/mruby/mrbgems/mruby-fiber/src/fiber.c
@@ -175,6 +175,9 @@ fiber_check_cfunc(mrb_state *mrb, struct mrb_context *c)
 static void
 fiber_switch_context(mrb_state *mrb, struct mrb_context *c)
 {
+  if (mrb->c->fib) {
+    mrb_write_barrier(mrb, (struct RBasic*)mrb->c->fib);
+  }
   c->status = MRB_FIBER_RUNNING;
   mrb->c = c;
 }
@@ -184,26 +187,30 @@ fiber_switch(mrb_state *mrb, mrb_value self, mrb_int len, const mrb_value *a, mr
 {
   struct mrb_context *c = fiber_check(mrb, self);
   struct mrb_context *old_c = mrb->c;
+  enum mrb_fiber_state status;
   mrb_value value;
 
   fiber_check_cfunc(mrb, c);
-  if (resume && c->status == MRB_FIBER_TRANSFERRED) {
+  status = c->status;
+  if (resume && status == MRB_FIBER_TRANSFERRED) {
     mrb_raise(mrb, E_FIBER_ERROR, "resuming transferred fiber");
   }
-  if (c->status == MRB_FIBER_RUNNING || c->status == MRB_FIBER_RESUMED) {
-    mrb_raise(mrb, E_FIBER_ERROR, "double resume (fib)");
+  if (status == MRB_FIBER_RUNNING || status == MRB_FIBER_RESUMED) {
+    mrb_raise(mrb, E_FIBER_ERROR, "double resume");
   }
-  if (c->status == MRB_FIBER_TERMINATED) {
+  if (status == MRB_FIBER_TERMINATED) {
     mrb_raise(mrb, E_FIBER_ERROR, "resuming dead fiber");
   }
-  mrb->c->status = resume ? MRB_FIBER_RESUMED : MRB_FIBER_TRANSFERRED;
+  old_c->status = resume ? MRB_FIBER_RESUMED : MRB_FIBER_TRANSFERRED;
   c->prev = resume ? mrb->c : (c->prev ? c->prev : mrb->root_c);
-  if (c->status == MRB_FIBER_CREATED) {
+  fiber_switch_context(mrb, c);
+  if (status == MRB_FIBER_CREATED) {
     mrb_value *b, *e;
 
-    if (len >= c->stend - c->stack) {
-      mrb_raise(mrb, E_FIBER_ERROR, "too many arguments to fiber");
+    if (!c->ci->proc) {
+      mrb_raise(mrb, E_FIBER_ERROR, "double resume (current)");
     }
+    mrb_stack_extend(mrb, len+2); /* for receiver and (optional) block */
     b = c->stack+1;
     e = b + len;
     while (b<e) {
@@ -215,7 +222,6 @@ fiber_switch(mrb_state *mrb, mrb_value self, mrb_int len, const mrb_value *a, mr
   else {
     value = fiber_result(mrb, a, len);
   }
-  fiber_switch_context(mrb, c);
 
   if (vmexec) {
     c->vmexec = TRUE;

--- a/deps/mruby/mrbgems/mruby-inline-struct/test/inline.c
+++ b/deps/mruby/mrbgems/mruby-inline-struct/test/inline.c
@@ -47,7 +47,7 @@ istruct_test_test_receive(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "o", &object);
   if (mrb_obj_class(mrb, object) != mrb_class_get(mrb, "InlineStructTest"))
   {
-    mrb_raisef(mrb, E_TYPE_ERROR, "Expected InlineStructTest");
+    mrb_raise(mrb, E_TYPE_ERROR, "Expected InlineStructTest");
   }
   return mrb_bool_value(((char*)mrb_istruct_ptr(object))[0] == 's');
 }

--- a/deps/mruby/mrbgems/mruby-io/mrbgem.rake
+++ b/deps/mruby/mrbgems/mruby-io/mrbgem.rake
@@ -4,7 +4,7 @@ MRuby::Gem::Specification.new('mruby-io') do |spec|
   spec.summary = 'IO and File class'
 
   spec.cc.include_paths << "#{build.root}/src"
-  
+
   case RUBY_PLATFORM
   when /mingw|mswin/
     spec.linker.libraries += ['Ws2_32']
@@ -14,4 +14,5 @@ MRuby::Gem::Specification.new('mruby-io') do |spec|
   if build.kind_of?(MRuby::CrossBuild) && %w(x86_64-w64-mingw32 i686-w64-mingw32).include?(build.host_target)
     spec.linker.libraries += ['ws2_32']
   end
+  spec.add_test_dependency 'mruby-time', core: 'mruby-time'
 end

--- a/deps/mruby/mrbgems/mruby-io/test/file.rb
+++ b/deps/mruby/mrbgems/mruby-io/test/file.rb
@@ -75,12 +75,12 @@ assert('File#mtime') do
   begin
     now = Time.now.to_i
     mt = 0
-    File.open('mtime-test', 'w') do |f|
+    File.open("#{$mrbtest_io_wfname}.mtime", 'w') do |f|
       mt = f.mtime.to_i
     end
     assert_equal true, mt >= now
   ensure
-    File.delete('mtime-test')
+    File.delete("#{$mrbtest_io_wfname}.mtime")
   end
 end
 

--- a/deps/mruby/mrbgems/mruby-kernel-ext/mrblib/kernel.rb
+++ b/deps/mruby/mrbgems/mruby-kernel-ext/mrblib/kernel.rb
@@ -1,6 +1,7 @@
 module Kernel
   # call-seq:
   #   obj.yield_self {|_obj|...} -> an_object
+  #   obj.then {|_obj|...}       -> an_object
   #
   # Yields <i>obj</i> and returns the result.
   #
@@ -10,4 +11,5 @@ module Kernel
     return to_enum :yield_self unless block
     block.call(self)
   end
+  alias then yield_self
 end

--- a/deps/mruby/mrbgems/mruby-pack/src/pack.c
+++ b/deps/mruby/mrbgems/mruby-pack/src/pack.c
@@ -510,7 +510,7 @@ utf8_to_uv(mrb_state *mrb, const char *p, long *lenp)
   }
   if (n > *lenp) {
     mrb_raisef(mrb, E_ARGUMENT_ERROR, "malformed UTF-8 character (expected %S bytes, given %S bytes)",
-    mrb_fixnum_value(n), mrb_fixnum_value(*lenp));
+               mrb_fixnum_value(n), mrb_fixnum_value(*lenp));
   }
   *lenp = n--;
   if (n != 0) {
@@ -1055,7 +1055,7 @@ alias:
       while (tmpl->idx < tlen && isdigit(tptr[tmpl->idx])) {
         count = count * 10 + (tptr[tmpl->idx++] - '0');
         if (count < 0) {
-          mrb_raisef(mrb, E_RUNTIME_ERROR, "too big template length");
+          mrb_raise(mrb, E_RUNTIME_ERROR, "too big template length");
         }
       }
       continue;  /* special case */

--- a/deps/mruby/mrbgems/mruby-pack/test/pack.rb
+++ b/deps/mruby/mrbgems/mruby-pack/test/pack.rb
@@ -129,7 +129,7 @@ assert 'pack/unpack "i"' do
   if PACK_IS_LITTLE_ENDIAN
     str = "\xC7\xCF" + "\xFF" * (int_size-2)
   else
-    str = "\xFF" * (int_size-2) + "\xC7\xCF"
+    str = "\xFF" * (int_size-2) + "\xCF\xC7"
   end
   assert_pack 'i', str, [-12345]
 end
@@ -141,7 +141,7 @@ assert 'pack/unpack "I"' do
   if PACK_IS_LITTLE_ENDIAN
     str = "\x39\x30" + "\0" * (uint_size-2)
   else
-    str = "\0" * (uint_size-2) + "\x39\x30"
+    str = "\0" * (uint_size-2) + "\x30\x39"
   end
   assert_pack 'I', str, [12345]
 end

--- a/deps/mruby/mrbgems/mruby-socket/mrbgem.rake
+++ b/deps/mruby/mrbgems/mruby-socket/mrbgem.rake
@@ -4,6 +4,7 @@ MRuby::Gem::Specification.new('mruby-socket') do |spec|
   spec.summary = 'standard socket class'
 
   spec.cc.include_paths << "#{build.root}/src"
+  #spec.cc.defines << "HAVE_SA_LEN=0"
 
   # If Windows, use winsock
   if ( /mswin|mingw|win32/ =~ RUBY_PLATFORM ) then

--- a/deps/mruby/mrbgems/mruby-socket/test/addrinfo.rb
+++ b/deps/mruby/mrbgems/mruby-socket/test/addrinfo.rb
@@ -7,7 +7,7 @@ assert('super class of Addrinfo') do
 end
 
 assert('Addrinfo.getaddrinfo') do
-  ary = Addrinfo.getaddrinfo("localhost", "domain", Socket::AF_INET, Socket::SOCK_STREAM)
+  ary = Addrinfo.getaddrinfo("localhost", 53, Socket::AF_INET, Socket::SOCK_STREAM)
   assert_true(ary.size >= 1)
   ai = ary[0]
   assert_equal(ai.afamily, Socket::AF_INET)
@@ -19,9 +19,9 @@ end
 
 assert('Addrinfo.foreach') do
   # assume Addrinfo.getaddrinfo works well
-  a = Addrinfo.getaddrinfo("localhost", "domain")
+  a = Addrinfo.getaddrinfo("localhost", 80)
   b = []
-  Addrinfo.foreach("localhost", "domain") { |ai| b << ai }
+  Addrinfo.foreach("localhost", 80) { |ai| b << ai }
   assert_equal(a.size, b.size)
 end
 
@@ -35,7 +35,7 @@ assert('Addrinfo.ip') do
 end
 
 assert('Addrinfo.tcp') do
-  ai = Addrinfo.tcp('127.0.0.1', 'smtp')
+  ai = Addrinfo.tcp('127.0.0.1', 25)
   assert_equal('127.0.0.1', ai.ip_address)
   assert_equal(Socket::AF_INET, ai.afamily)
   assert_equal(25, ai.ip_port)
@@ -44,7 +44,7 @@ assert('Addrinfo.tcp') do
 end
 
 assert('Addrinfo.udp') do
-  ai = Addrinfo.udp('127.0.0.1', 'domain')
+  ai = Addrinfo.udp('127.0.0.1', 53)
   assert_equal('127.0.0.1', ai.ip_address)
   assert_equal(Socket::AF_INET, ai.afamily)
   assert_equal(53, ai.ip_port)

--- a/deps/mruby/mrbgems/mruby-socket/test/socket.rb
+++ b/deps/mruby/mrbgems/mruby-socket/test/socket.rb
@@ -5,7 +5,7 @@ assert('Socket.gethostname') do
 end
 
 assert('Socket::getaddrinfo') do
-  ret = Socket.getaddrinfo("localhost", "domain", Socket::AF_INET, Socket::SOCK_DGRAM)
+  ret = Socket.getaddrinfo("localhost", 53, Socket::AF_INET, Socket::SOCK_DGRAM)
   assert_true ret.size >= 1
   a = ret[0]
   assert_equal "AF_INET",           a[0]

--- a/deps/mruby/mrbgems/mruby-sprintf/src/sprintf.c
+++ b/deps/mruby/mrbgems/mruby-sprintf/src/sprintf.c
@@ -119,13 +119,11 @@ mrb_fix2binstr(mrb_state *mrb, mrb_value x, int base)
 #define FPREC0 128
 
 #define CHECK(l) do {\
-/*  int cr = ENC_CODERANGE(result);*/\
   while ((l) >= bsiz - blen) {\
+    if (bsiz > MRB_INT_MAX/2) mrb_raise(mrb, E_ARGUMENT_ERROR, "too big specifier"); \
     bsiz*=2;\
-    if (bsiz < 0) mrb_raise(mrb, E_ARGUMENT_ERROR, "too big specifier"); \
   }\
   mrb_str_resize(mrb, result, bsiz);\
-/*  ENC_CODERANGE_SET(result, cr);*/\
   buf = RSTRING_PTR(result);\
 } while (0)
 
@@ -202,11 +200,10 @@ check_name_arg(mrb_state *mrb, int posarg, const char *name, mrb_int len)
 
 #define GETNUM(n, val) \
   for (; p < end && ISDIGIT(*p); p++) {\
-    mrb_int next_n = 10 * n + (*p - '0'); \
-    if (next_n / 10 != n) {\
+    if (n > MRB_INT_MAX/10) {\
       mrb_raise(mrb, E_ARGUMENT_ERROR, #val " too big"); \
     } \
-    n = next_n; \
+    n = 10 * n + (*p - '0'); \
   } \
   if (p >= end) { \
     mrb_raise(mrb, E_ARGUMENT_ERROR, "malformed format string - %*[0-9]"); \

--- a/deps/mruby/mrbgems/mruby-string-ext/mrblib/string.rb
+++ b/deps/mruby/mrbgems/mruby-string-ext/mrblib/string.rb
@@ -365,4 +365,98 @@ class String
     self[0, 0] = arg
     self
   end
+
+  ##
+  #  call-seq:
+  #    string.lines                ->  array of string
+  #    string.lines {|s| block}    ->  array of string
+  #
+  #  Returns strings per line;
+  #
+  #    a = "abc\ndef"
+  #    a.lines    #=> ["abc\n", "def"]
+  #
+  #  If a block is given, it works the same as <code>each_line</code>.
+  def lines(&blk)
+    lines = self.__lines
+    if blk
+      lines.each do |line|
+        blk.call(line)
+      end
+    end
+    lines
+  end
+
+  ##
+  #  call-seq:
+  #     str.upto(other_str, exclusive=false) {|s| block }   -> str
+  #     str.upto(other_str, exclusive=false)                -> an_enumerator
+  #
+  #  Iterates through successive values, starting at <i>str</i> and
+  #  ending at <i>other_str</i> inclusive, passing each value in turn to
+  #  the block. The <code>String#succ</code> method is used to generate
+  #  each value.  If optional second argument exclusive is omitted or is false,
+  #  the last value will be included; otherwise it will be excluded.
+  #
+  #  If no block is given, an enumerator is returned instead.
+  #
+  #     "a8".upto("b6") {|s| print s, ' ' }
+  #     for s in "a8".."b6"
+  #       print s, ' '
+  #     end
+  #
+  #  <em>produces:</em>
+  #
+  #     a8 a9 b0 b1 b2 b3 b4 b5 b6
+  #     a8 a9 b0 b1 b2 b3 b4 b5 b6
+  #
+  #  If <i>str</i> and <i>other_str</i> contains only ascii numeric characters,
+  #  both are recognized as decimal numbers. In addition, the width of
+  #  string (e.g. leading zeros) is handled appropriately.
+  #
+  #     "9".upto("11").to_a   #=> ["9", "10", "11"]
+  #     "25".upto("5").to_a   #=> []
+  #     "07".upto("11").to_a  #=> ["07", "08", "09", "10", "11"]
+  def upto(max, exclusive=false, &block)
+    return to_enum(:upto, max, exclusive) unless block
+    raise TypeError, "no implicit conversion of #{max.class} into String" unless max.kind_of? String
+
+    len = self.length
+    maxlen = max.length
+    # single character
+    if len == 1 and maxlen == 1
+      c = self.ord
+      e = max.ord
+      while c <= e
+        break if exclusive and c == e
+        yield c.chr
+        c += 1
+      end
+      return self
+    end
+    # both edges are all digits
+    bi = self.to_i(10)
+    ei = max.to_i(10)
+    len = self.length
+    if (bi > 0 or bi == "0"*len) and (ei > 0 or ei == "0"*maxlen)
+      while bi <= ei
+        break if exclusive and bi == ei
+        s = bi.to_s
+        s = s.rjust(len, "0") if s.length < len
+        yield s
+        bi += 1
+      end
+      return self
+    end
+    bs = self
+    while true
+      n = (bs <=> max)
+      break if n > 0
+      break if exclusive and n == 0
+      yield bs
+      break if n == 0
+      bs = bs.succ
+    end
+    self
+  end
 end

--- a/deps/mruby/mrbgems/mruby-string-ext/src/string.c
+++ b/deps/mruby/mrbgems/mruby-string-ext/src/string.c
@@ -309,60 +309,6 @@ mrb_fixnum_chr(mrb_state *mrb, mrb_value num)
 
 /*
  *  call-seq:
- *     string.lines    ->  array of string
- *
- *  Returns strings per line;
- *
- *     a = "abc\ndef"
- *     a.lines    #=> ["abc\n", "def"]
- */
-static mrb_value
-mrb_str_lines(mrb_state *mrb, mrb_value self)
-{
-  mrb_value result;
-  mrb_value blk;
-  int ai;
-  mrb_int len;
-  mrb_value arg;
-  char *b = RSTRING_PTR(self);
-  char *p = b, *t;
-  char *e = b + RSTRING_LEN(self);
-
-  mrb_get_args(mrb, "&", &blk);
-
-  result = mrb_ary_new(mrb);
-  ai = mrb_gc_arena_save(mrb);
-  if (!mrb_nil_p(blk)) {
-    while (p < e) {
-      t = p;
-      while (p < e && *p != '\n') p++;
-      if (*p == '\n') p++;
-      len = (mrb_int) (p - t);
-      arg = mrb_str_new(mrb, t, len);
-      mrb_yield_argv(mrb, blk, 1, &arg);
-      mrb_gc_arena_restore(mrb, ai);
-      if (b != RSTRING_PTR(self)) {
-        ptrdiff_t diff = p - b;
-        b = RSTRING_PTR(self);
-        p = b + diff;
-      }
-      e = b + RSTRING_LEN(self);
-    }
-    return self;
-  }
-  while (p < e) {
-    t = p;
-    while (p < e && *p != '\n') p++;
-    if (*p == '\n') p++;
-    len = (mrb_int) (p - t);
-    mrb_ary_push(mrb, result, mrb_str_new(mrb, t, len));
-    mrb_gc_arena_restore(mrb, ai);
-  }
-  return result;
-}
-
-/*
- *  call-seq:
  *     string.succ    ->  string
  *
  *  Returns next sequence of the string;
@@ -524,135 +470,6 @@ mrb_str_ord(mrb_state* mrb, mrb_value str)
 }
 #endif
 
-static mrb_bool
-all_digits_p(const char *s, mrb_int len)
-{
-  while (len-- > 0) {
-    if (!ISDIGIT(*s)) return FALSE;
-    s++;
-  }
-  return TRUE;
-}
-
-/*
- *  call-seq:
- *     str.upto(other_str, exclusive=false) {|s| block }   -> str
- *     str.upto(other_str, exclusive=false)                -> an_enumerator
- *
- *  Iterates through successive values, starting at <i>str</i> and
- *  ending at <i>other_str</i> inclusive, passing each value in turn to
- *  the block. The <code>String#succ</code> method is used to generate
- *  each value.  If optional second argument exclusive is omitted or is false,
- *  the last value will be included; otherwise it will be excluded.
- *
- *  If no block is given, an enumerator is returned instead.
- *
- *     "a8".upto("b6") {|s| print s, ' ' }
- *     for s in "a8".."b6"
- *       print s, ' '
- *     end
- *
- *  <em>produces:</em>
- *
- *     a8 a9 b0 b1 b2 b3 b4 b5 b6
- *     a8 a9 b0 b1 b2 b3 b4 b5 b6
- *
- *  If <i>str</i> and <i>other_str</i> contains only ascii numeric characters,
- *  both are recognized as decimal numbers. In addition, the width of
- *  string (e.g. leading zeros) is handled appropriately.
- *
- *     "9".upto("11").to_a   #=> ["9", "10", "11"]
- *     "25".upto("5").to_a   #=> []
- *     "07".upto("11").to_a  #=> ["07", "08", "09", "10", "11"]
- */
-static mrb_value
-mrb_str_upto(mrb_state *mrb, mrb_value beg)
-{
-  mrb_value end;
-  mrb_value exclusive = mrb_false_value();
-  mrb_value block = mrb_nil_value();
-  mrb_value current, after_end;
-  mrb_int n;
-  mrb_bool excl;
-
-  mrb_get_args(mrb, "o|o&", &end, &exclusive, &block);
-
-  if (mrb_nil_p(block)) {
-    return mrb_funcall(mrb, beg, "to_enum", 3, mrb_symbol_value(mrb_intern_lit(mrb, "upto")), end, exclusive);
-  }
-  end = mrb_string_type(mrb, end);
-  excl = mrb_test(exclusive);
-
-  /* single character */
-  if (RSTRING_LEN(beg) == 1 && RSTRING_LEN(end) == 1 &&
-  ISASCII(RSTRING_PTR(beg)[0]) && ISASCII(RSTRING_PTR(end)[0])) {
-    char c = RSTRING_PTR(beg)[0];
-    char e = RSTRING_PTR(end)[0];
-    int ai = mrb_gc_arena_save(mrb);
-
-    if (c > e || (excl && c == e)) return beg;
-    for (;;) {
-      mrb_yield(mrb, block, mrb_str_new(mrb, &c, 1));
-      mrb_gc_arena_restore(mrb, ai);
-      if (!excl && c == e) break;
-      c++;
-      if (excl && c == e) break;
-    }
-    return beg;
-  }
-  /* both edges are all digits */
-  if (ISDIGIT(RSTRING_PTR(beg)[0]) && ISDIGIT(RSTRING_PTR(end)[0]) &&
-      all_digits_p(RSTRING_PTR(beg), RSTRING_LEN(beg)) &&
-      all_digits_p(RSTRING_PTR(end), RSTRING_LEN(end))) {
-    mrb_int min_width = RSTRING_LEN(beg);
-    mrb_int bi = mrb_int(mrb, mrb_str_to_inum(mrb, beg, 10, FALSE));
-    mrb_int ei = mrb_int(mrb, mrb_str_to_inum(mrb, end, 10, FALSE));
-    int ai = mrb_gc_arena_save(mrb);
-
-    while (bi <= ei) {
-      mrb_value ns, str;
-
-      if (excl && bi == ei) break;
-      ns = mrb_format(mrb, "%S", mrb_fixnum_value(bi));
-      if (min_width > RSTRING_LEN(ns)) {
-        str = mrb_str_new(mrb, NULL, min_width);
-        memset(RSTRING_PTR(str), '0', min_width-RSTRING_LEN(ns));
-        memcpy(RSTRING_PTR(str)+min_width-RSTRING_LEN(ns),
-               RSTRING_PTR(ns), RSTRING_LEN(ns));
-      }
-      else {
-        str = ns;
-      }
-      mrb_yield(mrb, block, str);
-      mrb_gc_arena_restore(mrb, ai);
-      bi++;
-    }
-
-    return beg;
-  }
-  /* normal case */
-  n = mrb_int(mrb, mrb_funcall(mrb, beg, "<=>", 1, end));
-  if (n > 0 || (excl && n == 0)) return beg;
-
-  after_end = mrb_funcall(mrb, end, "succ", 0);
-  current = mrb_str_dup(mrb, beg);
-  while (!mrb_str_equal(mrb, current, after_end)) {
-    int ai = mrb_gc_arena_save(mrb);
-    mrb_value next = mrb_nil_value();
-    if (excl || !mrb_str_equal(mrb, current, end))
-      next = mrb_funcall(mrb, current, "succ", 0);
-    mrb_yield(mrb, block, current);
-    if (mrb_nil_p(next)) break;
-    current = mrb_str_to_str(mrb, next);
-    if (excl && mrb_str_equal(mrb, current, end)) break;
-    if (RSTRING_LEN(current) > RSTRING_LEN(end) || RSTRING_LEN(current) == 0)
-      break;
-    mrb_gc_arena_restore(mrb, ai);
-  }
-
-  return beg;
-}
-
 /*
  *  call-seq:
  *     str.delete_prefix!(prefix) -> self or nil
@@ -765,6 +582,31 @@ mrb_str_del_suffix(mrb_state *mrb, mrb_value self)
   return mrb_str_substr(mrb, self, 0, slen-plen);
 }
 
+static mrb_value
+mrb_str_lines(mrb_state *mrb, mrb_value self)
+{
+  mrb_value result;
+  int ai;
+  mrb_int len;
+  char *b = RSTRING_PTR(self);
+  char *p = b, *t;
+  char *e = b + RSTRING_LEN(self);
+
+  mrb_get_args(mrb, "");
+
+  result = mrb_ary_new(mrb);
+  ai = mrb_gc_arena_save(mrb);
+  while (p < e) {
+    t = p;
+    while (p < e && *p != '\n') p++;
+    if (*p == '\n') p++;
+    len = (mrb_int) (p - t);
+    mrb_ary_push(mrb, result, mrb_str_new(mrb, t, len));
+    mrb_gc_arena_restore(mrb, ai);
+  }
+  return result;
+}
+
 void
 mrb_mruby_string_ext_gem_init(mrb_state* mrb)
 {
@@ -783,18 +625,17 @@ mrb_mruby_string_ext_gem_init(mrb_state* mrb)
   mrb_define_method(mrb, s, "hex",             mrb_str_hex,             MRB_ARGS_NONE());
   mrb_define_method(mrb, s, "oct",             mrb_str_oct,             MRB_ARGS_NONE());
   mrb_define_method(mrb, s, "chr",             mrb_str_chr,             MRB_ARGS_NONE());
-  mrb_define_method(mrb, s, "lines",           mrb_str_lines,           MRB_ARGS_NONE());
   mrb_define_method(mrb, s, "succ",            mrb_str_succ,            MRB_ARGS_NONE());
   mrb_define_method(mrb, s, "succ!",           mrb_str_succ_bang,       MRB_ARGS_NONE());
   mrb_alias_method(mrb, s, mrb_intern_lit(mrb, "next"), mrb_intern_lit(mrb, "succ"));
   mrb_alias_method(mrb, s, mrb_intern_lit(mrb, "next!"), mrb_intern_lit(mrb, "succ!"));
   mrb_define_method(mrb, s, "ord",             mrb_str_ord,             MRB_ARGS_NONE());
-  mrb_define_method(mrb, s, "upto",            mrb_str_upto,            MRB_ARGS_ANY());
   mrb_define_method(mrb, s, "delete_prefix!",  mrb_str_del_prefix_bang, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, s, "delete_prefix",   mrb_str_del_prefix,      MRB_ARGS_REQ(1));
   mrb_define_method(mrb, s, "delete_suffix!",  mrb_str_del_suffix_bang, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, s, "delete_suffix",   mrb_str_del_suffix,      MRB_ARGS_REQ(1));
 
+  mrb_define_method(mrb, s, "__lines",         mrb_str_lines,           MRB_ARGS_NONE());
   mrb_define_method(mrb, mrb->fixnum_class, "chr", mrb_fixnum_chr, MRB_ARGS_NONE());
 }
 

--- a/deps/mruby/mrblib/array.rb
+++ b/deps/mruby/mrblib/array.rb
@@ -197,24 +197,28 @@ class Array
   # left  : the beginning of sort region
   # right : the end of sort region
   def __sort_sub__(left, right, &block)
-    if left < right
-      i = left
-      j = right
-      pivot = self[i + (j - i) / 2]
-      while true
-        while ((block)? block.call(self[i], pivot): (self[i] <=> pivot)) < 0
+    stack = [ [left, right] ]
+    until stack.empty?
+      left, right = stack.pop
+      if left < right
+        i = left
+        j = right
+        pivot = self[i + (j - i) / 2]
+        while true
+          while ((block)? block.call(self[i], pivot): (self[i] <=> pivot)) < 0
+            i += 1
+          end
+          while ((block)? block.call(pivot, self[j]): (pivot <=> self[j])) < 0
+            j -= 1
+          end
+          break if (i >= j)
+          tmp = self[i]; self[i] = self[j]; self[j] = tmp;
           i += 1
-        end
-        while ((block)? block.call(pivot, self[j]): (pivot <=> self[j])) < 0
           j -= 1
         end
-        break if (i >= j)
-        tmp = self[i]; self[i] = self[j]; self[j] = tmp;
-        i += 1
-        j -= 1
+        stack.push [left, i-1]
+        stack.push [j+1, right]
       end
-      __sort_sub__(left, i-1, &block)
-      __sort_sub__(j+1, right, &block)
     end
   end
   #  private :__sort_sub__

--- a/deps/mruby/mrblib/enum.rb
+++ b/deps/mruby/mrblib/enum.rb
@@ -339,8 +339,7 @@ module Enumerable
     h = 12347
     i = 0
     self.each do |e|
-      n = (e.hash & (0x7fffffff >> (i % 16))) << (i % 16)
-      h ^= n
+      h = __update_hash(h, i, e.hash)
       i += 1
     end
     h

--- a/deps/mruby/mrblib/hash.rb
+++ b/deps/mruby/mrblib/hash.rb
@@ -179,10 +179,9 @@ class Hash
   #
   # ISO 15.2.13.4.22
   def merge(other, &block)
-    h = {}
     raise TypeError, "can't convert argument into Hash" unless other.respond_to?(:to_hash)
     other = other.to_hash
-    self.each_key{|k| h[k] = self[k]}
+    h = self.dup
     if block
       other.each_key{|k|
         h[k] = (self.has_key?(k))? block.call(k, self[k], other[k]): other[k]

--- a/deps/mruby/src/array.c
+++ b/deps/mruby/src/array.c
@@ -377,6 +377,9 @@ ary_replace(mrb_state *mrb, struct RArray *a, struct RArray *b)
     if (ARY_EMBED_P(a)) {
       ARY_UNSET_EMBED_FLAG(a);
     }
+    else {
+      mrb_free(mrb, a->as.heap.ptr);
+    }
     a->as.heap.ptr = b->as.heap.ptr;
     a->as.heap.len = len;
     a->as.heap.aux.shared = b->as.heap.aux.shared;

--- a/deps/mruby/src/backtrace.c
+++ b/deps/mruby/src/backtrace.c
@@ -51,6 +51,7 @@ each_backtrace(mrb_state *mrb, ptrdiff_t ciidx, mrb_code *pc0, each_backtrace_fu
       pc = mrb->c->cibase[i].err;
     }
     else if (i+1 <= ciidx) {
+      if (!mrb->c->cibase[i + 1].pc) continue;
       pc = &mrb->c->cibase[i+1].pc[-1];
     }
     else {

--- a/deps/mruby/src/enum.c
+++ b/deps/mruby/src/enum.c
@@ -5,10 +5,40 @@
 */
 
 #include <mruby.h>
+#include <mruby/proc.h>
+
+/* internal method `__update_hash(oldhash, index, itemhash)` */
+static mrb_value
+enum_update_hash(mrb_state *mrb, mrb_value self)
+{
+  mrb_int hash;
+  mrb_int index;
+  mrb_int hv;
+  mrb_value item_hash;
+
+  mrb_get_args(mrb, "iio", &hash, &index, &item_hash);
+  if (mrb_fixnum_p(item_hash)) {
+    hv = mrb_fixnum(item_hash);
+  }
+#ifndef MRB_WITHOUT_FLOAT
+  else if (mrb_float_p(item_hash)) {
+    hv = (mrb_int)mrb_float(item_hash);
+  }
+#endif
+  else {
+    mrb_raise(mrb, E_TYPE_ERROR, "can't calculate hash");
+    /* not reached */
+    hv = 0;
+  }
+  hash ^= (hv << (index % 16));
+
+  return mrb_fixnum_value(hash);
+}
 
 void
 mrb_init_enumerable(mrb_state *mrb)
 {
-  mrb_define_module(mrb, "Enumerable");  /* 15.3.2 */
+  struct RClass *enumerable;
+  enumerable = mrb_define_module(mrb, "Enumerable");  /* 15.3.2 */
+  mrb_define_module_function(mrb, enumerable, "__update_hash", enum_update_hash, MRB_ARGS_REQ(1));
 }
-

--- a/deps/mruby/src/error.c
+++ b/deps/mruby/src/error.c
@@ -233,7 +233,7 @@ mrb_exc_set(mrb_state *mrb, mrb_value exc)
         (struct RBasic*)mrb->exc == mrb->gc.arena[mrb->gc.arena_idx-1]) {
       mrb->gc.arena_idx--;
     }
-    if (!mrb->gc.out_of_memory) {
+    if (!mrb->gc.out_of_memory && !MRB_FROZEN_P(mrb->exc)) {
       exc_debug_info(mrb, mrb->exc);
       mrb_keep_backtrace(mrb, exc);
     }

--- a/deps/mruby/src/gc.c
+++ b/deps/mruby/src/gc.c
@@ -622,7 +622,7 @@ gc_mark_children(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
   case MRB_TT_ICLASS:
     {
       struct RClass *c = (struct RClass*)obj;
-      if (MRB_FLAG_TEST(c, MRB_FLAG_IS_ORIGIN))
+      if (MRB_FLAG_TEST(c, MRB_FL_CLASS_IS_ORIGIN))
         mrb_gc_mark_mt(mrb, c);
       mrb_gc_mark(mrb, (struct RBasic*)((struct RClass*)obj)->super);
     }
@@ -761,7 +761,7 @@ obj_free(mrb_state *mrb, struct RBasic *obj, int end)
     mrb_gc_free_iv(mrb, (struct RObject*)obj);
     break;
   case MRB_TT_ICLASS:
-    if (MRB_FLAG_TEST(obj, MRB_FLAG_IS_ORIGIN))
+    if (MRB_FLAG_TEST(obj, MRB_FL_CLASS_IS_ORIGIN))
       mrb_gc_free_mt(mrb, (struct RClass*)obj);
     break;
   case MRB_TT_ENV:
@@ -938,7 +938,7 @@ gc_gray_mark(mrb_state *mrb, mrb_gc *gc, struct RBasic *obj)
     break;
 
   case MRB_TT_ENV:
-    children += (int)obj->flags;
+    children += MRB_ENV_STACK_LEN(obj);
     break;
 
   case MRB_TT_FIBER:

--- a/deps/mruby/src/load.c
+++ b/deps/mruby/src/load.c
@@ -128,8 +128,13 @@ read_irep_record_1(mrb_state *mrb, const uint8_t *bin, size_t *len, uint8_t flag
       switch (tt) { /* pool data */
       case IREP_TT_FIXNUM: {
         mrb_value num = mrb_str_to_inum(mrb, s, 10, FALSE);
+#ifdef MRB_WITHOUT_FLOAT
+        irep->pool[i] = num;
+#else
         irep->pool[i] = mrb_float_p(num)? mrb_float_pool(mrb, mrb_float(num)) : num;
-      } break;
+#endif
+        }
+        break;
 
 #ifndef MRB_WITHOUT_FLOAT
       case IREP_TT_FLOAT:

--- a/deps/mruby/src/numeric.c
+++ b/deps/mruby/src/numeric.c
@@ -23,9 +23,9 @@
 #define floor(f) floorf(f)
 #define ceil(f) ceilf(f)
 #define fmod(x,y) fmodf(x,y)
-#define MRB_FLO_TO_STR_FMT "%.7g"
+#define MRB_FLO_TO_STR_FMT "%.8g"
 #else
-#define MRB_FLO_TO_STR_FMT "%.14g"
+#define MRB_FLO_TO_STR_FMT "%.16g"
 #endif
 #endif
 

--- a/deps/mruby/src/range.c
+++ b/deps/mruby/src/range.c
@@ -120,6 +120,7 @@ range_init(mrb_state *mrb, mrb_value range, mrb_value beg, mrb_value end, mrb_bo
   }
   r->edges->beg = beg;
   r->edges->end = end;
+  mrb_write_barrier(mrb, (struct RBasic*)r);
 }
 /*
  *  call-seq:

--- a/deps/mruby/tasks/libmruby.rake
+++ b/deps/mruby/tasks/libmruby.rake
@@ -4,6 +4,7 @@ MRuby.each_target do
   end
 
   file "#{build_dir}/lib/libmruby.flags.mak" => [__FILE__, libfile("#{build_dir}/lib/libmruby")] do |t|
+    FileUtils.mkdir_p File.dirname t.name
     open(t.name, 'w') do |f|
       f.puts "MRUBY_CFLAGS = #{cc.all_flags}"
 

--- a/deps/mruby/tasks/mrbgems.rake
+++ b/deps/mruby/tasks/mrbgems.rake
@@ -53,6 +53,7 @@ MRuby.each_target do
 
   # legal documents
   file "#{build_dir}/LEGAL" => [MRUBY_CONFIG, __FILE__] do |t|
+    FileUtils.mkdir_p File.dirname t.name
     open(t.name, 'w+') do |f|
      f.puts <<LEGAL
 Copyright (c) #{Time.now.year} mruby developers

--- a/deps/mruby/tasks/toolchains/android.rake
+++ b/deps/mruby/tasks/toolchains/android.rake
@@ -7,6 +7,7 @@ class MRuby::Toolchain::Android
   DEFAULT_NDK_HOMES = %w{
     /usr/local/opt/android-sdk/ndk-bundle
     /usr/local/opt/android-ndk
+    ~/Android/Sdk/ndk-bundle
     %LOCALAPPDATA%/Android/android-sdk/ndk-bundle
     %LOCALAPPDATA%/Android/android-ndk
     ~/Library/Android/sdk/ndk-bundle

--- a/deps/mruby/test/t/array.rb
+++ b/deps/mruby/test/t/array.rb
@@ -392,3 +392,10 @@ assert('Array#freeze') do
     a[0] = 1
   end
 end
+
+assert('shared array replace') do
+  a = [0] * 40
+  b = [0, 1, 2]
+  b.replace a[1, 20].dup
+  assert_equal 20, b.size
+end

--- a/deps/mruby/test/t/kernel.rb
+++ b/deps/mruby/test/t/kernel.rb
@@ -171,6 +171,10 @@ assert('Kernel#clone', '15.3.1.3.8') do
   assert_true a.respond_to?(:test)
   assert_false b.respond_to?(:test)
   assert_true c.respond_to?(:test)
+  
+  a.freeze
+  d = a.clone
+  assert_true d.frozen?
 end
 
 assert('Kernel#dup', '15.3.1.3.9') do


### PR DESCRIPTION
Fixes https://github.com/h2o/h2o/issues/1830.
I found that https://github.com/mruby/mruby/commit/c6736357a72049a0eb2a31ccabcc3cd2baba7c9e is so harmful that live objects can be accidentally freed, but it's reverted at https://github.com/mruby/mruby/commit/23a4e7149dc4253caf5ed0a528ffe5c21c4afb80.