### PR TITLE
Add userdata pointer into st_h2o_handler_t struct

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -139,6 +139,7 @@ typedef struct st_h2o_handler_t {
     void (*on_context_dispose)(struct st_h2o_handler_t *self, h2o_context_t *ctx);
     void (*dispose)(struct st_h2o_handler_t *self);
     int (*on_req)(struct st_h2o_handler_t *self, h2o_req_t *req);
+    void* userdata;
     /**
      * If the flag is set, protocol handler may invoke the request handler before receiving the end of the request body. The request
      * handler can determine if the protocol handler has actually done so by checking if `req->proceed_req` is set to non-NULL.


### PR DESCRIPTION
It wold be nice to add possibility for user to add custom user data into handlers.
With custom user data it would be simpler to integrate h2o with other products or for example implement authorization counter.
Just 1 field add absolutley more flexability to the handler. Also it would be easier to access accossiated with handler data.