### PR TITLE
zero-clear the memory used by http1/http2 client implementiation

### DIFF
--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -69,10 +69,10 @@ static struct st_h2o_httpclient_private_t *create_client(h2o_mem_pool_t *pool, v
                                                          h2o_httpclient_connect_cb cb)
 {
 #define SZ_MAX(x, y) ((x) > (y) ? (x) : (y))
-    size_t sz = SZ_MAX(sizeof(struct st_h2o_http1client_t), sizeof(struct st_h2o_http2client_stream_t));
+    static const size_t sz = SZ_MAX(sizeof(struct st_h2o_http1client_t), sizeof(struct st_h2o_http2client_stream_t));
 #undef SZ_MAX
     struct st_h2o_httpclient_private_t *client = h2o_mem_alloc(sz);
-    memset(client, 0, sizeof(*client));
+    memset(client, 0, sz);
     client->super.pool = pool;
     client->super.ctx = ctx;
     client->super.data = data;


### PR DESCRIPTION
Offending log (it is from a different branch and the function names are different):
```
h2o: /h2o/lib/http2/hpack.c:571: h2o_hpack_parse_response: Assertion `*status == 0' failed.
received fatal signal 6
[24819] /home/ci/build/h2o[0x4cac3e] on_sigfatal at /h2o/src/main.c:1497
[24819] /lib/x86_64-linux-gnu/libpthread.so.0(+0x11390)[0x7f38d5a15390] ?? ??:0
[24819] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x38)[0x7f38d566f428] ?? ??:0
[24819] /lib/x86_64-linux-gnu/libc.so.6(abort+0x16a)[0x7f38d567102a] ?? ??:0
[24819] /lib/x86_64-linux-gnu/libc.so.6(+0x2dbd7)[0x7f38d5667bd7] ?? ??:0
[24819] /lib/x86_64-linux-gnu/libc.so.6(+0x2dc82)[0x7f38d5667c82] ?? ??:0
[24819] /home/ci/build/h2o[0x473895] h2o_hpack_parse_response at /h2o/lib/http2/hpack.c:571 (discriminator 1)
[24819] /home/ci/build/h2o[0x438a29] on_head at /h2o/lib/common/http2client.c:198
[24819] /home/ci/build/h2o[0x439d38] handle_headers_frame at /h2o/lib/common/http2client.c:407
[24819] /home/ci/build/h2o(expect_default+0x56)[0x4381f6] expect_default at /h2o/lib/common/http2client.c:642
[24819] /home/ci/build/h2o[0x43964c] parse_input at /h2o/lib/common/http2client.c:806
[24819] /home/ci/build/h2o[0x43fdd1] read_on_ready at /h2o/lib/common/socket/evloop.c.h:248
[24819] /home/ci/build/h2o[0x43fec6] run_pending at /h2o/lib/common/socket/evloop.c.h:547
[24819] /home/ci/build/h2o(h2o_evloop_run+0x3f)[0x44236f] h2o_evloop_run at /h2o/lib/common/socket/evloop.c.h:602
```