### PR TITLE
Add an API to get the underlying socket from an httpclient

### DIFF
--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -131,6 +131,10 @@ struct st_h2o_httpclient_t {
      */
     h2o_socket_t *(*steal_socket)(h2o_httpclient_t *client);
     /**
+     * returns a pointer to the underlying h2o_socket_t
+     */
+    h2o_socket_t *(*get_socket)(h2o_httpclient_t *client);
+    /**
      * callback that should be called when some data is fetched out from `buf`.
      */
     void (*update_window)(h2o_httpclient_t *client);

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -643,11 +643,18 @@ static h2o_socket_t *do_steal_socket(h2o_httpclient_t *_client)
     return sock;
 }
 
+static h2o_socket_t *do_get_socket(h2o_httpclient_t *_client)
+{
+    struct st_h2o_http1client_t *client = (void *)_client;
+    return client->sock;
+}
+
 static void setup_client(struct st_h2o_http1client_t *client, h2o_socket_t *sock, h2o_url_t *origin)
 {
     memset(&client->sock, 0, sizeof(*client) - offsetof(struct st_h2o_http1client_t, sock));
     client->super.cancel = do_cancel;
     client->super.steal_socket = do_steal_socket;
+    client->super.get_socket = do_get_socket;
     client->super.update_window = do_update_window;
     client->super.write_req = do_write_req;
     client->super.buf = &sock->input;

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -1217,6 +1217,12 @@ static void do_cancel(h2o_httpclient_t *_client)
     close_stream(stream);
 }
 
+static h2o_socket_t *do_get_socket(h2o_httpclient_t *_client)
+{
+    struct st_h2o_http2client_stream_t *stream = (void *)_client;
+    return stream->conn->super.sock;
+}
+
 static void do_update_window(h2o_httpclient_t *_client)
 {
     struct st_h2o_http2client_stream_t *stream = (void *)_client;
@@ -1264,6 +1270,7 @@ static void setup_stream(struct st_h2o_http2client_stream_t *stream)
     stream->super.buf = &stream->input.body;
     stream->super.cancel = do_cancel;
     stream->super.steal_socket = NULL;
+    stream->super.get_socket = do_get_socket;
     stream->super.update_window = do_update_window;
     stream->super.write_req = do_write_req;
 }

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -75,6 +75,7 @@ static h2o_httpclient_t *create_client(h2o_mem_pool_t *pool, void *data, h2o_htt
     client->data = data;
     client->cancel = do_cancel;
     client->steal_socket = NULL;
+    client->get_socket = NULL;
     client->update_window = NULL;
     client->write_req = NULL;
     client->_cb.on_connect = cb;


### PR DESCRIPTION
This is an API we added to the Fastly fork that we'd like to contribute back to the H2O community.

- Add an API to `h2o_httpclient_t` for obtaining the underlying network socket

Thanks!