### PR TITLE
Connection culling

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -578,18 +578,16 @@ struct st_h2o_context_t {
      */
     int shutdown_requested;
 
-    struct {
-        /**
-         * link-list of h2o_http1_conn_t
-         */
-        h2o_linklist_t _conns;
-    } http1;
+    /**
+     * linked list of active h2o_http1_conn_t and h2o_http2_conn_t
+     */
+    h2o_linklist_t _active_conns;
+    /**
+     * linked list of inactive h2o_http1_conn_t and h2o_http2_conn_t
+     */
+    h2o_linklist_t _inactive_conns;
 
     struct {
-        /**
-         * link-list of h2o_http2_conn_t
-         */
-        h2o_linklist_t _conns;
         /**
          * timeout entry used for graceful shutdown
          */
@@ -784,6 +782,10 @@ typedef struct st_h2o_conn_callbacks_t {
      */
     h2o_http2_debug_state_t *(*get_debug_state)(h2o_req_t *req, int hpack_enabled);
     /**
+     * close connection if idle
+     */
+    int (*close_idle_connection)(h2o_conn_t *conn);
+    /**
      * logging callbacks (may be NULL)
      */
     union {
@@ -837,6 +839,8 @@ struct st_h2o_conn_t {
      * callbacks
      */
     const h2o_conn_callbacks_t *callbacks;
+    /* internal structure */
+    h2o_linklist_t _conns;
 };
 
 /**
@@ -1438,6 +1442,11 @@ void h2o_context_dispose_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pa
 static h2o_timestamp_t h2o_get_timestamp(h2o_context_t *ctx, h2o_mem_pool_t *pool);
 void h2o_context_update_timestamp_string_cache(h2o_context_t *ctx);
 /**
+ * Closes at most @max_connections_to_close inactive connection
+ * @return true if it closed exactly @max_connections_to_close
+ */
+int h2o_context_close_idle_connections(h2o_context_t *ctx, int max_connections_to_close);
+/**
  * returns per-module context set
  */
 static void *h2o_context_get_handler_context(h2o_context_t *ctx, h2o_handler_t *handler);
@@ -1965,6 +1974,7 @@ inline h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_host
     conn->id = __sync_add_and_fetch(&h2o_connection_id, 1);
 #endif
     conn->callbacks = callbacks;
+    conn->_conns = (h2o_linklist_t){};
 
     return conn;
 }

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -148,7 +148,6 @@ struct st_h2o_http2_conn_t {
     /* internal */
     h2o_http2_scheduler_node_t scheduler;
     h2o_http2_conn_state_t state;
-    h2o_linklist_t _conns; /* linklist to h2o_context_t::http2._conns */
     ssize_t (*_read_expect)(h2o_http2_conn_t *conn, const uint8_t *src, size_t len, const char **err_desc);
     h2o_buffer_t *_http1_req_input; /* contains data referred to by original request via HTTP/1.1 */
     h2o_hpack_header_table_t _input_header_table;

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -93,8 +93,8 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     h2o_multithread_register_receiver(ctx->queue, &ctx->receivers.hostinfo_getaddr, h2o_hostinfo_getaddr_receiver);
     ctx->filecache = h2o_filecache_create(config->filecache.capacity);
 
-    h2o_linklist_init_anchor(&ctx->http1._conns);
-    h2o_linklist_init_anchor(&ctx->http2._conns);
+    h2o_linklist_init_anchor(&ctx->_active_conns);
+    h2o_linklist_init_anchor(&ctx->_inactive_conns);
     ctx->proxy.client_ctx.loop = loop;
     ctx->proxy.client_ctx.io_timeout = ctx->globalconf->proxy.io_timeout;
     ctx->proxy.client_ctx.connect_timeout = ctx->globalconf->proxy.connect_timeout;
@@ -186,4 +186,24 @@ void h2o_context_update_timestamp_string_cache(h2o_context_t *ctx)
     gmtime_r(&ctx->_timestamp_cache.tv_at.tv_sec, &gmt);
     h2o_time2str_rfc1123(ctx->_timestamp_cache.value->rfc1123, &gmt);
     h2o_time2str_log(ctx->_timestamp_cache.value->log, ctx->_timestamp_cache.tv_at.tv_sec);
+}
+
+int h2o_context_close_idle_connections(h2o_context_t *ctx, int max_connections_to_close)
+{
+    int closed = 0;
+    h2o_linklist_t *node, *nprev;
+    for (node = ctx->_inactive_conns.prev; node != &ctx->_inactive_conns; node = nprev) {
+        struct timeval now;
+        h2o_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_conn_t, _conns, node);
+        nprev = node->prev;
+
+        now = h2o_gettimeofday(ctx->loop);
+        if (conn->connected_at.tv_sec == now.tv_sec && conn->connected_at.tv_usec == now.tv_usec)
+            continue;
+        if (conn->callbacks->close_idle_connection(conn))
+            closed++;
+        if (closed == max_connections_to_close)
+            break;
+    }
+    return closed == max_connections_to_close;
 }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -54,7 +54,6 @@ struct st_h2o_http1_conn_t {
     h2o_conn_t super;
     h2o_socket_t *sock;
     /* internal structure */
-    h2o_linklist_t _conns;
     h2o_timer_t _timeout_entry;
     uint64_t _req_index;
     size_t _prevreqlen;
@@ -131,7 +130,7 @@ static void close_connection(struct st_h2o_http1_conn_t *conn, int close_socket)
     h2o_dispose_request(&conn->req);
     if (conn->sock != NULL && close_socket)
         h2o_socket_close(conn->sock);
-    h2o_linklist_unlink(&conn->_conns);
+    h2o_linklist_unlink(&conn->super._conns);
     free(conn);
 }
 
@@ -143,8 +142,13 @@ static void set_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, h2o_
     if (conn->_timeout_entry.cb != NULL)
         h2o_timer_unlink(&conn->_timeout_entry);
     conn->_timeout_entry.cb = cb;
-    if (cb != NULL)
+    h2o_linklist_unlink(&conn->super._conns);
+    if (cb != NULL) {
+        h2o_linklist_insert(&conn->super.ctx->_inactive_conns, &conn->super._conns);
         h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_timeout_entry);
+    } else {
+        h2o_linklist_insert(&conn->super.ctx->_active_conns, &conn->super._conns);
+    }
 }
 
 static void process_request(struct st_h2o_http1_conn_t *conn)
