### PR TITLE
add 'h2o_socket_write_finished()'

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -219,6 +219,15 @@ size_t h2o_socket_do_prepare_for_latency_optimized_write(h2o_socket_t *sock,
  * @param cb callback to be called when write is complete
  */
 void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb);
+
+/**
+ * judge **immediately** after h2o_socket_write to see whether the write finished successfully or not
+ * @param sock the socket
+ *
+ * @return 1 when write successfully or 0 when write pending or error
+ */
+int h2o_socket_write_finished(h2o_socket_t *sock);
+
 /**
  * starts polling on the socket (for read) and calls given callback when data arrives
  * @param sock the socket

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -711,6 +711,11 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
     }
 }
 
+int h2o_socket_write_finished(h2o_socket_t *sock)
+{
+    return is_write_finished(sock);
+}
+
 void on_write_complete(h2o_socket_t *sock, const char *err)
 {
     h2o_socket_cb cb;

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -305,6 +305,12 @@ void do_write(h2o_socket_t *_sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_
     link_to_statechanged(sock);
 }
 
+static int is_write_finished(h2o_socket_t *_sock)
+{
+    struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;
+    return (sock->_wreq.cnt == 0) && (sock->_flags & H2O_SOCKET_FLAG_IS_WRITE_NOTIFY);
+}
+
 int h2o_socket_get_fd(h2o_socket_t *_sock)
 {
     struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -194,6 +194,14 @@ void do_write(h2o_socket_t *_sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_
     uv_write(&sock->stream._wreq, (uv_stream_t *)sock->handle, (uv_buf_t *)bufs, (int)bufcnt, on_do_write_complete);
 }
 
+static int is_write_finished(h2o_socket_t *_sock)
+{
+    struct st_h2o_uv_socket_t *sock = (struct st_h2o_uv_socket_t *)_sock;
+
+    /*  FIXME: 'error' and 'bufs' are not public member in uv_write_t */
+    return sock->stream._wreq.error == 0 && sock->stream._wreq.bufs == NULL;
+}
+
 void h2o_socket_notify_write(h2o_socket_t *_sock, h2o_socket_cb cb)
 {
     struct st_h2o_uv_socket_t *sock = (struct st_h2o_uv_socket_t *)_sock;


### PR DESCRIPTION
can be used to judge **immediately** after h2o_socket_write to see whether the write
finished successfully or not.

