### PR TITLE
Remove dependency to execinfo.h from socketpool.h.

### DIFF
--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -26,7 +26,6 @@
 extern "C" {
 #endif
 
-#include <execinfo.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <pthread.h>


### PR DESCRIPTION
The `backtrace` family is only used in `src/main.c` and it already has a `#include <execinfo.h>` line, so it seems safe to remove it.

Fixes #1843