### PR TITLE
[mruby/middleware.c] Fix invalid read on the stack

### DIFF
--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -324,7 +324,7 @@ static socklen_t parse_hostport(h2o_mem_pool_t *pool, h2o_iovec_t host, h2o_iove
                 sin.sin_family = AF_INET;
                 sin.sin_port = htons(_port);
                 sin.sin_addr.s_addr = ntohl((d1 << 24) + (d2 << 16) + (d3 << 8) + d4);
-                *ss = *((struct sockaddr_storage *)&sin);
+                memcpy(ss, &sin, sizeof(sin));
                 return sizeof(sin);
             }
         }

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -313,19 +313,16 @@ static socklen_t parse_hostport(h2o_mem_pool_t *pool, h2o_iovec_t host, h2o_iove
 {
     /* fast path for IPv4 addresses */
     {
-        unsigned int d1, d2, d3, d4, _port;
+        unsigned d1, d2, d3, d4, _port;
         int parsed_len;
-        if (sscanf(host.base, "%" SCNd32 "%*[.]%" SCNd32 "%*[.]%" SCNd32 "%*[.]%" SCNd32 "%n", &d1, &d2, &d3, &d4, &parsed_len) ==
-                4 &&
-            parsed_len == host.len && d1 <= UCHAR_MAX && d2 <= UCHAR_MAX && d3 <= UCHAR_MAX && d4 <= UCHAR_MAX) {
-            if (sscanf(port.base, "%" SCNd32 "%n", &_port, &parsed_len) == 1 && parsed_len == port.len && _port <= USHRT_MAX) {
-                struct sockaddr_in sin;
-                memset(&sin, 0, sizeof(sin));
-                sin.sin_family = AF_INET;
-                sin.sin_port = htons(_port);
-                sin.sin_addr.s_addr = ntohl((d1 << 24) + (d2 << 16) + (d3 << 8) + d4);
-                memcpy(ss, &sin, sizeof(sin));
-                return sizeof(sin);
+        if (sscanf(host.base, "%u%*[.]%u%*[.]%u%*[.]%u%n", &d1, &d2, &d3, &d4, &parsed_len) == 4 && parsed_len == host.len &&
+            d1 <= 255 && d2 <= 255 && d3 <= 255 && d4 <= 255) {
+            if (sscanf(port.base, "%u%n", &_port, &parsed_len) == 1 && parsed_len == port.len && _port <= 65535) {
+                struct sockaddr_in *sin = (void *)ss;
+                sin->sin_family = AF_INET;
+                sin->sin_port = htons(_port);
+                sin->sin_addr.s_addr = ntohl((d1 << 24) + (d2 << 16) + (d3 << 8) + d4);
+                return sizeof(*sin);
             }
         }
     }


### PR DESCRIPTION
`*((struct sockaddr_storage *)&sin);` would cause a read that's larger
than `sin`, reaching to other parts of the stack. We fix this with a
memcpy that only reads `sizeof(sin);` bytes.