### PR TITLE
h2o ad-hoc tracer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,7 @@ SET(LIB_SOURCE_FILES
     deps/libyrmcds/text_mode.c
     deps/picohttpparser/picohttpparser.c
 
+    lib/common/tracing.c
     lib/common/cache.c
     lib/common/file.c
     lib/common/filecache.c
@@ -366,7 +367,9 @@ SET(LIB_SOURCE_FILES
     lib/http2/hpack.c
     lib/http2/scheduler.c
     lib/http2/stream.c
-    lib/http2/http2_debug_state.c)
+    lib/http2/http2_debug_state.c
+
+    lib/tracing/tracing.c)
 
 SET(UNIT_TEST_SOURCE_FILES
     ${LIB_SOURCE_FILES}

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -629,6 +629,13 @@ struct st_h2o_context_t {
 
     struct {
         /**
+         * link-list of h2o_http1_conn_t
+         */
+        h2o_linklist_t _conns;
+    } tracing;
+
+    struct {
+        /**
          * counter for SSL errors
          */
         uint64_t errors;
@@ -1137,6 +1144,7 @@ typedef struct st_h2o_accept_ctx_t {
     h2o_iovec_t *http2_origin_frame;
     int expect_proxy_line;
     h2o_multithread_receiver_t *libmemcached_receiver;
+    int tracing;
 } h2o_accept_ctx_t;
 
 typedef struct st_h2o_doublebuffer_t {
@@ -1942,6 +1950,17 @@ void h2o_duration_stats_register(h2o_globalconf_t *conf);
  * registers the configurator
  */
 void h2o_status_register_configurator(h2o_globalconf_t *conf);
+/**
+ * registers the tracing handlers
+*/
+void h2o_trace_init(void);
+void h2o_trace_req(h2o_req_t *req);
+void h2o_trace_res(h2o_req_t *req);
+void h2o_trace_newssl(struct timeval tv, h2o_socket_t *sock);
+void h2o_trace_newh1(struct timeval tv, h2o_socket_t *sock);
+void h2o_trace_newh2(struct timeval tv, h2o_socket_t *sock);
+void h2o_trace_proxyreq(h2o_req_t *req);
+void h2o_trace_proxyres(h2o_req_t *req);
 
 /* lib/handler/headers_util.c */
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -629,13 +629,6 @@ struct st_h2o_context_t {
 
     struct {
         /**
-         * link-list of h2o_http1_conn_t
-         */
-        h2o_linklist_t _conns;
-    } tracing;
-
-    struct {
-        /**
          * counter for SSL errors
          */
         uint64_t errors;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1144,7 +1144,6 @@ typedef struct st_h2o_accept_ctx_t {
     h2o_iovec_t *http2_origin_frame;
     int expect_proxy_line;
     h2o_multithread_receiver_t *libmemcached_receiver;
-    int tracing;
 } h2o_accept_ctx_t;
 
 typedef struct st_h2o_doublebuffer_t {

--- a/include/h2o/sdt.h
+++ b/include/h2o/sdt.h
@@ -1,0 +1,435 @@
+/* sdt.h
+
+   mostly based off <sys/sdt.h> - Systemtap static probe definition macros.
+   where line 211 (#include "sdt-config.h) was commented out to allow
+   standalone usage of the header
+
+   This file is dedicated to the public domain, pursuant to CC0
+   (https://creativecommons.org/publicdomain/zero/1.0/)
+*/
+
+#ifndef _SYS_SDT_H
+#define _SYS_SDT_H    1
+
+/*
+  This file defines a family of macros
+
+       STAP_PROBEn(op1, ..., opn)
+
+  that emit a nop into the instruction stream, and some data into an auxiliary
+  note section.  The data in the note section describes the operands, in terms
+  of size and location.  Each location is encoded as assembler operand string.
+  Consumer tools such as gdb or systemtap insert breakpoints on top of
+  the nop, and decode the location operand-strings, like an assembler,
+  to find the values being passed.
+
+  The operand strings are selected by the compiler for each operand.
+  They are constrained by gcc inline-assembler codes.  The default is:
+
+  #define STAP_SDT_ARG_CONSTRAINT nor
+
+  This is a good default if the operands tend to be integral and
+  moderate in number (smaller than number of registers).  In other
+  cases, the compiler may report "'asm' requires impossible reload" or
+  similar.  In this case, consider simplifying the macro call (fewer
+  and simpler operands), reduce optimization, or override the default
+  constraints string via:
+
+  #define STAP_SDT_ARG_CONSTRAINT g
+  #include <sys/sdt.h>
+
+  See also:
+  https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation
+  https://gcc.gnu.org/onlinedocs/gcc/Constraints.html
+ */
+
+
+
+#ifdef __ASSEMBLER__
+# define _SDT_PROBE(provider, name, n, arglist)	\
+  _SDT_ASM_BODY(provider, name, _SDT_ASM_STRING_1, (_SDT_DEPAREN_##n arglist)) \
+  _SDT_ASM_BASE
+# define _SDT_ASM_1(x)			x;
+# define _SDT_ASM_2(a, b)		a,b;
+# define _SDT_ASM_3(a, b, c)		a,b,c;
+# define _SDT_ASM_5(a, b, c, d, e)	a,b,c,d,e;
+# define _SDT_ASM_STRING_1(x)		.asciz #x;
+# define _SDT_DEPAREN_0()				/* empty */
+# define _SDT_DEPAREN_1(a)				a
+# define _SDT_DEPAREN_2(a,b)				a b
+# define _SDT_DEPAREN_3(a,b,c)				a b c
+# define _SDT_DEPAREN_4(a,b,c,d)			a b c d
+# define _SDT_DEPAREN_5(a,b,c,d,e)			a b c d e
+# define _SDT_DEPAREN_6(a,b,c,d,e,f)			a b c d e f
+# define _SDT_DEPAREN_7(a,b,c,d,e,f,g)			a b c d e f g
+# define _SDT_DEPAREN_8(a,b,c,d,e,f,g,h)		a b c d e f g h
+# define _SDT_DEPAREN_9(a,b,c,d,e,f,g,h,i)		a b c d e f g h i
+# define _SDT_DEPAREN_10(a,b,c,d,e,f,g,h,i,j)		a b c d e f g h i j
+# define _SDT_DEPAREN_11(a,b,c,d,e,f,g,h,i,j,k)		a b c d e f g h i j k
+# define _SDT_DEPAREN_12(a,b,c,d,e,f,g,h,i,j,k,l)	a b c d e f g h i j k l
+#else
+# define _SDT_PROBE(provider, name, n, arglist) \
+  do {									    \
+    __asm__ __volatile__ (_SDT_ASM_BODY(provider, name, _SDT_ASM_ARGS, (n)) \
+			  :: _SDT_ASM_OPERANDS_##n arglist);		    \
+    __asm__ __volatile__ (_SDT_ASM_BASE);				    \
+  } while (0)
+# define _SDT_S(x)			#x
+# define _SDT_ASM_1(x)			_SDT_S(x) "\n"
+# define _SDT_ASM_2(a, b)		_SDT_S(a) "," _SDT_S(b) "\n"
+# define _SDT_ASM_3(a, b, c)		_SDT_S(a) "," _SDT_S(b) "," \
+					_SDT_S(c) "\n"
+# define _SDT_ASM_5(a, b, c, d, e)	_SDT_S(a) "," _SDT_S(b) "," \
+					_SDT_S(c) "," _SDT_S(d) "," \
+					_SDT_S(e) "\n"
+# define _SDT_ASM_ARGS(n)		_SDT_ASM_STRING(_SDT_ASM_TEMPLATE_##n)
+# define _SDT_ASM_STRING_1(x)		_SDT_ASM_1(.asciz #x)
+
+# define _SDT_ARGFMT(no)		%n[_SDT_S##no]@_SDT_ARGTMPL(_SDT_A##no)
+
+# ifndef STAP_SDT_ARG_CONSTRAINT
+# if defined __powerpc__
+# define STAP_SDT_ARG_CONSTRAINT        nZr
+# else
+# define STAP_SDT_ARG_CONSTRAINT        nor
+# endif
+# endif
+
+# define _SDT_STRINGIFY(x)              #x
+# define _SDT_ARG_CONSTRAINT_STRING(x)  _SDT_STRINGIFY(x)
+# define _SDT_ARG(n, x)			\
+  [_SDT_S##n] "n" ((_SDT_ARGSIGNED (x) ? 1 : -1) * (int) _SDT_ARGSIZE (x)), \
+  [_SDT_A##n] _SDT_ARG_CONSTRAINT_STRING (STAP_SDT_ARG_CONSTRAINT) (_SDT_ARGVAL (x))
+#endif
+#define _SDT_ASM_STRING(x)		_SDT_ASM_STRING_1(x)
+
+#define _SDT_ARGARRAY(x)	(__builtin_classify_type (x) == 14	\
+				 || __builtin_classify_type (x) == 5)
+
+#ifdef __cplusplus
+# define _SDT_ARGSIGNED(x)	(!_SDT_ARGARRAY (x) \
+				 && __sdt_type<__typeof (x)>::__sdt_signed)
+# define _SDT_ARGSIZE(x)	(_SDT_ARGARRAY (x) \
+				 ? sizeof (void *) : sizeof (x))
+# define _SDT_ARGVAL(x)		(x)
+
+# include <cstddef>
+
+template<typename __sdt_T>
+struct __sdt_type
+{
+  static const bool __sdt_signed = false;
+};
+
+#define __SDT_ALWAYS_SIGNED(T) \
+template<> struct __sdt_type<T> { static const bool __sdt_signed = true; };
+#define __SDT_COND_SIGNED(T,CT)						\
+template<> struct __sdt_type<T> { static const bool __sdt_signed = ((CT)(-1) < 1); };
+__SDT_ALWAYS_SIGNED(signed char)
+__SDT_ALWAYS_SIGNED(short)
+__SDT_ALWAYS_SIGNED(int)
+__SDT_ALWAYS_SIGNED(long)
+__SDT_ALWAYS_SIGNED(long long)
+__SDT_ALWAYS_SIGNED(volatile signed char)
+__SDT_ALWAYS_SIGNED(volatile short)
+__SDT_ALWAYS_SIGNED(volatile int)
+__SDT_ALWAYS_SIGNED(volatile long)
+__SDT_ALWAYS_SIGNED(volatile long long)
+__SDT_ALWAYS_SIGNED(const signed char)
+__SDT_ALWAYS_SIGNED(const short)
+__SDT_ALWAYS_SIGNED(const int)
+__SDT_ALWAYS_SIGNED(const long)
+__SDT_ALWAYS_SIGNED(const long long)
+__SDT_ALWAYS_SIGNED(const volatile signed char)
+__SDT_ALWAYS_SIGNED(const volatile short)
+__SDT_ALWAYS_SIGNED(const volatile int)
+__SDT_ALWAYS_SIGNED(const volatile long)
+__SDT_ALWAYS_SIGNED(const volatile long long)
+__SDT_COND_SIGNED(char, char)
+__SDT_COND_SIGNED(wchar_t, wchar_t)
+__SDT_COND_SIGNED(volatile char, char)
+__SDT_COND_SIGNED(volatile wchar_t, wchar_t)
+__SDT_COND_SIGNED(const char, char)
+__SDT_COND_SIGNED(const wchar_t, wchar_t)
+__SDT_COND_SIGNED(const volatile char, char)
+__SDT_COND_SIGNED(const volatile wchar_t, wchar_t)
+#if defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4))
+/* __SDT_COND_SIGNED(char16_t) */
+/* __SDT_COND_SIGNED(char32_t) */
+#endif
+
+template<typename __sdt_E>
+struct __sdt_type<__sdt_E[]> : public __sdt_type<__sdt_E *> {};
+
+template<typename __sdt_E, size_t __sdt_N>
+struct __sdt_type<__sdt_E[__sdt_N]> : public __sdt_type<__sdt_E *> {};
+
+#elif !defined(__ASSEMBLER__)
+__extension__ extern unsigned long long __sdt_unsp;
+# define _SDT_ARGINTTYPE(x)						\
+  __typeof (__builtin_choose_expr (((__builtin_classify_type (x)	\
+				     + 3) & -4) == 4, (x), 0U))
+# define _SDT_ARGSIGNED(x)						\
+  (!__extension__							\
+   (__builtin_constant_p ((((unsigned long long)			\
+			    (_SDT_ARGINTTYPE (x)) __sdt_unsp)		\
+			   & ((unsigned long long)1 << (sizeof (unsigned long long)	\
+				       * __CHAR_BIT__ - 1))) == 0)	\
+    || (_SDT_ARGINTTYPE (x)) -1 > (_SDT_ARGINTTYPE (x)) 0))
+# define _SDT_ARGSIZE(x)	\
+  (_SDT_ARGARRAY (x) ? sizeof (void *) : sizeof (x))
+# define _SDT_ARGVAL(x)		(x)
+#endif
+
+#if defined __powerpc__ || defined __powerpc64__
+# define _SDT_ARGTMPL(id)	%I[id]%[id]
+#elif defined __i386__
+# define _SDT_ARGTMPL(id)	%w[id]  /* gcc.gnu.org/PR80115 */
+#else
+# define _SDT_ARGTMPL(id)	%[id]
+#endif
+
+#ifdef __LP64__
+# define _SDT_ASM_ADDR	.8byte
+#else
+# define _SDT_ASM_ADDR	.4byte
+#endif
+
+/* The ia64 and s390 nop instructions take an argument. */
+#if defined(__ia64__) || defined(__s390__) || defined(__s390x__)
+#define _SDT_NOP	nop 0
+#else
+#define _SDT_NOP	nop
+#endif
+
+#define _SDT_NOTE_NAME	"stapsdt"
+#define _SDT_NOTE_TYPE	3
+
+/* If the assembler supports the necessary feature, then we can play
+   nice with code in COMDAT sections, which comes up in C++ code.
+   Without that assembler support, some combinations of probe placements
+   in certain kinds of C++ code may produce link-time errors.
+#include "sdt-config.h"
+*/
+#if _SDT_ASM_SECTION_AUTOGROUP_SUPPORT
+# define _SDT_ASM_AUTOGROUP "?"
+#else
+# define _SDT_ASM_AUTOGROUP ""
+#endif
+
+#define _SDT_ASM_BODY(provider, name, pack_args, args)			      \
+  _SDT_ASM_1(990:	_SDT_NOP)					      \
+  _SDT_ASM_3(		.pushsection .note.stapsdt,_SDT_ASM_AUTOGROUP,"note") \
+  _SDT_ASM_1(		.balign 4)					      \
+  _SDT_ASM_3(		.4byte 992f-991f, 994f-993f, _SDT_NOTE_TYPE)	      \
+  _SDT_ASM_1(991:	.asciz _SDT_NOTE_NAME)				      \
+  _SDT_ASM_1(992:	.balign 4)					      \
+  _SDT_ASM_1(993:	_SDT_ASM_ADDR 990b)				      \
+  _SDT_ASM_1(		_SDT_ASM_ADDR _.stapsdt.base)			      \
+  _SDT_SEMAPHORE(provider,name)						      \
+  _SDT_ASM_STRING(provider)						      \
+  _SDT_ASM_STRING(name)							      \
+  pack_args args							      \
+  _SDT_ASM_1(994:	.balign 4)					      \
+  _SDT_ASM_1(		.popsection)
+
+#define _SDT_ASM_BASE							      \
+  _SDT_ASM_1(.ifndef _.stapsdt.base)					      \
+  _SDT_ASM_5(		.pushsection .stapsdt.base,"aG","progbits",	      \
+							.stapsdt.base,comdat) \
+  _SDT_ASM_1(		.weak _.stapsdt.base)				      \
+  _SDT_ASM_1(		.hidden _.stapsdt.base)				      \
+  _SDT_ASM_1(	_.stapsdt.base: .space 1)				      \
+  _SDT_ASM_2(		.size _.stapsdt.base, 1)			      \
+  _SDT_ASM_1(		.popsection)					      \
+  _SDT_ASM_1(.endif)
+
+#if defined _SDT_HAS_SEMAPHORES
+#define _SDT_SEMAPHORE(p,n) _SDT_ASM_1(		_SDT_ASM_ADDR p##_##n##_semaphore)
+#else
+#define _SDT_SEMAPHORE(p,n) _SDT_ASM_1(		_SDT_ASM_ADDR 0)
+#endif
+
+#define _SDT_ASM_TEMPLATE_0		/* no arguments */
+#define _SDT_ASM_TEMPLATE_1		_SDT_ARGFMT(1)
+#define _SDT_ASM_TEMPLATE_2		_SDT_ASM_TEMPLATE_1 _SDT_ARGFMT(2)
+#define _SDT_ASM_TEMPLATE_3		_SDT_ASM_TEMPLATE_2 _SDT_ARGFMT(3)
+#define _SDT_ASM_TEMPLATE_4		_SDT_ASM_TEMPLATE_3 _SDT_ARGFMT(4)
+#define _SDT_ASM_TEMPLATE_5		_SDT_ASM_TEMPLATE_4 _SDT_ARGFMT(5)
+#define _SDT_ASM_TEMPLATE_6		_SDT_ASM_TEMPLATE_5 _SDT_ARGFMT(6)
+#define _SDT_ASM_TEMPLATE_7		_SDT_ASM_TEMPLATE_6 _SDT_ARGFMT(7)
+#define _SDT_ASM_TEMPLATE_8		_SDT_ASM_TEMPLATE_7 _SDT_ARGFMT(8)
+#define _SDT_ASM_TEMPLATE_9		_SDT_ASM_TEMPLATE_8 _SDT_ARGFMT(9)
+#define _SDT_ASM_TEMPLATE_10		_SDT_ASM_TEMPLATE_9 _SDT_ARGFMT(10)
+#define _SDT_ASM_TEMPLATE_11		_SDT_ASM_TEMPLATE_10 _SDT_ARGFMT(11)
+#define _SDT_ASM_TEMPLATE_12		_SDT_ASM_TEMPLATE_11 _SDT_ARGFMT(12)
+#define _SDT_ASM_OPERANDS_0()		[__sdt_dummy] "g" (0)
+#define _SDT_ASM_OPERANDS_1(arg1)	_SDT_ARG(1, arg1)
+#define _SDT_ASM_OPERANDS_2(arg1, arg2) \
+  _SDT_ASM_OPERANDS_1(arg1), _SDT_ARG(2, arg2)
+#define _SDT_ASM_OPERANDS_3(arg1, arg2, arg3) \
+  _SDT_ASM_OPERANDS_2(arg1, arg2), _SDT_ARG(3, arg3)
+#define _SDT_ASM_OPERANDS_4(arg1, arg2, arg3, arg4) \
+  _SDT_ASM_OPERANDS_3(arg1, arg2, arg3), _SDT_ARG(4, arg4)
+#define _SDT_ASM_OPERANDS_5(arg1, arg2, arg3, arg4, arg5) \
+  _SDT_ASM_OPERANDS_4(arg1, arg2, arg3, arg4), _SDT_ARG(5, arg5)
+#define _SDT_ASM_OPERANDS_6(arg1, arg2, arg3, arg4, arg5, arg6) \
+  _SDT_ASM_OPERANDS_5(arg1, arg2, arg3, arg4, arg5), _SDT_ARG(6, arg6)
+#define _SDT_ASM_OPERANDS_7(arg1, arg2, arg3, arg4, arg5, arg6, arg7) \
+  _SDT_ASM_OPERANDS_6(arg1, arg2, arg3, arg4, arg5, arg6), _SDT_ARG(7, arg7)
+#define _SDT_ASM_OPERANDS_8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) \
+  _SDT_ASM_OPERANDS_7(arg1, arg2, arg3, arg4, arg5, arg6, arg7), \
+    _SDT_ARG(8, arg8)
+#define _SDT_ASM_OPERANDS_9(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9) \
+  _SDT_ASM_OPERANDS_8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8), \
+    _SDT_ARG(9, arg9)
+#define _SDT_ASM_OPERANDS_10(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10) \
+  _SDT_ASM_OPERANDS_9(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9), \
+    _SDT_ARG(10, arg10)
+#define _SDT_ASM_OPERANDS_11(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11) \
+  _SDT_ASM_OPERANDS_10(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10), \
+    _SDT_ARG(11, arg11)
+#define _SDT_ASM_OPERANDS_12(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12) \
+  _SDT_ASM_OPERANDS_11(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11), \
+    _SDT_ARG(12, arg12)
+
+/* These macros can be used in C, C++, or assembly code.
+   In assembly code the arguments should use normal assembly operand syntax.  */
+
+#define STAP_PROBE(provider, name) \
+  _SDT_PROBE(provider, name, 0, ())
+#define STAP_PROBE1(provider, name, arg1) \
+  _SDT_PROBE(provider, name, 1, (arg1))
+#define STAP_PROBE2(provider, name, arg1, arg2) \
+  _SDT_PROBE(provider, name, 2, (arg1, arg2))
+#define STAP_PROBE3(provider, name, arg1, arg2, arg3) \
+  _SDT_PROBE(provider, name, 3, (arg1, arg2, arg3))
+#define STAP_PROBE4(provider, name, arg1, arg2, arg3, arg4) \
+  _SDT_PROBE(provider, name, 4, (arg1, arg2, arg3, arg4))
+#define STAP_PROBE5(provider, name, arg1, arg2, arg3, arg4, arg5) \
+  _SDT_PROBE(provider, name, 5, (arg1, arg2, arg3, arg4, arg5))
+#define STAP_PROBE6(provider, name, arg1, arg2, arg3, arg4, arg5, arg6)	\
+  _SDT_PROBE(provider, name, 6, (arg1, arg2, arg3, arg4, arg5, arg6))
+#define STAP_PROBE7(provider, name, arg1, arg2, arg3, arg4, arg5, arg6, arg7) \
+  _SDT_PROBE(provider, name, 7, (arg1, arg2, arg3, arg4, arg5, arg6, arg7))
+#define STAP_PROBE8(provider,name,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8) \
+  _SDT_PROBE(provider, name, 8, (arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8))
+#define STAP_PROBE9(provider,name,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)\
+  _SDT_PROBE(provider, name, 9, (arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9))
+#define STAP_PROBE10(provider,name,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10) \
+  _SDT_PROBE(provider, name, 10, \
+	     (arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10))
+#define STAP_PROBE11(provider,name,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11) \
+  _SDT_PROBE(provider, name, 11, \
+	     (arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11))
+#define STAP_PROBE12(provider,name,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12) \
+  _SDT_PROBE(provider, name, 12, \
+	     (arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12))
+
+/* This STAP_PROBEV macro can be used in variadic scenarios, where the
+   number of probe arguments is not known until compile time.  Since
+   variadic macro support may vary with compiler options, you must
+   pre-#define SDT_USE_VARIADIC to enable this type of probe.
+
+   The trick to count __VA_ARGS__ was inspired by this post by
+   Laurent Deniau <laurent.deniau@cern.ch>:
+       http://groups.google.com/group/comp.std.c/msg/346fc464319b1ee5
+
+   Note that our _SDT_NARG is called with an extra 0 arg that's not
+   counted, so we don't have to worry about the behavior of macros
+   called without any arguments.  */
+
+#ifdef SDT_USE_VARIADIC
+#define _SDT_NARG(...) __SDT_NARG(__VA_ARGS__, 12,11,10,9,8,7,6,5,4,3,2,1,0)
+#define __SDT_NARG(_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12, N, ...) N
+#define _SDT_PROBE_N(provider, name, N, ...) \
+  _SDT_PROBE(provider, name, N, (__VA_ARGS__))
+#define STAP_PROBEV(provider, name, ...) \
+  _SDT_PROBE_N(provider, name, _SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+#endif
+
+/* These macros are for use in asm statements.  You must compile
+   with -std=gnu99 or -std=c99 to use the STAP_PROBE_ASM macro.
+
+   The STAP_PROBE_ASM macro generates a quoted string to be used in the
+   template portion of the asm statement, concatenated with strings that
+   contain the actual assembly code around the probe site.
+
+   For example:
+
+	asm ("before\n"
+	     STAP_PROBE_ASM(provider, fooprobe, %eax 4(%esi))
+	     "after");
+
+   emits the assembly code for "before\nafter", with a probe in between.
+   The probe arguments are the %eax register, and the value of the memory
+   word located 4 bytes past the address in the %esi register.  Note that
+   because this is a simple asm, not a GNU C extended asm statement, these
+   % characters do not need to be doubled to generate literal %reg names.
+
+   In a GNU C extended asm statement, the probe arguments can be specified
+   using the macro STAP_PROBE_ASM_TEMPLATE(n) for n arguments.  The paired
+   macro STAP_PROBE_ASM_OPERANDS gives the C values of these probe arguments,
+   and appears in the input operand list of the asm statement.  For example:
+
+	asm ("someinsn %0,%1\n" // %0 is output operand, %1 is input operand
+	     STAP_PROBE_ASM(provider, fooprobe, STAP_PROBE_ASM_TEMPLATE(3))
+	     "otherinsn %[namedarg]"
+	     : "r" (outvar)
+	     : "g" (some_value), [namedarg] "i" (1234),
+	       STAP_PROBE_ASM_OPERANDS(3, some_value, some_ptr->field, 1234));
+
+    This is just like writing:
+
+	STAP_PROBE3(provider, fooprobe, some_value, some_ptr->field, 1234));
+
+    but the probe site is right between "someinsn" and "otherinsn".
+
+    The probe arguments in STAP_PROBE_ASM can be given as assembly
+    operands instead, even inside a GNU C extended asm statement.
+    Note that these can use operand templates like %0 or %[name],
+    and likewise they must write %%reg for a literal operand of %reg.  */
+
+#if __STDC_VERSION__ >= 199901L
+# define STAP_PROBE_ASM(provider, name, ...)		\
+  _SDT_ASM_BODY(provider, name, _SDT_ASM_STRING, (__VA_ARGS__)) \
+  _SDT_ASM_BASE
+# define STAP_PROBE_ASM_OPERANDS(n, ...) _SDT_ASM_OPERANDS_##n(__VA_ARGS__)
+#else
+# define STAP_PROBE_ASM(provider, name, args)	\
+  _SDT_ASM_BODY(provider, name, _SDT_ASM_STRING, (args)) \
+  _SDT_ASM_BASE
+#endif
+#define STAP_PROBE_ASM_TEMPLATE(n)	_SDT_ASM_TEMPLATE_##n
+
+
+/* DTrace compatible macro names.  */
+#define DTRACE_PROBE(provider,probe)		\
+  STAP_PROBE(provider,probe)
+#define DTRACE_PROBE1(provider,probe,parm1)	\
+  STAP_PROBE1(provider,probe,parm1)
+#define DTRACE_PROBE2(provider,probe,parm1,parm2)	\
+  STAP_PROBE2(provider,probe,parm1,parm2)
+#define DTRACE_PROBE3(provider,probe,parm1,parm2,parm3) \
+  STAP_PROBE3(provider,probe,parm1,parm2,parm3)
+#define DTRACE_PROBE4(provider,probe,parm1,parm2,parm3,parm4)	\
+  STAP_PROBE4(provider,probe,parm1,parm2,parm3,parm4)
+#define DTRACE_PROBE5(provider,probe,parm1,parm2,parm3,parm4,parm5)	\
+  STAP_PROBE5(provider,probe,parm1,parm2,parm3,parm4,parm5)
+#define DTRACE_PROBE6(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6) \
+  STAP_PROBE6(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6)
+#define DTRACE_PROBE7(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7) \
+  STAP_PROBE7(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7)
+#define DTRACE_PROBE8(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8) \
+  STAP_PROBE8(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8)
+#define DTRACE_PROBE9(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9) \
+  STAP_PROBE9(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9)
+#define DTRACE_PROBE10(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10) \
+  STAP_PROBE10(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10)
+#define DTRACE_PROBE11(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10,parm11) \
+  STAP_PROBE11(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10,parm11)
+#define DTRACE_PROBE12(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10,parm11,parm12) \
+  STAP_PROBE12(provider,probe,parm1,parm2,parm3,parm4,parm5,parm6,parm7,parm8,parm9,parm10,parm11,parm12)
+
+
+#endif /* sys/sdt.h */

--- a/include/h2o/tracing.h
+++ b/include/h2o/tracing.h
@@ -16,21 +16,14 @@ extern "C" {
 #define H2O_TRACE_RES        ((uint64_t)1<<4)
 #define H2O_TRACE_TXHD       ((uint64_t)1<<5)
 #define H2O_TRACE_RXHD       ((uint64_t)1<<6)
-#define H2O_TRACE_PROXY_REQ  ((uint64_t)1<<7)
-#define H2O_TRACE_PROXY_RES  ((uint64_t)1<<8)
-#define H2O_TRACE_PROXY_TXHD ((uint64_t)1<<9)
-#define H2O_TRACE_PROXY_RXHD ((uint64_t)1<<10)
+#define H2O_TRACE_PROXY      ((uint64_t)1<<7)
+#define H2O_TRACE_PROXY_REQ  ((uint64_t)1<<8)
+#define H2O_TRACE_PROXY_RES  ((uint64_t)1<<9)
+#define H2O_TRACE_PROXY_TXHD ((uint64_t)1<<10)
+#define H2O_TRACE_PROXY_RXHD ((uint64_t)1<<11)
 
-struct st_h2o_tracing_conn_t {
-    h2o_conn_t super;
-    h2o_socket_t *sock;
-
-    /* internal structure */
-    h2o_linklist_t _conns;
-    h2o_req_t req;
-};
-
-void h2o_tracing_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at);
+void h2o_tracing_on_data(h2o_socket_t *sock);
+void h2o_tracing_on_read(h2o_socket_t *sock, const char *err);
 
 extern uint64_t h2o_tracing_now;
 

--- a/include/h2o/tracing.h
+++ b/include/h2o/tracing.h
@@ -1,0 +1,42 @@
+#ifndef h2o__tracing_h
+#define h2o__tracing_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// MSB indicates tracepoint should be disabled
+#define H2O_TRACE_REMOVE_PROBE ((uint64_t)1<<63)
+
+// list of available tracepoints
+#define H2O_TRACE_SSLNEW     ((uint64_t)1<<0)
+#define H2O_TRACE_H1NEW      ((uint64_t)1<<1)
+#define H2O_TRACE_H2NEW      ((uint64_t)1<<2)
+#define H2O_TRACE_REQ        ((uint64_t)1<<3)
+#define H2O_TRACE_RES        ((uint64_t)1<<4)
+#define H2O_TRACE_TXHD       ((uint64_t)1<<5)
+#define H2O_TRACE_RXHD       ((uint64_t)1<<6)
+#define H2O_TRACE_PROXY_REQ  ((uint64_t)1<<7)
+#define H2O_TRACE_PROXY_RES  ((uint64_t)1<<8)
+#define H2O_TRACE_PROXY_TXHD ((uint64_t)1<<9)
+#define H2O_TRACE_PROXY_RXHD ((uint64_t)1<<10)
+
+struct st_h2o_tracing_conn_t {
+    h2o_conn_t super;
+    h2o_socket_t *sock;
+
+    /* internal structure */
+    h2o_linklist_t _conns;
+    h2o_req_t req;
+};
+
+void h2o_tracing_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at);
+
+extern uint64_t h2o_tracing_now;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/lib/common/tracing.c
+++ b/lib/common/tracing.c
@@ -1,7 +1,6 @@
 #include "h2o.h"
 #include <h2o/sdt.h>
 #include <h2o/tracing.h>
-#include <fcntl.h>
 
 // tracer payload size
 #define PAYLOAD_SZ 150

--- a/lib/common/tracing.c
+++ b/lib/common/tracing.c
@@ -3,30 +3,28 @@
 #include <h2o/tracing.h>
 #include <fcntl.h>
 
-// ebpf tracer payload size
-#define EBPF_P0_SZ 150
-#define EBPF_P1_SZ 50
-#define EBPF_P2_SZ 50
+// tracer payload size
+#define PAYLOAD_SZ 150
 
 #define DOING_TRACE(trace) ((h2o_tracing_now & trace) == trace)
 
 #define CONN_GET_FD(conn) h2o_socket_get_fd((conn)->callbacks->get_socket(conn))
 
-#define STRINGIFY_VECT_TO_P0(vect, append)                                                                                         \
+#define VECT_TO_PAYLOAD(vect, append)                                                                                              \
     do {                                                                                                                           \
-        int _len = EBPF_P0_SZ - i - 2 > (vect).len ? (vect).len : EBPF_P0_SZ - i - 2;                                              \
-        memcpy(&payload0[i], (vect).base, _len);                                                                                   \
+        int _len = PAYLOAD_SZ - i - 2 > (vect).len ? (vect).len : PAYLOAD_SZ - i - 2;                                              \
+        memcpy(&payload[i], (vect).base, _len);                                                                                    \
         i += _len;                                                                                                                 \
-        payload0[i++] = append;                                                                                                    \
+        payload[i++] = append;                                                                                                     \
     } while (0)
 
-#define STRINGIFY_HEADER_TO_P0(hd)                                                                                                 \
+#define HEADER_TO_PAYLOAD(hd)                                                                                                      \
     do {                                                                                                                           \
-        STRINGIFY_VECT_TO_P0(*(hd->name), ' ');                                                                                    \
-        STRINGIFY_VECT_TO_P0(hd->value, '\0');                                                                                     \
+        VECT_TO_PAYLOAD(*(hd->name), ' ');                                                                                         \
+        VECT_TO_PAYLOAD(hd->value, '\0');                                                                                          \
     } while (0)
 
-void stringify_ip_tuple(char *payload, h2o_socket_t *sock)
+void ip_tuple(char *payload, h2o_socket_t *sock)
 {
     char sockname[50];
     char peername[50];
@@ -41,7 +39,7 @@ void stringify_ip_tuple(char *payload, h2o_socket_t *sock)
     salen = h2o_socket_getpeername(sock, (void *)&sa);
     h2o_socket_getnumerichost((void *)&sa, salen, &peername[0]);
     peerport = h2o_socket_getport((void *)&sa);
-    snprintf(payload, EBPF_P0_SZ, "%s:%d %s:%d", sockname, sockport, peername, peerport);
+    snprintf(payload, PAYLOAD_SZ, "%s:%d %s:%d", sockname, sockport, peername, peerport);
 }
 
 void h2o_trace_newssl(struct timeval ts, h2o_socket_t *sock)
@@ -49,11 +47,10 @@ void h2o_trace_newssl(struct timeval ts, h2o_socket_t *sock)
     if (!DOING_TRACE(H2O_TRACE_SSLNEW)) {
         return;
     }
-    char payload0[EBPF_P2_SZ];
+    char payload[PAYLOAD_SZ];
     h2o_iovec_t sessId = h2o_socket_get_ssl_session_id(sock);
-    snprintf(&payload0[0], EBPF_P2_SZ, "%p", &sessId.base);
-    DTRACE_PROBE6(h2otrace, SSLNew, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), h2o_socket_get_ssl_protocol_version(sock),
-                  h2o_socket_get_ssl_cipher(sock), &payload0[0]);
+    snprintf(&payload[0], PAYLOAD_SZ, "%s %s %p", h2o_socket_get_ssl_protocol_version(sock), h2o_socket_get_ssl_cipher(sock), &sessId.base);
+    DTRACE_PROBE4(h2otrace, SSLNew, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), &payload[0]);
 }
 
 void h2o_trace_newh1(struct timeval ts, h2o_socket_t *sock)
@@ -61,9 +58,9 @@ void h2o_trace_newh1(struct timeval ts, h2o_socket_t *sock)
     if (!DOING_TRACE(H2O_TRACE_H1NEW)) {
         return;
     }
-    char payload0[EBPF_P0_SZ];
-    stringify_ip_tuple(&payload0[0], sock);
-    DTRACE_PROBE4(h2otrace, NewConnH1, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), &payload0[0]);
+    char payload[PAYLOAD_SZ];
+    ip_tuple(&payload[0], sock);
+    DTRACE_PROBE4(h2otrace, NewConnH1, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), &payload[0]);
 }
 
 void h2o_trace_newh2(struct timeval ts, h2o_socket_t *sock)
@@ -71,9 +68,9 @@ void h2o_trace_newh2(struct timeval ts, h2o_socket_t *sock)
     if (!DOING_TRACE(H2O_TRACE_H2NEW)) {
         return;
     }
-    char payload0[EBPF_P0_SZ];
-    stringify_ip_tuple(&payload0[0], sock);
-    DTRACE_PROBE4(h2otrace, NewConnH2, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), &payload0[0]);
+    char payload[PAYLOAD_SZ];
+    ip_tuple(&payload[0], sock);
+    DTRACE_PROBE4(h2otrace, NewConnH2, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), &payload[0]);
 }
 
 void h2o_trace_req(h2o_req_t *req)
