### PR TITLE
Fix failed assertion in update_stream_output_window

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -402,7 +402,7 @@ static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta
     if (h2o_http2_window_update(&stream->output_window, delta) != 0)
         return -1;
     if (cur <= 0 && h2o_http2_window_get_avail(&stream->output_window) > 0 &&
-        (h2o_http2_stream_has_pending_data(stream) || stream->state >= H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL)) {
+        (h2o_http2_stream_has_pending_data(stream) || stream->state == H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL)) {
         assert(!h2o_linklist_is_linked(&stream->_link));
         h2o_http2_scheduler_activate(&stream->_scheduler);
     }


### PR DESCRIPTION
We've seen the following assert trigger:
```
h2o[0x448ce1] update_stream_output_window at h2o/lib/http2/connection.c:312
h2o[0x44b256] handle_window_update_frame at h2o/lib/http2/connection.c:699
h2o[0x4489c0] expect_default at h2o/lib/http2/connection.c:799
h2o[0x44a761] parse_input at h2o/lib/http2/connection.c:834
h2o[0x423922] run_socket at h2o/lib/common/socket/evloop.c.h:536
h2o[0x423a85] run_socket at h2o/lib/common/socket/evloop.c.h:508
h2o(h2o_evloop_run+0x29)[0x4244b9] h2o_evloop_run at h2o-fastly/lib/common/socket/evloop.c.h:568
h2o[0x4a01a9] run_loop at h2o/src/main.c:1364
```

This is a regression introduced here: https://github.com/h2o/h2o/pull/1040.

Kazuho hypothesized that this is happening:

> * emit_writereq_of_openref calls h2o_http2_stream_send_pending_data
>  * within the function, the stream state changes to END_STREAM
>  * and data is written to the network, but does not complete immediately
> * WINDOW_UPDATE gets received

We fix the issue by not trying to activate the scheduler if the stream
state is `H2O_HTTP2_STREAM_STATE_END_STREAM`, since we expect that at
that point, it is active.