### PR TITLE
HTTP/2 priorities fixes

### DIFF
--- a/include/h2o/http2_scheduler.h
+++ b/include/h2o/http2_scheduler.h
@@ -109,6 +109,10 @@ static h2o_http2_scheduler_node_t *h2o_http2_scheduler_get_parent(h2o_http2_sche
  */
 void h2o_http2_scheduler_activate(h2o_http2_scheduler_openref_t *ref);
 /**
+ * deactivates a reference while retaining it in the scheduler
+ */
+void h2o_http2_scheduler_deactivate(h2o_http2_scheduler_openref_t *ref);
+/**
  * calls the callback of the references linked to the dependency tree one by one, in the order defined by the dependency and the
  * weight.
  */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -266,6 +266,7 @@ static void preserve_stream_scheduler(h2o_http2_conn_t *conn, h2o_http2_stream_t
 
     (*dst)->stream_id = src->stream_id;
     h2o_http2_scheduler_relocate(&(*dst)->_scheduler, &src->_scheduler);
+    h2o_http2_scheduler_deactivate(&(*dst)->_scheduler);
 }
 
 void h2o_http2_conn_unregister_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)

--- a/lib/http2/scheduler.c
+++ b/lib/http2/scheduler.c
@@ -341,6 +341,14 @@ void h2o_http2_scheduler_dispose(h2o_http2_scheduler_node_t *root)
     root->_queue = NULL;
 }
 
+void h2o_http2_scheduler_deactivate(h2o_http2_scheduler_openref_t *ref)
+{
+    if (!ref->_self_is_active)
+        return;
+    ref->_self_is_active = 0;
+    decr_active_cnt(&ref->node);
+}
+
 void h2o_http2_scheduler_activate(h2o_http2_scheduler_openref_t *ref)
 {
     if (ref->_self_is_active)

--- a/lib/http2/scheduler.c
+++ b/lib/http2/scheduler.c
@@ -267,8 +267,10 @@ void h2o_http2_scheduler_relocate(h2o_http2_scheduler_openref_t *dst, h2o_http2_
         h2o_linklist_insert_list(&dst->node._all_refs, &src->node._all_refs);
         /* node._queue */
         dst->node._queue = src->node._queue;
-        src->node._queue = NULL;
+    } else {
+        free(src->node._queue);
     }
+    src->node._queue = NULL;
 
     /* swap all_link */
     h2o_linklist_insert(&src->_all_link, &dst->_all_link);

--- a/lib/http2/scheduler.c
+++ b/lib/http2/scheduler.c
@@ -252,7 +252,7 @@ void h2o_http2_scheduler_relocate(h2o_http2_scheduler_openref_t *dst, h2o_http2_
     dst->_active_cnt = src->_active_cnt;
     dst->_self_is_active = src->_self_is_active;
     dst->_queue_node._link = (h2o_linklist_t){NULL};
-    dst->_queue_node._deficit = dst->_queue_node._deficit;
+    dst->_queue_node._deficit = src->_queue_node._deficit;
 
     /* update refs from descendants */
     if (!h2o_linklist_is_empty(&src->node._all_refs)) {


### PR DESCRIPTION
These fixes are a follow up to https://github.com/h2o/h2o/pull/1924 . It includes the following fixes:
- we would leak memory if the relocated stream had no children
- a relocated stream wouldn't be deactivated, causing invalid reads
- `_queue_node._deficit` wasn't correctly carried over from the old stream.