### PR TITLE
Split up the buffer reservation API

### DIFF
--- a/include/h2o/http2_common.h
+++ b/include/h2o/http2_common.h
@@ -50,7 +50,7 @@
 #define H2O_HTTP2_ERROR_ENHANCE_YOUR_CALM -11
 #define H2O_HTTP2_ERROR_INADEQUATE_SECURITY -12
 #define H2O_HTTP2_ERROR_MAX 13
-/* end of the HTT2-spec defined errors */
+/* end of the HTTP2-spec defined errors */
 #define H2O_HTTP2_ERROR_INVALID_HEADER_CHAR                                                                                        \
     -254 /* an internal value indicating that invalid characters were found in the header name or value */
 #define H2O_HTTP2_ERROR_INCOMPLETE -255 /* an internal value indicating that all data is not ready */

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -257,6 +257,11 @@ void h2o_buffer__do_free(h2o_buffer_t *buffer);
  */
 static void h2o_buffer_dispose(h2o_buffer_t **buffer);
 /**
+ * allocates a buffer with h2o_buffer_try_reserve. aborts on allocation failure.
+ * @return buffer to which the next data should be stored
+ */
+h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **inbuf, size_t min_guarantee);
+/**
  * allocates a buffer.
  * @param inbuf - pointer to a pointer pointing to the structure (set *inbuf to NULL to allocate a new buffer)
  * @param min_guarantee minimum number of bytes to reserve
@@ -264,7 +269,7 @@ static void h2o_buffer_dispose(h2o_buffer_t **buffer);
  * @note When called against a new buffer, the function returns a buffer twice the size of requested guarantee.  The function uses
  * exponential backoff for already-allocated buffers.
  */
