### PR TITLE
fix issue in 'h2o_perror' about 'strerror_r'

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -170,8 +170,8 @@ extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 #define h2o_fatal(msg) h2o__fatal(__FILE__ ":" H2O_TO_STR(__LINE__) ":" msg)
 H2O_NORETURN void h2o__fatal(const char *msg);
 
-static void h2o_perror(const char *msg);
-static void h2o_strerror_r(int err, char *buf, size_t len);
+void h2o_perror(const char *msg);
+void h2o_strerror_r(int err, char *buf, size_t len);
 
 /**
  * A version of memcpy that can take a NULL @src to avoid UB
@@ -478,27 +478,6 @@ inline void *h2o_memrchr(const void *s, int c, size_t n)
 inline void *h2o_mem_set_secure(void *b, int c, size_t len)
 {
     return h2o_mem__set_secure(b, c, len);
-}
-
-inline void h2o_strerror_r(int err, char *buf, size_t len)
-{
-#ifndef _GNU_SOURCE
-    strerror_r(err, buf, len);
-#else
-    char *p = strerror_r(err, buf, len);
-    if (p != buf) {
-        strncpy(buf, p, len - 1);
-        buf[len - 1] = '\0';
-    }
-#endif
-}
-
-inline void h2o_perror(const char *msg)
-{
-    char buf[128];
-
-    h2o_strerror_r(errno, buf, sizeof(buf));
-    h2o_error_printf("%s: %s\n", msg, buf);
 }
 
 #ifdef __cplusplus

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -171,7 +171,7 @@ extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 H2O_NORETURN void h2o__fatal(const char *msg);
 
 void h2o_perror(const char *msg);
-void h2o_strerror_r(int err, char *buf, size_t len);
+char *h2o_strerror_r(int err, char *buf, size_t len);
 
 /**
  * A version of memcpy that can take a NULL @src to avoid UB

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -171,6 +171,7 @@ extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 H2O_NORETURN void h2o__fatal(const char *msg);
 
 static void h2o_perror(const char *msg);
+static void h2o_strerror_r(int err, char *buf, size_t len);
 
 /**
  * A version of memcpy that can take a NULL @src to avoid UB
@@ -479,10 +480,24 @@ inline void *h2o_mem_set_secure(void *b, int c, size_t len)
     return h2o_mem__set_secure(b, c, len);
 }
 
+inline void h2o_strerror_r(int err, char *buf, size_t len)
+{
+#ifndef _GNU_SOURCE
+    strerror_r(err, buf, len);
+#else
+    char *p = strerror_r(err, buf, len);
+    if (p != buf) {
+        strncpy(buf, p, len - 1);
+        buf[len - 1] = '\0';
+    }
+#endif
+}
+
 inline void h2o_perror(const char *msg)
 {
-    char buf[256];
-    strerror_r(errno, buf, sizeof(buf));
+    char buf[128];
+
+    h2o_strerror_r(errno, buf, sizeof(buf));
     h2o_error_printf("%s: %s\n", msg, buf);
 }
 

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -414,21 +414,18 @@ void h2o_append_to_null_terminated_list(void ***list, void *element)
     (*list)[cnt] = NULL;
 }
 
-void h2o_strerror_r(int err, char *buf, size_t len)
+char *h2o_strerror_r(int err, char *buf, size_t len)
 {
 #ifndef _GNU_SOURCE
     strerror_r(err, buf, len);
+    return buf;
 #else
     /**
      * The GNU-specific strerror_r() returns a pointer to a string containing the error message.
      * This may be either a pointer to a string that the function stores in  buf,
      * or a pointer to some (immutable) static string (in which case buf is unused)
      */
-    char *p = strerror_r(err, buf, len);
-    if (p != buf) {
-        strncpy(buf, p, len - 1);
-        buf[len - 1] = '\0';
-    }
+    return strerror_r(err, buf, len);
 #endif
 }
 
@@ -436,6 +433,5 @@ void h2o_perror(const char *msg)
 {
     char buf[128];
 
-    h2o_strerror_r(errno, buf, sizeof(buf));
-    h2o_error_printf("%s: %s\n", msg, buf);
+    h2o_error_printf("%s: %s\n", msg, h2o_strerror_r(errno, buf, sizeof(buf)));
 }

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -413,3 +413,29 @@ void h2o_append_to_null_terminated_list(void ***list, void *element)
     (*list)[cnt++] = element;
     (*list)[cnt] = NULL;
 }
+
+void h2o_strerror_r(int err, char *buf, size_t len)
+{
+#ifndef _GNU_SOURCE
+    strerror_r(err, buf, len);
+#else
+    /**
+     * The GNU-specific strerror_r() returns a pointer to a string containing the error message.
+     * This may be either a pointer to a string that the function stores in  buf,
+     * or a pointer to some (immutable) static string (in which case buf is unused)
+     */
+    char *p = strerror_r(err, buf, len);
+    if (p != buf) {
+        strncpy(buf, p, len - 1);
+        buf[len - 1] = '\0';
+    }
+#endif
+}
+
+void h2o_perror(const char *msg)
+{
+    char buf[128];
+
+    h2o_strerror_r(errno, buf, sizeof(buf));
+    h2o_error_printf("%s: %s\n", msg, buf);
+}


### PR DESCRIPTION
The GNU-specific strerror_r() returns a pointer to a string containing the error message.  This may be either a pointer to a string that the function stores in  buf,  or  a  pointer  to  some(immutable)  static string (in which case buf is unused).

`h2o_perror` should handle this case.