### PR TITLE
Suppress GCC warnings

### DIFF
--- a/include/h2o/hiredis_.h
+++ b/include/h2o/hiredis_.h
@@ -21,6 +21,7 @@
  */
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #include "hiredis.h"
 #include "async.h"

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -53,6 +53,7 @@
 
 #define OPENSSL_HOSTNAME_VALIDATION_LINKAGE static
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
 #include "../../deps/ssl-conservatory/openssl/openssl_hostname_validation.c"
 #pragma GCC diagnostic pop

--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -423,7 +423,7 @@ int h2o_url_init_with_hostport(h2o_url_t *url, h2o_mem_pool_t *pool, const h2o_u
     } else {
         url->_port = port;
         char _port[sizeof(H2O_UINT16_LONGEST_STR)];
-        int port_len = sprintf(_port, "%" PRIu16, port);
+        int port_len = sprintf(_port, "%" "hu", port);
         if (port_len < 0)
             return -1;
 

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -584,7 +584,7 @@ int h2o_hpack_parse_response_headers(h2o_mem_pool_t *pool, int *status, h2o_head
                                      h2o_hpack_header_table_t *header_table, const uint8_t *src, size_t len, const char **err_desc)
 {
     assert(*status == 0);
-    assert(*content_length = SIZE_MAX);
+    assert(*content_length == SIZE_MAX);
 
     const uint8_t *src_end = src + len;
 


### PR DESCRIPTION
gcc7.3.0 dont recognize Wshorten-64-to-32.
Maybe it is better to add Macro to proect them, but I think we can just suppress Wpragmas.

In gcc7.3.0, PRIu16 is equal to 'u'. It is not accurate and it cause some print checking failed. For example, the buffer is shorter for int.
So just use 'hu', it is shorter and accurate.

In lib/http2/hpack.c , there is an assignment in assert.... It is a typo, I guess.
