### PR TITLE
fix prototype for 'h2o_fatal' and replace 'abort(3)' with it

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -167,8 +167,10 @@ extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 /**
  * prints an error message and aborts
  */
-#define h2o_fatal(msg) h2o__fatal(__FILE__ ":" H2O_TO_STR(__LINE__) ":" msg)
-H2O_NORETURN void h2o__fatal(const char *msg);
+H2O_NORETURN void h2o__fatal(const char *file, int line, const char *msg, ...) __attribute__((format(printf, 3, 4)));
+#ifndef h2o_fatal
+#define h2o_fatal(...) h2o__fatal(__FILE__, __LINE__, __VA_ARGS__)
+#endif
 
 void h2o_perror(const char *msg);
 char *h2o_strerror_r(int err, char *buf, size_t len);

--- a/lib/common/hostinfo.c
+++ b/lib/common/hostinfo.c
@@ -98,11 +98,11 @@ static void create_lookup_thread(void)
     pthread_attr_setdetachstate(&attr, 1);
     pthread_attr_setstacksize(&attr, 100 * 1024);
     if ((ret = pthread_create(&tid, NULL, lookup_thread_main, NULL)) != 0) {
+        char buf[128];
         if (queue.num_threads == 0) {
-            h2o_error_printf("failed to start first thread for getaddrinfo:%s\n", strerror(ret));
-            abort();
+            h2o_fatal("failed to start first thread for getaddrinfo: %s", h2o_strerror_r(ret, buf, sizeof(buf)));
         } else {
-            h2o_perror("pthread_create(for getaddrinfo)");
+            h2o_error_printf("pthread_create(for getaddrinfo): %s", h2o_strerror_r(ret, buf, sizeof(buf)));
         }
         return;
     }

--- a/lib/common/memcached.c
+++ b/lib/common/memcached.c
@@ -245,12 +245,13 @@ static void reader_main(h2o_memcached_context_t *ctx)
     pthread_t writer_thread;
     yrmcds_response resp;
     yrmcds_error err;
+    int ret;
 
     /* connect to server and start the writer thread */
     connect_to_server(conn.ctx, &conn.yrmcds);
-    if (pthread_create(&writer_thread, NULL, writer_main, &conn) != 0) {
-        h2o_perror("pthread_create");
-        abort();
+    if ((ret = pthread_create(&writer_thread, NULL, writer_main, &conn)) != 0) {
+        char buf[128];
+        h2o_fatal("pthread_create: %s", h2o_strerror_r(ret, buf, sizeof(buf)));
     }
 
     pthread_mutex_lock(&conn.ctx->mutex);

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #include "h2o/memory.h"
@@ -69,9 +70,17 @@ void *(*volatile h2o_mem__set_secure)(void *, int, size_t) = memset;
 
 __thread h2o_mem_recycle_t h2o_mem_pool_allocator = {16};
 
-void h2o__fatal(const char *msg)
+void h2o__fatal(const char *file, int line, const char *msg, ...)
 {
-    h2o_error_printf("fatal:%s\n", msg);
+    char buf[1024];
+    va_list args;
+
+    va_start(args, msg);
+    vsnprintf(buf, sizeof(buf), msg, args);
+    va_end(args);
+
+    h2o_error_printf("fatal:%s:%d:%s\n", file, line, buf);
+
     abort();
 }
 

--- a/lib/common/socket/evloop/epoll.c.h
+++ b/lib/common/socket/evloop/epoll.c.h
@@ -198,8 +198,8 @@ h2o_evloop_t *h2o_evloop_create(void)
     loop->ep = epoll_create(10);
     while (fcntl(loop->ep, F_SETFD, FD_CLOEXEC) == -1) {
         if (errno != EAGAIN) {
-            h2o_error_printf("h2o_evloop_create: failed to set FD_CLOEXEC to the epoll fd (errno=%d)\n", errno);
-            abort();
+            char buf[128];
+            h2o_fatal("h2o_evloop_create: failed to set FD_CLOEXEC: %s\n", h2o_strerror_r(errno, buf, sizeof(buf)));
         }
     }
     pthread_mutex_unlock(&cloexec_mutex);

--- a/lib/common/timerwheel.c
+++ b/lib/common/timerwheel.c
@@ -41,7 +41,7 @@
 #define ABORT_CORRUPT_TIMER(ctx, t, fmt, ...)                                                                                      \
     do {                                                                                                                           \
         REPORT_CORRUPT_TIMER(ctx, t, fmt, __VA_ARGS__);                                                                            \
-        abort();                                                                                                                   \
+        h2o_fatal("timerwheel");                                                                                                   \
     } while (0)
 
 struct st_h2o_timerwheel_t {

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -653,8 +653,7 @@ static int set_mimetypes(h2o_configurator_command_t *cmd, h2o_mimemap_t *mimemap
             }
         } break;
         default:
-            h2o_error_printf("logic flaw at %s:%d\n", __FILE__, __LINE__);
-            abort();
+            h2o_fatal("logic flaw");
         }
     }
 
