### PR TITLE
add 'H2O_ERROR_PRINTF' macro, default is 'fprintf(stderr,...)'

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -73,6 +73,13 @@ extern "C" {
 
 #define H2O_BUILD_ASSERT(condition) ((void)sizeof(char[2 * !!(!__builtin_constant_p(condition) || (condition)) - 1]))
 
+/**
+ * library users can use their own log method by define this macro
+ */
+#ifndef H2O_ERROR_PRINTF
+#define H2O_ERROR_PRINTF(...) fprintf(stderr, __VA_ARGS__)
+#endif
+
 typedef struct st_h2o_buffer_prototype_t h2o_buffer_prototype_t;
 
 /**

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -168,6 +169,8 @@ extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
  */
 #define h2o_fatal(msg) h2o__fatal(__FILE__ ":" H2O_TO_STR(__LINE__) ":" msg)
 H2O_NORETURN void h2o__fatal(const char *msg);
+
+static void h2o_perror(const char *msg);
 
 /**
  * A version of memcpy that can take a NULL @src to avoid UB
@@ -474,6 +477,13 @@ inline void *h2o_memrchr(const void *s, int c, size_t n)
 inline void *h2o_mem_set_secure(void *b, int c, size_t len)
 {
     return h2o_mem__set_secure(b, c, len);
+}
+
+inline void h2o_perror(const char *msg)
+{
+    char buf[256];
+    strerror_r(errno, buf, sizeof(buf));
+    H2O_ERROR_PRINTF("%s: %s\n", msg, buf);
 }
 
 #ifdef __cplusplus

--- a/lib/common/hostinfo.c
+++ b/lib/common/hostinfo.c
@@ -102,7 +102,7 @@ static void create_lookup_thread(void)
             H2O_ERROR_PRINTF("failed to start first thread for getaddrinfo:%s\n", strerror(ret));
             abort();
         } else {
-            perror("pthread_create(for getaddrinfo)");
+            h2o_perror("pthread_create(for getaddrinfo)");
         }
         return;
     }

--- a/lib/common/hostinfo.c
+++ b/lib/common/hostinfo.c
@@ -99,7 +99,7 @@ static void create_lookup_thread(void)
     pthread_attr_setstacksize(&attr, 100 * 1024);
     if ((ret = pthread_create(&tid, NULL, lookup_thread_main, NULL)) != 0) {
         if (queue.num_threads == 0) {
-            fprintf(stderr, "failed to start first thread for getaddrinfo:%s\n", strerror(ret));
+            H2O_ERROR_PRINTF("failed to start first thread for getaddrinfo:%s\n", strerror(ret));
             abort();
         } else {
             perror("pthread_create(for getaddrinfo)");

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -745,7 +745,7 @@ ssize_t expect_default(struct st_h2o_http2client_conn_t *conn, const uint8_t *sr
         if (hret != 0)
             ret = hret;
     } else {
-        fprintf(stderr, "skipping frame (type:%d)\n", frame.type);
+        H2O_ERROR_PRINTF("skipping frame (type:%d)\n", frame.type);
     }
 
     return ret;

--- a/lib/common/memcached.c
+++ b/lib/common/memcached.c
@@ -199,7 +199,7 @@ static void *writer_main(void *_conn)
                     goto Error;
                 break;
             default:
-                fprintf(stderr, "[lib/common/memcached.c] unknown type:%d\n", (int)req->type);
+                H2O_ERROR_PRINTF("[lib/common/memcached.c] unknown type:%d\n", (int)req->type);
                 err = YRMCDS_NOT_IMPLEMENTED;
                 goto Error;
             }
@@ -213,7 +213,7 @@ static void *writer_main(void *_conn)
     return NULL;
 
 Error:
-    fprintf(stderr, "[lib/common/memcached.c] failed to send request; %s\n", yrmcds_strerror(err));
+    H2O_ERROR_PRINTF("[lib/common/memcached.c] failed to send request; %s\n", yrmcds_strerror(err));
     /* doc says the call can be used to interrupt yrmcds_recv */
     yrmcds_shutdown(&conn->yrmcds);
 
@@ -227,7 +227,7 @@ static void connect_to_server(h2o_memcached_context_t *ctx, yrmcds *yrmcds)
 
     for (failcnt = 0; (err = yrmcds_connect(yrmcds, ctx->host, ctx->port)) != YRMCDS_OK; ++failcnt) {
         if (failcnt == 0) {
-            fprintf(stderr, "[lib/common/memcached.c] failed to connect to memcached at %s:%" PRIu16 ", %s\n", ctx->host, ctx->port,
+            H2O_ERROR_PRINTF("[lib/common/memcached.c] failed to connect to memcached at %s:%" PRIu16 ", %s\n", ctx->host, ctx->port,
                     yrmcds_strerror(err));
         }
         ++failcnt;
@@ -236,7 +236,7 @@ static void connect_to_server(h2o_memcached_context_t *ctx, yrmcds *yrmcds)
     /* connected */
     if (ctx->text_protocol)
         yrmcds_text_mode(yrmcds);
-    fprintf(stderr, "[lib/common/memcached.c] connected to memcached at %s:%" PRIu16 "\n", ctx->host, ctx->port);
+    H2O_ERROR_PRINTF("[lib/common/memcached.c] connected to memcached at %s:%" PRIu16 "\n", ctx->host, ctx->port);
 }
 
 static void reader_main(h2o_memcached_context_t *ctx)
@@ -260,14 +260,14 @@ static void reader_main(h2o_memcached_context_t *ctx)
     /* receive data until an error occurs */
     while (1) {
         if ((err = yrmcds_recv(&conn.yrmcds, &resp)) != YRMCDS_OK) {
-            fprintf(stderr, "[lib/common/memcached.c] yrmcds_recv:%s\n", yrmcds_strerror(err));
+            H2O_ERROR_PRINTF("[lib/common/memcached.c] yrmcds_recv:%s\n", yrmcds_strerror(err));
             break;
         }
         h2o_memcached_req_t *req = pop_inflight(&conn, resp.serial);
         if (req == NULL) {
             if (conn.yrmcds.text_mode)
                 continue;
-            fprintf(stderr, "[lib/common/memcached.c] received unexpected serial\n");
+            H2O_ERROR_PRINTF("[lib/common/memcached.c] received unexpected serial\n");
             break;
         }
         if (resp.status == YRMCDS_STATUS_OK) {

--- a/lib/common/memcached.c
+++ b/lib/common/memcached.c
@@ -249,7 +249,7 @@ static void reader_main(h2o_memcached_context_t *ctx)
     /* connect to server and start the writer thread */
     connect_to_server(conn.ctx, &conn.yrmcds);
     if (pthread_create(&writer_thread, NULL, writer_main, &conn) != 0) {
-        perror("pthread_create");
+        h2o_perror("pthread_create");
         abort();
     }
 

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -263,7 +263,7 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
                     char *tmpfn = alloca(strlen(inbuf->_prototype->mmap_settings->fn_template) + 1);
                     strcpy(tmpfn, inbuf->_prototype->mmap_settings->fn_template);
                     if ((fd = mkstemp(tmpfn)) == -1) {
-                        H2O_ERROR_PRINTF("failed to create temporary file:%s:%s\n", tmpfn, strerror(errno));
+                        h2o_perror("failed to create temporary file");
                         goto MapError;
                     }
                     unlink(tmpfn);
@@ -277,11 +277,11 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
                 fallocate_ret = ftruncate(fd, new_allocsize);
 #endif
                 if (fallocate_ret != 0) {
-                    perror("failed to resize temporary file");
+                    h2o_perror("failed to resize temporary file");
                     goto MapError;
                 }
                 if ((newp = (void *)mmap(NULL, new_allocsize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)) == MAP_FAILED) {
-                    perror("mmap failed");
+                    h2o_perror("mmap failed");
                     goto MapError;
                 }
                 if (inbuf->_fd == -1) {

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -71,7 +71,7 @@ __thread h2o_mem_recycle_t h2o_mem_pool_allocator = {16};
 
 void h2o__fatal(const char *msg)
 {
-    fprintf(stderr, "fatal:%s\n", msg);
+    H2O_ERROR_PRINTF("fatal:%s\n", msg);
     abort();
 }
 
@@ -263,7 +263,7 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
                     char *tmpfn = alloca(strlen(inbuf->_prototype->mmap_settings->fn_template) + 1);
                     strcpy(tmpfn, inbuf->_prototype->mmap_settings->fn_template);
                     if ((fd = mkstemp(tmpfn)) == -1) {
-                        fprintf(stderr, "failed to create temporary file:%s:%s\n", tmpfn, strerror(errno));
+                        H2O_ERROR_PRINTF("failed to create temporary file:%s:%s\n", tmpfn, strerror(errno));
                         goto MapError;
                     }
                     unlink(tmpfn);

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -102,7 +102,7 @@ static void init_async(h2o_multithread_queue_t *queue, h2o_loop_t *loop)
 
     fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     if (fd == -1) {
-        perror("eventfd");
+        h2o_perror("eventfd");
         abort();
     }
     queue->async.write = fd;
@@ -111,7 +111,7 @@ static void init_async(h2o_multithread_queue_t *queue, h2o_loop_t *loop)
     int fds[2];
 
     if (cloexec_pipe(fds) != 0) {
-        perror("pipe");
+        h2o_perror("pipe");
         abort();
     }
     fcntl(fds[1], F_SETFL, O_NONBLOCK);
@@ -227,7 +227,7 @@ void h2o_multithread_send_message(h2o_multithread_receiver_t *receiver, h2o_mult
 void h2o_multithread_create_thread(pthread_t *tid, const pthread_attr_t *attr, void *(*func)(void *), void *arg)
 {
     if (pthread_create(tid, attr, func, arg) != 0) {
-        perror("pthread_create");
+        h2o_perror("pthread_create");
         abort();
     }
 }

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -83,7 +83,7 @@ pthread_mutex_t h2o_conn_id_mutex = PTHREAD_MUTEX_INITIALIZER;
 static void on_read(h2o_socket_t *sock, const char *err)
 {
     if (err != NULL) {
-        fprintf(stderr, "pipe error\n");
+        H2O_ERROR_PRINTF("pipe error\n");
         abort();
     }
 

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -64,19 +64,19 @@ int h2o_setuidgid(const char *user)
         return -1;
     }
     if (pw == NULL) {
-        fprintf(stderr, "unknown user:%s\n", user);
+        H2O_ERROR_PRINTF("unknown user:%s\n", user);
         return -1;
     }
     if (setgid(pw->pw_gid) != 0) {
-        fprintf(stderr, "setgid(%d) failed:%s\n", (int)pw->pw_gid, strerror(errno));
+        H2O_ERROR_PRINTF("setgid(%d) failed:%s\n", (int)pw->pw_gid, strerror(errno));
         return -1;
     }
     if (initgroups(pw->pw_name, pw->pw_gid) != 0) {
-        fprintf(stderr, "initgroups(%s, %d) failed:%s\n", pw->pw_name, (int)pw->pw_gid, strerror(errno));
+        H2O_ERROR_PRINTF("initgroups(%s, %d) failed:%s\n", pw->pw_name, (int)pw->pw_gid, strerror(errno));
         return -1;
     }
     if (setuid(pw->pw_uid) != 0) {
-        fprintf(stderr, "setuid(%d) failed:%s\n", (int)pw->pw_uid, strerror(errno));
+        H2O_ERROR_PRINTF("setuid(%d) failed:%s\n", (int)pw->pw_uid, strerror(errno));
         return -1;
     }
 
@@ -92,7 +92,7 @@ size_t h2o_server_starter_get_fds(int **_fds)
     if ((ports_env = getenv(SERVER_STARTER_PORT)) == NULL)
         return 0;
     if (ports_env[0] == '\0') {
-        fprintf(stderr, "$" SERVER_STARTER_PORT " is empty\n");
+        H2O_ERROR_PRINTF("$" SERVER_STARTER_PORT " is empty\n");
         return SIZE_MAX;
     }
 
@@ -101,11 +101,11 @@ size_t h2o_server_starter_get_fds(int **_fds)
         if ((end = strchr(start, ';')) == NULL)
             end = start + strlen(start);
         if ((eq = memchr(start, '=', end - start)) == NULL) {
-            fprintf(stderr, "invalid $" SERVER_STARTER_PORT ", an element without `=` in: %s\n", ports_env);
+            H2O_ERROR_PRINTF("invalid $" SERVER_STARTER_PORT ", an element without `=` in: %s\n", ports_env);
             goto Error;
         }
         if ((t = h2o_strtosize(eq + 1, end - eq - 1)) == SIZE_MAX) {
-            fprintf(stderr, "invalid file descriptor number in $" SERVER_STARTER_PORT ": %s\n", ports_env);
+            H2O_ERROR_PRINTF("invalid file descriptor number in $" SERVER_STARTER_PORT ": %s\n", ports_env);
             goto Error;
         }
         h2o_vector_reserve(NULL, &fds, fds.size + 1);
@@ -309,7 +309,7 @@ size_t h2o_numproc(void)
     int ncpu;
     size_t ncpu_sz = sizeof(ncpu);
     if (sysctl(name, sizeof(name) / sizeof(name[0]), &ncpu, &ncpu_sz, NULL, 0) != 0 || sizeof(ncpu) != ncpu_sz) {
-        fprintf(stderr, "[ERROR] failed to obtain number of CPU cores, assuming as one\n");
+        H2O_ERROR_PRINTF("[ERROR] failed to obtain number of CPU cores, assuming as one\n");
         ncpu = 1;
     }
     return ncpu;

--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -60,7 +60,7 @@ int h2o_setuidgid(const char *user)
 
     errno = 0;
     if (getpwnam_r(user, &pwbuf, buf, sizeof(buf), &pw) != 0) {
-        perror("getpwnam_r");
+        h2o_perror("getpwnam_r");
         return -1;
     }
     if (pw == NULL) {

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -638,7 +638,7 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
     for (i = 0; i != bufcnt; ++i) {
         sock->bytes_written += bufs[i].len;
 #if H2O_SOCKET_DUMP_WRITE
-        fprintf(stderr, "writing %zu bytes to fd:%d\n", bufs[i].len, h2o_socket_get_fd(sock));
+        H2O_ERROR_PRINTF("writing %zu bytes to fd:%d\n", bufs[i].len, h2o_socket_get_fd(sock));
         h2o_dump_memory(stderr, bufs[i].base, bufs[i].len);
 #endif
     }

--- a/lib/common/socket/evloop/epoll.c.h
+++ b/lib/common/socket/evloop/epoll.c.h
@@ -25,7 +25,7 @@
 #include <sys/epoll.h>
 
 #if 0
-#define DEBUG_LOG(...) fprintf(stderr, __VA_ARGS__)
+#define DEBUG_LOG(...) H2O_ERROR_PRINTF(__VA_ARGS__)
 #else
 #define DEBUG_LOG(...)
 #endif
@@ -144,7 +144,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop, int32_t max_wait)
             pthread_mutex_lock(&lock);
             if (last_reported + 60 < now) {
                 last_reported = now;
-                fprintf(stderr, "ignoring epoll event (fd:%d,event:%x)\n", sock->fd, (int)events[i].events);
+                H2O_ERROR_PRINTF("ignoring epoll event (fd:%d,event:%x)\n", sock->fd, (int)events[i].events);
             }
             pthread_mutex_unlock(&lock);
         }
@@ -169,7 +169,7 @@ static void evloop_do_on_socket_close(struct st_h2o_evloop_socket_t *sock)
     while ((ret = epoll_ctl(loop->ep, EPOLL_CTL_DEL, sock->fd, NULL)) != 0 && errno == EINTR)
         ;
     if (ret != 0)
-        fprintf(stderr, "socket_close: epoll(DEL) returned error %d (fd=%d)\n", errno, sock->fd);
+        H2O_ERROR_PRINTF("socket_close: epoll(DEL) returned error %d (fd=%d)\n", errno, sock->fd);
 }
 
 static void evloop_do_on_socket_export(struct st_h2o_evloop_socket_t *sock)
@@ -182,7 +182,7 @@ static void evloop_do_on_socket_export(struct st_h2o_evloop_socket_t *sock)
     while ((ret = epoll_ctl(loop->ep, EPOLL_CTL_DEL, sock->fd, NULL)) != 0 && errno == EINTR)
         ;
     if (ret != 0)
-        fprintf(stderr, "socket_export: epoll(DEL) returned error %d (fd=%d)\n", errno, sock->fd);
+        H2O_ERROR_PRINTF("socket_export: epoll(DEL) returned error %d (fd=%d)\n", errno, sock->fd);
 }
 
 static void evloop_do_dispose(h2o_evloop_t *_loop)
@@ -198,7 +198,7 @@ h2o_evloop_t *h2o_evloop_create(void)
     loop->ep = epoll_create(10);
     while (fcntl(loop->ep, F_SETFD, FD_CLOEXEC) == -1) {
         if (errno != EAGAIN) {
-            fprintf(stderr, "h2o_evloop_create: failed to set FD_CLOEXEC to the epoll fd (errno=%d)\n", errno);
+            H2O_ERROR_PRINTF("h2o_evloop_create: failed to set FD_CLOEXEC to the epoll fd (errno=%d)\n", errno);
             abort();
         }
     }

--- a/lib/common/socket/evloop/kqueue.c.h
+++ b/lib/common/socket/evloop/kqueue.c.h
@@ -26,7 +26,7 @@
 #include <sys/time.h>
 
 #if 0
-#define DEBUG_LOG(...) fprintf(stderr, __VA_ARGS__)
+#define DEBUG_LOG(...) H2O_ERROR_PRINTF(__VA_ARGS__)
 #else
 #define DEBUG_LOG(...)
 #endif
@@ -173,7 +173,7 @@ static void evloop_do_on_socket_export(struct st_h2o_evloop_socket_t *sock)
     while ((ret = kevent(loop->kq, changelist, change_index, NULL, 0, NULL)) != 0 && errno == EINTR)
         ;
     if (ret == -1)
-        fprintf(stderr, "kevent returned error %d (fd=%d)", errno, sock->fd);
+        H2O_ERROR_PRINTF("kevent returned error %d (fd=%d)", errno, sock->fd);
 }
 
 static void evloop_do_dispose(h2o_evloop_t *_loop)

--- a/lib/common/socket/evloop/poll.c.h
+++ b/lib/common/socket/evloop/poll.c.h
@@ -23,7 +23,7 @@
 #include <poll.h>
 
 #if 0
-#define DEBUG_LOG(...) fprintf(stderr, __VA_ARGS__)
+#define DEBUG_LOG(...) H2O_ERROR_PRINTF(__VA_ARGS__)
 #else
 #define DEBUG_LOG(...)
 #endif

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -525,11 +525,11 @@ void h2o_socketpool_connect(h2o_socketpool_connect_request_t **_req, h2o_socketp
         if (rret <= 0) {
             static long counter = 0;
             if (__sync_fetch_and_add(&counter, 1) == 0)
-                fprintf(stderr, "[WARN] detected close by upstream before the expected timeout (see issue #679)\n");
+                H2O_ERROR_PRINTF("[WARN] detected close by upstream before the expected timeout (see issue #679)\n");
         } else {
             static long counter = 0;
             if (__sync_fetch_and_add(&counter, 1) == 0)
-                fprintf(stderr, "[WARN] unexpectedly received data to a pooled socket (see issue #679)\n");
+                H2O_ERROR_PRINTF("[WARN] unexpectedly received data to a pooled socket (see issue #679)\n");
         }
         destroy_detached(entry);
         pthread_mutex_lock(&pool->_shared.mutex);

--- a/lib/common/timerwheel.c
+++ b/lib/common/timerwheel.c
@@ -34,7 +34,7 @@
 #define REPORT_CORRUPT_TIMER(ctx, e, fmt, ...)                                                                                     \
     do {                                                                                                                           \
         h2o_timerwheel_entry_t *_e = (e);                                                                                          \
-        fprintf(stderr, "%s:%d:last_run=%" PRIu64 fmt ", timer(%p)={expire_at=%" PRIu64 ", cb=%p}\n", __FUNCTION__, __LINE__,      \
+        H2O_ERROR_PRINTF("%s:%d:last_run=%" PRIu64 fmt ", timer(%p)={expire_at=%" PRIu64 ", cb=%p}\n", __FUNCTION__, __LINE__,      \
                 (ctx)->last_run, __VA_ARGS__, _e, _e->expire_at, _e->cb);                                                          \
     } while (0)
 
@@ -65,13 +65,13 @@ void h2o_timerwheel_dump(h2o_timerwheel_t *ctx)
 {
     size_t wheel, slot;
 
-    fprintf(stderr, "%s(%p):\n", __FUNCTION__, ctx);
+    H2O_ERROR_PRINTF("%s(%p):\n", __FUNCTION__, ctx);
     for (wheel = 0; wheel < ctx->num_wheels; wheel++) {
         for (slot = 0; slot < H2O_TIMERWHEEL_SLOTS_PER_WHEEL; slot++) {
             h2o_linklist_t *anchor = &ctx->wheels[wheel][slot], *l;
             for (l = anchor->next; l != anchor; l = l->next) {
                 h2o_timerwheel_entry_t *e = H2O_STRUCT_FROM_MEMBER(h2o_timerwheel_entry_t, _link, l);
-                fprintf(stderr, "  - {wheel: %zu, slot: %zu, expires:%" PRIu64 ", self: %p, cb:%p}\n", wheel, slot, e->expire_at, e,
+                H2O_ERROR_PRINTF("  - {wheel: %zu, slot: %zu, expires:%" PRIu64 ", self: %p, cb:%p}\n", wheel, slot, e->expire_at, e,
                         e->cb);
             }
         }
@@ -311,7 +311,7 @@ void h2o_timerwheel_get_expired(h2o_timerwheel_t *ctx, uint64_t now, h2o_linklis
 
     /* time might rewind if the clock is reset */
     if (now < ctx->last_run) {
-        fprintf(stderr, "%s:detected rewind; last_run=%" PRIu64 ", now=%" PRIu64 "\n", __FUNCTION__, ctx->last_run, now);
+        H2O_ERROR_PRINTF("%s:detected rewind; last_run=%" PRIu64 ", now=%" PRIu64 "\n", __FUNCTION__, ctx->last_run, now);
         return;
     }
 

--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -165,7 +165,7 @@ Rewrite:
         goto RewriteError;
     return ret;
 RewriteError:
-    fprintf(stderr, "failed to normalize path: `%.*s` => `%.*s`\n", (int)len, path, (int)ret.len, ret.base);
+    H2O_ERROR_PRINTF("failed to normalize path: `%.*s` => `%.*s`\n", (int)len, path, (int)ret.len, ret.base);
     ret = h2o_iovec_init("/", 1);
     return ret;
 }

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -653,7 +653,7 @@ static int set_mimetypes(h2o_configurator_command_t *cmd, h2o_mimemap_t *mimemap
             }
         } break;
         default:
-            fprintf(stderr, "logic flaw at %s:%d\n", __FILE__, __LINE__);
+            H2O_ERROR_PRINTF("logic flaw at %s:%d\n", __FILE__, __LINE__);
             abort();
         }
     }
@@ -1096,15 +1096,16 @@ int h2o_configurator_apply(h2o_globalconf_t *config, yoml_t *node, int dry_run)
 
 void h2o_configurator_errprintf(h2o_configurator_command_t *cmd, yoml_t *node, const char *reason, ...)
 {
+    char buf[1024];
     va_list args;
 
-    fprintf(stderr, "[%s:%zu] ", node->filename ? node->filename : "-", node->line + 1);
+    H2O_ERROR_PRINTF("[%s:%zu] ", node->filename ? node->filename : "-", node->line + 1);
     if (cmd != NULL)
-        fprintf(stderr, "in command %s, ", cmd->name);
+        H2O_ERROR_PRINTF("in command %s, ", cmd->name);
     va_start(args, reason);
-    vfprintf(stderr, reason, args);
+    vsnprintf(buf, sizeof(buf), reason, args);
     va_end(args);
-    fputc('\n', stderr);
+    H2O_ERROR_PRINTF("%s\n", buf);
 }
 
 int h2o_configurator_scanf(h2o_configurator_command_t *cmd, yoml_t *node, const char *fmt, ...)
@@ -1191,7 +1192,7 @@ static const char *get_next_key(const char *start, h2o_iovec_t *output, unsigned
     return NULL;
 
 Error:
-    fprintf(stderr, "%s: detected invalid or missing type specifier; input is: %s\n", __FUNCTION__, start);
+    H2O_ERROR_PRINTF("%s: detected invalid or missing type specifier; input is: %s\n", __FUNCTION__, start);
     abort();
 }
 

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -712,7 +712,7 @@ void h2o_send_redirect_internal(h2o_req_t *req, h2o_iovec_t method, const char *
 
     /* parse the location URL */
     if (h2o_url_parse_relative(url_str, url_len, &url) != 0) {
-        /* TODO log fprintf(stderr, "[proxy] cannot handle location header: %.*s\n", (int)url_len, url); */
+        /* TODO log H2O_ERROR_PRINTF("[proxy] cannot handle location header: %.*s\n", (int)url_len, url); */
         h2o_send_error_deferred_502(req, "Gateway Error", "internal error", 0);
         return;
     }

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -168,17 +168,17 @@ void h2o_accept_setup_memcached_ssl_resumption(h2o_memcached_context_t *memc, un
 
 static void on_redis_connect(void)
 {
-    fprintf(stderr, "connected to redis at %s:%" PRIu16 "\n", async_resumption_context.redis.host.base,
+    H2O_ERROR_PRINTF("connected to redis at %s:%" PRIu16 "\n", async_resumption_context.redis.host.base,
             async_resumption_context.redis.port);
 }
 
 static void on_redis_close(const char *errstr)
 {
     if (errstr == NULL) {
-        fprintf(stderr, "disconnected from redis at %s:%" PRIu16 "\n", async_resumption_context.redis.host.base,
+        H2O_ERROR_PRINTF("disconnected from redis at %s:%" PRIu16 "\n", async_resumption_context.redis.host.base,
                 async_resumption_context.redis.port);
     } else {
-        fprintf(stderr, "redis connection failure: %s\n", errstr);
+        H2O_ERROR_PRINTF("redis connection failure: %s\n", errstr);
     }
 }
 

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -78,11 +78,11 @@ int h2o_access_log_open_log(const char *path)
         char *argv[4] = {"/bin/sh", "-c", (char *)(path + 1), NULL};
         /* create pipe */
         if (pipe(pipefds) != 0) {
-            perror("pipe failed");
+            h2o_perror("pipe failed");
             return -1;
         }
         if (fcntl(pipefds[1], F_SETFD, FD_CLOEXEC) == -1) {
-            perror("failed to set FD_CLOEXEC on pipefds[1]");
+            h2o_perror("failed to set FD_CLOEXEC on pipefds[1]");
             return -1;
         }
         /* spawn the logger */

--- a/lib/handler/access_log.c
+++ b/lib/handler/access_log.c
@@ -89,7 +89,7 @@ int h2o_access_log_open_log(const char *path)
         int mapped_fds[] = {pipefds[0], 0, /* map pipefds[0] to stdin */
                             -1};
         if ((pid = h2o_spawnp(argv[0], argv, mapped_fds, 0)) == -1) {
-            fprintf(stderr, "failed to open logger: %s:%s\n", path + 1, strerror(errno));
+            H2O_ERROR_PRINTF("failed to open logger: %s:%s\n", path + 1, strerror(errno));
             return -1;
         }
         /* close the read side of the pipefds and return the write side */
@@ -103,25 +103,25 @@ int h2o_access_log_open_log(const char *path)
         if (ret == 0 && (st.st_mode & S_IFMT) == S_IFSOCK) {
             struct sockaddr_un sa;
             if (strlen(path) >= sizeof(sa.sun_path)) {
-                fprintf(stderr, "path:%s is too long as a unix socket name", path);
+                H2O_ERROR_PRINTF("path:%s is too long as a unix socket name", path);
                 return -1;
             }
             if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
-                fprintf(stderr, "failed to create socket for log file:%s:%s\n", path, strerror(errno));
+                H2O_ERROR_PRINTF("failed to create socket for log file:%s:%s\n", path, strerror(errno));
                 return -1;
             }
             memset(&sa, 0, sizeof(sa));
             sa.sun_family = AF_UNIX;
             strcpy(sa.sun_path, path);
             if (connect(fd, (struct sockaddr *)&sa, sizeof(sa)) == -1) {
-                fprintf(stderr, "failed to connect socket for log file:%s:%s\n", path, strerror(errno));
+                H2O_ERROR_PRINTF("failed to connect socket for log file:%s:%s\n", path, strerror(errno));
                 close(fd);
                 return -1;
             }
 
         } else {
             if ((fd = open(path, O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC, 0644)) == -1) {
-                fprintf(stderr, "failed to open log file:%s:%s\n", path, strerror(errno));
+                H2O_ERROR_PRINTF("failed to open log file:%s:%s\n", path, strerror(errno));
                 return -1;
             }
         }
@@ -141,7 +141,7 @@ h2o_access_log_filehandle_t *h2o_access_log_open_handle(const char *path, const 
     if (fmt == NULL)
         fmt = "%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"";
     if ((logconf = h2o_logconf_compile(fmt, escape, errbuf)) == NULL) {
-        fprintf(stderr, "%s\n", errbuf);
+        H2O_ERROR_PRINTF("%s\n", errbuf);
         return NULL;
     }
 

--- a/lib/handler/configurator/fastcgi.c
+++ b/lib/handler/configurator/fastcgi.c
@@ -184,7 +184,7 @@ static int create_spawnproc(h2o_configurator_command_t *cmd, yoml_t *node, const
                         -1};
     pid_t pid = h2o_spawnp(argv[0], argv, mapped_fds, 0);
     if (pid == -1) {
-        fprintf(stderr, "[lib/handler/fastcgi.c] failed to launch helper program %s:%s\n", argv[0], strerror(errno));
+        H2O_ERROR_PRINTF("[lib/handler/fastcgi.c] failed to launch helper program %s:%s\n", argv[0], strerror(errno));
         goto Error;
     }
 

--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -45,7 +45,7 @@ static mrb_state *get_mrb(struct mruby_configurator_t *self)
     if (self->mrb == NULL) {
         self->mrb = mrb_open();
         if (self->mrb == NULL) {
-            fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
+            H2O_ERROR_PRINTF("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
             abort();
         }
         h2o_mruby_setup_globals(self->mrb);

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -452,7 +452,7 @@ static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t
         self->vars->ssl_ctx = create_ssl_ctx();
         char *ca_bundle = h2o_configurator_get_cmd_path("share/h2o/ca-bundle.crt");
         if (SSL_CTX_load_verify_locations(self->vars->ssl_ctx, ca_bundle, NULL) != 1)
-            fprintf(stderr, "Warning: failed to load the default certificates file at %s. Proxying to HTTPS servers may fail.\n",
+            H2O_ERROR_PRINTF("Warning: failed to load the default certificates file at %s. Proxying to HTTPS servers may fail.\n",
                     ca_bundle);
         free(ca_bundle);
         SSL_CTX_set_verify(self->vars->ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -604,7 +604,7 @@ static int try_dynamic_request(h2o_file_handler_t *self, h2o_req_t *req, char *r
         return delegate_dynamic_request(req, script_name, path_info, rpath, slash_at, mime_type);
     }
     }
-    fprintf(stderr, "unknown h2o_miemmap_type_t::type (%d)\n", (int)mime_type->type);
+    H2O_ERROR_PRINTF("unknown h2o_miemmap_type_t::type (%d)\n", (int)mime_type->type);
     abort();
 }
 

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -47,7 +47,7 @@
 
 void h2o_mruby__abort_exc(mrb_state *mrb, const char *mess, const char *file, int line)
 {
-    fprintf(stderr, "%s at file: \"%s\", line %d: %s\n", mess, file, line, RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
+    H2O_ERROR_PRINTF("%s at file: \"%s\", line %d: %s\n", mess, file, line, RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
     abort();
 }
 
@@ -109,10 +109,10 @@ void h2o_mruby_setup_globals(mrb_state *mrb)
     /* require core modules and include built-in libraries */
     h2o_mruby_eval_expr(mrb, "require \"#{$H2O_ROOT}/share/h2o/mruby/preloads.rb\"");
     if (mrb->exc != NULL) {
-        fprintf(stderr, "an error occurred while loading %s/%s: %s\n", root, "share/h2o/mruby/preloads.rb",
+        H2O_ERROR_PRINTF("an error occurred while loading %s/%s: %s\n", root, "share/h2o/mruby/preloads.rb",
                 RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
         if (mrb_obj_is_instance_of(mrb, mrb_obj_value(mrb->exc), mrb_class_get(mrb, "LoadError"))) {
-            fprintf(stderr, "Did you forget to run `make install`?\n");
+            H2O_ERROR_PRINTF("Did you forget to run `make install`?\n");
         }
         abort();
     }
@@ -154,7 +154,7 @@ void h2o_mruby_define_callback(mrb_state *mrb, const char *name, h2o_mruby_callb
     mrb_funcall_argv(mrb, mrb_top_self(mrb), mrb_intern_lit(mrb, "_h2o_define_callback"), 2, args);
 
     if (mrb->exc != NULL) {
-        fprintf(stderr, "failed to define mruby function: %s\n", name);
+        H2O_ERROR_PRINTF("failed to define mruby function: %s\n", name);
         h2o_mruby_assert(mrb);
     }
 }
@@ -174,7 +174,7 @@ struct RProc *h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *co
 
     /* parse */
     if ((cxt = mrbc_context_new(mrb)) == NULL) {
-        fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
+        H2O_ERROR_PRINTF("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
         abort();
     }
     if (config->path != NULL)
@@ -182,13 +182,13 @@ struct RProc *h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *co
     cxt->capture_errors = 1;
     cxt->lineno = config->lineno;
     if ((parser = mrb_parse_nstring(mrb, config->source.base, (int)config->source.len, cxt)) == NULL) {
-        fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
+        H2O_ERROR_PRINTF("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
         abort();
     }
     /* return erro if errbuf is supplied, or abort */
     if (parser->nerr != 0) {
         if (errbuf == NULL) {
-            fprintf(stderr, "%s: internal error (unexpected state)\n", H2O_MRUBY_MODULE_NAME);
+            H2O_ERROR_PRINTF("%s: internal error (unexpected state)\n", H2O_MRUBY_MODULE_NAME);
             abort();
         }
         snprintf(errbuf, 256, "line %d:%s", parser->error_buffer[0].lineno, parser->error_buffer[0].message);
@@ -202,7 +202,7 @@ struct RProc *h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *co
     }
     /* generate code */
     if ((proc = mrb_generate_code(mrb, parser)) == NULL) {
-        fprintf(stderr, "%s: internal error (mrb_generate_code failed)\n", H2O_MRUBY_MODULE_NAME);
+        H2O_ERROR_PRINTF("%s: internal error (mrb_generate_code failed)\n", H2O_MRUBY_MODULE_NAME);
         abort();
     }
 
@@ -346,7 +346,7 @@ static void handle_exception(h2o_mruby_context_t *ctx, h2o_mruby_generator_t *ge
     assert(mrb->exc != NULL);
 
     if (generator == NULL || generator->req->_generator != NULL) {
-        fprintf(stderr, "mruby raised: %s\n", RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
+        H2O_ERROR_PRINTF("mruby raised: %s\n", RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
     } else {
         h2o_req_log_error(generator->req, H2O_MRUBY_MODULE_NAME, "mruby raised: %s\n",
                           RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
@@ -450,7 +450,7 @@ static h2o_mruby_shared_context_t *create_shared_context(h2o_context_t *ctx)
     /* init mruby in every thread */
     h2o_mruby_shared_context_t *shared_ctx = h2o_mem_alloc(sizeof(*shared_ctx));
     if ((shared_ctx->mrb = mrb_open()) == NULL) {
-        fprintf(stderr, "%s: no memory\n", H2O_MRUBY_MODULE_NAME);
+        H2O_ERROR_PRINTF("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
         abort();
     }
     shared_ctx->mrb->ud = shared_ctx;

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -309,7 +309,7 @@ static void post_response(struct st_h2o_mruby_http_request_context_t *ctx, int s
         /* is async */
         mrb_funcall(mrb, ctx->refs.request, "_set_response", 1, resp);
         if (mrb->exc != NULL) {
-            fprintf(stderr, "_set_response failed\n");
+            H2O_ERROR_PRINTF("_set_response failed\n");
             abort();
         }
     } else {

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -433,7 +433,7 @@ static void on_subreq_error_callback(void *data, h2o_iovec_t prefix, h2o_iovec_t
     mrb_value msgstr = h2o_mruby_new_str(mrb, concat.base, concat.len);
     mrb_funcall(mrb, subreq->error_stream, "write", 1, msgstr);
     if (mrb->exc != NULL) {
-        fprintf(stderr, "%s\n", RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
+        H2O_ERROR_PRINTF("%s\n", RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
         mrb->exc = NULL;
     }
 }

--- a/lib/handler/status/requests.c
+++ b/lib/handler/status/requests.c
@@ -126,7 +126,7 @@ static void *requests_status_init(void)
     /* compile logconf */
     if ((rsc->logconf = h2o_logconf_compile(fmt, H2O_LOGCONF_ESCAPE_JSON, errbuf)) == NULL)
         /* log format compilation error is an internal logic flaw, therefore we need not send the details to the client */
-        fprintf(stderr, "[lib/handler/status/requests.c] failed to compile log format: %s", errbuf);
+        H2O_ERROR_PRINTF("[lib/handler/status/requests.c] failed to compile log format: %s", errbuf);
 
     rsc->req_data = (h2o_iovec_t){NULL};
     pthread_mutex_init(&rsc->mutex, NULL);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1035,7 +1035,7 @@ ssize_t expect_default(h2o_http2_conn_t *conn, const uint8_t *src, size_t len, c
         if (hret != 0)
             ret = hret;
     } else {
-        fprintf(stderr, "skipping frame (type:%d)\n", frame.type);
+        H2O_ERROR_PRINTF("skipping frame (type:%d)\n", frame.type);
     }
 
     return ret;


### PR DESCRIPTION
According to Issues #2006 
The fix focus on `lib` directory in the source tree.

Library uses can define this macro to something else to use their log function.