### PR TITLE
activate error check in proptest

### DIFF
--- a/t/00prop/prop.c
+++ b/t/00prop/prop.c
@@ -73,10 +73,6 @@ static enum theft_trial_res prop_wake_time_should_be_before_expiry(struct theft 
         return THEFT_TRIAL_FAIL;
     if (h2o_timerwheel_get_wake_at(ctx) != UINT64_MAX)
         return THEFT_TRIAL_FAIL;
-    wake_time = h2o_timerwheel_get_wake_at(ctx);
-    if (wake_time != UINT64_MAX) {
-        return THEFT_TRIAL_FAIL;
-    }
     h2o_timerwheel_destroy(ctx);
     return THEFT_TRIAL_PASS;
 }
@@ -212,7 +208,7 @@ static struct theft_type_info random_buffer_info = {
             .prop1 = fn_,                                                                                                          \
             .type_info = {&random_buffer_info},                                                                                    \
             .seed = seed,                                                                                                          \
-            .trials = 100,                                                                                                         \
+            .trials = 10000,                                                                                                         \
         };                                                                                                                         \
                                                                                                                                    \
         enum theft_run_res res = theft_run(&config);                                                                               \

--- a/t/00prop/prop.c
+++ b/t/00prop/prop.c
@@ -73,12 +73,12 @@ static enum theft_trial_res prop_wake_time_should_be_before_expiry(struct theft 
         return THEFT_TRIAL_FAIL;
     if (h2o_timerwheel_get_wake_at(ctx) != UINT64_MAX)
         return THEFT_TRIAL_FAIL;
-    return THEFT_TRIAL_PASS;
     wake_time = h2o_timerwheel_get_wake_at(ctx);
     if (wake_time != UINT64_MAX) {
         return THEFT_TRIAL_FAIL;
     }
-    h2o_timer_destroy(ctx);
+    h2o_timerwheel_destroy(ctx);
+    return THEFT_TRIAL_PASS;
 }
 
 static enum theft_trial_res prop_inserted_timer_should_run_at_expiry(struct theft *theft, void *input_)


### PR DESCRIPTION
Due to an early return, one check (and the destruction of the timerwheel) has always been skipped. The issue was introduced in b78de0a4.