### PR TITLE
send the TLS alert on handshake errors

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1129,6 +1129,7 @@ Redo:
         ret = SSL_connect(sock->ssl->ossl);
     }
 
+    int is_complete = 0;
     if (ret == 0 || (ret < 0 && SSL_get_error(sock->ssl->ossl, ret) != SSL_ERROR_WANT_READ)) {
         /* failed */
         long verify_result = SSL_get_verify_result(sock->ssl->ossl);
@@ -1137,12 +1138,18 @@ Redo:
         } else {
             err = "ssl handshake failure";
         }
-        goto Complete;
+
+        if (sock->ssl->output.bufs.size == 0)
+            goto Complete;
+
+        is_complete = 1;
     }
 
     if (sock->ssl->output.bufs.size != 0) {
         h2o_socket_read_stop(sock);
         flush_pending_ssl(sock, ret == 1 ? on_handshake_complete : proceed_handshake);
+        if (is_complete)
+            goto Complete;
     } else {
         if (ret == 1) {
             if (!SSL_is_server(sock->ssl->ossl)) {


### PR DESCRIPTION
Hello,
noticed h2o does not send the TLS alert on handshake errors and instead sends a TCP FIN right away. Perhaps this could cause unexpected results with certain clients: e.g. a scan tool.

Just wondering if the proposed change is sound. Could let it spin once after the flush, which would then exit on `output.bufs.size == 0`, but the flag `is_complete` avoids the additional spin.

thanks