### PR TITLE
[WIP] mruby request streaming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,6 +559,7 @@ IF (WITH_MRUBY)
     LIST(APPEND STANDALONE_SOURCE_FILES
         lib/handler/mruby.c
         lib/handler/mruby/sender.c
+        lib/handler/mruby/input_stream.c
         lib/handler/mruby/http_request.c
         lib/handler/mruby/redis.c
         lib/handler/mruby/sleep.c

--- a/examples/libh2o/httpclient.c
+++ b/examples/libh2o/httpclient.c
@@ -240,13 +240,7 @@ h2o_httpclient_head_cb on_connect(h2o_httpclient_t *client, const char *errstr, 
     *body = h2o_iovec_init(NULL, 0);
 
     if (cur_body_size > 0) {
-        char *clbuf = h2o_mem_alloc_pool(&pool, char, sizeof(H2O_UINT32_LONGEST_STR) - 1);
-        size_t clbuf_len = sprintf(clbuf, "%d", cur_body_size);
-        h2o_headers_t headers_vec = (h2o_headers_t){NULL};
-        h2o_add_header(&pool, &headers_vec, H2O_TOKEN_CONTENT_LENGTH, NULL, clbuf, clbuf_len);
-        *headers = headers_vec.entries;
-        *num_headers = 1;
-
+        props->content_length = cur_body_size;
         *proceed_req_cb = proceed_request;
 
         struct st_timeout_ctx *tctx;

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 		7D0341FB1FE4D5B60052E0A1 /* http2client.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D0341FA1FE4D5B60052E0A1 /* http2client.c */; };
 		7D0341FC1FE4D5BD0052E0A1 /* http2client.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D0341FA1FE4D5B60052E0A1 /* http2client.c */; };
 		7D0E5D5A20761BD800DA3E5A /* hiredis_.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DF88EF820761972005DB8D8 /* hiredis_.h */; };
+		7D205FC722179C6900444C18 /* input_stream.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D205FC522179C6300444C18 /* input_stream.c */; };
 		7D25E33C20B288710092C982 /* http2_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D25E33B20B270BA0092C982 /* http2_common.h */; };
 		7D2DF4EE20297EEF004AD361 /* header.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D2DF4ED20297EE0004AD361 /* header.h */; };
 		7D67C721204F8C0E0049E935 /* httpclient.c in Sources */ = {isa = PBXBuildFile; fileRef = 7D67C720204F8C0E0049E935 /* httpclient.c */; };
@@ -861,6 +862,7 @@
 		10FFEE091BB23A8C0087AD75 /* neverbleed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neverbleed.h; sourceTree = "<group>"; };
 		7D0285C81EF422D40094292B /* sleep.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sleep.c; sourceTree = "<group>"; };
 		7D0341FA1FE4D5B60052E0A1 /* http2client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http2client.c; sourceTree = "<group>"; };
+		7D205FC522179C6300444C18 /* input_stream.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = input_stream.c; sourceTree = "<group>"; };
 		7D25E33B20B270BA0092C982 /* http2_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = http2_common.h; sourceTree = "<group>"; };
 		7D2DF4ED20297EE0004AD361 /* header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = header.h; sourceTree = "<group>"; };
 		7D67C720204F8C0E0049E935 /* httpclient.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = httpclient.c; sourceTree = "<group>"; };
@@ -1179,6 +1181,7 @@
 				7D0285C81EF422D40094292B /* sleep.c */,
 				7DF26B071FBC020600FBE2E7 /* middleware.c */,
 				7D9FA5381FC323AC00189F88 /* channel.c */,
+				7D205FC522179C6300444C18 /* input_stream.c */,
 			);
 			path = mruby;
 			sourceTree = "<group>";
