### PR TITLE
'SSL_set_alpn_protos' not supported for openssl 1.0.1

### DIFF
--- a/include/h2o/openssl_backport.h
+++ b/include/h2o/openssl_backport.h
@@ -61,6 +61,8 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
 
 #define SSL_is_server(ssl) ((ssl)->server)
 
+#define SSL_set_alpn_protos(ssl, protos, protos_len) (-1)
+
 #endif
 
 #endif


### PR DESCRIPTION
this PR add 'SSL_set_alpn_protos' to openssl_backport.h, so that openssl 1.0.1 can be used.