### PR TITLE
Add a CI build for openssl 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,12 @@ matrix:
       before_install: *bi
       script:
         - make -f misc/docker-ci/check.mk fuzz
+    - os: linux
+      sudo: required
+      services:
+        - docker
+      env:
+        - label=openssl-1.1.0
+      before_install: *bi
+      script:
+        - make -f misc/docker-ci/check.mk ossl1.1.0

--- a/misc/docker-ci/Dockerfile
+++ b/misc/docker-ci/Dockerfile
@@ -18,6 +18,16 @@ ENV PATH=/usr/lib/llvm-4.0/bin:$PATH
 RUN wget --no-verbose -O - https://curl.haxx.se/download/curl-7.57.0.tar.gz | tar xzf -
 RUN (cd curl-7.57.0 && ./configure --prefix=/usr/local --with-nghttp2 --disable-shared && make && sudo make install)
 
+# openssl 1.1.0
+ARG OPENSSL_URL="https://www.openssl.org/source/"
+ARG OPENSSL_VERSION="1.1.0i"
+ARG OPENSSL_SHA1="6713f8b083e4c0b0e70fd090bf714169baf3717c"
+RUN curl -O ${OPENSSL_URL}openssl-${OPENSSL_VERSION}.tar.gz
+RUN (echo "${OPENSSL_SHA1} openssl-${OPENSSL_VERSION}.tar.gz" | sha1sum -c - && tar xf openssl-${OPENSSL_VERSION}.tar.gz)
+RUN (cd openssl-${OPENSSL_VERSION} && \
+	./config --prefix=/opt/openssl-1.1.0 --openssldir=/opt/openssl-1.1.0 shared enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers && \
+	make -j $(nproc) && make -j install_sw install_ssldirs)
+
 # cpan modules
 RUN apt-get install --yes cpanminus
 RUN apt-get install --yes libfcgi-perl libfcgi-procmanager-perl libipc-signal-perl libjson-perl liblist-moreutils-perl libplack-perl libscope-guard-perl libtest-exception-perl libwww-perl libio-socket-ssl-perl

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -11,6 +11,9 @@ ALL:
 fuzz:
 	docker run $(DOCKER_RUN_OPTS) $(CONTAINER_NAME) make -f /h2o/misc/docker-ci/check.mk _fuzz
 
+ossl1.1.0:
+	docker run $(DOCKER_RUN_OPTS) $(CONTAINER_NAME) make -f /h2o/misc/docker-ci/check.mk _ossl1.1.0
+
 _check:
 	mkdir -p build
 	$(MAKE) -f $(CHECK_MK) -C build _do-check CMAKE_ARGS=$(CMAKE_ARGS)
@@ -20,6 +23,9 @@ _do-check:
 	make all
 	make check
 	sudo make check-as-root
+
+_ossl1.1.0:
+	$(MAKE) -f $(CHECK_MK) _check CMAKE_ARGS=-DOPENSSL_ROOT_DIR=/opt/openssl-1.1.0
 
 _fuzz:
 	$(FUZZ_ASAN) CC=clang CXX=clang++ $(MAKE) -f $(CHECK_MK) _check CMAKE_ARGS=-DBUILD_FUZZER=ON


### PR DESCRIPTION
This PR adds a build that tests openssl 1.1.0 (the other two builds are using openssl 1.0.2). Merging this PR does require a change to the docker image used for CI, I pushed a temporary image for testing to `deweerdt/h2o-ci:latest`.

Link to a passing CI build: https://travis-ci.org/deweerdt/h2o/jobs/443577367
Link to the docker image change used for testing: https://github.com/deweerdt/h2o/commit/d30f0c5c