### PR TITLE
HTTP/1: handle the absolute url form

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -354,10 +354,11 @@ static ssize_t fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_header
     entity_header_index =
         init_headers(&conn->req.pool, &conn->req.headers, headers, num_headers, &connection, &host, &upgrade, expect);
 
-    if (h2o_url_parse(conn->req.input.path.base, conn->req.input.path.len, &url) == 0)
+    if (conn->req.input.path.len > 0 && conn->req.input.path.base[0] != '/' && h2o_url_parse(conn->req.input.path.base, conn->req.input.path.len, &url) == 0)
         conn->req.input.path = h2o_strdup(&conn->req.pool, url.path.base, url.path.len);
     else
         conn->req.input.path = h2o_strdup(&conn->req.pool, conn->req.input.path.base, conn->req.input.path.len);
+
     /* copy the values to pool, since the buffer pointed by the headers may get realloced */
     if (entity_header_index != -1) {
         size_t i;


### PR DESCRIPTION
From RFC7230 5.3.2.  absolute-form:
>  To allow for transition to the absolute-form for all requests in some
>  future version of HTTP, a server MUST accept the absolute-form in
>  requests, even though HTTP/1.1 clients will only send them in
>  requests to proxies.