### PR TITLE
wait for server to terminate before collecting the log lines

### DIFF
--- a/t/50internal-redirect.t
+++ b/t/50internal-redirect.t
@@ -85,6 +85,7 @@ $path_conf2
 EOT
     my $server = _spawn_h2o_raw($conf, [$port1, $port2]);
     $cb->();
+    undef $server; # wait for server to die before collecting the log
 
     my @log = do {
         open my $fh, '<', $access_log or die "failed to open log file: $!";


### PR DESCRIPTION
The race condition between the server emitting the log and the test script collecting them has sometimes resulted in CI failures like below (https://travis-ci.org/h2o/h2o/jobs/425131563).

This PR fixes the issue by killing the server (and waiting for it to terminate by calling `wait`) before collecting the logs.

```
t/50internal-redirect.t .............................. spawning plackup... Plack::Handler::Starlet: Accepting connections at http://0:35698/

    # Subtest: reproxy[0m
done
spawning /home/ci/build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:12449) is ready to serve requests
done
    not ok 1 - redirected internally[0m
    
    #   Failed test 'redirected internally'
    #   at t/50internal-redirect.t line 93.
    #          got: '0'
    #     expected: '1'
killing /home/ci/build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..1[0m
    # Looks like you failed 1 test of 1.
[31mnot ok 1 - reproxy[0m

#   Failed test 'reproxy'
#   at t/50internal-redirect.t line 28.
    # Subtest: location[0m
spawning /home/ci/build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:12455) is ready to serve requests
done
    ok 1 - redirected internally[0m
killing /home/ci/build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..1[0m
ok 2 - location[0m
    # Subtest: errordoc[0m
spawning /home/ci/build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:12461) is ready to serve requests
done
    ok 1 - redirected internally[0m
killing /home/ci/build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..1[0m
ok 3 - errordoc[0m
1..3[0m
killing plackup... killed (got 0)
# Looks like you failed 1 test of 3.
[31mDubious, test returned 1 (wstat 256, 0x100)[0m
[31mFailed 1/3 subtests [0m
```