### PR TITLE
add 'const' for httpclient1|2 struct size global variable

### DIFF
--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -193,11 +193,11 @@ void h2o_httpclient_connect(h2o_httpclient_t **client, h2o_mem_pool_t *pool, voi
                             h2o_httpclient_connection_pool_t *connpool, h2o_url_t *target, h2o_httpclient_connect_cb cb);
 
 void h2o_httpclient__h1_on_connect(h2o_httpclient_t *client, h2o_socket_t *sock, h2o_url_t *origin);
-extern size_t h2o_httpclient__h1_size;
+extern const size_t h2o_httpclient__h1_size;
 
 void h2o_httpclient__h2_on_connect(h2o_httpclient_t *client, h2o_socket_t *sock, h2o_url_t *origin);
 uint32_t h2o_httpclient__h2_get_max_concurrent_streams(h2o_httpclient__h2_conn_t *conn);
-extern size_t h2o_httpclient__h2_size;
+extern const size_t h2o_httpclient__h2_size;
 
 #ifdef __cplusplus
 }

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -678,4 +678,4 @@ void h2o_httpclient__h1_on_connect(h2o_httpclient_t *_client, h2o_socket_t *sock
     on_connection_ready(client);
 }
 
-size_t h2o_httpclient__h1_size = sizeof(struct st_h2o_http1client_t);
+const size_t h2o_httpclient__h1_size = sizeof(struct st_h2o_http1client_t);

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -1297,4 +1297,4 @@ void h2o_httpclient__h2_on_connect(h2o_httpclient_t *_client, h2o_socket_t *sock
     on_connection_ready(stream, conn);
 }
 
-size_t h2o_httpclient__h2_size = sizeof(struct st_h2o_http2client_stream_t);
+const size_t h2o_httpclient__h2_size = sizeof(struct st_h2o_http2client_stream_t);


### PR DESCRIPTION
This PR add `const` for for httpclient1|2 struct size global variable prototype and definition.