### PR TITLE
let httpclient determine content-length and transfer-encoding headers

### DIFF
--- a/examples/libh2o/httpclient.c
+++ b/examples/libh2o/httpclient.c
@@ -240,13 +240,7 @@ h2o_httpclient_head_cb on_connect(h2o_httpclient_t *client, const char *errstr, 
     *body = h2o_iovec_init(NULL, 0);
 
     if (cur_body_size > 0) {
-        char *clbuf = h2o_mem_alloc_pool(&pool, char, sizeof(H2O_UINT32_LONGEST_STR) - 1);
-        size_t clbuf_len = sprintf(clbuf, "%d", cur_body_size);
-        h2o_headers_t headers_vec = (h2o_headers_t){NULL};
-        h2o_add_header(&pool, &headers_vec, H2O_TOKEN_CONTENT_LENGTH, NULL, clbuf, clbuf_len);
-        *headers = headers_vec.entries;
-        *num_headers = 1;
-
+        props->content_length = cur_body_size;
         *proceed_req_cb = proceed_request;
 
         struct st_timeout_ctx *tctx;

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -33,8 +33,8 @@ extern "C" {
 typedef struct st_h2o_httpclient_t h2o_httpclient_t;
 
 typedef struct st_h2o_httpclient_properties_t {
+    size_t content_length;
     h2o_iovec_t *proxy_protocol;
-    int *chunked;
     h2o_iovec_t *connection_header;
 } h2o_httpclient_properties_t;
 
@@ -198,6 +198,8 @@ extern const size_t h2o_httpclient__h1_size;
 void h2o_httpclient__h2_on_connect(h2o_httpclient_t *client, h2o_socket_t *sock, h2o_url_t *origin);
 uint32_t h2o_httpclient__h2_get_max_concurrent_streams(h2o_httpclient__h2_conn_t *conn);
 extern const size_t h2o_httpclient__h2_size;
+
+void h2o_httpclient__add_cl_or_te_header(h2o_mem_pool_t *pool, h2o_iovec_t method, h2o_headers_t *headers, h2o_iovec_t body, size_t content_length, int *chunked, int is_streaming);
 
 #ifdef __cplusplus
 }

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -947,7 +947,7 @@ static void on_connection_ready(struct st_h2o_http2client_stream_t *stream, stru
     h2o_header_t *headers;
     size_t num_headers;
     h2o_iovec_t body;
-    h2o_httpclient_properties_t props = (h2o_httpclient_properties_t){NULL};
+    h2o_httpclient_properties_t props = (h2o_httpclient_properties_t){SIZE_MAX};
 
     register_stream(stream, conn);
 
@@ -957,6 +957,13 @@ static void on_connection_ready(struct st_h2o_http2client_stream_t *stream, stru
     if (stream->super._cb.on_head == NULL) {
         close_stream(stream);
         return;
+    }
+
+    {
+        h2o_headers_t headers_vec = (h2o_headers_t){headers, num_headers, num_headers};
+        h2o_httpclient__add_cl_or_te_header(stream->super.pool, method, &headers_vec, body, props.content_length, NULL, stream->streaming.proceed_req != NULL);
+        headers = headers_vec.entries;
+        num_headers = headers_vec.size;
     }
 
     h2o_http2_window_init(&stream->output.window, conn->peer_settings.initial_window_size);

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -195,3 +195,58 @@ UseSocketPool:
     h2o_socketpool_connect(&client->_connect_req, connpool->socketpool, origin, ctx->loop, ctx->getaddr_receiver, alpn_protos,
                            on_pool_connect, client);
 }
+
+/*
+ * A request without neither Content-Length or Transfer-Encoding header implies a zero-length request body (see 6th rule of RFC 7230
+ * 3.3.3).
+ * OTOH, section 3.3.3 states:
+ *
+ *   A user agent SHOULD send a Content-Length in a request message when
+ *   no Transfer-Encoding is sent and the request method defines a meaning
+ *   for an enclosed payload body.  For example, a Content-Length header
+ *   field is normally sent in a POST request even when the value is 0
+ *   (indicating an empty payload body).  A user agent SHOULD NOT send a
+ *   Content-Length header field when the request message does not contain
+ *   a payload body and the method semantics do not anticipate such a
+ *   body.
+ *
+ * PUT and POST define a meaning for the payload body, let's emit a
+ * Content-Length header if it doesn't exist already, since the server
+ * might send a '411 Length Required' response.
+ *
+ * see also: ML thread starting at https://lists.w3.org/Archives/Public/ietf-http-wg/2016JulSep/0580.html
+ */
+static int req_requires_content_length(h2o_iovec_t method, h2o_headers_t *headers)
+{
+    int is_put_or_post =
+    (method.len >= 1 && method.base[0] == 'P' && (h2o_memis(method.base, method.len, H2O_STRLIT("POST")) ||
+                                                  h2o_memis(method.base, method.len, H2O_STRLIT("PUT"))));
+
+    return is_put_or_post && h2o_find_header(headers, H2O_TOKEN_TRANSFER_ENCODING, -1) == -1;
+}
+
+static h2o_iovec_t build_content_length(h2o_mem_pool_t *pool, size_t cl)
+{
+    h2o_iovec_t cl_buf;
+    cl_buf.base = h2o_mem_alloc_pool(pool, char, sizeof(H2O_UINT64_LONGEST_STR) - 1);
+    cl_buf.len = sprintf(cl_buf.base, "%zu", cl);
+    return cl_buf;
+}
+
+void h2o_httpclient__add_cl_or_te_header(h2o_mem_pool_t *pool, h2o_iovec_t method, h2o_headers_t *headers, h2o_iovec_t body, size_t content_length, int *chunked, int is_streaming)
+{
+    if (is_streaming) {
+        if (content_length != SIZE_MAX) {
+            h2o_iovec_t cl_buf = build_content_length(pool, content_length);
+            h2o_add_header(pool, headers, H2O_TOKEN_CONTENT_LENGTH, NULL, cl_buf.base, cl_buf.len);
+        } else if (chunked != NULL) {
+            h2o_add_header(pool, headers, H2O_TOKEN_TRANSFER_ENCODING, NULL, H2O_STRLIT("chunked"));
+            *chunked = 1;
+        }
+    } else {
+        if (body.base != NULL || req_requires_content_length(method, headers)) {
+            h2o_iovec_t cl_buf = build_content_length(pool, body.len);
+            h2o_add_header(pool, headers, H2O_TOKEN_CONTENT_LENGTH, NULL, cl_buf.base, cl_buf.len);
+        }
+    }
+}

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -101,43 +101,6 @@ static h2o_iovec_t build_request_merge_headers(h2o_mem_pool_t *pool, h2o_iovec_t
     return merged;
 }
 
-/*
- * A request without neither Content-Length or Transfer-Encoding header implies a zero-length request body (see 6th rule of RFC 7230
- * 3.3.3).
- * OTOH, section 3.3.3 states:
- *
- *   A user agent SHOULD send a Content-Length in a request message when
- *   no Transfer-Encoding is sent and the request method defines a meaning
- *   for an enclosed payload body.  For example, a Content-Length header
- *   field is normally sent in a POST request even when the value is 0
- *   (indicating an empty payload body).  A user agent SHOULD NOT send a
- *   Content-Length header field when the request message does not contain
- *   a payload body and the method semantics do not anticipate such a
- *   body.
- *
- * PUT and POST define a meaning for the payload body, let's emit a
- * Content-Length header if it doesn't exist already, since the server
- * might send a '411 Length Required' response.
- *
- * see also: ML thread starting at https://lists.w3.org/Archives/Public/ietf-http-wg/2016JulSep/0580.html
- */
-static int req_requires_content_length(h2o_req_t *req)
-{
-    int is_put_or_post = (req->method.len >= 1 && req->method.base[0] == 'P' &&
-                          (h2o_memis(req->method.base, req->method.len, H2O_STRLIT("POST")) ||
-                           h2o_memis(req->method.base, req->method.len, H2O_STRLIT("PUT"))));
-
-    return is_put_or_post && h2o_find_header(&req->res.headers, H2O_TOKEN_TRANSFER_ENCODING, -1) == -1;
-}
-
-static h2o_iovec_t build_content_length(h2o_mem_pool_t *pool, size_t cl)
-{
-    h2o_iovec_t cl_buf;
-    cl_buf.base = h2o_mem_alloc_pool(pool, char, sizeof(H2O_UINT64_LONGEST_STR) - 1);
-    cl_buf.len = sprintf(cl_buf.base, "%zu", cl);
-    return cl_buf;
-}
-
 static void build_request(h2o_req_t *req, h2o_iovec_t *method, h2o_url_t *url, h2o_headers_t *headers,
                           h2o_httpclient_properties_t *props, int keepalive, int is_websocket_handshake, int use_proxy_protocol,
                           int *reprocess_if_too_early, h2o_url_t *origin)
@@ -177,22 +140,7 @@ static void build_request(h2o_req_t *req, h2o_iovec_t *method, h2o_url_t *url, h
         }
     }
 
-    /* CL or TE? Depends on whether we're streaming the request body or
-       not, and if CL was advertised in the original request */
-    if (req->proceed_req == NULL) {
-        if (req->entity.base != NULL || req_requires_content_length(req)) {
-            h2o_iovec_t cl_buf = build_content_length(&req->pool, req->entity.len);
-            h2o_add_header(&req->pool, headers, H2O_TOKEN_CONTENT_LENGTH, NULL, cl_buf.base, cl_buf.len);
-        }
-    } else {
-        if (req->content_length != SIZE_MAX) {
-            h2o_iovec_t cl_buf = build_content_length(&req->pool, req->content_length);
-            h2o_add_header(&req->pool, headers, H2O_TOKEN_CONTENT_LENGTH, NULL, cl_buf.base, cl_buf.len);
-        } else if (props->chunked != NULL) {
-            *(props->chunked) = 1;
-            h2o_add_header(&req->pool, headers, H2O_TOKEN_TRANSFER_ENCODING, NULL, H2O_STRLIT("chunked"));
-        }
-    }
+    props->content_length = req->content_length;
 
     /* headers */
     /* rewrite headers if necessary */


### PR DESCRIPTION
This PR moves the functionality of adding content-length and transfer-encoding headers from `proxy.c` to `httpclient.c`. Also this removes some code duplications such as building content-length header string.