### PR TITLE
forward content-length from upstream

### DIFF
--- a/include/h2o/http2_common.h
+++ b/include/h2o/http2_common.h
@@ -123,7 +123,7 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
                                size_t num_headers, int is_end_stream);
 void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
                                 size_t max_frame_size, const h2o_header_t *headers, size_t num_headers);
-int h2o_hpack_parse_response_headers(h2o_mem_pool_t *pool, int *status, h2o_headers_t *headers, size_t *content_length,
+int h2o_hpack_parse_response_headers(h2o_mem_pool_t *pool, int *status, h2o_headers_t *headers,
                                      h2o_hpack_header_table_t *header_table, const uint8_t *src, size_t len, const char **err_desc);
 
 /* frames */

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -268,9 +268,8 @@ static int on_head(struct st_h2o_http2client_conn_t *conn, struct st_h2o_http2cl
 
     assert(stream->state == H2O_HTTP2CLIENT_STREAM_STATE_RECV_HEADERS);
 
-    size_t dummy_content_length;
     if ((ret = h2o_hpack_parse_response_headers(stream->super.pool, &stream->input.status, &stream->input.headers,
-                                                &dummy_content_length, &conn->input.header_table, src, len, err_desc)) != 0) {
+                                                &conn->input.header_table, src, len, err_desc)) != 0) {
         if (ret == H2O_HTTP2_ERROR_INVALID_HEADER_CHAR) {
             ret = H2O_HTTP2_ERROR_PROTOCOL;
             goto SendRSTStream;

--- a/t/50reverse-proxy-http2.t
+++ b/t/50reverse-proxy-http2.t
@@ -41,6 +41,26 @@ subtest 'no :status header' => sub {
     like $body, qr/upstream protocol error/;
 };
 
+subtest 'content-length' => sub {
+    my $upstream_port = $ENV{UPSTREAM_PORT} || empty_port({ host => '0.0.0.0' });
+    my $upstream = create_upstream($upstream_port, +{
+        &HALF_CLOSED => sub {
+            my ($conn, $stream_id) = @_;
+            $conn->send_headers($stream_id, [
+                ':status' => 200,
+                'content-length' => '11'
+            ], 0);
+            $conn->send_data($stream_id, 'hello world', 1);
+        },
+    });
+
+    my $server = create_h2o($upstream_port);
+    my ($headers, $body) = run_prog("curl -s --dump-header /dev/stderr http://127.0.0.1:@{[$server->{port}]}");
+    like $headers, qr{^HTTP/[0-9.]+ 200}is;
+    like $headers, qr{^content-length: 11\r$}im;
+    like $body, qr/hello world/;
+};
+
 sub create_h2o {
     my ($upstream_port) = @_;
     if (my $port = $ENV{H2O_PORT}) {


### PR DESCRIPTION
Fixes https://github.com/h2o/h2o/issues/1869.

Actually there's no need to grab content-length in `h2o_hpack_parse_response_headers ` at this time, so removed it.