### PR TITLE
Fix several compiler warnings

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -2196,7 +2196,9 @@ static inline void h2o_doublebuffer_consume(h2o_doublebuffer_t *db)
         }                                                                                                                          \
         *delta_usec = h2o_timeval_subtract((from), (until));                                                                       \
         return 1;                                                                                                                  \
-    }
+    }                                                                                                                              \
+                                                                                                                                   \
+    static inline int h2o_time_compute_##name(struct st_h2o_req_t *req, int64_t *delta_usec)
 
 COMPUTE_DURATION(connect_time, &req->conn->connected_at, &req->timestamps.request_begin_at);
 COMPUTE_DURATION(header_time, &req->timestamps.request_begin_at,

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -293,7 +293,7 @@ void h2o_buffer__dispose_linked(void *p);
  * @param new_capacity the capacity of the buffer after the function returns
  */
 #define h2o_vector_reserve(pool, vector, new_capacity)                                                                             \
-    h2o_vector__reserve((pool), (h2o_vector_t *)(void *)(vector), H2O_ALIGNOF((vector)->entries[0]), sizeof((vector)->entries[0]), \
+    h2o_vector__reserve((pool), (h2o_vector_t *)(void *)(vector), H2O_ALIGNOF(__typeof__((vector)->entries[0])), sizeof((vector)->entries[0]), \
                         (new_capacity))
 static void h2o_vector__reserve(h2o_mem_pool_t *pool, h2o_vector_t *vector, size_t alignment, size_t element_size,
                                 size_t new_capacity);

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -369,12 +369,14 @@ inline size_t h2o_socket_prepare_for_latency_optimized_write(h2o_socket_t *sock,
 
 inline h2o_iovec_t h2o_socket_log_ssl_protocol_version(h2o_socket_t *sock, h2o_mem_pool_t *pool)
 {
+    (void) pool;
     const char *s = h2o_socket_get_ssl_protocol_version(sock);
     return s != NULL ? h2o_iovec_init(s, strlen(s)) : h2o_iovec_init(NULL, 0);
 }
 
 inline h2o_iovec_t h2o_socket_log_ssl_session_reused(h2o_socket_t *sock, h2o_mem_pool_t *pool)
 {
+    (void) pool;
     switch (h2o_socket_get_ssl_session_reused(sock)) {
     case 0:
         return h2o_iovec_init(H2O_STRLIT("0"));
@@ -387,6 +389,7 @@ inline h2o_iovec_t h2o_socket_log_ssl_session_reused(h2o_socket_t *sock, h2o_mem
 
 inline h2o_iovec_t h2o_socket_log_ssl_cipher(h2o_socket_t *sock, h2o_mem_pool_t *pool)
 {
+    (void) pool;
     const char *s = h2o_socket_get_ssl_cipher(sock);
     return s != NULL ? h2o_iovec_init(s, strlen(s)) : h2o_iovec_init(NULL, 0);
 }


### PR DESCRIPTION
This commit benefits mainly the users of `libh2o`.

Consider the following example:
```
// test.c
#include <h2o.h>

int main(void)
{
	return 0;
}
```
Assuming that the installation is in `/tmp/h2o`, compile with:
`gcc -std=gnu11 -pedantic -Wall -Wextra -DH2O_USE_LIBUV=0 -I/tmp/h2o/include test.c`
On Ubuntu 16.04 that results in:
```
In file included from /tmp/h2o.bak/include/h2o/multithread.h:27:0,
                 from /tmp/h2o.bak/include/h2o/hostinfo.h:32,
                 from /tmp/h2o.bak/include/h2o.h:41,
                 from test.c:1:
/tmp/h2o.bak/include/h2o/socket.h: In function ‘h2o_socket_log_ssl_protocol_version’:
/tmp/h2o.bak/include/h2o/socket.h:370:92: warning: unused parameter ‘pool’ [-Wunused-parameter]
 inline h2o_iovec_t h2o_socket_log_ssl_protocol_version(h2o_socket_t *sock, h2o_mem_pool_t *pool)
                                                                                            ^
/tmp/h2o.bak/include/h2o/socket.h: In function ‘h2o_socket_log_ssl_session_reused’:
/tmp/h2o.bak/include/h2o/socket.h:376:90: warning: unused parameter ‘pool’ [-Wunused-parameter]
 inline h2o_iovec_t h2o_socket_log_ssl_session_reused(h2o_socket_t *sock, h2o_mem_pool_t *pool)
                                                                                          ^
/tmp/h2o.bak/include/h2o/socket.h: In function ‘h2o_socket_log_ssl_cipher’:
/tmp/h2o.bak/include/h2o/socket.h:388:82: warning: unused parameter ‘pool’ [-Wunused-parameter]
 inline h2o_iovec_t h2o_socket_log_ssl_cipher(h2o_socket_t *sock, h2o_mem_pool_t *pool)
                                                                                  ^
In file included from /tmp/h2o.bak/include/h2o/filecache.h:29:0,
                 from /tmp/h2o.bak/include/h2o.h:39,
                 from test.c:1:
/tmp/h2o.bak/include/h2o.h: In function ‘h2o_req_getenv’:
/tmp/h2o.bak/include/h2o/memory.h:40:28: warning: ISO C does not allow ‘__alignof__ (expression)’ [-Wpedantic]
 #define H2O_ALIGNOF(type) (__alignof__(type))
                            ^
/tmp/h2o.bak/include/h2o/memory.h:296:67: note: in expansion of macro ‘H2O_ALIGNOF’
     h2o_vector__reserve((pool), (h2o_vector_t *)(void *)(vector), H2O_ALIGNOF((vector)->entries[0]), sizeof((vector)->entries[0]), \
                                                                   ^
/tmp/h2o.bak/include/h2o.h:2030:5: note: in expansion of macro ‘h2o_vector_reserve’
     h2o_vector_reserve(&req->pool, &req->env, req->env.size + 2);
     ^
/tmp/h2o.bak/include/h2o.h: In function ‘h2o_context_get_storage’:
/tmp/h2o.bak/include/h2o/memory.h:40:28: warning: ISO C does not allow ‘__alignof__ (expression)’ [-Wpedantic]
 #define H2O_ALIGNOF(type) (__alignof__(type))
                            ^
/tmp/h2o.bak/include/h2o/memory.h:296:67: note: in expansion of macro ‘H2O_ALIGNOF’
     h2o_vector__reserve((pool), (h2o_vector_t *)(void *)(vector), H2O_ALIGNOF((vector)->entries[0]), sizeof((vector)->entries[0]), \
                                                                   ^
/tmp/h2o.bak/include/h2o.h:2131:9: note: in expansion of macro ‘h2o_vector_reserve’
         h2o_vector_reserve(NULL, &ctx->storage, *key + 1);
         ^
In file included from test.c:1:0:
/tmp/h2o.bak/include/h2o.h: At top level:
/tmp/h2o.bak/include/h2o.h:2201:92: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(connect_time, &req->conn->connected_at, &req->timestamps.request_begin_at);
                                                                                            ^
/tmp/h2o.bak/include/h2o.h:2204:119: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
                                                                              : &req->timestamps.request_body_begin_at);
                                                                                                                       ^
/tmp/h2o.bak/include/h2o.h:2208:40: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
                  &req->processed_at.at);
                                        ^
/tmp/h2o.bak/include/h2o.h:2209:95: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(request_total_time, &req->timestamps.request_begin_at, &req->processed_at.at);
                                                                                               ^
/tmp/h2o.bak/include/h2o.h:2210:90: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(process_time, &req->processed_at.at, &req->timestamps.response_start_at);
                                                                                          ^
/tmp/h2o.bak/include/h2o.h:2211:102: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(response_time, &req->timestamps.response_start_at, &req->timestamps.response_end_at);
                                                                                                      ^
/tmp/h2o.bak/include/h2o.h:2212:98: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(total_time, &req->timestamps.request_begin_at, &req->timestamps.response_end_at);
                                                                                                  ^
/tmp/h2o.bak/include/h2o.h:2214:102: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(proxy_idle_time, &req->timestamps.request_begin_at, &req->timestamps.proxy.start_at);
                                                                                                      ^
/tmp/h2o.bak/include/h2o.h:2215:111: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(proxy_connect_time, &req->timestamps.proxy.start_at, &req->timestamps.proxy.request_begin_at);
                                                                                                               ^
/tmp/h2o.bak/include/h2o.h:2216:117: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(proxy_request_time, &req->timestamps.proxy.request_begin_at, &req->timestamps.proxy.request_end_at);
                                                                                                                     ^
/tmp/h2o.bak/include/h2o.h:2217:118: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(proxy_process_time, &req->timestamps.proxy.request_end_at, &req->timestamps.proxy.response_start_at);
                                                                                                                      ^
/tmp/h2o.bak/include/h2o.h:2218:120: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(proxy_response_time, &req->timestamps.proxy.response_start_at, &req->timestamps.proxy.response_end_at);
                                                                                                                        ^
/tmp/h2o.bak/include/h2o.h:2219:116: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 COMPUTE_DURATION(proxy_total_time, &req->timestamps.proxy.request_begin_at, &req->timestamps.proxy.response_end_at);
                                                                                                                    ^
```