### PR TITLE
upgrade h2spec to specific revision

### DIFF
--- a/misc/docker-ci/Dockerfile
+++ b/misc/docker-ci/Dockerfile
@@ -24,10 +24,8 @@ RUN apt-get install --yes libfcgi-perl libfcgi-procmanager-perl libipc-signal-pe
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
 RUN sudo cpanm --notest Starlet Test::TCP Protocol::HTTP2
 
-# h2get
-RUN apt-get install --yes golang && mkdir -p /golang && ln -sf /usr/local/bin /golang/bin
-ENV GOPATH=/golang
-RUN (go get github.com/summerwind/h2spec && cd /golang/src/github.com/summerwind/h2spec/cmd/h2spec && git checkout v2.0.0^ && go install)
+# h2spec
+RUN curl -Ls https://github.com/i110/h2spec/releases/download/v2.1.1-b3a1814/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin
 
 # use dumb-init
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 \

--- a/t/40http2-h2spec.t
+++ b/t/40http2-h2spec.t
@@ -15,6 +15,6 @@ hosts:
 EOT
 
 my $output = `h2spec -t -k -p $server->{tls_port} 2>&1`;
-like $output, qr/All tests passed/;
+unlike $output, qr/Failures:/;
 
 done_testing();


### PR DESCRIPTION
https://github.com/summerwind/h2spec/commit/b3a181469923ff46ec30352eb34e89b4e55d6254 fixed a problem which prevented us from updating h2spec to v2.1.1. But it hasn't been released yet, so I forked h2spec and filed a release including that commit. Also considering further use cases (disabling problematic test cases, use `h2specd` for h2client tests, etc), I think it's nice decision to have our fork of h2spec.