### PR TITLE
[wip] iovec with callbacks

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1032,7 +1032,7 @@ struct st_h2o_req_t {
     /**
      * number of bytes sent by the generator (excluding headers)
      */
-    size_t bytes_sent;
+    uint64_t bytes_sent;
     /**
      * the number of times the request can be reprocessed (excluding delegation)
      */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1691,8 +1691,8 @@ typedef struct st_h2o_compress_context_t {
     /**
      * compress or decompress callback (inbufs are raw buffers)
      */
-    void (*do_transform)(struct st_h2o_compress_context_t *self, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
-                         h2o_sendvec_t **outbufs, size_t *outbufcnt);
+    h2o_send_state_t (*do_transform)(struct st_h2o_compress_context_t *self, h2o_sendvec_t *inbufs, size_t inbufcnt,
+                                     h2o_send_state_t state, h2o_sendvec_t **outbufs, size_t *outbufcnt);
     /**
      * push buffer
      */
@@ -1716,8 +1716,8 @@ void h2o_compress_register(h2o_pathconf_t *pathconf, h2o_compress_args_t *args);
 /**
  * compresses given chunk
  */
-void h2o_compress_transform(h2o_compress_context_t *self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt,
-                            h2o_send_state_t state, h2o_sendvec_t **outbufs, size_t *outbufcnt);
+h2o_send_state_t h2o_compress_transform(h2o_compress_context_t *self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt,
+                                        h2o_send_state_t state, h2o_sendvec_t **outbufs, size_t *outbufcnt);
 /**
  * instantiates the gzip compressor
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1689,10 +1689,14 @@ typedef struct st_h2o_compress_context_t {
      */
     h2o_iovec_t name;
     /**
-     * compress or decompress callback (inbufs MUST be raw buffers)
+     * compress or decompress callback (inbufs are raw buffers)
      */
-    void (*transform)(struct st_h2o_compress_context_t *self, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
-                      h2o_sendvec_t **outbufs, size_t *outbufcnt);
+    void (*do_transform)(struct st_h2o_compress_context_t *self, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
+                         h2o_sendvec_t **outbufs, size_t *outbufcnt);
+    /**
+     * push buffer
+     */
+    char *push_buf;
 } h2o_compress_context_t;
 
 typedef struct st_h2o_compress_args_t {
@@ -1709,6 +1713,11 @@ typedef struct st_h2o_compress_args_t {
  * registers the gzip/brotli encoding output filter (added by default, for now)
  */
 void h2o_compress_register(h2o_pathconf_t *pathconf, h2o_compress_args_t *args);
+/**
+ * compresses given chunk
+ */
+void h2o_compress_transform(h2o_compress_context_t *self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt,
+                            h2o_send_state_t state, h2o_sendvec_t **outbufs, size_t *outbufcnt);
 /**
  * instantiates the gzip compressor
  */

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -97,8 +97,8 @@ struct st_h2o_http2_stream_t {
         size_t bytes_unnotified;
     } input_window;
     h2o_http2_priority_t received_priority;
-    H2O_VECTOR(h2o_iovec_t) _data;
-    h2o_ostream_pull_cb _pull_cb;
+    H2O_VECTOR(h2o_sendvec_t) _data;
+    size_t _data_off; /* offset within _data.entries[0] */
     /**
      * points to http2_conn_t::num_streams::* in which the stream is counted
      */

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -243,7 +243,7 @@ h2o_mruby_sender_t *h2o_mruby_sender_create(h2o_mruby_generator_t *generator, mr
 /**
  * a wrapper of h2o_send with counting and checking content-length
  */
-void h2o_mruby_sender_do_send(h2o_mruby_generator_t *generator, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state);
+void h2o_mruby_sender_do_send(h2o_mruby_generator_t *generator, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state);
 /**
  * utility function used by sender implementations that needs buffering
  */

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -546,7 +546,7 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             break;
         case ELEMENT_TYPE_BYTES_SENT: /* %b */
             RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
-            pos += sprintf(pos, "%" PRIu64, (uint64_t)req->bytes_sent);
+            pos += sprintf(pos, "%" PRIu64, req->bytes_sent);
             break;
         case ELEMENT_TYPE_PROTOCOL: /* %H */
             if (req->version == 0)

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -483,7 +483,14 @@ void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)
     }
 }
 
-void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
+int h2o_sendvec_fill_raw(h2o_req_t *req, h2o_iovec_t dst, h2o_sendvec_t *src, size_t off)
+{
+    assert(off + dst.len <= src->len);
+    memcpy(dst.base, src->raw + off, dst.len);
+    return 0;
+}
+
+static void do_sendvec(h2o_req_t *req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state)
 {
     assert(req->_generator != NULL);
 
@@ -491,6 +498,23 @@ void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t
         req->_generator = NULL;
 
     req->_ostr_top->do_send(req->_ostr_top, req, bufs, bufcnt, state);
+}
+
+void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
+{
+    h2o_sendvec_t *vecs = alloca(sizeof(*vecs) * bufcnt);
+    size_t i;
+
+    for (i = 0; i != bufcnt; ++i)
+        h2o_sendvec_init_raw(vecs + i, bufs[i].base, bufs[i].len);
+
+    do_sendvec(req, vecs, bufcnt, state);
+}
+
+void h2o_sendvec(h2o_req_t *req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state)
+{
+    assert(bufcnt == 0 || (bufs[0].fill_cb == h2o_sendvec_fill_raw || bufcnt == 1));
+    do_sendvec(req, bufs, bufcnt, state);
 }
 
 h2o_req_prefilter_t *h2o_add_prefilter(h2o_req_t *req, size_t alignment, size_t sz)
@@ -507,7 +531,6 @@ h2o_ostream_t *h2o_add_ostream(h2o_req_t *req, size_t alignment, size_t sz, h2o_
     ostr->next = *slot;
     ostr->do_send = NULL;
     ostr->stop = NULL;
-    ostr->start_pull = NULL;
     ostr->send_informational = NULL;
 
     *slot = ostr;
@@ -547,7 +570,7 @@ void h2o_proceed_response_deferred(h2o_req_t *req)
     h2o_timer_link(req->conn->ctx->loop, 0, &req->_timeout_entry);
 }
 
-void h2o_ostream_send_next(h2o_ostream_t *ostream, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
+void h2o_ostream_send_next(h2o_ostream_t *ostream, h2o_req_t *req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state)
 {
     if (!h2o_send_state_is_in_progress(state)) {
         assert(req->_ostr_top == ostream);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -487,7 +487,7 @@ int h2o_sendvec_fill_raw(h2o_req_t *req, h2o_iovec_t dst, h2o_sendvec_t *src, si
 {
     assert(off + dst.len <= src->len);
     memcpy(dst.base, src->raw + off, dst.len);
-    return 0;
+    return 1;
 }
 
 static void do_sendvec(h2o_req_t *req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state)

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -162,12 +162,12 @@ h2o_send_state_t h2o_compress_transform(h2o_compress_context_t *self, h2o_req_t 
 {
     h2o_sendvec_t flattened;
 
-    if (inbufcnt != 0 && inbufs->fill_cb != h2o_sendvec_fill_raw) {
+    if (inbufcnt != 0 && inbufs->callbacks->flatten != &h2o_sendvec_flatten_raw) {
         assert(inbufcnt == 1);
         assert(inbufs->len <= H2O_PULL_SENDVEC_MAX_SIZE);
         if (self->push_buf == NULL)
             self->push_buf = h2o_mem_alloc(h2o_send_state_is_in_progress(state) ? H2O_PULL_SENDVEC_MAX_SIZE : inbufs->len);
-        if (!(*inbufs->fill_cb)(req, h2o_iovec_init(self->push_buf, inbufs->len), inbufs, 0)) {
+        if (!(*inbufs->callbacks->flatten)(inbufs, req, h2o_iovec_init(self->push_buf, inbufs->len), 0)) {
             *outbufs = NULL;
             *outbufcnt = 0;
             return H2O_SEND_STATE_ERROR;

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -35,13 +35,12 @@ struct st_compress_filter_t {
 struct st_compress_encoder_t {
     h2o_ostream_t super;
     h2o_compress_context_t *compressor;
-    char *pull_buf;
 };
 
 static void do_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     struct st_compress_encoder_t *self = (void *)_self;
-    h2o_sendvec_t flattened, *outbufs;
+    h2o_sendvec_t *outbufs;
     size_t outbufcnt;
 
     if (inbufcnt == 0 && h2o_send_state_is_in_progress(state)) {
@@ -49,20 +48,7 @@ static void do_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_sendvec_t *inbufs,
         return;
     }
 
-    if (inbufcnt != 0 && inbufs->fill_cb != h2o_sendvec_fill_raw) {
-        assert(inbufcnt == 1);
-        if (self->pull_buf == NULL)
-            self->pull_buf = h2o_mem_alloc_pool(&req->pool, char,
-                                                h2o_send_state_is_in_progress(state) ? H2O_PULL_SENDVEC_MAX_SIZE : inbufs->len);
-        h2o_sendvec_init_raw(&flattened, self->pull_buf, inbufs->len);
-        if (!(*inbufs->fill_cb)(req, h2o_iovec_init(flattened.raw, flattened.len), inbufs, 0)) {
-            h2o_ostream_send_next(&self->super, req, NULL, 0, H2O_SEND_STATE_ERROR); /* FIXME is this the correct way? */
-            return;
-        }
-        inbufs = &flattened;
-    }
-
-    self->compressor->transform(self->compressor, inbufs, inbufcnt, state, &outbufs, &outbufcnt);
+    h2o_compress_transform(self->compressor, req, inbufs, inbufcnt, state, &outbufs, &outbufcnt);
     h2o_ostream_send_next(&self->super, req, outbufs, outbufcnt, state);
 }
 
@@ -155,7 +141,6 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     encoder->super.do_send = do_send;
     slot = &encoder->super.next;
     encoder->compressor = compressor;
-    encoder->pull_buf = NULL;
 
     /* adjust preferred chunk size (compress by 8192 bytes) */
     if (req->preferred_chunk_size > BUF_SIZE)
@@ -170,4 +155,23 @@ void h2o_compress_register(h2o_pathconf_t *pathconf, h2o_compress_args_t *args)
     struct st_compress_filter_t *self = (void *)h2o_create_filter(pathconf, sizeof(*self));
     self->super.on_setup_ostream = on_setup_ostream;
     self->args = *args;
+}
+
+void h2o_compress_transform(h2o_compress_context_t *self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt,
+                            h2o_send_state_t state, h2o_sendvec_t **outbufs, size_t *outbufcnt)
+{
+    h2o_sendvec_t flattened;
+
+    if (inbufcnt != 0 && inbufs->fill_cb != h2o_sendvec_fill_raw) {
+        assert(inbufcnt == 1);
+        assert(inbufs->len <= H2O_PULL_SENDVEC_MAX_SIZE);
+        if (self->push_buf == NULL)
+            self->push_buf = h2o_mem_alloc(h2o_send_state_is_in_progress(state) ? H2O_PULL_SENDVEC_MAX_SIZE : inbufs->len);
+        if (!(*inbufs->fill_cb)(req, h2o_iovec_init(self->push_buf, inbufs->len), inbufs, 0))
+            h2o_fatal("FIXME handle error");
+        h2o_sendvec_init_raw(&flattened, self->push_buf, inbufs->len);
+        inbufs = &flattened;
+    }
+
+    self->do_transform(self, inbufs, inbufcnt, state, outbufs, outbufcnt);
 }

--- a/lib/handler/compress/brotli.c
+++ b/lib/handler/compress/brotli.c
@@ -60,8 +60,8 @@ static void compress_core(struct st_brotli_context_t *self, BrotliEncoderOperati
     self->bufs.entries[bufindex].len = self->buf_capacity - dstlen;
 }
 
-static void compress_(h2o_compress_context_t *_self, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
-                      h2o_sendvec_t **outbufs, size_t *outbufcnt)
+static h2o_send_state_t compress_(h2o_compress_context_t *_self, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
+                                  h2o_sendvec_t **outbufs, size_t *outbufcnt)
 {
     struct st_brotli_context_t *self = (void *)_self;
     BrotliEncoderOperation final_op = h2o_send_state_is_in_progress(state) ? BROTLI_OPERATION_FLUSH : BROTLI_OPERATION_FINISH;
@@ -96,6 +96,8 @@ static void compress_(h2o_compress_context_t *_self, h2o_sendvec_t *inbufs, size
 
     *outbufs = self->bufs.entries;
     *outbufcnt = self->bufs.size - (self->bufs.entries[self->bufs.size - 1].len == 0);
+
+    return state;
 }
 
 static void on_dispose(void *_self)

--- a/lib/handler/compress/brotli.c
+++ b/lib/handler/compress/brotli.c
@@ -105,6 +105,7 @@ static void on_dispose(void *_self)
     BrotliEncoderDestroyInstance(self->state);
     shrink_buf(self, 0);
     free(self->bufs.entries);
+    free(self->super.push_buf);
 }
 
 h2o_compress_context_t *h2o_compress_brotli_open(h2o_mem_pool_t *pool, int quality, size_t estimated_content_length,
@@ -113,7 +114,8 @@ h2o_compress_context_t *h2o_compress_brotli_open(h2o_mem_pool_t *pool, int quali
     struct st_brotli_context_t *self = h2o_mem_alloc_shared(pool, sizeof(struct st_brotli_context_t), on_dispose);
 
     self->super.name = h2o_iovec_init(H2O_STRLIT("br"));
-    self->super.transform = compress_;
+    self->super.do_transform = compress_;
+    self->super.push_buf = NULL;
     self->state = BrotliEncoderCreateInstance(NULL, NULL, NULL);
     memset(&self->bufs, 0, sizeof(self->bufs));
     self->buf_capacity = preferred_chunk_size;

--- a/lib/handler/compress/brotli.c
+++ b/lib/handler/compress/brotli.c
@@ -27,20 +27,20 @@
 struct st_brotli_context_t {
     h2o_compress_context_t super;
     BrotliEncoderState *state;
-    H2O_VECTOR(h2o_iovec_t) bufs;
+    H2O_VECTOR(h2o_sendvec_t) bufs;
     size_t buf_capacity;
 };
 
 static void expand_buf(struct st_brotli_context_t *self)
 {
     h2o_vector_reserve(NULL, &self->bufs, self->bufs.size + 1);
-    self->bufs.entries[self->bufs.size++] = h2o_iovec_init(h2o_mem_alloc(self->buf_capacity), 0);
+    h2o_sendvec_init_raw(self->bufs.entries + self->bufs.size++, h2o_mem_alloc(self->buf_capacity), 0);
 }
 
 static void shrink_buf(struct st_brotli_context_t *self, size_t new_size)
 {
     while (new_size < self->bufs.size)
-        free(self->bufs.entries[--self->bufs.size].base);
+        free(self->bufs.entries[--self->bufs.size].raw);
 }
 
 static void compress_core(struct st_brotli_context_t *self, BrotliEncoderOperation op, const uint8_t **src, size_t *srclen)
@@ -51,7 +51,7 @@ static void compress_core(struct st_brotli_context_t *self, BrotliEncoderOperati
         expand_buf(self);
         ++bufindex;
     }
-    uint8_t *dst = (uint8_t *)self->bufs.entries[bufindex].base + self->bufs.entries[bufindex].len;
+    uint8_t *dst = (uint8_t *)self->bufs.entries[bufindex].raw + self->bufs.entries[bufindex].len;
     size_t dstlen = self->buf_capacity - self->bufs.entries[bufindex].len;
 
     if (!BrotliEncoderCompressStream(self->state, op, srclen, src, &dstlen, &dst, NULL))
@@ -60,8 +60,8 @@ static void compress_core(struct st_brotli_context_t *self, BrotliEncoderOperati
     self->bufs.entries[bufindex].len = self->buf_capacity - dstlen;
 }
 
-static void compress_(h2o_compress_context_t *_self, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
-                      h2o_iovec_t **outbufs, size_t *outbufcnt)
+static void compress_(h2o_compress_context_t *_self, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state,
+                      h2o_sendvec_t **outbufs, size_t *outbufcnt)
 {
     struct st_brotli_context_t *self = (void *)_self;
     BrotliEncoderOperation final_op = h2o_send_state_is_in_progress(state) ? BROTLI_OPERATION_FLUSH : BROTLI_OPERATION_FINISH;
@@ -74,7 +74,8 @@ static void compress_(h2o_compress_context_t *_self, h2o_iovec_t *inbufs, size_t
     /* encode chunks and flush */
     if (inbufcnt != 0) {
         for (i = 0; i < inbufcnt; ++i) {
-            src = (void *)inbufs[i].base;
+            assert(inbufs[i].fill_cb == h2o_sendvec_fill_raw);
+            src = (void *)inbufs[i].raw;
             srclen = inbufs[i].len;
             BrotliEncoderOperation op = i + 1 == inbufcnt ? final_op : BROTLI_OPERATION_PROCESS;
             while (srclen != 0)

--- a/lib/handler/compress/brotli.c
+++ b/lib/handler/compress/brotli.c
@@ -74,7 +74,7 @@ static h2o_send_state_t compress_(h2o_compress_context_t *_self, h2o_sendvec_t *
     /* encode chunks and flush */
     if (inbufcnt != 0) {
         for (i = 0; i < inbufcnt; ++i) {
-            assert(inbufs[i].fill_cb == h2o_sendvec_fill_raw);
+            assert(inbufs[i].callbacks->flatten == h2o_sendvec_flatten_raw);
             src = (void *)inbufs[i].raw;
             srclen = inbufs[i].len;
             BrotliEncoderOperation op = i + 1 == inbufcnt ? final_op : BROTLI_OPERATION_PROCESS;

--- a/lib/handler/compress/gzip.c
+++ b/lib/handler/compress/gzip.c
@@ -101,10 +101,10 @@ static h2o_send_state_t do_process(h2o_compress_context_t *_self, h2o_sendvec_t 
     if (inbufcnt != 0) {
         size_t i;
         for (i = 0; i != inbufcnt - 1; ++i) {
-            assert(inbufs[i].fill_cb == h2o_sendvec_fill_raw);
+            assert(inbufs[i].callbacks->flatten == h2o_sendvec_flatten_raw);
             outbufindex = process_chunk(self, inbufs[i].raw, inbufs[i].len, Z_NO_FLUSH, outbufindex, proc);
         }
-        assert(inbufs[i].fill_cb == h2o_sendvec_fill_raw);
+        assert(inbufs[i].callbacks->flatten == h2o_sendvec_flatten_raw);
         last_buf = inbufs + i;
     } else {
         static const h2o_sendvec_t zero_buf = {0};

--- a/lib/handler/errordoc.c
+++ b/lib/handler/errordoc.c
@@ -67,7 +67,7 @@ static void on_prefilter_setup_stream(h2o_req_prefilter_t *_self, h2o_req_t *req
     h2o_setup_next_prefilter(&self->super, req, slot);
 }
 
-static void on_ostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
+static void on_ostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     /* nothing to do */
 }

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -310,10 +310,10 @@ static void send_decompressed(h2o_ostream_t *_self, h2o_req_t *req, h2o_sendvec_
     }
 
     struct st_gzip_decompress_t *self = (void *)_self;
-    h2o_iovec_t *outbufs;
+    h2o_sendvec_t *outbufs;
     size_t outbufcnt;
 
-    self->decompressor->transform(self->decompressor, inbufs, inbufcnt, state, &outbufs, &outbufcnt);
+    h2o_compress_transform(self->decompressor, req, inbufs, inbufcnt, state, &outbufs, &outbufcnt);
     h2o_ostream_send_next(&self->super, req, outbufs, outbufcnt, state);
 }
 

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -313,7 +313,7 @@ static void send_decompressed(h2o_ostream_t *_self, h2o_req_t *req, h2o_sendvec_
     h2o_sendvec_t *outbufs;
     size_t outbufcnt;
 
-    h2o_compress_transform(self->decompressor, req, inbufs, inbufcnt, state, &outbufs, &outbufcnt);
+    state = h2o_compress_transform(self->decompressor, req, inbufs, inbufcnt, state, &outbufs, &outbufcnt);
     h2o_ostream_send_next(&self->super, req, outbufs, outbufcnt, state);
 }
 

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -203,7 +203,7 @@ static void append_bufs(struct st_mruby_subreq_t *subreq, h2o_sendvec_t *inbufs,
     for (i = 0; i != inbufcnt; ++i) {
         char *dst = h2o_buffer_reserve(&subreq->buf, inbufs[i].len).base;
         assert(dst != NULL && "no memory or disk space; FIXME bail out gracefully");
-        if (!(*inbufs[i].fill_cb)(&subreq->super, h2o_iovec_init(dst, inbufs[i].len), inbufs + i, 0))
+        if (!(*inbufs[i].callbacks->flatten)(inbufs + i, &subreq->super, h2o_iovec_init(dst, inbufs[i].len), 0))
             h2o_fatal("FIXME handle error from pull handler");
         subreq->buf->size += inbufs[i].len;
     }

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -201,9 +201,9 @@ static void append_bufs(struct st_mruby_subreq_t *subreq, h2o_sendvec_t *inbufs,
 {
     size_t i;
     for (i = 0; i != inbufcnt; ++i) {
-        h2o_iovec_t dst = h2o_buffer_reserve(&subreq->buf, inbufs[i].len);
-        assert(dst.base != NULL && "no memory or disk space; FIXME bail out gracefully");
-        if (!(*inbufs[i].fill_cb)(&subreq->super, dst, inbufs + i, 0))
+        char *dst = h2o_buffer_reserve(&subreq->buf, inbufs[i].len).base;
+        assert(dst != NULL && "no memory or disk space; FIXME bail out gracefully");
+        if (!(*inbufs[i].fill_cb)(&subreq->super, h2o_iovec_init(dst, inbufs[i].len), inbufs + i, 0))
             h2o_fatal("FIXME handle error from pull handler");
         subreq->buf->size += inbufs[i].len;
     }

--- a/lib/handler/mruby/sender.c
+++ b/lib/handler/mruby/sender.c
@@ -34,7 +34,7 @@ struct st_h2o_mruby_callback_sender_t {
     unsigned has_error : 1;
 };
 
-void h2o_mruby_sender_do_send(h2o_mruby_generator_t *generator, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
+void h2o_mruby_sender_do_send(h2o_mruby_generator_t *generator, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state)
 {
     h2o_mruby_sender_t *sender = generator->sender;
     assert(!sender->final_sent);
@@ -59,7 +59,7 @@ void h2o_mruby_sender_do_send(h2o_mruby_generator_t *generator, h2o_iovec_t *buf
     if (!h2o_send_state_is_in_progress(state))
         sender->final_sent = 1;
 
-    h2o_send(generator->req, bufs, bufcnt, state);
+    h2o_sendvec(generator->req, bufs, bufcnt, state);
 }
 
 void h2o_mruby_sender_do_send_buffer(h2o_mruby_generator_t *generator, h2o_doublebuffer_t *db, h2o_buffer_t **input, int is_final)
@@ -80,7 +80,9 @@ void h2o_mruby_sender_do_send_buffer(h2o_mruby_generator_t *generator, h2o_doubl
         send_state = H2O_SEND_STATE_IN_PROGRESS;
     }
 
-    h2o_mruby_sender_do_send(generator, &buf, bufcnt, send_state);
+    h2o_sendvec_t vec;
+    h2o_sendvec_init_raw(&vec, buf.base, buf.len);
+    h2o_mruby_sender_do_send(generator, &vec, bufcnt, send_state);
 }
 
 void h2o_mruby_sender_close_body(h2o_mruby_generator_t *generator)

--- a/lib/handler/reproxy.c
+++ b/lib/handler/reproxy.c
@@ -21,7 +21,7 @@
  */
 #include "h2o.h"
 
-static void on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
+static void on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     /* nothing to do */
 }

--- a/lib/handler/throttle_resp.c
+++ b/lib/handler/throttle_resp.c
@@ -30,8 +30,6 @@
 #define ONE_SECOND 1000
 #endif
 
-typedef H2O_VECTOR(h2o_iovec_t) iovec_vector_t;
-
 typedef struct st_throttle_resp_t {
     h2o_ostream_t super;
     h2o_timer_t timeout_entry;
@@ -40,7 +38,7 @@ typedef struct st_throttle_resp_t {
     h2o_context_t *ctx;
     h2o_req_t *req;
     struct {
-        iovec_vector_t bufs;
+        H2O_VECTOR(h2o_sendvec_t) bufs;
         h2o_send_state_t stream_state;
     } state;
 } throttle_resp_t;
@@ -75,7 +73,7 @@ static void add_token(h2o_timer_t *entry)
         real_send(self);
 }
 
-static void on_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
+static void on_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     throttle_resp_t *self = (void *)_self;
     size_t i;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -29,21 +29,16 @@
 #include "h2o/http1.h"
 #include "h2o/http2.h"
 
-#define MAX_PULL_BUF_SZ 65536
-
 struct st_h2o_http1_finalostream_t {
     h2o_ostream_t super;
     int sent_headers;
     char *chunked_buf; /* buffer used for chunked-encoding (NULL unless chunked encoding is used) */
-    struct {
-        void *buf;
-        h2o_ostream_pull_cb cb;
-    } pull;
+    char *pull_buf;
     struct {
         h2o_iovec_vector_t bufs;
         unsigned sending : 1;
         struct {
-            h2o_iovec_t *inbufs;
+            h2o_sendvec_t *inbufs;
             size_t inbufcnt;
             h2o_send_state_t send_state;
         } pending_final;
@@ -84,9 +79,7 @@ struct st_h2o_http1_chunked_entity_reader {
     size_t prev_input_size;
 };
 
-static void proceed_pull(struct st_h2o_http1_conn_t *conn, size_t nfilled);
-static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb);
-static void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t state);
+static void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state);
 static void finalostream_send_informational(h2o_ostream_t *_self, h2o_req_t *req);
 static void reqread_on_read(h2o_socket_t *sock, const char *err);
 static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata);
@@ -116,10 +109,9 @@ static void init_request(struct st_h2o_http1_conn_t *conn)
     conn->req._ostr_top = &conn->_ostr_final.super;
 
     conn->_ostr_final = (struct st_h2o_http1_finalostream_t){{
-        NULL,                    /* next */
-        finalostream_send,       /* do_send */
-        NULL,                    /* stop */
-        finalostream_start_pull, /* start_pull */
+        NULL,              /* next */
+        finalostream_send, /* do_send */
+        NULL,              /* stop */
         conn->super.ctx->globalconf->send_informational_mode == H2O_SEND_INFORMATIONAL_MODE_ALL ? finalostream_send_informational
                                                                                                 : NULL, /* send_informational */
     }};
@@ -558,7 +550,7 @@ static inline void reqread_start(struct st_h2o_http1_conn_t *conn)
         handle_incoming_request(conn);
 }
 
-static void on_send_next_push(h2o_socket_t *sock, const char *err)
+static void on_send_next(h2o_socket_t *sock, const char *err)
 {
     struct st_h2o_http1_conn_t *conn = sock->data;
 
@@ -566,16 +558,6 @@ static void on_send_next_push(h2o_socket_t *sock, const char *err)
         close_connection(conn, 1);
     else
         h2o_proceed_response(&conn->req);
-}
-
-static void on_send_next_pull(h2o_socket_t *sock, const char *err)
-{
-    struct st_h2o_http1_conn_t *conn = sock->data;
-
-    if (err != NULL)
-        close_connection(conn, 1);
-    else
-        proceed_pull(conn, 0);
 }
 
 static void cleanup_connection(struct st_h2o_http1_conn_t *conn)
@@ -762,153 +744,118 @@ static void encode_chunked(h2o_iovec_t *prefix, h2o_iovec_t *suffix, h2o_send_st
     }
 }
 
-static void proceed_pull(struct st_h2o_http1_conn_t *conn, size_t nfilled)
-{
-    h2o_iovec_t bufs[4];
-    size_t bufcnt = 0;
-    h2o_send_state_t send_state;
-    h2o_iovec_t prefix = h2o_iovec_init(NULL, 0), suffix = h2o_iovec_init(NULL, 0);
-
-    if (nfilled != 0)
-        bufs[bufcnt++] = h2o_iovec_init(conn->_ostr_final.pull.buf, nfilled);
-
-    if (nfilled < MAX_PULL_BUF_SZ) {
-        h2o_iovec_t cbuf = h2o_iovec_init((char *)conn->_ostr_final.pull.buf + nfilled, MAX_PULL_BUF_SZ - nfilled);
-        send_state = h2o_pull(&conn->req, conn->_ostr_final.pull.cb, &cbuf);
-        conn->req.bytes_sent += cbuf.len;
-        if (conn->_ostr_final.chunked_buf != NULL) {
-            encode_chunked(&prefix, &suffix, send_state, cbuf.len, conn->req.send_server_timing != 0,
-                           conn->_ostr_final.chunked_buf);
-            if (prefix.len != 0)
-                bufs[bufcnt++] = prefix;
-            bufs[bufcnt++] = cbuf;
-            if (suffix.len != 0)
-                bufs[bufcnt++] = suffix;
-        } else if (nfilled != 0) {
-            bufs[bufcnt - 1].len += cbuf.len;
-        } else {
-            bufs[bufcnt++] = cbuf;
-        }
-        if (send_state == H2O_SEND_STATE_ERROR) {
-            conn->req.http1_is_persistent = 0;
-            conn->req.send_server_timing = 0; /* suppress sending trailers */
-        }
-    } else {
-        send_state = H2O_SEND_STATE_IN_PROGRESS;
-    }
-
-    /* write */
-    h2o_socket_write(conn->sock, bufs, bufcnt, h2o_send_state_is_in_progress(send_state) ? on_send_next_pull : on_send_complete);
-}
-
-static void finalostream_start_pull(h2o_ostream_t *_self, h2o_ostream_pull_cb cb)
-{
-    struct st_h2o_http1_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1_conn_t, _ostr_final.super, _self);
-    const char *connection = conn->req.http1_is_persistent ? "keep-alive" : "close";
-    size_t bufsz, headers_len;
-
-    assert(conn->req._ostr_top == &conn->_ostr_final.super);
-    assert(!conn->_ostr_final.sent_headers);
-
-    conn->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
-
-    setup_chunked(&conn->_ostr_final, &conn->req);
-
-    if (conn->req.send_server_timing)
-        h2o_add_server_timing_header(&conn->req, conn->_ostr_final.chunked_buf != NULL);
-
-    /* register the pull callback */
-    conn->_ostr_final.pull.cb = cb;
-
-    /* setup the buffer */
-    bufsz = flatten_headers_estimate_size(&conn->req, conn->super.ctx->globalconf->server_name.len + strlen(connection));
-    if (bufsz < MAX_PULL_BUF_SZ) {
-        if (MAX_PULL_BUF_SZ - bufsz < conn->req.res.content_length) {
-            bufsz = MAX_PULL_BUF_SZ;
-        } else {
-            bufsz += conn->req.res.content_length;
-        }
-    }
-    conn->_ostr_final.pull.buf = h2o_mem_alloc_pool(&conn->req.pool, char, bufsz);
-
-    /* fill-in the header */
-    headers_len = flatten_headers(conn->_ostr_final.pull.buf, &conn->req, connection);
-    conn->_ostr_final.sent_headers = 1;
-
-    proceed_pull(conn, headers_len);
-}
-
 static void on_delayed_send_complete(h2o_timer_t *entry)
 {
     struct st_h2o_http1_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1_conn_t, _timeout_entry, entry);
     on_send_complete(conn->sock, 0);
 }
 
-void finalostream_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t send_state)
+static void allocate_pull_buf(struct st_h2o_http1_conn_t *conn, h2o_send_state_t send_state, size_t bytes_to_be_sent,
+                              size_t size_add)
 {
-    struct st_h2o_http1_finalostream_t *self = (void *)_self;
-    struct st_h2o_http1_conn_t *conn = (struct st_h2o_http1_conn_t *)req->conn;
+    size_t sz = h2o_send_state_is_in_progress(send_state) ? H2O_PULL_SENDVEC_MAX_SIZE : bytes_to_be_sent;
+    sz += size_add;
+    conn->_ostr_final.pull_buf = h2o_mem_alloc_pool(&conn->req.pool, char, sz);
+}
+
+void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t send_state)
+{
+    struct st_h2o_http1_conn_t *conn = (struct st_h2o_http1_conn_t *)_req->conn;
     h2o_iovec_t *bufs = alloca(sizeof(h2o_iovec_t) * (inbufcnt + 1 + 2)) /* 1 for header, 2 for chunked encoding */, chunked_suffix;
-    int i;
-    int bufcnt = 0;
+    size_t i, bytes_to_be_sent, bufcnt = 0, pullbuf_off = 0;
+    enum { NOT_PULL, IS_PULL, LASTBUF_IS_PULL } pull_mode = conn->_ostr_final.pull_buf != NULL ? IS_PULL : NOT_PULL;
 
-    assert(self == &conn->_ostr_final);
+    assert(&conn->req == _req);
+    assert(_self == &conn->_ostr_final.super);
 
-    if (self->informational.sending) {
-        self->informational.pending_final.inbufs = h2o_mem_alloc_pool(&req->pool, h2o_iovec_t, inbufcnt);
-        memcpy(self->informational.pending_final.inbufs, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
-        self->informational.pending_final.inbufcnt = inbufcnt;
-        self->informational.pending_final.send_state = send_state;
+    if (conn->_ostr_final.informational.sending) {
+        conn->_ostr_final.informational.pending_final.inbufs = h2o_mem_alloc_pool(&conn->req.pool, h2o_sendvec_t, inbufcnt);
+        memcpy(conn->_ostr_final.informational.pending_final.inbufs, inbufs, sizeof(*inbufs) * inbufcnt);
+        conn->_ostr_final.informational.pending_final.inbufcnt = inbufcnt;
+        conn->_ostr_final.informational.pending_final.send_state = send_state;
         return;
     }
 
-    /* count bytes_sent if other ostreams haven't counted */
-    size_t bytes_to_be_sent = 0;
+    /* count bytes_sent if other ostreams haven't counted, as well as checking if we should use pull mode */
+    bytes_to_be_sent = 0;
     for (i = 0; i != inbufcnt; ++i) {
         bytes_to_be_sent += inbufs[i].len;
+        if (!pull_mode && inbufs[i].fill_cb != h2o_sendvec_fill_raw)
+            pull_mode = IS_PULL;
     }
-    req->bytes_sent += bytes_to_be_sent;
+    assert(pull_mode == NOT_PULL || inbufcnt == 0 || (inbufcnt == 1 && inbufs[0].len <= H2O_PULL_SENDVEC_MAX_SIZE));
+    conn->req.bytes_sent += bytes_to_be_sent;
 
     if (send_state == H2O_SEND_STATE_ERROR) {
         conn->req.http1_is_persistent = 0;
         conn->req.send_server_timing = 0;
-        if (req->upstream_refused) {
+        if (conn->req.upstream_refused) {
             /* to let the client retry, immediately close the connection without sending any data */
             on_send_complete(conn->sock, NULL);
             return;
         }
     }
 
-    if (!self->sent_headers) {
+    if (!conn->_ostr_final.sent_headers) {
+        /* build headers and send */
         conn->req.timestamps.response_start_at = h2o_gettimeofday(conn->super.ctx->loop);
-        setup_chunked(self, req);
+        setup_chunked(&conn->_ostr_final, &conn->req);
         if (conn->req.send_server_timing)
             h2o_add_server_timing_header(&conn->req, conn->_ostr_final.chunked_buf != NULL);
 
-        /* build headers and send */
-        const char *connection = req->http1_is_persistent ? "keep-alive" : "close";
-        bufs[bufcnt].base = h2o_mem_alloc_pool(
-            &req->pool, char,
-            flatten_headers_estimate_size(req, conn->super.ctx->globalconf->server_name.len + strlen(connection)));
-        bufs[bufcnt].len = flatten_headers(bufs[bufcnt].base, req, connection);
+        const char *connection = conn->req.http1_is_persistent ? "keep-alive" : "close";
+        size_t headers_est_size =
+            flatten_headers_estimate_size(&conn->req, conn->super.ctx->globalconf->server_name.len + strlen(connection));
+        if (pull_mode) {
+            allocate_pull_buf(conn, send_state, bytes_to_be_sent, headers_est_size);
+            bufs[bufcnt].base = conn->_ostr_final.pull_buf;
+        } else {
+            bufs[bufcnt].base = h2o_mem_alloc_pool(&conn->req.pool, char, headers_est_size);
+        }
+        bufs[bufcnt].len = flatten_headers(bufs[bufcnt].base, &conn->req, connection);
+        if (pull_mode == IS_PULL) {
+            pull_mode = LASTBUF_IS_PULL;
+            pullbuf_off = bufs[bufcnt].len;
+        }
         ++bufcnt;
-        self->sent_headers = 1;
+        conn->_ostr_final.sent_headers = 1;
+    } else {
+        if (pull_mode != NOT_PULL && conn->_ostr_final.pull_buf == NULL)
+            allocate_pull_buf(conn, send_state, bytes_to_be_sent, 0);
     }
 
-    if (self->chunked_buf != NULL) {
-        encode_chunked(bufs + bufcnt, &chunked_suffix, send_state, bytes_to_be_sent, req->send_server_timing != 0,
-                       self->chunked_buf);
-        if (bufs[bufcnt].len != 0)
+    if (conn->_ostr_final.chunked_buf != NULL) {
+        encode_chunked(bufs + bufcnt, &chunked_suffix, send_state, bytes_to_be_sent, conn->req.send_server_timing != 0,
+                       conn->_ostr_final.chunked_buf);
+        if (bufs[bufcnt].len != 0) {
             ++bufcnt;
+            if (pull_mode == LASTBUF_IS_PULL)
+                pull_mode = IS_PULL;
+        }
     }
-    h2o_memcpy(bufs + bufcnt, inbufs, sizeof(h2o_iovec_t) * inbufcnt);
-    bufcnt += inbufcnt;
-    if (self->chunked_buf != NULL && chunked_suffix.len != 0)
+    if (pull_mode == NOT_PULL) {
+        for (i = 0; i != inbufcnt; ++i)
+            bufs[bufcnt++] = h2o_iovec_init(inbufs[i].raw, inbufs[i].len);
+    } else if (inbufcnt != 0) {
+        assert(inbufcnt == 1);
+        if (!(inbufs->fill_cb(&conn->req, h2o_iovec_init(conn->_ostr_final.pull_buf + pullbuf_off, inbufs->len), inbufs, 0))) {
+            /* error, close abruptly */
+            send_state = H2O_SEND_STATE_ERROR;
+        } else {
+            if (pull_mode == IS_PULL) {
+                bufs[bufcnt++] = h2o_iovec_init(conn->_ostr_final.pull_buf + pullbuf_off, inbufs->len);
+            } else {
+                assert(pull_mode == LASTBUF_IS_PULL);
+                bufs[bufcnt - 1].len += inbufs->len;
+            }
+        }
+    }
+
+    if (conn->_ostr_final.chunked_buf != NULL && chunked_suffix.len != 0)
         bufs[bufcnt++] = chunked_suffix;
 
     if (bufcnt != 0) {
-        h2o_socket_write(conn->sock, bufs, bufcnt,
-                         h2o_send_state_is_in_progress(send_state) ? on_send_next_push : on_send_complete);
+        h2o_socket_write(conn->sock, bufs, bufcnt, h2o_send_state_is_in_progress(send_state) ? on_send_next : on_send_complete);
     } else {
         set_timeout(conn, 0, on_delayed_send_complete);
     }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -780,7 +780,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
     bytes_to_be_sent = 0;
     for (i = 0; i != inbufcnt; ++i) {
         bytes_to_be_sent += inbufs[i].len;
-        if (!pull_mode && inbufs[i].fill_cb != h2o_sendvec_fill_raw)
+        if (!pull_mode && inbufs[i].callbacks->flatten != h2o_sendvec_flatten_raw)
             pull_mode = IS_PULL;
     }
     assert(pull_mode == NOT_PULL || inbufcnt == 0 || (inbufcnt == 1 && inbufs[0].len <= H2O_PULL_SENDVEC_MAX_SIZE));
@@ -838,7 +838,8 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
             bufs[bufcnt++] = h2o_iovec_init(inbufs[i].raw, inbufs[i].len);
     } else if (inbufcnt != 0) {
         assert(inbufcnt == 1);
-        if (!(inbufs->fill_cb(&conn->req, h2o_iovec_init(conn->_ostr_final.pull_buf + pullbuf_off, inbufs->len), inbufs, 0))) {
+        if (!(inbufs->callbacks->flatten(inbufs, &conn->req, h2o_iovec_init(conn->_ostr_final.pull_buf + pullbuf_off, inbufs->len),
+                                         0))) {
             /* error, close abruptly */
             send_state = H2O_SEND_STATE_ERROR;
         } else {

--- a/lib/http2/http2_debug_state.c
+++ b/lib/http2/http2_debug_state.c
@@ -152,7 +152,7 @@ h2o_http2_debug_state_t *h2o_http2_get_debug_state(h2o_req_t *req, int hpack_ena
                          "      \"flowIn\": %zd,\n"
                          "      \"flowOut\": %zd,\n"
                          "      \"dataIn\": %zu,\n"
-                         "      \"dataOut\": %zu,\n"
+                         "      \"dataOut\": %" PRIu64 ",\n"
                          "      \"created\": %" PRIu64 "\n"
                          "    },",
                          stream->stream_id, state_string, h2o_http2_window_get_avail(&stream->input_window.window),

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -159,7 +159,7 @@ static h2o_sendvec_t *send_data(h2o_http2_conn_t *conn, h2o_http2_stream_t *stre
     }
     while (bufcnt != 0) {
         size_t fill_size = sz_min(dst.len, bufs->len - *off_within_buf);
-        if (!(*bufs->fill_cb)(&stream->req, h2o_iovec_init(dst.base, fill_size), bufs, *off_within_buf))
+        if (!(*bufs->callbacks->flatten)(bufs, &stream->req, h2o_iovec_init(dst.base, fill_size), *off_within_buf))
             return NULL;
         dst.base += fill_size;
         dst.len -= fill_size;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -23,8 +23,7 @@
 #include "h2o/http2.h"
 #include "h2o/http2_internal.h"
 
-static void finalostream_start_pull(h2o_ostream_t *self, h2o_ostream_pull_cb cb);
-static void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state);
+static void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state);
 static void finalostream_send_informational(h2o_ostream_t *_self, h2o_req_t *req);
 
 static size_t sz_min(size_t x, size_t y)
@@ -41,7 +40,6 @@ h2o_http2_stream_t *h2o_http2_stream_open(h2o_http2_conn_t *conn, uint32_t strea
     memset(stream, 0, offsetof(h2o_http2_stream_t, req));
     stream->stream_id = stream_id;
     stream->_ostr_final.do_send = finalostream_send;
-    stream->_ostr_final.start_pull = finalostream_start_pull;
     stream->_ostr_final.send_informational =
         conn->super.ctx->globalconf->send_informational_mode == H2O_SEND_INFORMATIONAL_MODE_NONE ? NULL
                                                                                                  : finalostream_send_informational;
@@ -137,29 +135,8 @@ static void commit_data_header(h2o_http2_conn_t *conn, h2o_http2_stream_t *strea
     }
 }
 
-static h2o_send_state_t send_data_pull(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
-{
-    size_t max_payload_size;
-    h2o_iovec_t cbuf;
-    h2o_send_state_t send_state = H2O_SEND_STATE_IN_PROGRESS;
-
-    if ((max_payload_size = calc_max_payload_size(conn, stream)) == 0)
-        goto Exit;
-    /* reserve buffer */
-    h2o_buffer_reserve(&conn->_write.buf, H2O_HTTP2_FRAME_HEADER_SIZE + max_payload_size);
-    /* obtain content */
-    cbuf.base = conn->_write.buf->bytes + conn->_write.buf->size + H2O_HTTP2_FRAME_HEADER_SIZE;
-    cbuf.len = max_payload_size;
-    send_state = h2o_pull(&stream->req, stream->_pull_cb, &cbuf);
-    /* write the header */
-    commit_data_header(conn, stream, &conn->_write.buf, cbuf.len, send_state);
-
-Exit:
-    return send_state;
-}
-
-static h2o_iovec_t *send_data_push(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_iovec_t *bufs, size_t bufcnt,
-                                   h2o_send_state_t send_state)
+static h2o_sendvec_t *send_data_push(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_sendvec_t *bufs, size_t bufcnt,
+                                     size_t *off_within_buf, h2o_send_state_t send_state)
 {
     h2o_iovec_t dst;
     size_t max_payload_size;
@@ -174,21 +151,23 @@ static h2o_iovec_t *send_data_push(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
 
     /* emit data */
     while (bufcnt != 0) {
-        if (bufs->len != 0)
+        if (bufs->len != *off_within_buf)
             break;
         ++bufs;
         --bufcnt;
+        *off_within_buf = 0;
     }
     while (bufcnt != 0) {
-        size_t fill_size = sz_min(dst.len, bufs->len);
-        memcpy(dst.base, bufs->base, fill_size);
+        size_t fill_size = sz_min(dst.len, bufs->len - *off_within_buf);
+        if (!(*bufs->fill_cb)(&stream->req, h2o_iovec_init(dst.base, fill_size), bufs, *off_within_buf))
+            h2o_fatal("FIXME");
         dst.base += fill_size;
         dst.len -= fill_size;
-        bufs->base += fill_size;
-        bufs->len -= fill_size;
-        while (bufs->len == 0) {
+        *off_within_buf += fill_size;
+        while (bufs->len == *off_within_buf) {
             ++bufs;
             --bufcnt;
+            *off_within_buf = 0;
             if (bufcnt == 0)
                 break;
         }
@@ -326,39 +305,7 @@ CancelPush:
     return -1;
 }
 
-void finalostream_start_pull(h2o_ostream_t *self, h2o_ostream_pull_cb cb)
-{
-    h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _ostr_final, self);
-    h2o_http2_conn_t *conn = (void *)stream->req.conn;
-
-    assert(stream->req._ostr_top == &stream->_ostr_final);
-    assert(stream->state == H2O_HTTP2_STREAM_STATE_SEND_HEADERS);
-
-    assert(stream->blocked_by_server);
-    h2o_http2_stream_set_blocked_by_server(conn, stream, 0);
-
-    if (stream->req.upstream_refused) {
-        send_refused_stream(conn, stream);
-        return;
-    }
-
-    /* register the pull callback */
-    stream->_pull_cb = cb;
-
-    /* send headers */
-    if (send_headers(conn, stream) != 0)
-        return;
-
-    /* set dummy data in the send buffer */
-    h2o_vector_reserve(&stream->req.pool, &stream->_data, 1);
-    stream->_data.entries[0].base = "<pull interface>";
-    stream->_data.entries[0].len = 1;
-    stream->_data.size = 1;
-
-    h2o_http2_conn_register_for_proceed_callback(conn, stream);
-}
-
-void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)
+void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _ostr_final, self);
     h2o_http2_conn_t *conn = (h2o_http2_conn_t *)req->conn;
@@ -401,7 +348,7 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *bufs, s
     /* save the contents in queue */
     if (bufcnt != 0) {
         h2o_vector_reserve(&req->pool, &stream->_data, bufcnt);
-        memcpy(stream->_data.entries, bufs, sizeof(h2o_iovec_t) * bufcnt);
+        memcpy(stream->_data.entries, bufs, sizeof(*bufs) * bufcnt);
         stream->_data.size = bufcnt;
     }
 
@@ -424,32 +371,19 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
     if (h2o_http2_window_get_avail(&stream->output_window) <= 0)
         return;
 
-    h2o_send_state_t send_state;
-
-    if (stream->_pull_cb != NULL) {
-        /* pull mode */
-        assert(stream->state != H2O_HTTP2_STREAM_STATE_END_STREAM);
-        send_state = send_data_pull(conn, stream);
-        if (send_state != H2O_SEND_STATE_IN_PROGRESS) {
-            /* sent all data */
-            stream->_data.size = 0;
+    h2o_send_state_t send_state = stream->send_state;
+    h2o_sendvec_t *nextbuf =
+        send_data_push(conn, stream, stream->_data.entries, stream->_data.size, &stream->_data_off, stream->send_state);
+    if (nextbuf == stream->_data.entries + stream->_data.size) {
+        /* sent all data */
+        stream->_data.size = 0;
+        if (stream->state == H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL)
             h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);
-        }
-    } else {
-        /* push mode */
-        send_state = stream->send_state;
-        h2o_iovec_t *nextbuf = send_data_push(conn, stream, stream->_data.entries, stream->_data.size, stream->send_state);
-        if (nextbuf == stream->_data.entries + stream->_data.size) {
-            /* sent all data */
-            stream->_data.size = 0;
-            if (stream->state == H2O_HTTP2_STREAM_STATE_SEND_BODY_IS_FINAL)
-                h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_END_STREAM);
-        } else if (nextbuf != stream->_data.entries) {
-            /* adjust the buffer */
-            size_t newsize = stream->_data.size - (nextbuf - stream->_data.entries);
-            memmove(stream->_data.entries, nextbuf, sizeof(h2o_iovec_t) * newsize);
-            stream->_data.size = newsize;
-        }
+    } else if (nextbuf != stream->_data.entries) {
+        /* adjust the buffer */
+        size_t newsize = stream->_data.size - (nextbuf - stream->_data.entries);
+        memmove(stream->_data.entries, nextbuf, sizeof(h2o_iovec_t) * newsize);
+        stream->_data.size = newsize;
     }
 
     if (send_state == H2O_SEND_STATE_ERROR) {

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -24,14 +24,16 @@
 #include "../../src/standalone.h"
 #include "./test.h"
 
-static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_send_state_t send_state)
+static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt,
+                             h2o_send_state_t send_state)
 {
     h2o_loopback_conn_t *conn = H2O_STRUCT_FROM_MEMBER(h2o_loopback_conn_t, _ostr_final, self);
     size_t i;
 
     for (i = 0; i != inbufcnt; ++i) {
         h2o_buffer_reserve(&conn->body, inbufs[i].len);
-        memcpy(conn->body->bytes + conn->body->size, inbufs[i].base, inbufs[i].len);
+        if (!(*inbufs[i].fill_cb)(req, h2o_iovec_init(conn->body->bytes + conn->body->size, inbufs[i].len), inbufs + i, 0))
+            h2o_fatal("ohoh");
         conn->body->size += inbufs[i].len;
     }
 

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -32,7 +32,8 @@ static void loopback_on_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t 
 
     for (i = 0; i != inbufcnt; ++i) {
         h2o_buffer_reserve(&conn->body, inbufs[i].len);
-        if (!(*inbufs[i].fill_cb)(req, h2o_iovec_init(conn->body->bytes + conn->body->size, inbufs[i].len), inbufs + i, 0))
+        if (!(*inbufs[i].callbacks->flatten)(inbufs + i, req, h2o_iovec_init(conn->body->bytes + conn->body->size, inbufs[i].len),
+                                             0))
             h2o_fatal("ohoh");
         conn->body->size += inbufs[i].len;
     }


### PR DESCRIPTION
Introduces `h2o_sendvec_t`, uses that to convey HTTP response body in place of `h2o_iovec_t`. The difference is that `h2o_sendvec_t` has a callback that can be used to delay the fetching of data until it becomes actually needed.

It replaces the "pull-mode", simplifying the code. The other benefit would be that the proxy handler can stop using the double-buffer approach. Instead, it could just issue `h2o_sendvec_t` instances with a custom callback that, upon request from the protocol handler, fills the send buffer using the data stored in receive buffer of the httpclient.