@@ -84,20 +81,20 @@ void h2o_trace_req(h2o_req_t *req)
     int i = 0;
     h2o_headers_t *hds = &req->headers;
     struct timeval ts = req->conn->connected_at;
-    char payload0[EBPF_P0_SZ];
+    char payload[PAYLOAD_SZ];
 
     for (int j = 0; DOING_TRACE(H2O_TRACE_RXHD) && j < hds->size; j++, i = 0) {
         h2o_header_t *hd = &hds->entries[j];
-        STRINGIFY_HEADER_TO_P0(hd);
-        DTRACE_PROBE4(h2otrace, RxHeader, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+        HEADER_TO_PAYLOAD(hd);
+        DTRACE_PROBE4(h2otrace, RxHeader, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
     }
 
     if (DOING_TRACE(H2O_TRACE_REQ)) {
-        i = h2o_stringify_protocol_version(&payload0[0], req->version);
-        payload0[i++] = ' ';
-        STRINGIFY_VECT_TO_P0(req->method, ' ');
-        STRINGIFY_VECT_TO_P0(req->path, '\0');
-        DTRACE_PROBE4(h2otrace, NewReq, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+        i = h2o_stringify_protocol_version(&payload[0], req->version);
+        payload[i++] = ' ';
+        VECT_TO_PAYLOAD(req->method, ' ');
+        VECT_TO_PAYLOAD(req->path, '\0');
+        DTRACE_PROBE4(h2otrace, NewReq, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
     }
 }
 
@@ -110,18 +107,18 @@ void h2o_trace_res(h2o_req_t *req)
     h2o_res_t *res = &req->res;
     h2o_headers_t *hds = &res->headers;
     struct timeval ts = req->conn->connected_at;
-    char payload0[EBPF_P0_SZ];
+    char payload[PAYLOAD_SZ];
 
     for (int j = 0; DOING_TRACE(H2O_TRACE_TXHD) && j < hds->size; j++, i = 0) {
         h2o_header_t *hd = &hds->entries[j];
-        STRINGIFY_HEADER_TO_P0(hd);
-        DTRACE_PROBE4(h2otrace, TxHeader, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+        HEADER_TO_PAYLOAD(hd);
+        DTRACE_PROBE4(h2otrace, TxHeader, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
     }
 
     if (DOING_TRACE(H2O_TRACE_RES)) {
-        i = h2o_stringify_protocol_version(&payload0[0], req->version);
-        snprintf(&payload0[i], EBPF_P0_SZ - i, " %d len: %ld", res->status, res->content_length);
-        DTRACE_PROBE4(h2otrace, NewRes, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+        i = h2o_stringify_protocol_version(&payload[0], req->version);
+        snprintf(&payload[i], PAYLOAD_SZ - i, " %d len: %ld", res->status, res->content_length);
+        DTRACE_PROBE4(h2otrace, NewRes, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
     }
 }
 
@@ -133,23 +130,25 @@ void h2o_trace_proxyreq(h2o_req_t *req)
     int i = 0;
     h2o_headers_t *hds = &req->headers;
     struct timeval ts = req->conn->connected_at;
-    char payload0[EBPF_P0_SZ];
+    char payload[PAYLOAD_SZ];
 
-    STRINGIFY_VECT_TO_P0(req->authority, '\0');
-    DTRACE_PROBE4(h2otrace, Proxy, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    if (DOING_TRACE(H2O_TRACE_PROXY)) {
+        VECT_TO_PAYLOAD(req->authority, '\0');
+        DTRACE_PROBE4(h2otrace, Proxy, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
+    }
 
     for (int j = 0, i = 0; DOING_TRACE(H2O_TRACE_PROXY_TXHD) && j < hds->size; j++, i = 0) {
         h2o_header_t *hd = &hds->entries[j];
-        STRINGIFY_HEADER_TO_P0(hd);
-        DTRACE_PROBE4(h2otrace, ProxyTxHdr, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+        HEADER_TO_PAYLOAD(hd);
+        DTRACE_PROBE4(h2otrace, ProxyTxHdr, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
     }
 
     if (DOING_TRACE(H2O_TRACE_PROXY_REQ)) {
-        i = h2o_stringify_protocol_version(&payload0[0], 0x101);
-        payload0[i++] = ' ';
-        STRINGIFY_VECT_TO_P0(req->method, ' ');
-        STRINGIFY_VECT_TO_P0(req->path, '\0');
-        DTRACE_PROBE4(h2otrace, ProxyNewReq, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+        i = h2o_stringify_protocol_version(&payload[0], 0x101);
+        payload[i++] = ' ';
+        VECT_TO_PAYLOAD(req->method, ' ');
+        VECT_TO_PAYLOAD(req->path, '\0');
+        DTRACE_PROBE4(h2otrace, ProxyNewReq, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
     }
 }
 
@@ -162,17 +161,17 @@ void h2o_trace_proxyres(h2o_req_t *req)
     h2o_res_t *res = &req->res;
     h2o_headers_t *hds = &res->headers;
     struct timeval ts = req->conn->connected_at;
-    char payload0[EBPF_P0_SZ];
+    char payload[PAYLOAD_SZ];
 
     for (int j = 0; DOING_TRACE(H2O_TRACE_PROXY_RXHD) && j < hds->size; j++, i = 0) {
         h2o_header_t *hd = &hds->entries[j];
-        STRINGIFY_HEADER_TO_P0(hd);
-        DTRACE_PROBE4(h2otrace, ProxyRxHdr, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+        HEADER_TO_PAYLOAD(hd);
+        DTRACE_PROBE4(h2otrace, ProxyRxHdr, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
     }
 
     if (DOING_TRACE(H2O_TRACE_PROXY_RES)) {
-        i = h2o_stringify_protocol_version(&payload0[0], 0x101);
-        snprintf(&payload0[i], EBPF_P0_SZ - i, " %d len: %ld", res->status, res->content_length);
-        DTRACE_PROBE4(h2otrace, ProxyNewRes, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+        i = h2o_stringify_protocol_version(&payload[0], 0x101);
+        snprintf(&payload[i], PAYLOAD_SZ - i, " %d len: %ld", res->status, res->content_length);
+        DTRACE_PROBE4(h2otrace, ProxyNewRes, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload[0]);
     }
 }

--- a/lib/common/tracing.c
+++ b/lib/common/tracing.c
@@ -1,0 +1,178 @@
+#include "h2o.h"
+#include <h2o/sdt.h>
+#include <h2o/tracing.h>
+#include <fcntl.h>
+
+// ebpf tracer payload size
+#define EBPF_P0_SZ 150
+#define EBPF_P1_SZ 50
+#define EBPF_P2_SZ 50
+
+#define DOING_TRACE(trace) ((h2o_tracing_now & trace) == trace)
+
+#define CONN_GET_FD(conn) h2o_socket_get_fd((conn)->callbacks->get_socket(conn))
+
+#define STRINGIFY_VECT_TO_P0(vect, append)                                                                                         \
+    do {                                                                                                                           \
+        int _len = EBPF_P0_SZ - i - 2 > (vect).len ? (vect).len : EBPF_P0_SZ - i - 2;                                              \
+        memcpy(&payload0[i], (vect).base, _len);                                                                                   \
+        i += _len;                                                                                                                 \
+        payload0[i++] = append;                                                                                                    \
+    } while (0)
+
+#define STRINGIFY_HEADER_TO_P0(hd)                                                                                                 \
+    do {                                                                                                                           \
+        STRINGIFY_VECT_TO_P0(*(hd->name), ' ');                                                                                    \
+        STRINGIFY_VECT_TO_P0(hd->value, '\0');                                                                                     \
+    } while (0)
+
+void stringify_ip_tuple(char *payload, h2o_socket_t *sock)
+{
+    char sockname[50];
+    char peername[50];
+    int32_t sockport, peerport;
+    struct sockaddr_storage sa;
+    socklen_t salen;
+
+    salen = h2o_socket_getsockname(sock, (void *)&sa);
+    h2o_socket_getnumerichost((void *)&sa, salen, &sockname[0]);
+    sockport = h2o_socket_getport((void *)&sa);
+
+    salen = h2o_socket_getpeername(sock, (void *)&sa);
+    h2o_socket_getnumerichost((void *)&sa, salen, &peername[0]);
+    peerport = h2o_socket_getport((void *)&sa);
+    snprintf(payload, EBPF_P0_SZ, "%s:%d %s:%d", sockname, sockport, peername, peerport);
+}
+
+void h2o_trace_newssl(struct timeval ts, h2o_socket_t *sock)
+{
+    if (!DOING_TRACE(H2O_TRACE_SSLNEW)) {
+        return;
+    }
+    char payload0[EBPF_P2_SZ];
+    h2o_iovec_t sessId = h2o_socket_get_ssl_session_id(sock);
+    snprintf(&payload0[0], EBPF_P2_SZ, "%p", &sessId.base);
+    DTRACE_PROBE6(h2otrace, SSLNew, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), h2o_socket_get_ssl_protocol_version(sock),
+                  h2o_socket_get_ssl_cipher(sock), &payload0[0]);
+}
+
+void h2o_trace_newh1(struct timeval ts, h2o_socket_t *sock)
+{
+    if (!DOING_TRACE(H2O_TRACE_H1NEW)) {
+        return;
+    }
+    char payload0[EBPF_P0_SZ];
+    stringify_ip_tuple(&payload0[0], sock);
+    DTRACE_PROBE4(h2otrace, NewConnH1, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), &payload0[0]);
+}
+
+void h2o_trace_newh2(struct timeval ts, h2o_socket_t *sock)
+{
+    if (!DOING_TRACE(H2O_TRACE_H2NEW)) {
+        return;
+    }
+    char payload0[EBPF_P0_SZ];
+    stringify_ip_tuple(&payload0[0], sock);
+    DTRACE_PROBE4(h2otrace, NewConnH2, ts.tv_sec, ts.tv_usec, h2o_socket_get_fd(sock), &payload0[0]);
+}
+
+void h2o_trace_req(h2o_req_t *req)
+{
+    if (!DOING_TRACE(H2O_TRACE_REQ) && !DOING_TRACE(H2O_TRACE_RXHD)) {
+        return;
+    }
+    int i = 0;
+    h2o_headers_t *hds = &req->headers;
+    struct timeval ts = req->conn->connected_at;
+    char payload0[EBPF_P0_SZ];
+
+    for (int j = 0; DOING_TRACE(H2O_TRACE_RXHD) && j < hds->size; j++, i = 0) {
+        h2o_header_t *hd = &hds->entries[j];
+        STRINGIFY_HEADER_TO_P0(hd);
+        DTRACE_PROBE4(h2otrace, RxHeader, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    }
+
+    if (DOING_TRACE(H2O_TRACE_REQ)) {
+        i = h2o_stringify_protocol_version(&payload0[0], req->version);
+        payload0[i++] = ' ';
+        STRINGIFY_VECT_TO_P0(req->method, ' ');
+        STRINGIFY_VECT_TO_P0(req->path, '\0');
+        DTRACE_PROBE4(h2otrace, NewReq, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    }
+}
+
+void h2o_trace_res(h2o_req_t *req)
+{
+    if (!DOING_TRACE(H2O_TRACE_RES) && !DOING_TRACE(H2O_TRACE_TXHD)) {
+        return;
+    }
+    int i = 0;
+    h2o_res_t *res = &req->res;
+    h2o_headers_t *hds = &res->headers;
+    struct timeval ts = req->conn->connected_at;
+    char payload0[EBPF_P0_SZ];
+
+    for (int j = 0; DOING_TRACE(H2O_TRACE_TXHD) && j < hds->size; j++, i = 0) {
+        h2o_header_t *hd = &hds->entries[j];
+        STRINGIFY_HEADER_TO_P0(hd);
+        DTRACE_PROBE4(h2otrace, TxHeader, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    }
+
+    if (DOING_TRACE(H2O_TRACE_RES)) {
+        i = h2o_stringify_protocol_version(&payload0[0], req->version);
+        snprintf(&payload0[i], EBPF_P0_SZ - i, " %d len: %ld", res->status, res->content_length);
+        DTRACE_PROBE4(h2otrace, NewRes, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    }
+}
+
+void h2o_trace_proxyreq(h2o_req_t *req)
+{
+    if (!DOING_TRACE(H2O_TRACE_PROXY_REQ) && !DOING_TRACE(H2O_TRACE_PROXY_TXHD)) {
+        return;
+    }
+    int i = 0;
+    h2o_headers_t *hds = &req->headers;
+    struct timeval ts = req->conn->connected_at;
+    char payload0[EBPF_P0_SZ];
+
+    STRINGIFY_VECT_TO_P0(req->authority, '\0');
+    DTRACE_PROBE4(h2otrace, Proxy, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+
+    for (int j = 0, i = 0; DOING_TRACE(H2O_TRACE_PROXY_TXHD) && j < hds->size; j++, i = 0) {
+        h2o_header_t *hd = &hds->entries[j];
+        STRINGIFY_HEADER_TO_P0(hd);
+        DTRACE_PROBE4(h2otrace, ProxyTxHdr, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    }
+
+    if (DOING_TRACE(H2O_TRACE_PROXY_REQ)) {
+        i = h2o_stringify_protocol_version(&payload0[0], 0x101);
+        payload0[i++] = ' ';
+        STRINGIFY_VECT_TO_P0(req->method, ' ');
+        STRINGIFY_VECT_TO_P0(req->path, '\0');
+        DTRACE_PROBE4(h2otrace, ProxyNewReq, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    }
+}
+
+void h2o_trace_proxyres(h2o_req_t *req)
+{
+    if (!DOING_TRACE(H2O_TRACE_PROXY_RES) && !DOING_TRACE(H2O_TRACE_PROXY_RXHD)) {
+        return;
+    }
+    int i = 0;
+    h2o_res_t *res = &req->res;
+    h2o_headers_t *hds = &res->headers;
+    struct timeval ts = req->conn->connected_at;
+    char payload0[EBPF_P0_SZ];
+
+    for (int j = 0; DOING_TRACE(H2O_TRACE_PROXY_RXHD) && j < hds->size; j++, i = 0) {
+        h2o_header_t *hd = &hds->entries[j];
+        STRINGIFY_HEADER_TO_P0(hd);
+        DTRACE_PROBE4(h2otrace, ProxyRxHdr, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    }
+
+    if (DOING_TRACE(H2O_TRACE_PROXY_RES)) {
+        i = h2o_stringify_protocol_version(&payload0[0], 0x101);
+        snprintf(&payload0[i], EBPF_P0_SZ - i, " %d len: %ld", res->status, res->content_length);
+        DTRACE_PROBE4(h2otrace, ProxyNewRes, ts.tv_sec, ts.tv_usec, CONN_GET_FD(req->conn), &payload0[0]);
+    }
+}

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -109,7 +109,6 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     ctx->proxy.client_ctx.http2.counter = -1;
     ctx->proxy.connpool.socketpool = &ctx->globalconf->proxy.global_socketpool;
     h2o_linklist_init_anchor(&ctx->proxy.connpool.http2.conns);
-    h2o_linklist_init_anchor(&ctx->tracing._conns);
     ctx->_module_configs = h2o_mem_alloc(sizeof(*ctx->_module_configs) * config->_num_config_slots);
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);
 

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -24,7 +24,6 @@
 #include <sys/time.h>
 #include "h2o.h"
 #include "h2o/memcached.h"
-#include "h2o/tracing.h"
 
 void h2o_context_init_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pathconf)
 {
@@ -110,6 +109,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     ctx->proxy.connpool.socketpool = &ctx->globalconf->proxy.global_socketpool;
     h2o_linklist_init_anchor(&ctx->proxy.connpool.http2.conns);
     ctx->_module_configs = h2o_mem_alloc(sizeof(*ctx->_module_configs) * config->_num_config_slots);
+
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);
 
     static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -24,6 +24,7 @@
 #include <sys/time.h>
 #include "h2o.h"
 #include "h2o/memcached.h"
+#include "h2o/tracing.h"
 
 void h2o_context_init_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pathconf)
 {
@@ -108,7 +109,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     ctx->proxy.client_ctx.http2.counter = -1;
     ctx->proxy.connpool.socketpool = &ctx->globalconf->proxy.global_socketpool;
     h2o_linklist_init_anchor(&ctx->proxy.connpool.http2.conns);
-
+    h2o_linklist_init_anchor(&ctx->tracing._conns);
     ctx->_module_configs = h2o_mem_alloc(sizeof(*ctx->_module_configs) * config->_num_config_slots);
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -288,6 +288,8 @@ static void build_request(h2o_req_t *req, h2o_iovec_t *method, h2o_url_t *url, h
         via_buf = build_request_merge_headers(&req->pool, via_buf, added, ',');
         h2o_add_header(&req->pool, headers, H2O_TOKEN_VIA, NULL, via_buf.base, via_buf.len);
     }
+
+    h2o_trace_proxyreq(req);
 }
 
 static void do_close(struct rp_generator_t *self)
@@ -529,6 +531,8 @@ static h2o_httpclient_body_cb on_head(h2o_httpclient_t *client, const char *errs
         return NULL;
     }
 
+    h2o_trace_proxyres(req);
+
     /* declare the start of the response */
     h2o_start_response(req, &self->super);
 
@@ -540,7 +544,6 @@ static h2o_httpclient_body_cb on_head(h2o_httpclient_t *client, const char *errs
 
     /* if httpclient has no received body at this time, immediately send only headers using zero timeout */
     h2o_timer_link(req->conn->ctx->loop, 0, &self->send_headers_timeout);
-
     return on_body;
 }
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -544,6 +544,7 @@ static h2o_httpclient_body_cb on_head(h2o_httpclient_t *client, const char *errs
 
     /* if httpclient has no received body at this time, immediately send only headers using zero timeout */
     h2o_timer_link(req->conn->ctx->loop, 0, &self->send_headers_timeout);
+
     return on_body;
 }
 

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -338,6 +338,8 @@ void h2o_process_request(h2o_req_t *req)
         h2o_hostconf_t *hostconf = h2o_req_setup(req);
         setup_pathconf(req, hostconf);
     }
+
+    h2o_trace_req(req);
     call_handlers(req, req->pathconf->handlers.entries);
 }
 
@@ -481,6 +483,8 @@ void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)
     } else {
         h2o_setup_next_ostream(req, &req->_ostr_top);
     }
+
+    h2o_trace_res(req);
 }
 
 void h2o_send(h2o_req_t *req, h2o_iovec_t *bufs, size_t bufcnt, h2o_send_state_t state)

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -30,7 +30,6 @@
 #include "h2o/http1.h"
 #include "h2o/http2.h"
 #include "h2o/hiredis_.h"
-#include "h2o/tracing.h"
 
 struct st_h2o_accept_data_t {
     h2o_accept_ctx_t *ctx;
@@ -516,9 +515,7 @@ void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
 {
     struct timeval connected_at = h2o_gettimeofday(ctx->ctx->loop);
 
-    if (ctx->tracing) {
-        h2o_tracing_accept(ctx, sock, connected_at);
-    } else if (ctx->expect_proxy_line || ctx->ssl_ctx != NULL) {
+    if (ctx->expect_proxy_line || ctx->ssl_ctx != NULL) {
         sock->data = accept_data_callbacks.create(ctx, sock, connected_at);
         if (ctx->expect_proxy_line) {
             h2o_socket_read_start(sock, on_read_proxy_line);

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -30,6 +30,7 @@
 #include "h2o/http1.h"
 #include "h2o/http2.h"
 #include "h2o/hiredis_.h"
+#include "h2o/tracing.h"
 
 struct st_h2o_accept_data_t {
     h2o_accept_ctx_t *ctx;
@@ -348,6 +349,8 @@ static void on_ssl_handshake_complete(h2o_socket_t *sock, const char *err)
         goto Exit;
     }
 
+    h2o_trace_newssl(data->connected_at, sock);
+
     /* stats for handshake */
     struct timeval handshake_completed_at = h2o_gettimeofday(data->ctx->ctx->loop);
     int64_t handshake_time = h2o_timeval_subtract(&data->connected_at, &handshake_completed_at);
@@ -513,7 +516,9 @@ void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock)
 {
     struct timeval connected_at = h2o_gettimeofday(ctx->ctx->loop);
 
-    if (ctx->expect_proxy_line || ctx->ssl_ctx != NULL) {
+    if (ctx->tracing) {
+        h2o_tracing_accept(ctx, sock, connected_at);
+    } else if (ctx->expect_proxy_line || ctx->ssl_ctx != NULL) {
         sock->data = accept_data_callbacks.create(ctx, sock, connected_at);
         if (ctx->expect_proxy_line) {
             h2o_socket_read_start(sock, on_read_proxy_line);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -1055,6 +1055,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
 
     init_request(conn);
     reqread_start(conn);
+    h2o_trace_newh1(connected_at, sock);
 }
 
 void h2o_http1_upgrade(h2o_req_t *req, h2o_iovec_t *inbufs, size_t inbufcnt, h2o_http1_upgrade_cb on_complete, void *user_data)

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1438,6 +1438,8 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
 
     h2o_http2_conn_t *conn = (void *)h2o_create_connection(sizeof(*conn), ctx, hosts, connected_at, &callbacks);
 
+    h2o_trace_newh2(connected_at, sock);
+
     memset((char *)conn + sizeof(conn->super), 0, sizeof(*conn) - sizeof(conn->super));
     conn->sock = sock;
     conn->peer_settings = H2O_HTTP2_SETTINGS_DEFAULT;

--- a/lib/tracing/tracing.c
+++ b/lib/tracing/tracing.c
@@ -1,0 +1,187 @@
+#include "h2o.h"
+#include "h2o/tracing.h"
+struct tracing_msg {
+    uint64_t magic;
+};
+
+enum h2o_tracing_action {
+    H2O_TRACING_ACTION_OK,
+    H2O_TRACING_ACTION_CLOSE,
+};
+
+uint64_t h2o_tracing_now;
+uint64_t should_stop_probe;
+
+#define IS_REMOVE_BIT_SET(x) ((x & H2O_TRACE_REMOVE_PROBE) == H2O_TRACE_REMOVE_PROBE)
+
+static void on_tracing_message_done(struct st_h2o_tracing_conn_t *conn, enum h2o_tracing_action action);
+
+static void close_connection(struct st_h2o_tracing_conn_t *conn, int close_socket)
+{
+    if (should_stop_probe != 0) {
+        __sync_fetch_and_and(&h2o_tracing_now, should_stop_probe);
+        __sync_fetch_and_and(&should_stop_probe, 0x0);
+    } else {
+        __sync_fetch_and_and(&h2o_tracing_now, 0x0);
+    }
+
+    if (conn->sock != NULL && close_socket)
+        h2o_socket_close(conn->sock);
+    h2o_linklist_unlink(&conn->_conns);
+    free(conn);
+}
+
+static socklen_t get_sockname(h2o_conn_t *_conn, struct sockaddr *sa)
+{
+    struct st_h2o_tracing_conn_t *conn = (void *)_conn;
+    return h2o_socket_getsockname(conn->sock, sa);
+}
+
+static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
+{
+    struct st_h2o_tracing_conn_t *conn = (void *)_conn;
+    return h2o_socket_getpeername(conn->sock, sa);
+}
+
+static h2o_socket_t *get_socket(h2o_conn_t *_conn)
+{
+    struct st_h2o_tracing_conn_t *conn = (void *)_conn;
+    return conn->sock;
+}
+
+static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata)
+{
+    h2o_linklist_t *node;
+
+    for (node = ctx->tracing._conns.next; node != &ctx->tracing._conns; node = node->next) {
+        struct st_h2o_tracing_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_tracing_conn_t, _conns, node);
+        int ret = cb(&conn->req, cbdata);
+        if (ret != 0)
+            return ret;
+    }
+    return 0;
+}
+
+static void init_request(struct st_h2o_tracing_conn_t *conn, int reinit)
+{
+    if (reinit)
+        h2o_dispose_request(&conn->req);
+    h2o_init_request(&conn->req, &conn->super, NULL);
+}
+
+static void on_tracing_message(struct st_h2o_tracing_conn_t *conn, struct tracing_msg *bmsg);
+static void handle_incoming_request(struct st_h2o_tracing_conn_t *conn)
+{
+    size_t inreqlen = conn->sock->input->size < H2O_MAX_REQLEN ? conn->sock->input->size : H2O_MAX_REQLEN;
+    struct tracing_msg *bmsg;
+
+    if (inreqlen < sizeof(*bmsg)) {
+        return;
+    }
+    bmsg = (void *)conn->sock->input->bytes;
+
+    on_tracing_message(conn, bmsg);
+}
+
+static void reqread_on_read(h2o_socket_t *sock, const char *err)
+{
+    struct st_h2o_tracing_conn_t *conn = sock->data;
+
+    if (err != NULL) {
+        close_connection(conn, 1);
+        return;
+    }
+
+    handle_incoming_request(conn);
+}
+
+static inline void reqread_start(struct st_h2o_tracing_conn_t *conn)
+{
+    h2o_socket_read_start(conn->sock, reqread_on_read);
+    if (conn->sock->input->size != 0)
+        handle_incoming_request(conn);
+}
+
+
+void on_tracing_msg_written(h2o_socket_t *sock, const char *err)
+{
+    struct st_h2o_tracing_conn_t *conn = sock->data;
+
+    if (err) {
+        on_tracing_message_done(conn, H2O_TRACING_ACTION_CLOSE);
+        return;
+    }
+    on_tracing_message_done(conn, H2O_TRACING_ACTION_OK);
+}
+
+static void on_tracing_message(struct st_h2o_tracing_conn_t *conn, struct tracing_msg *bmsg)
+{
+    if (IS_REMOVE_BIT_SET(bmsg->magic)) {
+        // add probe in disable list
+        uint64_t stopping = (~bmsg->magic) & h2o_tracing_now;
+        __sync_fetch_and_or(&should_stop_probe, stopping);
+    } else {
+        // add new tracer query to filter
+        __sync_fetch_and_or(&h2o_tracing_now, bmsg->magic);
+    }
+
+    h2o_buffer_consume(&conn->sock->input, sizeof(struct tracing_msg));
+}
+
+const h2o_protocol_callbacks_t H2O_BLINK_CALLBACKS = {
+    NULL, /* graceful_shutdown (note: nothing special needs to be done for handling graceful shutdown) */
+    foreach_request};
+
+void h2o_tracing_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at)
+{
+    static const h2o_conn_callbacks_t callbacks = {
+        get_sockname, /* stringify address */
+        get_peername, /* ditto */
+        NULL,         /* push */
+        get_socket,   /* get underlying socket */
+        NULL,         /* get debug state */
+        {{
+            {NULL}, /* ssl */
+            {NULL}, /* http1 */
+            {NULL}  /* http2 */
+        }}};
+    struct st_h2o_tracing_conn_t *conn = (void *)h2o_create_connection(sizeof(*conn), ctx->ctx, ctx->hosts, connected_at, &callbacks);
+
+    /* FIXME: zero-fill all properties expect req */
+    memset(conn, 0, sizeof(*conn));
+
+    /* init properties that need to be non-zero */
+    conn->super.ctx = ctx->ctx;
+    conn->super.hosts = ctx->hosts;
+    conn->super.connected_at = connected_at;
+    conn->super.callbacks = &callbacks;
+    conn->sock = sock;
+    sock->data = conn;
+    h2o_linklist_insert(&ctx->ctx->tracing._conns, &conn->_conns);
+
+    init_request(conn, 0);
+    reqread_start(conn);
+}
+
+void on_tracing_message_done(struct st_h2o_tracing_conn_t *conn, enum h2o_tracing_action action)
+{
+    int do_close = 0;
+
+    h2o_buffer_consume(&conn->sock->input, sizeof(struct tracing_msg));
+
+    switch (action) {
+    case H2O_TRACING_ACTION_OK:
+        reqread_start(conn);
+        break;
+    case H2O_TRACING_ACTION_CLOSE:
+        do_close = 1;
+        break;
+    default:
+        assert(0 && "Unknown action for lib/blink.c handler");
+    }
+
+    if (do_close) {
+        close_connection(conn, 1);
+    }
+    return;
+}

--- a/lib/tracing/tracing.c
+++ b/lib/tracing/tracing.c
@@ -1,12 +1,8 @@
 #include "h2o.h"
 #include "h2o/tracing.h"
-struct tracing_msg {
-    uint64_t magic;
-};
 
-enum h2o_tracing_action {
-    H2O_TRACING_ACTION_OK,
-    H2O_TRACING_ACTION_CLOSE,
+struct tracing_msg {
+    uint64_t action;
 };
 
 uint64_t h2o_tracing_now;
@@ -14,174 +10,51 @@ uint64_t should_stop_probe;
 
 #define IS_REMOVE_BIT_SET(x) ((x & H2O_TRACE_REMOVE_PROBE) == H2O_TRACE_REMOVE_PROBE)
 
-static void on_tracing_message_done(struct st_h2o_tracing_conn_t *conn, enum h2o_tracing_action action);
-
-static void close_connection(struct st_h2o_tracing_conn_t *conn, int close_socket)
+static void close_connection(h2o_socket_t *sock)
 {
     if (should_stop_probe != 0) {
+        // disable selected probe from h2o_tracing_now
         __sync_fetch_and_and(&h2o_tracing_now, should_stop_probe);
         __sync_fetch_and_and(&should_stop_probe, 0x0);
     } else {
+        // disable all probes
         __sync_fetch_and_and(&h2o_tracing_now, 0x0);
     }
 
-    if (conn->sock != NULL && close_socket)
-        h2o_socket_close(conn->sock);
-    h2o_linklist_unlink(&conn->_conns);
-    free(conn);
+    h2o_socket_close(sock);
 }
 
-static socklen_t get_sockname(h2o_conn_t *_conn, struct sockaddr *sa)
+static void on_tracing_message(h2o_socket_t *sock, struct tracing_msg *msg)
 {
-    struct st_h2o_tracing_conn_t *conn = (void *)_conn;
-    return h2o_socket_getsockname(conn->sock, sa);
-}
-
-static socklen_t get_peername(h2o_conn_t *_conn, struct sockaddr *sa)
-{
-    struct st_h2o_tracing_conn_t *conn = (void *)_conn;
-    return h2o_socket_getpeername(conn->sock, sa);
-}
-
-static h2o_socket_t *get_socket(h2o_conn_t *_conn)
-{
-    struct st_h2o_tracing_conn_t *conn = (void *)_conn;
-    return conn->sock;
-}
-
-static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata)
-{
-    h2o_linklist_t *node;
-
-    for (node = ctx->tracing._conns.next; node != &ctx->tracing._conns; node = node->next) {
-        struct st_h2o_tracing_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_tracing_conn_t, _conns, node);
-        int ret = cb(&conn->req, cbdata);
-        if (ret != 0)
-            return ret;
-    }
-    return 0;
-}
-
-static void init_request(struct st_h2o_tracing_conn_t *conn, int reinit)
-{
-    if (reinit)
-        h2o_dispose_request(&conn->req);
-    h2o_init_request(&conn->req, &conn->super, NULL);
-}
-
-static void on_tracing_message(struct st_h2o_tracing_conn_t *conn, struct tracing_msg *bmsg);
-static void handle_incoming_request(struct st_h2o_tracing_conn_t *conn)
-{
-    size_t inreqlen = conn->sock->input->size < H2O_MAX_REQLEN ? conn->sock->input->size : H2O_MAX_REQLEN;
-    struct tracing_msg *bmsg;
-
-    if (inreqlen < sizeof(*bmsg)) {
-        return;
-    }
-    bmsg = (void *)conn->sock->input->bytes;
-
-    on_tracing_message(conn, bmsg);
-}
-
-static void reqread_on_read(h2o_socket_t *sock, const char *err)
-{
-    struct st_h2o_tracing_conn_t *conn = sock->data;
-
-    if (err != NULL) {
-        close_connection(conn, 1);
-        return;
-    }
-
-    handle_incoming_request(conn);
-}
-
-static inline void reqread_start(struct st_h2o_tracing_conn_t *conn)
-{
-    h2o_socket_read_start(conn->sock, reqread_on_read);
-    if (conn->sock->input->size != 0)
-        handle_incoming_request(conn);
-}
-
-
-void on_tracing_msg_written(h2o_socket_t *sock, const char *err)
-{
-    struct st_h2o_tracing_conn_t *conn = sock->data;
-
-    if (err) {
-        on_tracing_message_done(conn, H2O_TRACING_ACTION_CLOSE);
-        return;
-    }
-    on_tracing_message_done(conn, H2O_TRACING_ACTION_OK);
-}
-
-static void on_tracing_message(struct st_h2o_tracing_conn_t *conn, struct tracing_msg *bmsg)
-{
-    if (IS_REMOVE_BIT_SET(bmsg->magic)) {
-        // add probe in disable list
-        uint64_t stopping = (~bmsg->magic) & h2o_tracing_now;
+    if (IS_REMOVE_BIT_SET(msg->action)) {
+        // add probe in disable list, will be removed upon closing
+        uint64_t stopping = (~msg->action) & h2o_tracing_now;
         __sync_fetch_and_or(&should_stop_probe, stopping);
     } else {
-        // add new tracer query to filter
-        __sync_fetch_and_or(&h2o_tracing_now, bmsg->magic);
+        // add new probe to filter
+        __sync_fetch_and_or(&h2o_tracing_now, msg->action);
     }
 
-    h2o_buffer_consume(&conn->sock->input, sizeof(struct tracing_msg));
+    h2o_buffer_consume(&sock->input, sizeof(struct tracing_msg));
 }
 
-const h2o_protocol_callbacks_t H2O_BLINK_CALLBACKS = {
-    NULL, /* graceful_shutdown (note: nothing special needs to be done for handling graceful shutdown) */
-    foreach_request};
-
-void h2o_tracing_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval connected_at)
+void h2o_tracing_on_data(h2o_socket_t *sock)
 {
-    static const h2o_conn_callbacks_t callbacks = {
-        get_sockname, /* stringify address */
-        get_peername, /* ditto */
-        NULL,         /* push */
-        get_socket,   /* get underlying socket */
-        NULL,         /* get debug state */
-        {{
-            {NULL}, /* ssl */
-            {NULL}, /* http1 */
-            {NULL}  /* http2 */
-        }}};
-    struct st_h2o_tracing_conn_t *conn = (void *)h2o_create_connection(sizeof(*conn), ctx->ctx, ctx->hosts, connected_at, &callbacks);
+    size_t inreqlen = sock->input->size < H2O_MAX_REQLEN ? sock->input->size : H2O_MAX_REQLEN;
+    struct tracing_msg *msg;
 
-    /* FIXME: zero-fill all properties expect req */
-    memset(conn, 0, sizeof(*conn));
-
-    /* init properties that need to be non-zero */
-    conn->super.ctx = ctx->ctx;
-    conn->super.hosts = ctx->hosts;
-    conn->super.connected_at = connected_at;
-    conn->super.callbacks = &callbacks;
-    conn->sock = sock;
-    sock->data = conn;
-    h2o_linklist_insert(&ctx->ctx->tracing._conns, &conn->_conns);
-
-    init_request(conn, 0);
-    reqread_start(conn);
+    if (inreqlen < sizeof(*msg)) {
+        return;
+    }
+    msg = (void *)sock->input->bytes;
+    on_tracing_message(sock, msg);
 }
 
-void on_tracing_message_done(struct st_h2o_tracing_conn_t *conn, enum h2o_tracing_action action)
+void h2o_tracing_on_read(h2o_socket_t *sock, const char *err)
 {
-    int do_close = 0;
-
-    h2o_buffer_consume(&conn->sock->input, sizeof(struct tracing_msg));
-
-    switch (action) {
-    case H2O_TRACING_ACTION_OK:
-        reqread_start(conn);
-        break;
-    case H2O_TRACING_ACTION_CLOSE:
-        do_close = 1;
-        break;
-    default:
-        assert(0 && "Unknown action for lib/blink.c handler");
+    if (err != NULL) {
+        close_connection(sock);
+    } else {
+        h2o_tracing_on_data(sock);
     }
-
-    if (do_close) {
-        close_connection(conn, 1);
-    }
-    return;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1031,7 +1031,7 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
         yoml_t **port_node, **host_node, **type_node, **proxy_protocol_node, **tracing_mode;
         if (h2o_configurator_parse_mapping(cmd, node, "port:s", "host:s,type:s,owner:s,permission:*,ssl:m,proxy-protocol:*,tracing:*",
                                            &port_node, &host_node, &type_node, &owner_node, &permission_node, &ssl_node,
-                                          &proxy_protocol_node, &tracing_mode) != 0)
+                                           &proxy_protocol_node, &tracing_mode) != 0)
             return -1;
         servname = (*port_node)->data.scalar;
         if (host_node != NULL)
@@ -1608,7 +1608,9 @@ static void on_accept(h2o_socket_t *listener, const char *err)
 
         sock->on_close.cb = on_socketclose;
         sock->on_close.data = ctx->accept_ctx.ctx;
+
         h2o_accept(&ctx->accept_ctx, sock);
+
     } while (--num_accepts != 0);
 }
 


### PR DESCRIPTION
Hello

Here's a first proof-of-concept regarding an ad-hoc tracer for h2o based off dtrace probes. The aim was to be cost free when not attached, and still performant under load.

I implemented a small test client for it in python using EBPF/BCC, but any language can be used really. The [script is here](https://gist.github.com/pldubouilh/71de1dd7de2424c6077e5da1f5d16738), and would require [BCC](https://github.com/iovisor/bcc/blob/master/INSTALL.md). I pasted a sample output below.

The PR implements a communication socket to the tracing program. It allows to stop any tracing processing if the tracer program disconnects or crashes, and also some lightweight communication to filter out some events from being processed. This socket port is settable using the config below.

Cheers !

```yaml
listen:
    port: 4321
    tracing: ON
```

```sh
% sudo ./picotracer.py `pgrep h2o`
>> 1553636178731756      36    SSLNew            TLSv1.3 AES256-GCM 0x7ff626ffcac0
>> 1553636178731756      36    NewConnH2         10.0.2.15:9090 10.0.2.15:34200
>> 1553636178731756      36    RxHeader          user-agent curl/7.64.0
>> 1553636178731756      36    RxHeader          accept */*
>> 1553636178731756      36    NewReq            HTTP/2 GET /assets/2.ts
>> 1553636178731756      36    Proxy             [unix:/tmp/h2o.sock]
>> 1553636178731756      36    ProxyTxHdr        user-agent curl/7.64.0
>> 1553636178731756      36    ProxyTxHdr        accept */*
>> 1553636178731756      36    ProxyNewReq       HTTP/1.1 GET /assets/2.ts
>> 1553636178731756      36    ProxyRxHdr        date Tue, 26 Mar 2019 21:36:18 GMT
>> 1553636178731756      36    ProxyRxHdr        content-type video/mp2t
>> 1553636178731756      36    ProxyRxHdr        last-modified Mon, 06 Aug 2018 09:07:10 GMT
>> 1553636178731756      36    ProxyRxHdr        etag "5b680fbe-1a8780"
>> 1553636178731756      36    ProxyRxHdr        accept-ranges bytes
>> 1553636178731756      36    ProxyNewRes       HTTP/1.1 200 len: 1738624
>> 1553636178731756      36    TxHeader          date Tue, 26 Mar 2019 21:36:18 GMT
>> 1553636178731756      36    TxHeader          content-type video/mp2t
>> 1553636178731756      36    TxHeader          last-modified Mon, 06 Aug 2018 09:07:10 GMT
>> 1553636178731756      36    TxHeader          etag "5b680fbe-1a8780"
>> 1553636178731756      36    TxHeader          accept-ranges bytes
>> 1553636178731756      36    NewRes            HTTP/2 200 len: 1738624
```