-h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **inbuf, size_t min_guarantee);
+h2o_iovec_t h2o_buffer_try_reserve(h2o_buffer_t **inbuf, size_t min_guarantee) __attribute__((warn_unused_result));
 /**
  * copies @len bytes from @src to @dst, calling h2o_buffer_reserve
  * @return 0 if the allocation failed, 1 otherwise

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -237,7 +237,7 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
 {
     h2o_iovec_t reserved = h2o_buffer_try_reserve(_inbuf, min_guarantee);
     if (reserved.base == NULL) {
-        h2o_fatal("failed to reserve buffer");
+        h2o_fatal("failed to reserve buffer; capacity: %zu, min_gurantee: %zu", (*_inbuf)->capacity, min_guarantee);
     }
     return reserved;
 }

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -235,6 +235,15 @@ void h2o_buffer__do_free(h2o_buffer_t *buffer)
 
 h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
 {
+    h2o_iovec_t reserved = h2o_buffer_try_reserve(_inbuf, min_guarantee);
+    if (reserved.base == NULL) {
+        h2o_fatal("failed to reserve buffer");
+    }
+    return reserved;
+}
+
+h2o_iovec_t h2o_buffer_try_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
+{
     h2o_buffer_t *inbuf = *_inbuf;
     h2o_iovec_t ret;
 

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -247,7 +247,7 @@ const char *decode_ssl_input(h2o_socket_t *sock)
             h2o_iovec_t reserved;
             ptls_buffer_t rbuf;
             int ret;
-            if ((reserved = h2o_buffer_reserve(&sock->input, sock->ssl->input.encrypted->size)).base == NULL)
+            if ((reserved = h2o_buffer_try_reserve(&sock->input, sock->ssl->input.encrypted->size)).base == NULL)
                 return h2o_socket_error_out_of_memory;
             ptls_buffer_init(&rbuf, reserved.base, reserved.len);
             do {
@@ -258,7 +258,7 @@ const char *decode_ssl_input(h2o_socket_t *sock)
             } while (src != src_end);
             h2o_buffer_consume(&sock->ssl->input.encrypted, sock->ssl->input.encrypted->size - (src_end - src));
             if (rbuf.is_allocated) {
-                if ((reserved = h2o_buffer_reserve(&sock->input, rbuf.off)).base == NULL)
+                if ((reserved = h2o_buffer_try_reserve(&sock->input, rbuf.off)).base == NULL)
                     return h2o_socket_error_out_of_memory;
                 memcpy(reserved.base, rbuf.base, rbuf.off);
                 sock->input->size += rbuf.off;
@@ -275,7 +275,7 @@ const char *decode_ssl_input(h2o_socket_t *sock)
 
     while (sock->ssl->input.encrypted->size != 0 || SSL_pending(sock->ssl->ossl)) {
         int rlen;
-        h2o_iovec_t buf = h2o_buffer_reserve(&sock->input, 4096);
+        h2o_iovec_t buf = h2o_buffer_try_reserve(&sock->input, 4096);
         if (buf.base == NULL)
             return h2o_socket_error_out_of_memory;
         { /* call SSL_read (while detecting SSL renegotiation and reporting it as error) */

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -121,7 +121,7 @@ static const char *on_read_core(int fd, h2o_buffer_t **input)
 
     while (1) {
         ssize_t rret;
-        h2o_iovec_t buf = h2o_buffer_reserve(input, 4096);
+        h2o_iovec_t buf = h2o_buffer_try_reserve(input, 4096);
         if (buf.base == NULL) {
             /* memory allocation failed */
             return h2o_socket_error_out_of_memory;

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -41,7 +41,7 @@ static void alloc_inbuf_tcp(uv_handle_t *handle, size_t suggested_size, uv_buf_t
 {
     struct st_h2o_uv_socket_t *sock = handle->data;
 
-    h2o_iovec_t buf = h2o_buffer_reserve(&sock->super.input, 4096);
+    h2o_iovec_t buf = h2o_buffer_try_reserve(&sock->super.input, 4096);
     memcpy(_buf, &buf, sizeof(buf));
 }
 
@@ -49,7 +49,7 @@ static void alloc_inbuf_ssl(uv_handle_t *handle, size_t suggested_size, uv_buf_t
 {
     struct st_h2o_uv_socket_t *sock = handle->data;
 
-    h2o_iovec_t buf = h2o_buffer_reserve(&sock->super.ssl->input.encrypted, 4096);
+    h2o_iovec_t buf = h2o_buffer_try_reserve(&sock->super.ssl->input.encrypted, 4096);
     memcpy(_buf, &buf, sizeof(buf));
 }
 

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -562,8 +562,7 @@ static void append_content(struct st_fcgi_generator_t *generator, const void *sr
         }
         generator->leftsize -= len;
     }
-
-    h2o_iovec_t reserved = h2o_buffer_reserve(&generator->resp.receiving, len);
+    h2o_iovec_t reserved = h2o_buffer_try_reserve(&generator->resp.receiving, len);
     memcpy(reserved.base, src, len);
     generator->resp.receiving->size += len;
 }

--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -551,20 +551,24 @@ static int fill_headers(h2o_req_t *req, struct phr_header *headers, size_t num_h
     return 0;
 }
 
-static void append_content(struct st_fcgi_generator_t *generator, const void *src, size_t len)
+static int append_content(struct st_fcgi_generator_t *generator, const void *src, size_t len)
 {
     /* do not accumulate more than content-length bytes */
     if (generator->leftsize != SIZE_MAX) {
         if (generator->leftsize < len) {
             len = generator->leftsize;
             if (len == 0)
-                return;
+                return 0;
         }
         generator->leftsize -= len;
     }
     h2o_iovec_t reserved = h2o_buffer_try_reserve(&generator->resp.receiving, len);
+    if (reserved.base == NULL) {
+        return -1;
+    }
     memcpy(reserved.base, src, len);
     generator->resp.receiving->size += len;
+    return 0;
 }
 
 static int handle_stdin_record(struct st_fcgi_generator_t *generator, struct st_fcgi_record_header_t *header)
@@ -579,7 +583,10 @@ static int handle_stdin_record(struct st_fcgi_generator_t *generator, struct st_
 
     if (generator->sent_headers) {
         /* simply accumulate the data to response buffer */
-        append_content(generator, input->bytes + FCGI_RECORD_HEADER_SIZE, header->contentLength);
+        if (append_content(generator, input->bytes + FCGI_RECORD_HEADER_SIZE, header->contentLength) != 0) {
+            h2o_req_log_error(generator->req, MODULE_NAME, "failed to allocate memory");
+            return -1;
+        }
         return 0;
     }
 
@@ -621,7 +628,10 @@ static int handle_stdin_record(struct st_fcgi_generator_t *generator, struct st_
     if (generator->resp.receiving->size == 0) {
         size_t leftlen = header->contentLength - parse_result;
         if (leftlen != 0) {
-            append_content(generator, input->bytes + FCGI_RECORD_HEADER_SIZE + parse_result, leftlen);
+            if (append_content(generator, input->bytes + FCGI_RECORD_HEADER_SIZE + parse_result, leftlen) != 0) {
+                h2o_req_log_error(generator->req, MODULE_NAME, "failed to allocate memory");
+                return -1;
+            }
         }
     } else {
         h2o_buffer_consume(&generator->resp.receiving, parse_result);

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -425,6 +425,11 @@ static int send_dir_listing(h2o_req_t *req, const char *path, size_t path_len, i
     body = build_dir_listing_html(&req->pool, req->path_normalized, dp);
     closedir(dp);
 
+    if (body == NULL) {
+        h2o_send_error_503(req, "Service Unavailable", "please try again later", 0);
+        return 0;
+    }
+
     bodyvec = h2o_iovec_init(body->bytes, body->size);
     h2o_buffer_link_to_pool(body, &req->pool);
 

--- a/lib/handler/file/templates.c.h
+++ b/lib/handler/file/templates.c.h
@@ -129,7 +129,8 @@ static h2o_buffer_t *build_dir_listing_html(h2o_mem_pool_t *pool, h2o_iovec_t pa
             h2o_iovec_t _s = (link_escaped);
             if (_s.len != 0 && _s.base[_s.len - 1] == '\n')
                 --_s.len;
-            h2o_buffer_reserve(&_, _s.len);
+            if ((h2o_buffer_try_reserve(&_, _s.len)).base == NULL)
+	        return NULL;
             memcpy(_->bytes + _->size, _s.base, _s.len);
             _->size += _s.len;
         }
@@ -145,7 +146,8 @@ static h2o_buffer_t *build_dir_listing_html(h2o_mem_pool_t *pool, h2o_iovec_t pa
             h2o_iovec_t _s = (label_escaped);
             if (_s.len != 0 && _s.base[_s.len - 1] == '\n')
                 --_s.len;
-            h2o_buffer_reserve(&_, _s.len);
+            if ((h2o_buffer_try_reserve(&_, _s.len)).base == NULL)
+                return NULL;
             memcpy(_->bytes + _->size, _s.base, _s.len);
             _->size += _s.len;
         }

--- a/lib/handler/status/requests.c
+++ b/lib/handler/status/requests.c
@@ -45,7 +45,11 @@ static int collect_req_status(h2o_req_t *req, void *_cbdata)
     --len; /* omit trailing LF */
 
     /* append to buffer */
-    h2o_buffer_reserve(&cbdata->buffer, len + 3);
+    if ((h2o_buffer_try_reserve(&cbdata->buffer, len + 3)).base == NULL) {
+        if (logline != buf)
+            free(logline);
+        return -1;
+    }
     memcpy(cbdata->buffer->bytes + cbdata->buffer->size, logline, len);
     cbdata->buffer->size += len;
 
@@ -65,8 +69,14 @@ static void requests_status_per_thread(void *priv, h2o_context_t *ctx)
         return;
 
     h2o_buffer_init(&cbdata.buffer, &h2o_socket_buffer_prototype);
-    ctx->globalconf->http1.callbacks.foreach_request(ctx, collect_req_status, &cbdata);
-    ctx->globalconf->http2.callbacks.foreach_request(ctx, collect_req_status, &cbdata);
+    if (ctx->globalconf->http1.callbacks.foreach_request(ctx, collect_req_status, &cbdata) != 0) {
+        h2o_buffer_dispose(&cbdata.buffer);
+        return;
+    }
+    if (ctx->globalconf->http2.callbacks.foreach_request(ctx, collect_req_status, &cbdata) != 0) {
+        h2o_buffer_dispose(&cbdata.buffer);
+        return;
+    }
 
     /* concat JSON elements */
     if (cbdata.buffer->size != 0) {

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -458,7 +458,7 @@ static int write_req_non_streaming(void *_req, h2o_iovec_t payload, int is_end_e
 {
     struct st_h2o_http1_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1_conn_t, req, _req);
 
-    if (h2o_buffer_append(&conn->req._req_body.body, payload.base, payload.len) == 0)
+    if (h2o_buffer_try_append(&conn->req._req_body.body, payload.base, payload.len) == 0)
         return -1;
     conn->req.entity = h2o_iovec_init(conn->req._req_body.body->bytes, conn->req._req_body.body->size);
 

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1051,11 +1051,7 @@ static ssize_t expect_preface(h2o_http2_conn_t *conn, const uint8_t *src, size_t
     }
 
     { /* send SETTINGS and connection-level WINDOW_UPDATE */
-        h2o_iovec_t vec = h2o_buffer_try_reserve(&conn->_write.buf, SERVER_PREFACE.len);
-        if (vec.base == NULL) {
-            *err_desc = "failed to allocate memory";
-            return H2O_HTTP2_ERROR_PROTOCOL_CLOSE_IMMEDIATELY;
-        }
+        h2o_iovec_t vec = h2o_buffer_reserve(&conn->_write.buf, SERVER_PREFACE.len);
         memcpy(vec.base, SERVER_PREFACE.base, SERVER_PREFACE.len);
         conn->_write.buf->size += SERVER_PREFACE.len;
         if (conn->http2_origin_frame) {
@@ -1148,10 +1144,7 @@ static void on_upgrade_complete(void *_conn, h2o_socket_t *sock, size_t reqsize)
 
     if (conn->_http1_req_input->size > reqsize) {
         size_t remaining_bytes = conn->_http1_req_input->size - reqsize;
-        if ((h2o_buffer_try_reserve(&sock->input, remaining_bytes)).base == NULL) {
-            on_read(conn->sock, "failed to allocate memory");
-            return;
-        }
+        h2o_buffer_reserve(&sock->input, remaining_bytes);
         memcpy(sock->input->bytes, conn->_http1_req_input->bytes + reqsize, remaining_bytes);
         sock->input->size += remaining_bytes;
         on_read(conn->sock, NULL);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1051,7 +1051,11 @@ static ssize_t expect_preface(h2o_http2_conn_t *conn, const uint8_t *src, size_t
     }
 
     { /* send SETTINGS and connection-level WINDOW_UPDATE */
-        h2o_iovec_t vec = h2o_buffer_reserve(&conn->_write.buf, SERVER_PREFACE.len);
+        h2o_iovec_t vec = h2o_buffer_try_reserve(&conn->_write.buf, SERVER_PREFACE.len);
+        if (vec.base == NULL) {
+            *err_desc = "failed to allocate memory";
+            return H2O_HTTP2_ERROR_PROTOCOL_CLOSE_IMMEDIATELY;
+        }
         memcpy(vec.base, SERVER_PREFACE.base, SERVER_PREFACE.len);
         conn->_write.buf->size += SERVER_PREFACE.len;
         if (conn->http2_origin_frame) {
@@ -1144,7 +1148,10 @@ static void on_upgrade_complete(void *_conn, h2o_socket_t *sock, size_t reqsize)
 
     if (conn->_http1_req_input->size > reqsize) {
         size_t remaining_bytes = conn->_http1_req_input->size - reqsize;
-        h2o_buffer_reserve(&sock->input, remaining_bytes);
+        if ((h2o_buffer_try_reserve(&sock->input, remaining_bytes)).base == NULL) {
+            on_read(conn->sock, "failed to allocate memory");
+            return;
+        }
         memcpy(sock->input->bytes, conn->_http1_req_input->bytes + reqsize, remaining_bytes);
         sock->input->size += remaining_bytes;
         on_read(conn->sock, NULL);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -662,7 +662,8 @@ static int write_req_non_streaming(void *_req, h2o_iovec_t payload, int is_end_s
 static int write_req_streaming_pre_dispatch(void *_req, h2o_iovec_t payload, int is_end_stream)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
-    h2o_buffer_append(&stream->req._req_body.body, payload.base, payload.len);
+    if (h2o_buffer_append(&stream->req._req_body.body, payload.base, payload.len) == 0)
+        return -1;
     stream->req.entity = h2o_iovec_init(stream->req._req_body.body->bytes, stream->req._req_body.body->size);
 
     /* mark that we have seen eos */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -648,7 +648,7 @@ static int write_req_non_streaming(void *_req, h2o_iovec_t payload, int is_end_s
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
 
-    if (h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len) == 0)
+    if (h2o_buffer_try_append(&stream->_req_body.body, payload.base, payload.len) == 0)
         return -1;
     proceed_request(&stream->req, payload.len, is_end_stream);
 
@@ -662,9 +662,7 @@ static int write_req_non_streaming(void *_req, h2o_iovec_t payload, int is_end_s
 static int write_req_streaming_pre_dispatch(void *_req, h2o_iovec_t payload, int is_end_stream)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
-
-    if (h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len) == 0)
-        return -1;
+    h2o_buffer_append(&stream->_req_body.body, payload.base, payload.len);
     stream->req.entity = h2o_iovec_init(stream->_req_body.body->bytes, stream->_req_body.body->size);
 
     /* mark that we have seen eos */


### PR DESCRIPTION
## Objective

Ensure that unbounded memory allocation failures (e.g. buffers in non-streaming code path) are checked and handled peacefully. For bounded amount of memory allocations (e.g. low layer frame handling), abort with information of the underlying h2o_buffer_t, and the allocation amount.

## Design

- Add a variant of `h2o_buffer_reserve` that is forgiving on mmap failure
- Add a variant of `h2o_buffer_append` that is forgiving on mmap failure
- `h2o_buffer_(reserve|append)` to abort on mmap failure

Replace unbounded `h2o_buffer_(reserve|append)` calls with its forgiving variant, check the allocation result, and handle accordingly.