### PR TITLE
do nothing in `adjust_conn_linkedlist` if conn is already unlinked

### DIFF
--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -176,6 +176,8 @@ static void adjust_conn_linkedlist(h2o_httpclient_connection_pool_t *connpool, s
         assert(!h2o_linklist_is_linked(&conn->super.link));
         return;
     }
+    if (!h2o_linklist_is_linked(&conn->super.link))
+        return;
 
     double ratio = (double)conn->super.num_streams / h2o_httpclient__h2_get_max_concurrent_streams(&conn->super);
 


### PR DESCRIPTION
I found SEGV that says `conn->super.link` is already unlinked, that happens when `enqueue_goaway` is called before the connection is closed.
It was easy to reproduce the bug by running test`t/50reverse-proxy-http2.t`, so I'm not sure when this bug emerged, but if necessary I'll do git bisect.