### PR TITLE
add config fastcgi.chroot to support php-fpm chroot feature

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1742,6 +1742,9 @@ typedef struct st_h2o_fastcgi_config_vars_t {
     uint64_t io_timeout;
     uint64_t keepalive_timeout; /* 0 to disable */
     h2o_iovec_t document_root;  /* .base=NULL if not set */
+    struct {
+        int enabled;
+    } chroot;
     int send_delegated_uri;     /* whether to send the rewritten HTTP_HOST & REQUEST_URI by delegation, or the original */
     struct {
         void (*dispose)(h2o_fastcgi_handler_t *handler, void *data);

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -68,6 +68,18 @@ static int on_config_document_root(h2o_configurator_command_t *cmd, h2o_configur
     return 0;
 }
 
+static int on_config_chroot(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    struct fastcgi_configurator_t *self = (void *)cmd->configurator;
+
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    self->vars->chroot.enabled = (int)ret;
+
+    return 0;
+}
+
 static int on_config_send_delegated_uri(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct fastcgi_configurator_t *self = (void *)cmd->configurator;
@@ -362,6 +374,10 @@ void h2o_fastcgi_register_configurator(h2o_globalconf_t *conf)
     h2o_configurator_define_command(&c->super, "fastcgi.document_root",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_document_root);
+    /* fastcgi.chroot: ON | OFF */
+    h2o_configurator_define_command(&c->super, "fastcgi.chroot",
+                                    H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config_chroot);
     h2o_configurator_define_command(&c->super, "fastcgi.send-delegated-uri",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_send_delegated_uri);


### PR DESCRIPTION
Hi,

Some fastcgi servers running on the local host support chroot. For example php-fpm.

- http://php.net/manual/en/install.fpm.configuration.php

I added a setting named fastcgi.chroot (ON | OFF) to support this, and made changes that work as follows.

- OFF (by default): This is the same behavior as before.
- ON: to generate the SCRIPT_FILENAME string, omit it or use the setting of fastcgi.document_root instead of using the local_path from h2o.


configration example

```
file.custom-handler:
  extension: .php
  fastcgi.connect:
    port: /var/tmp/php-fpm.sock
    type: unix
  fastcgi.chroot: ON
  # fastcgi.document_root: /path/to/prefix
```

I confirmed the running with a single PHP script and WordPress (4.9.x). Regarding this behavior, I refer the setting for chrooting with nginx + php-fpm.

https://serverfault.com/questions/356081/chrooting-php-fpm-with-nginx

