### PR TITLE
Don't push a path if a connection is closing.

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1438,6 +1438,8 @@ static void push_path(h2o_req_t *src_req, const char *abspath, size_t abspath_le
         conn->num_streams.push.open >= conn->peer_settings.max_concurrent_streams)
         return;
 
+    if (conn->state >= H2O_HTTP2_CONN_STATE_IS_CLOSING)
+        return;
     if (conn->push_stream_ids.max_open >= 0x7ffffff0)
         return;
     if (!(h2o_linklist_is_empty(&conn->_pending_reqs) && can_run_requests(conn)))


### PR DESCRIPTION
This might happen if a link is being pushed in a reverse proxying
environment: proxy.c would be handling HTTP/1 headers when the HTTP/2
side of the connection has been set to `H2O_HTTP2_CONN_STATE_IS_CLOSING`