### PR TITLE
Fix an invalid memory access by an mruby middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ CMakeCache.txt
 CMakeFiles/
 Makefile
 build/
+mruby/
 cmake_install.cmake
 xcuserdata
 *.xccheckout

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -133,6 +133,8 @@ static h2o_iovec_t convert_env_to_header_name(h2o_mem_pool_t *pool, const char *
     ret.base = h2o_mem_alloc_pool(pool, char, ret.len);
 
     name += KEY_PREFIX_LEN;
+    len -= KEY_PREFIX_LEN;
+
     char *d = ret.base;
     for (; len != 0; ++name, --len)
         *d++ = *name == '_' ? '-' : h2o_tolower(*name);


### PR DESCRIPTION
## Objective

Fix an invalid read in `convert_env_to_header_name (middleware.c:140)`.

```
==77960== Invalid read of size 1
==77960==    at 0x204630: convert_env_to_header_name (middleware.c:140)
==77960==    by 0x204630: handle_header_env_key (middleware.c:406)
==77960==    by 0x2002B7: h2o_mruby_iterate_header_values (mruby.c:1151)
==77960==    by 0x2056DD: create_subreq (middleware.c:598)
==77960==    by 0x2056DD: middleware_request_method (middleware.c:791)
... snip ...
```

## Cause

We forward the `name` pointer by `KEY_PREFIX_LEN` and loop from there to copy byte-by-byte into the newly created `h2o_iovec_t`. The issue is that `len` remains the length of the string with `HTTP_` prefix.

## Fix

Subtract `len` by `KEY_PREFIX_LEN` so that we don't over iterate. The case of `len < KEY_PREFIX_LEN` is handled earlier in the function. As a result, Valgrind no longer reports an invalid read.