@@ -517,6 +521,17 @@ void reqread_on_read(h2o_socket_t *sock, const char *err)
         conn->_req_entity_reader->handle_incoming_entity(conn);
 }
 
+static int close_idle_connection(h2o_conn_t *_conn)
+{
+    struct st_h2o_http1_conn_t *conn = (void *)_conn;
+    if (conn->sock->input->size == 0) {
+        conn->req.http1_is_persistent = 0;
+        close_connection(conn, 1);
+        return 1;
+    }
+    return 0;
+}
+
 static void reqread_on_timeout(h2o_timer_t *entry)
 {
     struct st_h2o_http1_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1_conn_t, _timeout_entry, entry);
@@ -529,8 +544,7 @@ static void reqread_on_timeout(h2o_timer_t *entry)
         conn->req.res.reason = "Request Timeout";
     }
 
-    conn->req.http1_is_persistent = 0;
-    close_connection(conn, 1);
+    close_idle_connection(&conn->super);
 }
 
 static inline void reqread_start(struct st_h2o_http1_conn_t *conn)
@@ -994,15 +1008,27 @@ static h2o_iovec_t log_request_index(h2o_req_t *req)
     return h2o_iovec_init(s, len);
 }
 
+static int conn_is_h1(h2o_conn_t *conn)
+{
+    return conn->callbacks->get_sockname == get_sockname;
+}
+
 static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata)
 {
     h2o_linklist_t *node;
+    h2o_linklist_t *conn_list[] = {&ctx->_active_conns, &ctx->_inactive_conns};
+    int i;
 
-    for (node = ctx->http1._conns.next; node != &ctx->http1._conns; node = node->next) {
-        struct st_h2o_http1_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1_conn_t, _conns, node);
-        int ret = cb(&conn->req, cbdata);
-        if (ret != 0)
-            return ret;
+    for (i = 0; i < sizeof(conn_list) / sizeof(conn_list[0]); i++) {
+        for (node = conn_list[i]->next; node != conn_list[i]; node = node->next) {
+            h2o_conn_t *_conn = H2O_STRUCT_FROM_MEMBER(h2o_conn_t, _conns, node);
+            struct st_h2o_http1_conn_t *conn = (void *)_conn;
+            if (!conn_is_h1(_conn))
+                continue;
+            int ret = cb(&conn->req, cbdata);
+            if (ret != 0)
+                return ret;
+        }
     }
     return 0;
 }
