### PR TITLE
Non-numeric constants should be defined as `const []`

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1145,10 +1145,10 @@ static void h2o_doublebuffer_consume(h2o_doublebuffer_t *db);
 
 /* util */
 
-extern const char *h2o_http2_npn_protocols;
-extern const char *h2o_npn_protocols;
-extern const h2o_iovec_t *h2o_http2_alpn_protocols;
-extern const h2o_iovec_t *h2o_alpn_protocols;
+extern const char h2o_http2_npn_protocols[];
+extern const char h2o_npn_protocols[];
+extern const h2o_iovec_t h2o_http2_alpn_protocols[];
+extern const h2o_iovec_t h2o_alpn_protocols[];
 
 /**
  * accepts a connection

--- a/include/h2o/http2.h
+++ b/include/h2o/http2.h
@@ -28,9 +28,6 @@ extern "C" {
 
 #include "http2_common.h"
 
-extern const char *h2o_http2_npn_protocols;
-extern const h2o_iovec_t *h2o_http2_alpn_protocols;
-
 extern const h2o_protocol_callbacks_t H2O_HTTP2_CALLBACKS;
 
 /* don't forget to update SERVER_PREFACE when choosing non-default parameters */

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -176,8 +176,8 @@ typedef struct st_h2o_httpclient__h2_conn_t {
     h2o_linklist_t link;
 } h2o_httpclient__h2_conn_t;
 
-extern const char *const h2o_httpclient_error_is_eos;
-extern const char *const h2o_httpclient_error_refused_stream;
+extern const char h2o_httpclient_error_is_eos[];
+extern const char h2o_httpclient_error_refused_stream[];
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool);
 

--- a/include/h2o/redis.h
+++ b/include/h2o/redis.h
@@ -27,10 +27,10 @@
 struct redisAsyncContext;
 struct redisReply;
 
