### PR TITLE
stop applying filters multiple times

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -212,11 +212,13 @@ struct st_h2o_pathconf_t {
      */
     H2O_VECTOR(h2o_handler_t *) handlers;
     /**
-     * list of filters that will be copied into req->filters
+     * list of filters to be applied unless when processing a subrequest.
+     * The address of the list is set in `req->filters` and used when processing a request.
      */
     H2O_VECTOR(h2o_filter_t *) _filters;
     /**
-     * list of loggers (h2o_logger_t) that will be copied into req->loggers
+     * list of loggers to be applied unless when processing a subrequest.
+     * The address of the list is set in `req->loggers` and used when processing a request.
      */
     H2O_VECTOR(h2o_logger_t *) _loggers;
     /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -212,13 +212,13 @@ struct st_h2o_pathconf_t {
      */
     H2O_VECTOR(h2o_handler_t *) handlers;
     /**
-     * list of filters
+     * list of filters that will be copied into req->filters
      */
-    H2O_VECTOR(h2o_filter_t *) filters;
+    H2O_VECTOR(h2o_filter_t *) _filters;
     /**
-     * list of loggers (h2o_logger_t)
+     * list of loggers (h2o_logger_t) that will be copied into req->loggers
      */
-    H2O_VECTOR(h2o_logger_t *) loggers;
+    H2O_VECTOR(h2o_logger_t *) _loggers;
     /**
      * mimemap
      */
@@ -943,6 +943,14 @@ struct st_h2o_req_t {
      * the path context
      */
     h2o_pathconf_t *pathconf;
+    /**
+     * filters
+     */
+    H2O_VECTOR(h2o_filter_t *) filters;
+    /**
+     * loggers
+     */
+    H2O_VECTOR(h2o_logger_t *) loggers;
     /**
      * the handler that has been executed
      */
@@ -2021,8 +2029,8 @@ inline void h2o_setup_next_ostream(h2o_req_t *req, h2o_ostream_t **slot)
 {
     h2o_filter_t *next;
 
-    if (req->_next_filter_index < req->pathconf->filters.size) {
-        next = req->pathconf->filters.entries[req->_next_filter_index++];
+    if (req->_next_filter_index < req->filters.size) {
+        next = req->filters.entries[req->_next_filter_index++];
         next->on_setup_ostream(next, req, slot);
     }
 }

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -946,13 +946,15 @@ struct st_h2o_req_t {
      */
     h2o_pathconf_t *pathconf;
     /**
-     * filters
+     * filters and the size of it
      */
-    H2O_VECTOR(h2o_filter_t *) filters;
+    h2o_filter_t **filters;
+    size_t num_filters;
     /**
-     * loggers
+     * loggers and the size of it
      */
-    H2O_VECTOR(h2o_logger_t *) loggers;
+    h2o_logger_t **loggers;
+    size_t num_loggers;
     /**
      * the handler that has been executed
      */
@@ -2031,8 +2033,8 @@ inline void h2o_setup_next_ostream(h2o_req_t *req, h2o_ostream_t **slot)
 {
     h2o_filter_t *next;
 
-    if (req->_next_filter_index < req->filters.size) {
-        next = req->filters.entries[req->_next_filter_index++];
+    if (req->_next_filter_index < req->num_filters) {
+        next = req->filters[req->_next_filter_index++];
         next->on_setup_ostream(next, req, slot);
     }
 }

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1077,6 +1077,10 @@ struct st_h2o_req_t {
      * whether the request is a subrequest
      */
     unsigned char is_subrequest : 1;
+    /**
+     * whether the filters and prefilters will be applied
+     */
+    unsigned char disable_filters : 1;
 
     /**
      * whether if the response should include server-timing header. Logical OR of H2O_SEND_SERVER_TIMING_*

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1073,14 +1073,6 @@ struct st_h2o_req_t {
      * set by the prxy handler if the http2 upstream refused the stream so the client can retry the request
      */
     unsigned char upstream_refused : 1;
-    /**
-     * whether the request is a subrequest
-     */
-    unsigned char is_subrequest : 1;
-    /**
-     * whether the filters and prefilters will be applied
-     */
-    unsigned char disable_filters : 1;
 
     /**
      * whether if the response should include server-timing header. Logical OR of H2O_SEND_SERVER_TIMING_*

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -154,8 +154,8 @@ void h2o_config_dispose_pathconf(h2o_pathconf_t *pathconf)
         free(list.entries);                                                                                                        \
     } while (0)
     DESTROY_LIST(h2o_handler_t, pathconf->handlers);
-    DESTROY_LIST(h2o_filter_t, pathconf->filters);
-    DESTROY_LIST(h2o_logger_t, pathconf->loggers);
+    DESTROY_LIST(h2o_filter_t, pathconf->_filters);
+    DESTROY_LIST(h2o_logger_t, pathconf->_loggers);
 #undef DESTROY_LIST
 
     free(pathconf->path.base);
@@ -304,10 +304,10 @@ h2o_filter_t *h2o_create_filter(h2o_pathconf_t *conf, size_t sz)
     memset(filter, 0, sz);
     filter->_config_slot = conf->global->_num_config_slots++;
 
-    h2o_vector_reserve(NULL, &conf->filters, conf->filters.size + 1);
-    memmove(conf->filters.entries + 1, conf->filters.entries, conf->filters.size * sizeof(conf->filters.entries[0]));
-    conf->filters.entries[0] = filter;
-    ++conf->filters.size;
+    h2o_vector_reserve(NULL, &conf->_filters, conf->_filters.size + 1);
+    memmove(conf->_filters.entries + 1, conf->_filters.entries, conf->_filters.size * sizeof(conf->_filters.entries[0]));
+    conf->_filters.entries[0] = filter;
+    ++conf->_filters.size;
 
     return filter;
 }
@@ -319,8 +319,8 @@ h2o_logger_t *h2o_create_logger(h2o_pathconf_t *conf, size_t sz)
     memset(logger, 0, sz);
     logger->_config_slot = conf->global->_num_config_slots++;
 
-    h2o_vector_reserve(NULL, &conf->loggers, conf->loggers.size + 1);
-    conf->loggers.entries[conf->loggers.size++] = logger;
+    h2o_vector_reserve(NULL, &conf->_loggers, conf->_loggers.size + 1);
+    conf->_loggers.entries[conf->_loggers.size++] = logger;
 
     return logger;
 }

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -46,8 +46,8 @@ void h2o_context_init_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pathc
     } while (0)
 
     DOIT(h2o_handler_t, handlers);
-    DOIT(h2o_filter_t, filters);
-    DOIT(h2o_logger_t, loggers);
+    DOIT(h2o_filter_t, _filters);
+    DOIT(h2o_logger_t, _loggers);
 
 #undef DOIT
 }
@@ -74,8 +74,8 @@ void h2o_context_dispose_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pa
     } while (0)
 
     DOIT(h2o_handler_t, handlers);
-    DOIT(h2o_filter_t, filters);
-    DOIT(h2o_logger_t, loggers);
+    DOIT(h2o_filter_t, _filters);
+    DOIT(h2o_logger_t, _loggers);
 
 #undef DOIT
 }

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -312,7 +312,7 @@ void h2o_dispose_request(h2o_req_t *req)
 
     h2o_timer_unlink(&req->_timeout_entry);
 
-    if (req->pathconf != NULL && !req->is_subrequest) {
+    if (req->pathconf != NULL) {
         h2o_logger_t **logger = req->pathconf->loggers.entries, **end = logger + req->pathconf->loggers.size;
         for (; logger != end; ++logger) {
             (*logger)->log_access((*logger), req);
@@ -476,12 +476,10 @@ void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)
     req->_generator = generator;
 
     /* setup response filters */
-    if (!req->disable_filters) {
-        if (req->prefilters != NULL) {
-            req->prefilters->on_setup_ostream(req->prefilters, req, &req->_ostr_top);
-        } else {
-            h2o_setup_next_ostream(req, &req->_ostr_top);
-        }
+    if (req->prefilters != NULL) {
+        req->prefilters->on_setup_ostream(req->prefilters, req, &req->_ostr_top);
+    } else {
+        h2o_setup_next_ostream(req, &req->_ostr_top);
     }
 }
 

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -476,10 +476,12 @@ void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)
     req->_generator = generator;
 
     /* setup response filters */
-    if (req->prefilters != NULL) {
-        req->prefilters->on_setup_ostream(req->prefilters, req, &req->_ostr_top);
-    } else {
-        h2o_setup_next_ostream(req, &req->_ostr_top);
+    if (!req->disable_filters) {
+        if (req->prefilters != NULL) {
+            req->prefilters->on_setup_ostream(req->prefilters, req, &req->_ostr_top);
+        } else {
+            h2o_setup_next_ostream(req, &req->_ostr_top);
+        }
     }
 }
 

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -458,18 +458,16 @@ Default:
     return 0x101;
 }
 
-static h2o_pathconf_t *create_pathconf(h2o_mem_pool_t *pool, h2o_pathconf_t *base, int preserve_filters)
+static h2o_pathconf_t *create_pathconf(h2o_mem_pool_t *pool, h2o_pathconf_t *base)
 {
     h2o_pathconf_t *pathconf = h2o_mem_alloc_pool(pool, h2o_pathconf_t, 1);
     *pathconf = *base;
     pathconf->loggers.entries = NULL;
     pathconf->loggers.size = 0;
     pathconf->loggers.capacity = 0;
-    if (!preserve_filters) {
-        pathconf->filters.entries = NULL;
-        pathconf->filters.size = 0;
-        pathconf->filters.capacity = 0;
-    }
+    pathconf->filters.entries = NULL;
+    pathconf->filters.size = 0;
+    pathconf->filters.capacity = 0;
     return pathconf;
 }
 
@@ -710,7 +708,7 @@ static struct st_mruby_subreq_t *create_subreq(h2o_mruby_context_t *ctx, mrb_val
     subreq->super.input.path = h2o_strdup(&subreq->super.pool, url_parsed.path.base, url_parsed.path.len);
     h2o_hostconf_t *hostconf = h2o_req_setup(&subreq->super);
     subreq->super.hostconf = hostconf;
-    subreq->super.pathconf = create_pathconf(&subreq->super.pool, ctx->handler->pathconf, is_reprocess);
+    subreq->super.pathconf = create_pathconf(&subreq->super.pool, ctx->handler->pathconf);
     subreq->super.handler = &ctx->handler->super;
     subreq->super.version = parse_protocol_version(RSTRING_PTR(server_protocol), RSTRING_LEN(server_protocol));
 

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -458,19 +458,6 @@ Default:
     return 0x101;
 }
 
-static h2o_pathconf_t *create_pathconf(h2o_mem_pool_t *pool, h2o_pathconf_t *base)
-{
-    h2o_pathconf_t *pathconf = h2o_mem_alloc_pool(pool, h2o_pathconf_t, 1);
-    *pathconf = *base;
-    pathconf->loggers.entries = NULL;
-    pathconf->loggers.size = 0;
-    pathconf->loggers.capacity = 0;
-    pathconf->filters.entries = NULL;
-    pathconf->filters.size = 0;
-    pathconf->filters.capacity = 0;
-    return pathconf;
-}
-
 static struct st_mruby_subreq_t *create_subreq(h2o_mruby_context_t *ctx, mrb_value env, int is_reprocess)
 {
     static const h2o_conn_callbacks_t callbacks = {get_sockname, /* stringify address */
@@ -708,7 +695,7 @@ static struct st_mruby_subreq_t *create_subreq(h2o_mruby_context_t *ctx, mrb_val
     subreq->super.input.path = h2o_strdup(&subreq->super.pool, url_parsed.path.base, url_parsed.path.len);
     h2o_hostconf_t *hostconf = h2o_req_setup(&subreq->super);
     subreq->super.hostconf = hostconf;
-    subreq->super.pathconf = create_pathconf(&subreq->super.pool, ctx->handler->pathconf);
+    subreq->super.pathconf = ctx->handler->pathconf;
     subreq->super.handler = &ctx->handler->super;
     subreq->super.version = parse_protocol_version(RSTRING_PTR(server_protocol), RSTRING_LEN(server_protocol));
 

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -488,6 +488,9 @@ static struct st_mruby_subreq_t *create_subreq(h2o_mruby_context_t *ctx, mrb_val
     subreq->conn.super.ctx = ctx->shared->ctx;
     h2o_init_request(&subreq->super, &subreq->conn.super, NULL);
     subreq->super.is_subrequest = 1;
+    if (!is_reprocess) {
+        subreq->super.disable_filters = 1;
+    }
     h2o_ostream_t *ostream = h2o_add_ostream(&subreq->super, H2O_ALIGNOF(*ostream), sizeof(*ostream), &subreq->super._ostr_top);
     ostream->do_send = subreq_ostream_send;
     subreq->conn.super.hosts = ctx->handler->pathconf->global->hosts;

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -196,8 +196,8 @@ void h2o_duration_stats_register(h2o_globalconf_t *conf)
             int j;
             for (j = 0; j < hconf->paths.entries[i].handlers.size; j++) {
                 h2o_pathconf_t *pathconf = &hconf->paths.entries[i];
-                h2o_vector_reserve(NULL, &pathconf->loggers, pathconf->loggers.size + 1);
-                pathconf->loggers.entries[pathconf->loggers.size++] = (void *)logger;
+                h2o_vector_reserve(NULL, &pathconf->_loggers, pathconf->_loggers.size + 1);
+                pathconf->_loggers.entries[pathconf->_loggers.size++] = (void *)logger;
             }
         }
     }


### PR DESCRIPTION
Currently `H2O.next` has a problem that filters and prefilters will be applied to the response multiple times, that is:

```
/:
  - mruby-handler: proc {|env| H2O.next.call(env) }
  - file.dir: /path/to/doc_root
  - header.add: "x-foo: FOO"
```
responds `x-foo: FOO` 2 times. This PR addresses that issue.