### PR TITLE
Optional H1 behavior to forward connection closure

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -417,6 +417,10 @@ struct st_h2o_globalconf_t {
          * keepalive timeout (in milliseconds)
          */
         uint64_t keepalive_timeout;
+	/**
+	 * a boolean flag if set to true, instructs the proxy to close the frontend h1 connection on behalf of the upstream
+	 */
+	unsigned forward_close_connection: 1;
         /**
          * a boolean flag if set to true, instructs the proxy to preserve the x-forwarded-proto header passed by the client
          */

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -429,7 +429,6 @@ static h2o_httpclient_body_cb on_head(h2o_httpclient_t *client, const char *errs
     h2o_req_t *req = self->src_req;
     size_t i;
     int emit_missing_date_header = req->conn->ctx->globalconf->proxy.emit_missing_date_header;
-    int forward_close_connection = req->conn->ctx->globalconf->proxy.forward_close_connection;
     int seen_date_header = 0;
 
     self->src_req->timestamps.proxy = self->client->timings;
@@ -458,7 +457,7 @@ static h2o_httpclient_body_cb on_head(h2o_httpclient_t *client, const char *errs
         if (h2o_iovec_is_token(headers[i].name)) {
             const h2o_token_t *token = H2O_STRUCT_FROM_MEMBER(h2o_token_t, buf, headers[i].name);
             if (token->flags.proxy_should_drop_for_res) {
-                if (forward_close_connection && token == H2O_TOKEN_CONNECTION && self->src_req->version < 0x200) {
+                if (token == H2O_TOKEN_CONNECTION && self->src_req->version < 0x200 && req->conn->ctx->globalconf->proxy.forward_close_connection) {
                     if (h2o_lcstris(headers[i].value.base, headers[i].value.len, H2O_STRLIT("close")))
                         self->src_req->http1_is_persistent = 0;
                 }

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -436,6 +436,15 @@ static int on_config_http2_ratio(h2o_configurator_command_t *cmd, h2o_configurat
     return 0;
 }
 
+static int on_config_forward_close_connection(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
+    if (ret == -1)
+        return -1;
+    ctx->globalconf->proxy.forward_close_connection = (int)ret;
+    return 0;
+}
+
 static int on_config_enter(h2o_configurator_t *_self, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)_self;
@@ -570,4 +579,6 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
                                     on_config_http2_max_concurrent_streams);
     h2o_configurator_define_command(&c->super, "proxy.http2.ratio",
                                     H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_http2_ratio);
+    h2o_configurator_define_command(&c->super, "proxy.forward.close-connection",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR, on_config_forward_close_connection);
 }

--- a/t/50proxy-forward-close-connection.t
+++ b/t/50proxy-forward-close-connection.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $keep_alive_upstream_port = empty_port();
+my $close_conn_upstream_port = empty_port();
+my $curl = 'curl --silent --dump-header /dev/stderr';
+
+subtest 'basic' => sub {
+    my $doit = sub {
+        my ($toggle) = @_;
+        my $server = spawn_h2o(<< "EOT");
+proxy.forward.close-connection: $toggle
+hosts:
+  default:
+    paths:
+      "/ka-origin":
+        - proxy.reverse.url: http://127.0.0.1:$keep_alive_upstream_port
+      "/cc-origin":
+        - proxy.reverse.url: http://127.0.0.1:$close_conn_upstream_port
+EOT
+        my $g1 = one_shot_http_upstream("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\n\r\nOk", $keep_alive_upstream_port);
+        my $g2 = one_shot_http_upstream("HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nOk", $close_conn_upstream_port);
+
+        my ($headers, undef) = run_prog("$curl http://127.0.0.1:@{[$server->{port}]}/ka-origin 2>&1");
+        like $headers, qr/^Connection: keep-alive/mi, 'connection header has value: keep-alive';
+
+        ($headers, undef) = run_prog("$curl http://127.0.0.1:@{[$server->{port}]}/cc-origin 2>&1");
+        my $expected = $toggle eq 'ON' ? 'close' : 'keep-alive';
+        like $headers, qr/^Connection: $expected/mi, 'header forwarding successful';
+    };
+
+    subtest 'enabled' => sub {
+        $doit->("ON");
+    };
+    subtest 'disabled' => sub {
+        $doit->("OFF");
+    };
+};
+
+done_testing();


### PR DESCRIPTION
## Objective

Add an optional H1-specific behavior that enables H2O to forward the `Connection: close` response header from upstream. This behavior is triggered by the new `proxy.forward.close-connection` setting.

## Motive

This contribution is based on our learning that some applications appreciate this behavior, whether it's for draining or ensuring that their clients start a fresh new connection.