### PR TITLE
Unlink the pending write callback if we're about to close the connection

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1151,6 +1151,8 @@ static void on_write_complete(h2o_socket_t *sock, const char *err)
     /* close by error if necessary */
     if (err != NULL) {
         conn->super.ctx->http2.events.write_closed++;
+        if (h2o_timer_is_linked(&conn->_write.timeout_entry))
+            h2o_timer_unlink(&conn->_write.timeout_entry);
         close_connection_now(conn);
         return;
     }


### PR DESCRIPTION
1. connection.c calls `h2o_socket_write` to write certain amount of data
that does not get written immediately
2 . `request_gathered_write` is called (e.g. when receiving data from
upstream)
3. `on_write_complete` is called with an error
In this case, I believe that we would call `close_connection_now` with `conn->_write.timeout_entry` being linked