### PR TITLE
evloop: handle EINTR errors while polling in evloop_do_proceed() calls

### DIFF
--- a/lib/common/socket/evloop/epoll.c.h
+++ b/lib/common/socket/evloop/epoll.c.h
@@ -112,7 +112,8 @@ int evloop_do_proceed(h2o_evloop_t *_loop, int32_t max_wait)
 
     /* poll */
     max_wait = adjust_max_wait(&loop->super, max_wait);
-    nevents = epoll_wait(loop->ep, events, sizeof(events) / sizeof(events[0]), max_wait);
+    while ((nevents = epoll_wait(loop->ep, events, sizeof(events) / sizeof(events[0]), max_wait)) == -1 && errno == EINTR)
+      ;
     update_now(&loop->super);
     if (nevents == -1)
         return -1;

--- a/lib/common/socket/evloop/kqueue.c.h
+++ b/lib/common/socket/evloop/kqueue.c.h
@@ -117,7 +117,8 @@ int evloop_do_proceed(h2o_evloop_t *_loop, int32_t max_wait)
     max_wait = adjust_max_wait(&loop->super, max_wait);
     ts.tv_sec = max_wait / 1000;
     ts.tv_nsec = max_wait % 1000 * 1000 * 1000;
-    nevents = kevent(loop->kq, changelist, nchanges, events, sizeof(events) / sizeof(events[0]), &ts);
+    while ((nevents = kevent(loop->kq, changelist, nchanges, events, sizeof(events) / sizeof(events[0]), &ts)) == -1 && errno == EINTR)
+      ;
 
     update_now(&loop->super);
     if (nevents == -1)

--- a/lib/common/socket/evloop/poll.c.h
+++ b/lib/common/socket/evloop/poll.c.h
@@ -101,7 +101,8 @@ int evloop_do_proceed(h2o_evloop_t *_loop, int32_t max_wait)
 
     /* call */
     max_wait = adjust_max_wait(&loop->super, max_wait);
-    ret = poll(pollfds.entries, (nfds_t)pollfds.size, max_wait);
+    while ((ret = poll(pollfds.entries, (nfds_t)pollfds.size, max_wait)) == -1 && errno == EINTR)
+      ;
     update_now(&loop->super);
     if (ret == -1)
         goto Exit;


### PR DESCRIPTION
This PR tries to better handle `EINTR`errors in `evloop_do_proceed` calls.

It looks like such errors are systematically handled by `libh2o` anywhere else so I think it should be the case there too. Otherwise if I'm wrong here, maybe it would be great to add pointers on how to handle that outside of the `h2o_evloop_run()` in your examples (`examples/libh2o/simple.c`, `examples/libh2o/websocket.c`).