### PR TITLE
Don't call `h2o_http2_conn_request_write` from `emit_writereq_of_openref`

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1216,7 +1216,6 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
             }
             h2o_hpack_flatten_trailers(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
                                        conn->peer_settings.max_frame_size, trailers, num_trailers);
-            h2o_http2_conn_request_write(conn);
         }
         h2o_linklist_insert(&conn->_write.streams_to_proceed, &stream->_refs.link);
     }


### PR DESCRIPTION
This fixes an issue seen when 'server-timing: enforced' is set in the
configuration: proceed would set the write callback, and we'd hit the
assert in `do_emit_writereq()` checking that `buf_in_flight` is NULL:

```
h2o: lib/http2/connection.c:1229: do_emit_writereq: Assertion `conn->_write.buf_in_flight == NULL' failed.
```