@@ -1015,6 +1041,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
         NULL,         /* push */
         get_socket,   /* get underlying socket */
         NULL,         /* get debug state */
+        close_idle_connection,
         {{
             {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits, log_session_id}, /* ssl */
             {log_request_index},                                                                     /* http1 */
@@ -1028,7 +1055,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
     /* init properties that need to be non-zero */
     conn->sock = sock;
     sock->data = conn;
-    h2o_linklist_insert(&ctx->ctx->http1._conns, &conn->_conns);
+    h2o_linklist_insert(&ctx->ctx->_inactive_conns, &conn->super._conns);
 
     init_request(conn);
     reqread_start(conn);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -57,6 +57,7 @@ static void on_read(h2o_socket_t *sock, const char *err);
 static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_len, int is_critical);
 static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata);
 static void stream_send_error(h2o_http2_conn_t *conn, uint32_t stream_id, int errnum);
+static int conn_is_h2(h2o_conn_t *conn);
 
 const h2o_protocol_callbacks_t H2O_HTTP2_CALLBACKS = {initiate_graceful_shutdown, foreach_request};
 
@@ -79,12 +80,20 @@ static void graceful_shutdown_close_stragglers(h2o_timer_t *entry)
 {
     h2o_context_t *ctx = H2O_STRUCT_FROM_MEMBER(h2o_context_t, http2._graceful_shutdown_timeout, entry);
     h2o_linklist_t *node, *next;
+    h2o_linklist_t *conn_list[] = {&ctx->_active_conns, &ctx->_inactive_conns};
+    int i;
 
-    /* We've sent two GOAWAY frames, close the remaining connections */
-    for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = next) {
-        h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
-        next = node->next;
-        close_connection(conn);
+    for (i = 0; i < sizeof(conn_list) / sizeof(conn_list[0]); i++) {
+        for (node = conn_list[i]->next; node != conn_list[i]; node = node->next) {
+
+            /* We've sent two GOAWAY frames, close the remaining connections */
+            h2o_conn_t *conn_ = H2O_STRUCT_FROM_MEMBER(h2o_conn_t, _conns, node);
+            if (!conn_is_h2(conn_))
+                continue;
+            h2o_http2_conn_t *conn = (void *)conn_;
+            next = node->next;
+            close_connection(conn);
+        }
     }
 }
 
@@ -93,12 +102,20 @@ static void graceful_shutdown_resend_goaway(h2o_timer_t *entry)
     h2o_context_t *ctx = H2O_STRUCT_FROM_MEMBER(h2o_context_t, http2._graceful_shutdown_timeout, entry);
     h2o_linklist_t *node;
     int do_close_stragglers = 0;
+    h2o_linklist_t *conn_list[] = {&ctx->_active_conns, &ctx->_inactive_conns};
+    int i;
 
-    for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = node->next) {
-        h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
-        if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED) {
-            enqueue_goaway(conn, H2O_HTTP2_ERROR_NONE, (h2o_iovec_t){NULL});
-            do_close_stragglers = 1;
+    for (i = 0; i < sizeof(conn_list) / sizeof(conn_list[0]); i++) {
+        for (node = conn_list[i]->next; node != conn_list[i]; node = node->next) {
+
+            h2o_conn_t *conn_ = H2O_STRUCT_FROM_MEMBER(h2o_conn_t, _conns, node);
+            if (!conn_is_h2(conn_))
+                continue;
+            h2o_http2_conn_t *conn = (void *)conn_;
+            if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED) {
+                enqueue_goaway(conn, H2O_HTTP2_ERROR_NONE, (h2o_iovec_t){NULL});
+                do_close_stragglers = 1;
+            }
         }
     }
 
@@ -111,6 +128,14 @@ static void graceful_shutdown_resend_goaway(h2o_timer_t *entry)
     }
 }
 
