### PR TITLE
enables support of ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,3 +777,10 @@ IF ("${VERSION_PRERELEASE}" STREQUAL "-DEV" AND EXISTS "${CMAKE_SOURCE_DIR}/.git
         ADD_DEPENDENCIES(t-00unit-libuv.t gitrev)
     ENDIF (LIBUV_FOUND)
 ENDIF ()
+
+# Configure CCache if available
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)


### PR DESCRIPTION
based on https://www.virag.si/2015/07/use-ccache-with-cmake-for-faster-compilation/

to faster rebuild from scratch `ccache` can really improve build times

https://ccache.samba.org/