### PR TITLE
'pipe2' only declared under '_GNU_SOURCE'

### DIFF
--- a/deps/cloexec/cloexec.c
+++ b/deps/cloexec/cloexec.c
@@ -19,7 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-#include <fcntl.h>
 #include "cloexec.h"
 
 pthread_mutex_t cloexec_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/deps/cloexec/cloexec.h
+++ b/deps/cloexec/cloexec.h
@@ -25,7 +25,12 @@
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <fcntl.h>
 #include <unistd.h>
+
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+extern int pipe2(int pipefd[2], int flags);
+#endif
 
 extern pthread_mutex_t cloexec_mutex;
 


### PR DESCRIPTION
This eliminate compiler warnings under android.