-extern const char *const h2o_redis_error_connection;
-extern const char *const h2o_redis_error_protocol;
-extern const char *const h2o_redis_error_connect_timeout;
-extern const char *const h2o_redis_error_command_timeout;
+extern const char h2o_redis_error_connection[];
+extern const char h2o_redis_error_protocol[];
+extern const char h2o_redis_error_connect_timeout[];
+extern const char h2o_redis_error_command_timeout[];
 
 typedef enum {
     H2O_REDIS_CONNECTION_STATE_CLOSED = 0,

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -156,14 +156,14 @@ typedef void (*h2o_socket_ssl_resumption_remove_cb)(h2o_iovec_t session_id);
 extern h2o_buffer_mmap_settings_t h2o_socket_buffer_mmap_settings;
 extern __thread h2o_buffer_prototype_t h2o_socket_buffer_prototype;
 
-extern const char *h2o_socket_error_out_of_memory;
-extern const char *h2o_socket_error_io;
-extern const char *h2o_socket_error_closed;
-extern const char *h2o_socket_error_conn_fail;
-extern const char *h2o_socket_error_ssl_no_cert;
-extern const char *h2o_socket_error_ssl_cert_invalid;
-extern const char *h2o_socket_error_ssl_cert_name_mismatch;
-extern const char *h2o_socket_error_ssl_decode;
+extern const char h2o_socket_error_out_of_memory[];
+extern const char h2o_socket_error_io[];
+extern const char h2o_socket_error_closed[];
+extern const char h2o_socket_error_conn_fail[];
+extern const char h2o_socket_error_ssl_no_cert[];
+extern const char h2o_socket_error_ssl_cert_invalid[];
+extern const char h2o_socket_error_ssl_cert_name_mismatch[];
+extern const char h2o_socket_error_ssl_decode[];
 
 /**
  * returns the loop

--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -103,7 +103,7 @@ void h2o_url_copy(h2o_mem_pool_t *pool, h2o_url_t *dest, const h2o_url_t *src);
  * extracts sockaddr_un from host and returns NULL (or returns an error string if failed)
  */
 const char *h2o_url_host_to_sun(h2o_iovec_t host, struct sockaddr_un *sa);
-extern const char *h2o_url_host_to_sun_err_is_not_unix_socket;
+extern const char h2o_url_host_to_sun_err_is_not_unix_socket[];
 
 /* inline definitions */
 

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -22,8 +22,8 @@
 
 #include "h2o/httpclient.h"
 
-const char *const h2o_httpclient_error_is_eos = "end of stream";
-const char *const h2o_httpclient_error_refused_stream = "refused stream";
+const char h2o_httpclient_error_is_eos[] = "end of stream";
+const char h2o_httpclient_error_refused_stream[] = "refused stream";
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool)
 {

--- a/lib/common/redis.c
+++ b/lib/common/redis.c
@@ -24,10 +24,10 @@
 #include "h2o/hiredis_.h"
 #include "h2o/socket.h"
 
-const char *const h2o_redis_error_connection = "Connection Error";
-const char *const h2o_redis_error_protocol = "Protocol Error";
-const char *const h2o_redis_error_connect_timeout = "Connection Timeout";
-const char *const h2o_redis_error_command_timeout = "Command Timeout";
+const char h2o_redis_error_connection[] = "Connection Error";
+const char h2o_redis_error_protocol[] = "Protocol Error";
+const char h2o_redis_error_connect_timeout[] = "Connection Timeout";
+const char h2o_redis_error_command_timeout[] = "Command Timeout";
 
 struct st_redis_socket_data_t {
     redisAsyncContext *context;

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -131,14 +131,14 @@ __thread h2o_buffer_prototype_t h2o_socket_buffer_prototype = {
     {H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE * 2}, /* minimum initial capacity */
     &h2o_socket_buffer_mmap_settings};
 
-const char *h2o_socket_error_out_of_memory = "out of memory";
-const char *h2o_socket_error_io = "I/O error";
-const char *h2o_socket_error_closed = "socket closed by peer";
-const char *h2o_socket_error_conn_fail = "connection failure";
-const char *h2o_socket_error_ssl_no_cert = "no certificate";
-const char *h2o_socket_error_ssl_cert_invalid = "invalid certificate";
-const char *h2o_socket_error_ssl_cert_name_mismatch = "certificate name mismatch";
-const char *h2o_socket_error_ssl_decode = "SSL decode error";
+const char h2o_socket_error_out_of_memory[] = "out of memory";
+const char h2o_socket_error_io[] = "I/O error";
+const char h2o_socket_error_closed[] = "socket closed by peer";
+const char h2o_socket_error_conn_fail[] = "connection failure";
+const char h2o_socket_error_ssl_no_cert[] = "no certificate";
+const char h2o_socket_error_ssl_cert_invalid[] = "invalid certificate";
+const char h2o_socket_error_ssl_cert_name_mismatch[] = "certificate name mismatch";
+const char h2o_socket_error_ssl_decode[] = "SSL decode error";
 
 static void (*resumption_get_async)(h2o_socket_t *sock, h2o_iovec_t session_id);
 static void (*resumption_new)(h2o_socket_t *sock, h2o_iovec_t session_id, h2o_iovec_t session_data);

--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -408,7 +408,7 @@ const char *h2o_url_host_to_sun(h2o_iovec_t host, struct sockaddr_un *sa)
 #undef PREFIX
 }
 
-const char *h2o_url_host_to_sun_err_is_not_unix_socket = "supplied name does not look like an unix-domain socket";
+const char h2o_url_host_to_sun_err_is_not_unix_socket[] = "supplied name does not look like an unix-domain socket";
 
 int h2o_url_init_with_hostport(h2o_url_t *url, h2o_mem_pool_t *pool, const h2o_url_scheme_t *scheme, h2o_iovec_t host,
                                uint16_t port, h2o_iovec_t path)

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -928,14 +928,11 @@ h2o_iovec_t h2o_build_server_timing_trailer(h2o_req_t *req, const char *prefix, 
     "\x05"                                                                                                                         \
     "h2-14"
 
-static const h2o_iovec_t http2_alpn_protocols[] = {ALPN_PROTOCOLS_CORE, {NULL}};
-const h2o_iovec_t *h2o_http2_alpn_protocols = http2_alpn_protocols;
+const h2o_iovec_t h2o_http2_alpn_protocols[] = {ALPN_PROTOCOLS_CORE, {NULL}};
+const h2o_iovec_t h2o_alpn_protocols[] = {ALPN_PROTOCOLS_CORE, {H2O_STRLIT("http/1.1")}, {NULL}};
 
-static const h2o_iovec_t alpn_protocols[] = {ALPN_PROTOCOLS_CORE, {H2O_STRLIT("http/1.1")}, {NULL}};
-const h2o_iovec_t *h2o_alpn_protocols = alpn_protocols;
-
-const char *h2o_http2_npn_protocols = NPN_PROTOCOLS_CORE;
-const char *h2o_npn_protocols = NPN_PROTOCOLS_CORE "\x08"
+const char h2o_http2_npn_protocols[] = NPN_PROTOCOLS_CORE;
+const char h2o_npn_protocols[] = NPN_PROTOCOLS_CORE "\x08"
                                                    "http/1.1";
 
 uint64_t h2o_connection_id = 0;


### PR DESCRIPTION
Rather than `const *`, because defining it as a pointer allows the value to be changed, which also has a negative effect on compile-time binding.

credit goes to @robguima.