@@ -2840,6 +2843,7 @@
 			files = (
 				7D0285C91EF422D40094292B /* sleep.c in Sources */,
 				E9708B7C1E52C83D0029E0A5 /* status.c in Sources */,
+				7D205FC722179C6900444C18 /* input_stream.c in Sources */,
 				E987E5D81FD7BEB500DE4346 /* block_splitter.c in Sources */,
 				E9708B7D1E52C8430029E0A5 /* durations.c in Sources */,
 				E9BC76E81F00E73900EB7A09 /* chacha20.c in Sources */,

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -33,8 +33,8 @@ extern "C" {
 typedef struct st_h2o_httpclient_t h2o_httpclient_t;
 
 typedef struct st_h2o_httpclient_properties_t {
+    size_t content_length;
     h2o_iovec_t *proxy_protocol;
-    int *chunked;
     h2o_iovec_t *connection_header;
 } h2o_httpclient_properties_t;
 
@@ -198,6 +198,8 @@ extern const size_t h2o_httpclient__h1_size;
 void h2o_httpclient__h2_on_connect(h2o_httpclient_t *client, h2o_socket_t *sock, h2o_url_t *origin);
 uint32_t h2o_httpclient__h2_get_max_concurrent_streams(h2o_httpclient__h2_conn_t *conn);
 extern const size_t h2o_httpclient__h2_size;
+
+void h2o_httpclient__add_cl_or_te_header(h2o_mem_pool_t *pool, h2o_iovec_t method, h2o_headers_t *headers, h2o_iovec_t body, size_t content_length, int *chunked, int is_streaming);
 
 #ifdef __cplusplus
 }

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -561,10 +561,9 @@ static h2o_iovec_t build_request(struct st_h2o_http1client_t *client, h2o_iovec_
 static void on_connection_ready(struct st_h2o_http1client_t *client)
 {
     h2o_iovec_t proxy_protocol = h2o_iovec_init(NULL, 0);
-    int chunked = 0;
     h2o_iovec_t connection_header = h2o_iovec_init(NULL, 0);
     h2o_httpclient_properties_t props = {
-        &proxy_protocol, &chunked, &connection_header,
+        SIZE_MAX, &proxy_protocol, &connection_header
     };
     h2o_iovec_t method;
     h2o_url_t url;
@@ -580,13 +579,21 @@ static void on_connection_ready(struct st_h2o_http1client_t *client)
         return;
     }
 
+    {
+        h2o_headers_t headers_vec = (h2o_headers_t){headers, num_headers, num_headers};
+        int chunked = 0;
+        h2o_httpclient__add_cl_or_te_header(client->super.pool, method, &headers_vec, body, props.content_length, &chunked, client->proceed_req != NULL);
+        headers = headers_vec.entries;
+        num_headers = headers_vec.size;
+        client->_is_chunked = chunked;
+    }
+
     h2o_iovec_t reqbufs[3];
     size_t reqbufcnt = 0;
     if (props.proxy_protocol->base != NULL)
         reqbufs[reqbufcnt++] = *props.proxy_protocol;
     reqbufs[reqbufcnt++] = build_request(client, method, url, *props.connection_header, headers, num_headers);
 
-    client->_is_chunked = *props.chunked;
     client->_method_is_head = h2o_memis(method.base, method.len, H2O_STRLIT("HEAD"));
 
     if (client->proceed_req != NULL) {

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -195,3 +195,58 @@ UseSocketPool:
     h2o_socketpool_connect(&client->_connect_req, connpool->socketpool, origin, ctx->loop, ctx->getaddr_receiver, alpn_protos,
                            on_pool_connect, client);
 }
+
+/*
+ * A request without neither Content-Length or Transfer-Encoding header implies a zero-length request body (see 6th rule of RFC 7230
+ * 3.3.3).
+ * OTOH, section 3.3.3 states:
+ *
+ *   A user agent SHOULD send a Content-Length in a request message when
+ *   no Transfer-Encoding is sent and the request method defines a meaning
+ *   for an enclosed payload body.  For example, a Content-Length header
+ *   field is normally sent in a POST request even when the value is 0
+ *   (indicating an empty payload body).  A user agent SHOULD NOT send a
+ *   Content-Length header field when the request message does not contain
+ *   a payload body and the method semantics do not anticipate such a
+ *   body.
+ *
+ * PUT and POST define a meaning for the payload body, let's emit a
+ * Content-Length header if it doesn't exist already, since the server
+ * might send a '411 Length Required' response.
+ *
+ * see also: ML thread starting at https://lists.w3.org/Archives/Public/ietf-http-wg/2016JulSep/0580.html
+ */
+static int req_requires_content_length(h2o_iovec_t method, h2o_headers_t *headers)
+{
+    int is_put_or_post =
+    (method.len >= 1 && method.base[0] == 'P' && (h2o_memis(method.base, method.len, H2O_STRLIT("POST")) ||
+                                                  h2o_memis(method.base, method.len, H2O_STRLIT("PUT"))));
+
+    return is_put_or_post && h2o_find_header(headers, H2O_TOKEN_TRANSFER_ENCODING, -1) == -1;
+}
+
+static h2o_iovec_t build_content_length(h2o_mem_pool_t *pool, size_t cl)
+{
+    h2o_iovec_t cl_buf;
+    cl_buf.base = h2o_mem_alloc_pool(pool, char, sizeof(H2O_UINT64_LONGEST_STR) - 1);
+    cl_buf.len = sprintf(cl_buf.base, "%zu", cl);
+    return cl_buf;
+}
+
+void h2o_httpclient__add_cl_or_te_header(h2o_mem_pool_t *pool, h2o_iovec_t method, h2o_headers_t *headers, h2o_iovec_t body, size_t content_length, int *chunked, int is_streaming)
+{
+    if (is_streaming) {
+        if (content_length != SIZE_MAX) {
+            h2o_iovec_t cl_buf = build_content_length(pool, content_length);
+            h2o_add_header(pool, headers, H2O_TOKEN_CONTENT_LENGTH, NULL, cl_buf.base, cl_buf.len);
+        } else if (chunked != NULL) {
+            h2o_add_header(pool, headers, H2O_TOKEN_TRANSFER_ENCODING, NULL, H2O_STRLIT("chunked"));
+            *chunked = 1;
+        }
+    } else {
+        if (body.base != NULL || req_requires_content_length(method, headers)) {
+            h2o_iovec_t cl_buf = build_content_length(pool, body.len);
+            h2o_add_header(pool, headers, H2O_TOKEN_CONTENT_LENGTH, NULL, cl_buf.base, cl_buf.len);
+        }
+    }
+}

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -101,43 +101,6 @@ static h2o_iovec_t build_request_merge_headers(h2o_mem_pool_t *pool, h2o_iovec_t
     return merged;
 }
 
-/*
- * A request without neither Content-Length or Transfer-Encoding header implies a zero-length request body (see 6th rule of RFC 7230
- * 3.3.3).
- * OTOH, section 3.3.3 states:
- *
- *   A user agent SHOULD send a Content-Length in a request message when
- *   no Transfer-Encoding is sent and the request method defines a meaning
- *   for an enclosed payload body.  For example, a Content-Length header
- *   field is normally sent in a POST request even when the value is 0
- *   (indicating an empty payload body).  A user agent SHOULD NOT send a
- *   Content-Length header field when the request message does not contain
- *   a payload body and the method semantics do not anticipate such a
- *   body.
- *
- * PUT and POST define a meaning for the payload body, let's emit a
- * Content-Length header if it doesn't exist already, since the server
- * might send a '411 Length Required' response.
- *
- * see also: ML thread starting at https://lists.w3.org/Archives/Public/ietf-http-wg/2016JulSep/0580.html
- */
-static int req_requires_content_length(h2o_req_t *req)
-{
-    int is_put_or_post =
-        (req->method.len >= 1 && req->method.base[0] == 'P' && (h2o_memis(req->method.base, req->method.len, H2O_STRLIT("POST")) ||
-                                                                h2o_memis(req->method.base, req->method.len, H2O_STRLIT("PUT"))));
-
-    return is_put_or_post && h2o_find_header(&req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, -1) == -1;
-}
-
-static h2o_iovec_t build_content_length(h2o_mem_pool_t *pool, size_t cl)
-{
-    h2o_iovec_t cl_buf;
-    cl_buf.base = h2o_mem_alloc_pool(pool, char, sizeof(H2O_UINT64_LONGEST_STR) - 1);
-    cl_buf.len = sprintf(cl_buf.base, "%zu", cl);
-    return cl_buf;
-}
-
 static void build_request(h2o_req_t *req, h2o_iovec_t *method, h2o_url_t *url, h2o_headers_t *headers,
                           h2o_httpclient_properties_t *props, int keepalive, int is_websocket_handshake, int use_proxy_protocol,
                           int *reprocess_if_too_early, h2o_url_t *origin)
@@ -177,22 +140,7 @@ static void build_request(h2o_req_t *req, h2o_iovec_t *method, h2o_url_t *url, h
         }
     }
 
-    /* CL or TE? Depends on whether we're streaming the request body or
-       not, and if CL was advertised in the original request */
-    if (req->proceed_req == NULL) {
-        if (req->entity.base != NULL || req_requires_content_length(req)) {
-            h2o_iovec_t cl_buf = build_content_length(&req->pool, req->entity.len);
-            h2o_add_header(&req->pool, headers, H2O_TOKEN_CONTENT_LENGTH, NULL, cl_buf.base, cl_buf.len);
-        }
-    } else {
-        if (req->content_length != SIZE_MAX) {
-            h2o_iovec_t cl_buf = build_content_length(&req->pool, req->content_length);
-            h2o_add_header(&req->pool, headers, H2O_TOKEN_CONTENT_LENGTH, NULL, cl_buf.base, cl_buf.len);
-        } else if (props->chunked != NULL) {
-            *(props->chunked) = 1;
-            h2o_add_header(&req->pool, headers, H2O_TOKEN_TRANSFER_ENCODING, NULL, H2O_STRLIT("chunked"));
-        }
-    }
+    props->content_length = req->content_length;
 
     /* headers */
     /* rewrite headers if necessary */

--- a/lib/handler/mruby/embedded/input_stream.rb
+++ b/lib/handler/mruby/embedded/input_stream.rb
@@ -1,15 +1,15 @@
-# Copyright (c) 2015-2016 DeNA Co., Ltd., Kazuho Oku
-# 
+# Copyright (c) 2019 Ichito Nagata
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
 # deal in the Software without restriction, including without limitation the
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,57 +20,23 @@
 
 module H2O
 
-  class HttpRequest
-    def join
-      if !@resp
-        @resp = _h2o__http_join_response(self)
-      end
-      @resp
+  class InputStream
+
+    def gets
+      _h2o_input_stream_gets(self, $/)
     end
 
-    def _set_response(resp)
-      @resp = resp
+    def read(length = nil, buffer = nil)
+      _h2o_input_stream_read(self, length, buffer)
     end
 
-    def self.body_fiber_proc
-      proc {|body, req|
-        fiber = Fiber.new do
-          sleep 0
-          begin
-            chunk = ''
-            while body.read(4096, chunk)
-              req._write_chunk(chunk)
-            end
-            _h2o__http_request_write_eos(req)
-          rescue => e
-            _h2o__http_request_write_cancel(req)
-          end
-        end
-        fiber.resume
-      }
-    end
-  end
-
-
-  class HttpInputStream
     def each
-      first = true
-      while c = _h2o__http_fetch_chunk(self, first)
-        yield c
-        first = false
+      while chunk = self.gets
+        yield chunk
       end
-    end
-    def join
-      s = ""
-      each do |c|
-        s << c
-      end
-      s
     end
 
-    class Empty < HttpInputStream
-      def each; end
-    end
   end
 
 end
+

--- a/lib/handler/mruby/input_stream.c
+++ b/lib/handler/mruby/input_stream.c
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2019 Ichito Nagata
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/error.h>
+#include <mruby/hash.h>
+#include <mruby/string.h>
+#include <mruby/class.h>
+#include <mruby/variable.h>
+#include "h2o/mruby_.h"
+#include "embedded.c.h"
+
+static void on_gc_dispose_input_stream(mrb_state *mrb, void *_is)
+{
+    h2o_mruby_input_stream_t *is = _is;
+    /* input stream never be freed by gc before the request ended and it's generator gets disposed */
+    assert(is == NULL);
+}
+
+const static struct mrb_data_type input_stream_type = {"input_stream", on_gc_dispose_input_stream};
+
+static mrb_value create_io_error(mrb_state *mrb, const char *msg)
+{
+    struct RClass *klass = mrb_class_get(mrb, "IOError");
+    mrb_value str = mrb_str_new_static(mrb, msg, strlen(msg));
+    return mrb_exc_new_str(mrb, klass, str);
+}
+
+static h2o_mruby_input_stream_t *get_input_stream(mrb_state *mrb, mrb_value obj)
+{
+    h2o_mruby_input_stream_t *is = mrb_data_check_get_ptr(mrb, obj, &input_stream_type);
+    return is;
+}
+
+static mrb_value detach_receiver(h2o_mruby_input_stream_t *is)
+{
+    mrb_value receiver = is->receiver;
+    assert(!mrb_nil_p(receiver));
+    is->receiver = mrb_nil_value();
+    mrb_gc_unregister(is->generator->ctx->shared->mrb, receiver);
+    mrb_gc_protect(is->generator->ctx->shared->mrb, receiver);
+    return receiver;
+}
+
+static h2o_iovec_t get_buffer(h2o_mruby_input_stream_t *is)
+{
+    if (is->buf != NULL) {
+        return h2o_iovec_init(is->buf->bytes + is->pos, is->buf->size - is->pos);
+    } else {
+        return h2o_iovec_init(is->entity.base + is->pos, is->entity.len - is->pos);
+    }
+}
+
+static void consume_buffer(h2o_mruby_input_stream_t *is, size_t len)
+{
+    if (is->rewindable) {
+        is->pos += len;
+    } else {
+        if (is->buf != NULL) {
+            h2o_buffer_consume(&is->buf, len);
+        } else {
+            is->entity.base += len;
+            is->entity.len -= len;
+        }
+    }
+}
+
+static void clear_args(h2o_mruby_input_stream_t *is)
+{
+    is->args.length = SIZE_MAX;
+    is->args.buffer = mrb_nil_value();
+    is->args.delimiter = mrb_nil_value();
+}
+
+static int prepare_chunk(h2o_mruby_input_stream_t *is, mrb_value *chunk)
+{
+    mrb_state *mrb = is->generator->ctx->shared->mrb;
+    *chunk = mrb_nil_value();
+
+    h2o_iovec_t buf = get_buffer(is);
+
+    if (!mrb_nil_p(is->args.delimiter)) {
+        /* prepare for gets */
+
+        char *p = memmem(buf.base, buf.len, RSTRING_PTR(is->args.delimiter), RSTRING_LEN(is->args.delimiter));
+        if (p == NULL) {
+            if (!is->seen_eos) {
+                return -1;
+            } else if (buf.len == 0) {
+                return 0;
+            } else {
+                *chunk = h2o_mruby_new_str(mrb, buf.base, buf.len);
+                consume_buffer(is, buf.len);
+                return 0;
+            }
+        }
+        size_t len = p - buf.base + RSTRING_LEN(is->args.delimiter);
+        *chunk = h2o_mruby_new_str(mrb, buf.base, len);
+        consume_buffer(is, len);
+        return 0;
+    } else {
+        /* prepare for read */
+
+        if (buf.len < is->args.length && !is->seen_eos) {
+            return -1;
+        }
+
+        /* rack spec states that "When EOF is reached, this method returns nil if length is given and not nil" */
+        if (is->seen_eos && buf.len == 0 && is->args.length != SIZE_MAX) {
+            /* but even in this case, the buffer argument must be set empty string */
+            if (!mrb_nil_p(is->args.buffer) && RSTRING_LEN(is->args.buffer) != 0) {
+                mrb_str_resize(mrb, is->args.buffer, 0);
+            }
+            return 0;
+        }
+
+        size_t len = is->args.length < buf.len ? is->args.length : buf.len;
+        *chunk = is->args.buffer;
+        if (mrb_nil_p(*chunk)) {
+            *chunk = h2o_mruby_new_str(mrb, NULL, len);
+        }
+        mrb_str_resize(mrb, *chunk, len);
+        memcpy(RSTRING_PTR(*chunk), buf.base, len);
+        consume_buffer(is, len);
+        return 0;
+    }
+}
+
+static int do_write_req(void *_is, h2o_iovec_t chunk, int is_end_stream)
+{
+    h2o_mruby_input_stream_t *is = _is;
+    h2o_buffer_append(&is->buf, chunk.base, chunk.len);
+    is->seen_eos = is_end_stream;
+
+    if (!mrb_nil_p(is->receiver)) {
+        mrb_value chunk_str;
+        if (prepare_chunk(is, &chunk_str) == 0) {
+            h2o_mruby_run_fiber(is->generator->ctx, detach_receiver(is), chunk_str, NULL);
+            clear_args(is);
+        }
+    }
+
+    if (is->generator->req->proceed_req != NULL) {
+        is->generator->req->proceed_req(is->generator->req, chunk.len, is_end_stream);
+    }
+
+    return 0; // FIXME: 0 is ok while mruby mode, but how handle proxy mode?
+}
+
+static mrb_value input_stream_read_callback(h2o_mruby_context_t *mctx, mrb_value input, mrb_value *receiver, mrb_value args,
+                                                int *run_again)
+{
+    mrb_state *mrb = mctx->shared->mrb;
+    struct st_h2o_mruby_input_stream_t *is;
+
+    mrb_value obj = mrb_ary_entry(args, 0);
+    if (DATA_PTR(obj) == NULL) {
+        *run_again = 1;
+        return create_io_error(mrb, "downstream HTTP closed");
+    } else if ((is = get_input_stream(mrb, obj)) == NULL) {
+        *run_again = 1;
+        return mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "InputStream#each wrong self");
+    }
+
+    mrb_value length = mrb_ary_entry(args, 1);
+    if (mrb_nil_p(length)) {
+        is->args.length = SIZE_MAX;
+    } else {
+        length = h2o_mruby_to_int(mrb, length);
+        if (mrb->exc != NULL)
+            return mrb_obj_value(mrb->exc);
+        if (mrb_fixnum(length) < 0) {
+            return mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "length must be a non-negative Integer (>= 0) or nil");
+        }
+        is->args.length = mrb_fixnum(length);
+    }
+
+    mrb_value buffer = mrb_ary_entry(args, 2);
+    if (mrb_nil_p(buffer)) {
+        is->args.buffer = mrb_nil_value();
+    } else {
+        if (!mrb_string_p(buffer)) {
+            return mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "buffer must be a String or nil");
+        }
+        is->args.buffer = buffer;
+    }
+
+    assert(mrb_nil_p(is->receiver));
+
+    mrb_value chunk;
+    if (prepare_chunk(is, &chunk) == 0) {
+        *run_again = 1;
+        clear_args(is);
+        return chunk;
+    } else {
+        is->receiver = *receiver;
+        mrb_gc_register(mrb, *receiver);
+        return mrb_nil_value();
+    }
+}
+
+static mrb_value input_stream_gets_callback(h2o_mruby_context_t *mctx, mrb_value input, mrb_value *receiver, mrb_value args,
+                                            int *run_again)
+{
+    mrb_state *mrb = mctx->shared->mrb;
+    struct st_h2o_mruby_input_stream_t *is;
+
+    mrb_value obj = mrb_ary_entry(args, 0);
+    if (DATA_PTR(obj) == NULL) {
+        *run_again = 1;
+        return create_io_error(mrb, "downstream HTTP closed");
+    } else if ((is = get_input_stream(mrb, obj)) == NULL) {
+        *run_again = 1;
+        return mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "InputStream#each wrong self");
+    }
+
+    mrb_value delimiter = mrb_ary_entry(args, 1);
+    if (!mrb_nil_p(delimiter)) {
+        if (!mrb_string_p(delimiter)) {
+            return mrb_exc_new_str_lit(mrb, E_ARGUMENT_ERROR, "delimiter must be a String or nil");
+        }
+    }
+    is->args.delimiter = delimiter;
+
+    assert(mrb_nil_p(is->receiver));
+
+    mrb_value chunk;
+    if (prepare_chunk(is, &chunk) == 0) {
+        *run_again = 1;
+        clear_args(is);
+        return chunk;
+    } else {
+        is->receiver = *receiver;
+        mrb_gc_register(mrb, *receiver);
+        return mrb_nil_value();
+    }
+}
+
+static mrb_value rewindable_getter_method(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_input_stream_t *is = get_input_stream(mrb, self);
+    assert(is != NULL);
+    return mrb_bool_value(is->rewindable);
+}
+
+static mrb_value rewindable_setter_method(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_input_stream_t *is = get_input_stream(mrb, self);
+    assert(is != NULL);
+
+    mrb_bool value;
+    mrb_get_args(mrb, "b", &value);
+
+    is->rewindable = value;
+    if (!is->rewindable) {
+        consume_buffer(is, is->pos);
+        is->pos = 0;
+    }
+    return mrb_bool_value(is->rewindable);
+}
+
+static mrb_value rewind_method(mrb_state *mrb, mrb_value self)
+{
+    h2o_mruby_input_stream_t *is = get_input_stream(mrb, self);
+    assert(is != NULL);
+
+    if (!is->rewindable) {
+        mrb_raise(mrb, mrb_class_get(mrb, "IOError"), "this input stream is not rewindable");
+    }
+
+    is->pos = 0;
+
+    return mrb_fixnum_value(0);
+}
+
+h2o_mruby_input_stream_t *h2o_mruby_input_stream_create(h2o_mruby_generator_t *generator)
+{
+    h2o_mruby_shared_context_t *shared = generator->ctx->shared;
+    h2o_mruby_input_stream_t *is = h2o_mem_alloc(sizeof(*is));
+    is->generator = generator;
+    is->buf = NULL;
+    is->entity = h2o_iovec_init(NULL, 0);
+    is->pos = 0;
+    is->receiver = mrb_nil_value();
+    clear_args(is);
+    is->seen_eos = 0;
+    is->rewindable = 1;
+
+    if (generator->req->proceed_req != NULL) {
+        h2o_buffer_init(&is->buf, &h2o_socket_buffer_prototype);
+        if (generator->req->entity.len != 0) {
+            h2o_buffer_append(&is->buf, generator->req->entity.base, generator->req->entity.len);
+        }
+        generator->req->write_req.cb = do_write_req;
+        generator->req->write_req.ctx = is;
+    } else {
+        is->entity = h2o_iovec_init(generator->req->entity.base, generator->req->entity.len);
+        is->seen_eos = 1;
+    }
+
+    is->ref = h2o_mruby_create_data_instance(shared->mrb, mrb_ary_entry(shared->constants, H2O_MRUBY_INPUT_STREAM_CLASS), is, &input_stream_type);
+    return is;
+}
+
+void h2o_mruby_input_stream_dispose(h2o_mruby_input_stream_t *is)
+{
+    DATA_PTR(is->ref) = NULL;
+
+    if (!mrb_nil_p(is->receiver)) {
+        mrb_value exc = create_io_error(is->generator->ctx->shared->mrb, "downstream HTTP closed");
+        h2o_mruby_run_fiber(is->generator->ctx, detach_receiver(is), exc, NULL);
+    }
+
+    if (is->buf != NULL)
+        h2o_buffer_dispose(&is->buf);
+
+    free(is);
+}
+
+void h2o_mruby_input_stream_init_context(h2o_mruby_shared_context_t *shared_ctx)
+{
+    mrb_state *mrb = shared_ctx->mrb;
+
+    h2o_mruby_eval_expr_location(mrb, H2O_MRUBY_CODE_INPUT_STREAM, "(h2o)lib/handler/mruby/embedded/input_stream.rb", 1);
+    h2o_mruby_assert(mrb);
+
+    struct RClass *module, *klass;
+    module = mrb_define_module(mrb, "H2O");
+
+    klass = mrb_class_get_under(mrb, module, "InputStream");
+    MRB_SET_INSTANCE_TT(klass, MRB_TT_DATA);
+    mrb_ary_set(mrb, shared_ctx->constants, H2O_MRUBY_INPUT_STREAM_CLASS, mrb_obj_value(klass));
+
+    h2o_mruby_define_callback(mrb, "_h2o_input_stream_read", input_stream_read_callback);
+    h2o_mruby_define_callback(mrb, "_h2o_input_stream_gets", input_stream_gets_callback);
+
+    mrb_define_method(mrb, klass, "rewindable?", rewindable_getter_method, MRB_ARGS_NONE());
+    mrb_define_method(mrb, klass, "rewindable=", rewindable_setter_method,MRB_ARGS_ARG(1, 0));
+    mrb_define_method(mrb, klass, "rewind", rewind_method, MRB_ARGS_NONE());
+}

