### PR TITLE
[test] 40chunked.t: convert the length of the chunk from hexadecimal

### DIFF
--- a/t/40chunked.t
+++ b/t/40chunked.t
@@ -36,8 +36,8 @@ EOT
     my @list = split("\r\n", $body);
     my $content = '';
     while (scalar(@list) >= 2) {
-        my ($len, $data) = splice(@list, 0, 2);
-        is length($data), $len;
+        my ($hlen, $data) = splice(@list, 0, 2);
+        is length($data), hex $hlen;
         $content .= $data;
     }
     is $content, join("", (1..30));


### PR DESCRIPTION
this might explain https://github.com/h2o/h2o/issues/2028 : most of the
time we should see a number between 1 and 2, but timing issues might
result in a larger hex number, causing the test to fail