### PR TITLE
use predifined function 'h2o_socket_is_reading|writing'

### DIFF
--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -70,7 +70,7 @@ typedef struct st_h2o_httpclient_ctx_t {
     uint64_t connect_timeout;
     uint64_t first_byte_timeout;
     uint64_t *websocket_timeout; /* NULL if upgrade to websocket is not allowed */
-    uint64_t keepalive_timeout;
+    uint64_t keepalive_timeout;  /* only used for http2 for now */
     size_t max_buffer_size;
 
     struct {

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -459,7 +459,7 @@ static int do_write_req(h2o_httpclient_t *_client, h2o_iovec_t chunk, int is_end
             return -1;
     }
 
-    if (client->sock->_cb.write != NULL)
+    if (h2o_socket_is_writing(client->sock))
         return 0;
 
     assert(client->_body_buf_in_flight == NULL || client->_body_buf_in_flight->size == 0);
@@ -626,12 +626,12 @@ static void do_update_window(h2o_httpclient_t *_client)
 {
     struct st_h2o_http1client_t *client = (void *)_client;
     if ((*client->super.buf)->size >= client->super.ctx->max_buffer_size) {
-        if (client->sock->_cb.read != NULL) {
+        if (h2o_socket_is_reading(client->sock)) {
             client->reader = client->sock->_cb.read;
             h2o_socket_read_stop(client->sock);
         }
     } else {
-        if (client->sock->_cb.read == NULL) {
+        if (!h2o_socket_is_reading(client->sock)) {
             h2o_socket_read_start(client->sock, client->reader);
         }
     }

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -110,7 +110,7 @@ static void request_write(struct st_h2o_http2client_conn_t *conn)
 {
     if (conn->state == H2O_HTTP2CLIENT_CONN_STATE_IS_CLOSING)
         return;
-    if (conn->super.sock->_cb.write == NULL && !h2o_timer_is_linked(&conn->output.defer_timeout))
+    if (!h2o_socket_is_writing(conn->super.sock) && !h2o_timer_is_linked(&conn->output.defer_timeout))
         h2o_timer_link(conn->super.ctx->loop, 0, &conn->output.defer_timeout);
 }
 


### PR DESCRIPTION
This PR try using `h2o_socket_is_reading` and `h2o_socket_is_writing` instead of `sock->_cb` directly for http client.