### PR TITLE
Improve documentation about extension property

### DIFF
--- a/doc/configure/fastcgi_directives.html
+++ b/doc/configure/fastcgi_directives.html
@@ -154,6 +154,17 @@ The HTTP server records the process id of the expression, and sends <code>SIGTER
 </code></pre>
 </div>
 
+<div class="example">
+<div class="caption">Example. Map any executable file in path <code>/var/www/data/cgi-bin</code> to <code>fastcgi-cgi</code> wrapper</div>
+<pre><code>&quot;/cgi-bin&quot;:
+    file.dir: /var/www/data/cgi-bin
+    file.custom-handler:
+        extension: default # means &quot;no extension&quot; in this case
+        fastcgi.spawn:
+            command: &quot;exec /usr/local/share/h2o/fastcgi-cgi&quot;
+</code></pre>
+</div>
+
 <p>
 As of version 1.4.0, the spawned process is run under the privileges of user specified by the <a href="configure/base_directives.html#user"><code>user</code></a> directive (in version 1.3.x, the FastCGI process was spawned under the privileges that spawned the H2O standalone server).
 It is possible to specify a different user for running the FastCGI process, by providing a mapping that contains an attribute named <code>user</code> together with an attribute named <code>command</code>.

--- a/doc/configure/file_directives.html
+++ b/doc/configure/file_directives.html
@@ -120,6 +120,7 @@ The directive maps extensions to a custom handler (e.g. FastCGI).
 
 <p>
 The directive accepts a mapping containing configuration directives that can be used at the <code>extension</code> level, together with a property named <code>extension</code> specifying a extension (starting with <code>.</code>) or a sequence of extensions to which the directives should be applied.
+If several files with different extensions or no extensions at all shall be mapped, this property must be set to <code>default</code>. 
 Only one handler must exist within the directives.
 </p>
 <div class="example">

--- a/srcdoc/configure/fastcgi_directives.mt
+++ b/srcdoc/configure/fastcgi_directives.mt
@@ -63,6 +63,15 @@ file.custom-handler:
     fastcgi.spawn: "PHP_FCGI_CHILDREN=10 exec /usr/local/bin/php-cgi"
 EOT
 ?>
+<?= $ctx->{example}->('Map any executable file in path <code>/var/www/data/cgi-bin</code> to <code>fastcgi-cgi</code> wrapper', <<'EOT');
+"/cgi-bin":
+    file.dir: /var/www/data/cgi-bin
+    file.custom-handler:
+        extension: default # means "no extension" in this case
+        fastcgi.spawn:
+            command: "exec /usr/local/share/h2o/fastcgi-cgi"
+EOT
+?>
 <p>
 As of version 1.4.0, the spawned process is run under the privileges of user specified by the <a href="configure/base_directives.html#user"><code>user</code></a> directive (in version 1.3.x, the FastCGI process was spawned under the privileges that spawned the H2O standalone server).
 It is possible to specify a different user for running the FastCGI process, by providing a mapping that contains an attribute named <code>user</code> together with an attribute named <code>command</code>.

--- a/srcdoc/configure/file_directives.mt
+++ b/srcdoc/configure/file_directives.mt
@@ -20,6 +20,7 @@ $ctx->{directive}->(
 ?>
 <p>
 The directive accepts a mapping containing configuration directives that can be used at the <code>extension</code> level, together with a property named <code>extension</code> specifying a extension (starting with <code>.</code>) or a sequence of extensions to which the directives should be applied.
+If several files with different extensions or no extensions at all shall be mapped, this property must be set to <code>default</code>. 
 Only one handler must exist within the directives.
 </p>
 <?= $ctx->{example}->('Mapping PHP files to FastCGI', <<'EOT')


### PR DESCRIPTION
It took me a while to find out about the `default` value for the `extension` property of the `file-custom-handler`. That's why I added some relevant documentation.