+static int close_idle_connection(h2o_conn_t *_conn)
+{
+    h2o_http2_conn_t *conn = (void *)_conn;
+    enqueue_goaway(conn, H2O_HTTP2_ERROR_NONE, (h2o_iovec_t){NULL});
+    close_connection(conn);
+    return 1;
+}
+
 static void initiate_graceful_shutdown(h2o_context_t *ctx)
 {
     /* draft-16 6.8
@@ -120,18 +145,26 @@ static void initiate_graceful_shutdown(h2o_context_t *ctx)
      * updated last stream identifier. This ensures that a connection can be cleanly shut down without losing requests.
      */
     h2o_linklist_t *node;
+    h2o_linklist_t *conn_list[] = {&ctx->_active_conns, &ctx->_inactive_conns};
+    int i;
 
     /* only doit once */
     if (ctx->http2._graceful_shutdown_timeout.cb != NULL)
         return;
     ctx->http2._graceful_shutdown_timeout.cb = graceful_shutdown_resend_goaway;
 
-    for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = node->next) {
-        h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
-        if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED) {
-            h2o_http2_encode_goaway_frame(&conn->_write.buf, INT32_MAX, H2O_HTTP2_ERROR_NONE,
-                                          (h2o_iovec_t){H2O_STRLIT("graceful shutdown")});
-            h2o_http2_conn_request_write(conn);
+    for (i = 0; i < sizeof(conn_list) / sizeof(conn_list[0]); i++) {
+        for (node = conn_list[i]->next; node != conn_list[i]; node = node->next) {
+
+            h2o_conn_t *conn_ = H2O_STRUCT_FROM_MEMBER(h2o_conn_t, _conns, node);
+            if (!conn_is_h2(conn_))
+                continue;
+            h2o_http2_conn_t *conn = (void *)conn_;
+            if (conn->state < H2O_HTTP2_CONN_STATE_HALF_CLOSED) {
+                h2o_http2_encode_goaway_frame(&conn->_write.buf, INT32_MAX, H2O_HTTP2_ERROR_NONE,
+                                              (h2o_iovec_t){H2O_STRLIT("graceful shutdown")});
+                h2o_http2_conn_request_write(conn);
+            }
         }
     }
     h2o_timer_link(ctx->loop, 1000, &ctx->http2._graceful_shutdown_timeout);
@@ -327,7 +360,7 @@ static void close_connection_now(h2o_http2_conn_t *conn)
         h2o_cache_destroy(conn->push_memo);
     if (conn->casper != NULL)
         h2o_http2_casper_destroy(conn->casper);
-    h2o_linklist_unlink(&conn->_conns);
+    h2o_linklist_unlink(&conn->super._conns);
 
     if (conn->sock != NULL)
         h2o_socket_close(conn->sock);
@@ -1281,6 +1314,11 @@ static h2o_socket_t *get_socket(h2o_conn_t *_conn)
     return conn->sock;
 }
 