--- a/misc/regen.mk
+++ b/misc/regen.mk
@@ -12,6 +12,7 @@ tokens:
 
 lib/handler/mruby/embedded.c.h: misc/embed_mruby_code.pl \
                                 lib/handler/mruby/embedded/core.rb \
+                                lib/handler/mruby/embedded/input_stream.rb \
                                 lib/handler/mruby/embedded/sender.rb \
                                 lib/handler/mruby/embedded/middleware.rb \
                                 lib/handler/mruby/embedded/http_request.rb \

--- a/t/50mruby-input-stream.t
+++ b/t/50mruby-input-stream.t
@@ -1,0 +1,151 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use Test::More;
+use Test::Exception;
+use t::Util;
+
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
+subtest "gets" => sub {
+    my $server = spawn_h2o(<< 'EOT');
+hosts:
+  default:
+    paths:
+      /basic:
+        mruby.handler: |
+          proc {|env|
+            is = env['rack.input']
+            chunks = []
+            chunks << is.gets
+            chunks << is.gets
+            if is.gets
+              chunks << 'garbage found'
+            end
+            [200, {}, [chunks.join(',')]]
+          }
+      /other-separator:
+        mruby.handler: |
+          proc {|env|
+            $/ = '23'
+            is = env['rack.input']
+            chunks = []
+            chunks << is.gets
+            chunks << is.gets
+            if is.gets
+              chunks << 'garbage found'
+            end
+            [200, {}, [chunks.join(',')]]
+          }
+EOT
+    my $curl_opts = "--silent --dump-header /dev/stderr -X POST --data-binary '123\n45'";
+
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($stderr, $stdout) = run_prog("$curl $curl_opts $proto://127.0.0.1:$port/basic");
+        is $stdout, "123\n,45";
+    });
+
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($stderr, $stdout) = run_prog("$curl $curl_opts $proto://127.0.0.1:$port/other-separator");
+        is $stdout, "123,\n45";
+    });
+
+};
+
+subtest "rewind" => sub {
+    my $server = spawn_h2o(<< 'EOT');
+hosts:
+  default:
+    paths:
+      /no-rewind:
+        mruby.handler: |
+          proc {|env|
+            is = env['rack.input']
+            chunks = []
+            chunks << is.read(2)
+            chunks << is.read
+            [200, {}, chunks]
+          }
+      /rewind:
+        mruby.handler: |
+          proc {|env|
+            is = env['rack.input']
+            chunks = []
+            chunks << is.read(2)
+            is.rewind
+            chunks << is.read
+            [200, {}, chunks]
+          }
+      /not-rewindable-error:
+        mruby.handler: |
+          proc {|env|
+            is = env['rack.input']
+            is.rewindable = false
+            begin
+              is.rewind
+              [200, {}, []]
+            rescue IOError => e
+              [503, {}, [e.message]]
+            end
+          }
+      /true-to-false:
+        mruby.handler: |
+          proc {|env|
+            is = env['rack.input']
+            chunks = []
+            chunks << is.read(2)
+            is.rewindable = false
+            chunks << is.read
+            [200, {}, chunks]
+          }
+      /false-to-true:
+        mruby.handler: |
+          proc {|env|
+            is = env['rack.input']
+            chunks = []
+            is.rewindable = false
+            chunks << is.read(2)
+            is.rewindable = true
+            chunks << is.read(2)
+            is.rewind
+            chunks << is.read
+            [200, {}, chunks]
+          }
+EOT
+    my $curl_opts = '--silent --dump-header /dev/stderr -X POST --data-binary "12345"';
+
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($stderr, $stdout) = run_prog("$curl $curl_opts $proto://127.0.0.1:$port/no-rewind");
+        is $stdout, '12345';
+    });
+
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($stderr, $stdout) = run_prog("$curl $curl_opts $proto://127.0.0.1:$port/rewind");
+        is $stdout, '1212345';
+    });
+
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($stderr, $stdout) = run_prog("$curl $curl_opts $proto://127.0.0.1:$port/not-rewindable-error");
+        like $stderr, qr{^HTTP\/[\d\.]+ 503 }s;
+    });
+
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($stderr, $stdout) = run_prog("$curl $curl_opts $proto://127.0.0.1:$port/true-to-false");
+        is $stdout, '12345';
+    });
+
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($stderr, $stdout) = run_prog("$curl $curl_opts $proto://127.0.0.1:$port/false-to-true");
+        is $stdout, '1234345';
+    });
+};
+
+done_testing();


### PR DESCRIPTION
support request streaming in mruby handler. https://github.com/h2o/h2o/issues/1601
This PR aims to allow something like the followings:

```ruby
proc {|env|
   chunks = []
   env['rack_input'].each {|chunk| chunks << chunk } # receive the stream in mruby
   [200, {}, chunks]
}
```

 or 

```ruby
proc {|env|
   [200, {}, env['rack_input']] # streaming echo
}
```

or 

```ruby
proc {|env|
  # run the request body into http_request
   http_request('http://example.com', { :method => 'POST', :body => env['rack_input'] }).join
}
```

TODOs
- [ ] fastpath for http_request (bypass mruby layer if `:body` is input stream)
- [ ] refactor mainly in terminology (HttpRequest::InputStream should be renamed to ResponseBody)
- [ ] tests

