### PR TITLE
http2 upgrade of POST request

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -464,7 +464,7 @@ static int write_req_non_streaming(void *_req, h2o_iovec_t payload, int is_end_e
 
     if (is_end_entity) {
         conn->req.proceed_req = NULL;
-        h2o_process_request(&conn->req);
+        process_request(conn);
     } else {
         proceed_request(&conn->req, payload.len, is_end_entity);
     }

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -53,8 +53,12 @@ h2o_http2_stream_t *h2o_http2_stream_open(h2o_http2_conn_t *conn, uint32_t strea
     /* init request */
     h2o_init_request(&stream->req, &conn->super, src_req);
     stream->req.version = 0x200;
-    if (src_req != NULL)
+    if (src_req != NULL) {
         memset(&stream->req.upgrade, 0, sizeof(stream->req.upgrade));
+        /* steal request body */
+        stream->req._req_body = src_req->_req_body;
+        src_req->_req_body.body = NULL;
+    }
     stream->req._ostr_top = &stream->_ostr_final;
 
     h2o_http2_conn_register_stream(conn, stream);

--- a/t/40http2-upgrade.t
+++ b/t/40http2-upgrade.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Digest::MD5 qw(md5_hex);
+use Test::More;
+use t::Util;
+
+my $upstream_port = empty_port();
+my $upstream = spawn_server(
+    argv     => [ qw(plackup -s Starlet --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+    is_ready =>  sub { check_port($upstream_port) },
+);
+my $server = spawn_h2o(<< "EOT");
+http2-idle-timeout: 2
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+
+subtest 'POST' => sub {
+    plan skip_all => 'curl not found' unless prog_exists('curl');
+
+    for my $streaming (0, 1) {
+        subtest $streaming ? 'streaming' : 'non-streaming', sub {
+            my $size = $streaming ? 1024 * 1024 : 1024;
+            my $file = create_data_file($size);
+            my $file_md5 = md5_file($file);
+
+            my ($stderr, $stdout) = run_prog(join(' ',
+                'curl --silent --dump-header /dev/stderr --http2',
+                "-X POST -d '\@$file' -H 'Expect: '",
+                "http://127.0.0.1:$server->{port}/echo"));
+            like $stderr, qr{HTTP/1.1 101 Switching Protocols}is;
+            like $stderr, qr{HTTP/2 200}is;
+            is md5_hex($stdout), $file_md5, 'body matches';
+        };
+    }
+};
+
+subtest 'OPTIONS' => sub {
+    plan skip_all => 'nghttp not found' unless prog_exists('nghttp');
+
+    my $file = create_data_file(1024 * 1024);
+    my $file_md5 = md5_file($file);
+
+    my $args = "-u -d $file http://127.0.0.1:$server->{port}/echo";
+    my $resp = `nghttp -nv $args`;
+    like $resp, qr{HTTP/1.1 101 Switching Protocols}is;
+    like $resp, qr{recv \(stream_id=\d+\) :status: 200}is;
+    unlike $resp, qr{recv \(stream_id=1\) :status:}is, 'OPTIONS request should not be processed';
+
+    $resp = `nghttp $args`;
+    is md5_hex($resp), $file_md5, 'body matches';
+};
+
+done_testing;
+


### PR DESCRIPTION
[RFC7540 3.2](https://tools.ietf.org/html/rfc7540#section-3.2) allows us to do http2 upgrade even if the request has the body. 

Before this PR,
1. a request with body payload is never upgraded to http2
2.  `OPTIONS` upgrade request is processed too (i.e. the client gets 2 responses)

This PR make h2o able to upgrade such a request to http2 too, and stop processing `OPTIONS` upgrade request.