+static int conn_is_h2(h2o_conn_t *conn)
+{
+    return conn->callbacks->get_sockname == get_sockname;
+}
+
 #define DEFINE_TLS_LOGGER(name)                                                                                                    \
     static h2o_iovec_t log_##name(h2o_req_t *req)                                                                                  \
     {                                                                                                                              \
@@ -1380,6 +1418,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
         push_path,                 /* HTTP2 push */
         get_socket,                /* get underlying socket */
         h2o_http2_get_debug_state, /* get debug state */
+        close_idle_connection,
         {{
             {log_protocol_version, log_session_reused, log_cipher, log_cipher_bits, log_session_id}, /* ssl */
             {NULL},                                                                                  /* http1 */
@@ -1396,7 +1435,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
     conn->streams = kh_init(h2o_http2_stream_t);
     h2o_http2_scheduler_init(&conn->scheduler);
     conn->state = H2O_HTTP2_CONN_STATE_OPEN;
-    h2o_linklist_insert(&ctx->http2._conns, &conn->_conns);
+    h2o_linklist_insert(&ctx->_active_conns, &conn->super._conns);
     conn->_read_expect = expect_preface;
     conn->_input_header_table.hpack_capacity = conn->_input_header_table.hpack_max_capacity =
         H2O_HTTP2_SETTINGS_DEFAULT.header_table_size;
@@ -1516,15 +1555,22 @@ static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_le
 static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata)
 {
     h2o_linklist_t *node;
+    h2o_linklist_t *conn_list[] = {&ctx->_active_conns, &ctx->_inactive_conns};
+    int i;
 
-    for (node = ctx->http2._conns.next; node != &ctx->http2._conns; node = node->next) {
-        h2o_http2_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_http2_conn_t, _conns, node);
-        h2o_http2_stream_t *stream;
-        kh_foreach_value(conn->streams, stream, {
-            int ret = cb(&stream->req, cbdata);
-            if (ret != 0)
-                return ret;
-        });
+    for (i = 0; i < sizeof(conn_list) / sizeof(conn_list[0]); i++) {
+        for (node = conn_list[i]->next; node != conn_list[i]; node = node->next) {
+            h2o_conn_t *conn_ = H2O_STRUCT_FROM_MEMBER(h2o_conn_t, _conns, node);
+            if (!conn_is_h2(conn_))
+                continue;
+            h2o_http2_conn_t *conn = (void *)conn_;
+            h2o_http2_stream_t *stream;
+            kh_foreach_value(conn->streams, stream, {
+                int ret = cb(&stream->req, cbdata);
+                if (ret != 0)
+                    return ret;
+            });
+        }
     }
     return 0;
 }
@@ -1585,7 +1631,7 @@ int h2o_http2_handle_upgrade(h2o_req_t *req, struct timeval connected_at)
 
     return 0;
 Error:
-    h2o_linklist_unlink(&http2conn->_conns);
+    h2o_linklist_unlink(&http2conn->super._conns);
     kh_destroy(h2o_http2_stream_t, http2conn->streams);
     free(http2conn);
     return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -1565,13 +1565,16 @@ static void on_accept(h2o_socket_t *listener, const char *err)
 
     do {
         h2o_socket_t *sock;
-        if (num_connections(0) >= conf.max_connections) {
+        int excess_connections = num_connections(0) - conf.max_connections;
+        if (excess_connections >= 1) {
             /* The accepting socket is disactivated before entering the next in `run_loop`.
              * Note: it is possible that the server would accept at most `max_connections + num_threads` connections, since the
              * server does not check if the number of connections has exceeded _after_ epoll notifies of a new connection _but_
              * _before_ calling `accept`.  In other words t/40max-connections.t may fail.
              */
-            break;
+            if (!h2o_context_close_idle_connections(ctx->accept_ctx.ctx, excess_connections)) {
+                return;
+            }
         }
         if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
             break;

--- a/t/40max-connections.t
+++ b/t/40max-connections.t
@@ -5,23 +5,23 @@ use Test::More;
 use Time::HiRes qw(sleep);
 use t::Util;
 
-my $MAX_CONN = 2;
 my $WAIT = 0.1;
 
-subtest "single-threaded" => sub {
+subtest "single-connection" => sub {
     doit(1);
 };
-subtest "multi-threaded" => sub {
+
+subtest "multiple-connections" => sub {
     doit(4);
 };
 
 done_testing;
 
 sub doit {
-    my $num_threads = shift;
+    my $max_conn = shift;
     my $server = spawn_h2o(<< "EOT");
-num-threads: $num_threads
-max-connections: $MAX_CONN
+num-threads: 1
+max-connections: $max_conn
 hosts:
   default:
     paths:
@@ -34,7 +34,7 @@ EOT
 
     # establish connections to the maximum (and write partial requests so that the server would accept(2) the connections)
     my @conns;
-    for (1..$MAX_CONN) {
+    for (1..$max_conn) {
         my $conn = IO::Socket::INET->new(
             PeerAddr => "127.0.0.1:$port",
             Proto    => "tcp",

--- a/t/40max-connections.t
+++ b/t/40max-connections.t
@@ -60,7 +60,12 @@ EOT
 
     # close the preceeding connections
     while (@conns) {
-        close shift @conns;
+        my $conn = shift @conns;
+        syswrite($conn, "\r\n") or die "failed to complete partial request:$!";
+
+        my $resp = do { local $/; <$conn> };
+        like $resp, qr{^HTTP/1\.1 200 OK\r\n}s, "response is valid";
+        close $conn;
     }
 
     sleep $WAIT;


### PR DESCRIPTION
This PR implements a mechanism to cleanup idle connections when we reach `max-connections` (as opposed to delaying `accept(2)`).