@@ -1192,8 +1191,7 @@ static const char *get_next_key(const char *start, h2o_iovec_t *output, unsigned
     return NULL;
 
 Error:
-    h2o_error_printf("%s: detected invalid or missing type specifier; input is: %s\n", __FUNCTION__, start);
-    abort();
+    h2o_fatal("detected invalid or missing type specifier; input is: %s\n", start);
 }
 
 int h2o_configurator__do_parse_mapping(h2o_configurator_command_t *cmd, yoml_t *node, const char *keys_required,

--- a/lib/handler/configurator/mruby.c
+++ b/lib/handler/configurator/mruby.c
@@ -45,8 +45,7 @@ static mrb_state *get_mrb(struct mruby_configurator_t *self)
     if (self->mrb == NULL) {
         self->mrb = mrb_open();
         if (self->mrb == NULL) {
-            h2o_error_printf("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
-            abort();
+            h2o_fatal("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
         }
         h2o_mruby_setup_globals(self->mrb);
     }

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -604,8 +604,7 @@ static int try_dynamic_request(h2o_file_handler_t *self, h2o_req_t *req, char *r
         return delegate_dynamic_request(req, script_name, path_info, rpath, slash_at, mime_type);
     }
     }
-    h2o_error_printf("unknown h2o_miemmap_type_t::type (%d)\n", (int)mime_type->type);
-    abort();
+    h2o_fatal("unknown h2o_miemmap_type_t::type (%d)\n", (int)mime_type->type);
 }
 
 static void send_method_not_allowed(h2o_req_t *req)

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -47,8 +47,7 @@
 
 void h2o_mruby__abort_exc(mrb_state *mrb, const char *mess, const char *file, int line)
 {
-    h2o_error_printf("%s at file: \"%s\", line %d: %s\n", mess, file, line, RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
-    abort();
+    h2o_fatal("%s at file: \"%s\", line %d: %s\n", mess, file, line, RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
 }
 
 mrb_value h2o_mruby__new_str(mrb_state *mrb, const char *s, size_t len, int is_static, const char *file, int line)
@@ -109,12 +108,12 @@ void h2o_mruby_setup_globals(mrb_state *mrb)
     /* require core modules and include built-in libraries */
     h2o_mruby_eval_expr(mrb, "require \"#{$H2O_ROOT}/share/h2o/mruby/preloads.rb\"");
     if (mrb->exc != NULL) {
-        h2o_error_printf("an error occurred while loading %s/%s: %s\n", root, "share/h2o/mruby/preloads.rb",
-                         RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
+        const char *msg = "";
         if (mrb_obj_is_instance_of(mrb, mrb_obj_value(mrb->exc), mrb_class_get(mrb, "LoadError"))) {
-            h2o_error_printf("Did you forget to run `make install`?\n");
+            msg = "Did you forget to run `make install`?\n";
         }
-        abort();
+        h2o_fatal("an error occurred while loading %s/%s: %s\n%s", root, "share/h2o/mruby/preloads.rb",
+                  RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))), msg);
     }
 }
 
@@ -174,22 +173,19 @@ struct RProc *h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *co
 
     /* parse */
     if ((cxt = mrbc_context_new(mrb)) == NULL) {
-        h2o_error_printf("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
-        abort();
+        h2o_fatal("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
     }
     if (config->path != NULL)
         mrbc_filename(mrb, cxt, config->path);
     cxt->capture_errors = 1;
     cxt->lineno = config->lineno;
     if ((parser = mrb_parse_nstring(mrb, config->source.base, (int)config->source.len, cxt)) == NULL) {
-        h2o_error_printf("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
-        abort();
+        h2o_fatal("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
     }
     /* return erro if errbuf is supplied, or abort */
     if (parser->nerr != 0) {
         if (errbuf == NULL) {
-            h2o_error_printf("%s: internal error (unexpected state)\n", H2O_MRUBY_MODULE_NAME);
-            abort();
+            h2o_fatal("%s: internal error (unexpected state)\n", H2O_MRUBY_MODULE_NAME);
         }
         snprintf(errbuf, 256, "line %d:%s", parser->error_buffer[0].lineno, parser->error_buffer[0].message);
         strcat(errbuf, "\n\n");
@@ -202,8 +198,7 @@ struct RProc *h2o_mruby_compile_code(mrb_state *mrb, h2o_mruby_config_vars_t *co
     }
     /* generate code */
     if ((proc = mrb_generate_code(mrb, parser)) == NULL) {
-        h2o_error_printf("%s: internal error (mrb_generate_code failed)\n", H2O_MRUBY_MODULE_NAME);
-        abort();
+        h2o_fatal("%s: internal error (mrb_generate_code failed)\n", H2O_MRUBY_MODULE_NAME);
     }
 
 Exit:
@@ -450,8 +445,7 @@ static h2o_mruby_shared_context_t *create_shared_context(h2o_context_t *ctx)
     /* init mruby in every thread */
     h2o_mruby_shared_context_t *shared_ctx = h2o_mem_alloc(sizeof(*shared_ctx));
     if ((shared_ctx->mrb = mrb_open()) == NULL) {
-        h2o_error_printf("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
-        abort();
+        h2o_fatal("%s: no memory\n", H2O_MRUBY_MODULE_NAME);
     }
     shared_ctx->mrb->ud = shared_ctx;
     shared_ctx->ctx = ctx;

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -47,7 +47,7 @@
 
 void h2o_mruby__abort_exc(mrb_state *mrb, const char *mess, const char *file, int line)
 {
-    h2o_fatal("%s at file: \"%s\", line %d: %s\n", mess, file, line, RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
+    h2o__fatal(file, line, "%s:%s\n", mess, RSTRING_PTR(mrb_inspect(mrb, mrb_obj_value(mrb->exc))));
 }
 
 mrb_value h2o_mruby__new_str(mrb_state *mrb, const char *s, size_t len, int is_static, const char *file, int line)

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -309,8 +309,7 @@ static void post_response(struct st_h2o_mruby_http_request_context_t *ctx, int s
         /* is async */
         mrb_funcall(mrb, ctx->refs.request, "_set_response", 1, resp);
         if (mrb->exc != NULL) {
-            h2o_error_printf("_set_response failed\n");
-            abort();
+            h2o_fatal("_set_response failed\n");
         }
     } else {
         /* send response to the waiting receiver */


### PR DESCRIPTION
"Note that the pthreads functions do not set errno" from PTHREADS(7)
so we should use return value instead of 'errno' when pthread_create error