### PR TITLE
send TLS alert on handshake failure when recent versions of OpenSSL is used

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -164,6 +164,7 @@ extern const char *h2o_socket_error_ssl_no_cert;
 extern const char *h2o_socket_error_ssl_cert_invalid;
 extern const char *h2o_socket_error_ssl_cert_name_mismatch;
 extern const char *h2o_socket_error_ssl_decode;
+extern const char *h2o_socket_error_ssl_handshake;
 
 /**
  * returns the loop

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1022,11 +1022,7 @@ static void on_handshake_complete(h2o_socket_t *sock, const char *err)
 
 static void on_alert_sent(h2o_socket_t *sock, const char *err)
 {
-    if (err != NULL) {
-        on_handshake_complete(sock, err);
-    } else {
-        on_handshake_complete(sock, h2o_socket_error_ssl_handshake);
-    }
+    on_handshake_complete(sock, h2o_socket_error_ssl_handshake);
 }
 
 static void proceed_handshake(h2o_socket_t *sock, const char *err)

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -139,6 +139,7 @@ const char *h2o_socket_error_ssl_no_cert = "no certificate";
 const char *h2o_socket_error_ssl_cert_invalid = "invalid certificate";
 const char *h2o_socket_error_ssl_cert_name_mismatch = "certificate name mismatch";
 const char *h2o_socket_error_ssl_decode = "SSL decode error";
+const char *h2o_socket_error_ssl_handshake = "ssl handshake failure";
 
 static void (*resumption_get_async)(h2o_socket_t *sock, h2o_iovec_t session_id);
 static void (*resumption_new)(h2o_socket_t *sock, h2o_iovec_t session_id, h2o_iovec_t session_data);
@@ -1024,7 +1025,7 @@ static void on_alert_sent(h2o_socket_t *sock, const char *err)
     if (err != NULL) {
         on_handshake_complete(sock, err);
     } else {
-        on_handshake_complete(sock, "handshake failure");
+        on_handshake_complete(sock, h2o_socket_error_ssl_handshake);
     }
 }
 
@@ -1144,9 +1145,8 @@ Redo:
         if (verify_result != X509_V_OK) {
             err = X509_verify_cert_error_string(verify_result);
         } else {
-            err = "ssl handshake failure";
+            err = h2o_socket_error_ssl_handshake;
         }
-
         if (sock->ssl->output.bufs.size != 0) {
             h2o_socket_read_stop(sock);
             flush_pending_ssl(sock, on_alert_sent);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1129,6 +1129,7 @@ Redo:
         ret = SSL_connect(sock->ssl->ossl);
     }
 
+    int is_complete = 0;
     if (ret == 0 || (ret < 0 && SSL_get_error(sock->ssl->ossl, ret) != SSL_ERROR_WANT_READ)) {
         /* failed */
         long verify_result = SSL_get_verify_result(sock->ssl->ossl);
@@ -1137,12 +1138,18 @@ Redo:
         } else {
             err = "ssl handshake failure";
         }
-        goto Complete;
+
+        if (sock->ssl->output.bufs.size == 0)
+            goto Complete;
+
+        is_complete = 1;
     }
 
     if (sock->ssl->output.bufs.size != 0) {
         h2o_socket_read_stop(sock);
         flush_pending_ssl(sock, ret == 1 ? on_handshake_complete : proceed_handshake);
+        if (is_complete)
+            goto Complete;
     } else {
         if (ret == 1) {
             if (!SSL_is_server(sock->ssl->ossl)) {

--- a/t/40ssl-cipher-suite.t
+++ b/t/40ssl-cipher-suite.t
@@ -35,4 +35,8 @@ my ($guard, $pid) = spawn_server(
 my $log = `openssl s_client -cipher AES256-SHA:AES128-SHA -host 127.0.0.1 -port $port < /dev/null 2>&1`;
 like $log, qr/^\s*Cipher\s*:\s*AES128-SHA\s*$/m;
 
+# connect to the server with AES256-SHA as the only choice, and check that handshake failure is returned
+$log = `openssl s_client -cipher AES256-SHA -host 127.0.0.1 -port $port < /dev/null 2>&1`;
+like $log, qr/alert handshake failure/m; # "handshake failure" the official name for TLS alert 40
+
 done_testing;


### PR DESCRIPTION
It has turned out that H2O has stopped sending TLS alerts upon handshake failure, when a recent version of OpenSSL is being used (the issue known to happen in 1.1.0g, but not in 1.1.0d). See 
https://github.com/h2o/h2o/pull/1865#issuecomment-428455419 for how it happens.

This PR brushes up the fix proposed in #1865 as well as adding a test.