### PR TITLE
[minor] Fix UBSAN warning in lib/http1.c

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -884,7 +884,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs
         if (bufs[bufcnt].len != 0)
             ++bufcnt;
     }
-    memcpy(bufs + bufcnt, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
+    h2o_memcpy(bufs + bufcnt, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
     bufcnt += inbufcnt;
     if (self->chunked_buf != NULL && chunked_suffix.len != 0)
         bufs[bufcnt++] = chunked_suffix;


### PR DESCRIPTION
```
/lib/http1.c:887:27: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:43:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /lib/http1.c:887:27
```