### PR TITLE
Add an h2o_now_nanosec() func to the Event Loop API

### DIFF
--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -42,7 +42,7 @@ typedef struct st_h2o_evloop_t {
         struct st_h2o_evloop_socket_t *head;
         struct st_h2o_evloop_socket_t **tail_ref;
     } _statechanged;
-    uint64_t _now;
+    uint64_t _now_ms;
     uint64_t _now_ns;
     struct timeval _tv_at;
     h2o_timerwheel_t *_timeouts;
@@ -80,7 +80,7 @@ static inline struct timeval h2o_gettimeofday(h2o_evloop_t *loop)
 
 static inline uint64_t h2o_now(h2o_evloop_t *loop)
 {
-    return loop->_now;
+    return loop->_now_ms;
 }
 
 static inline uint64_t h2o_now_nanosec(h2o_evloop_t *loop)
@@ -95,7 +95,7 @@ static inline uint64_t h2o_evloop_get_execution_time(h2o_evloop_t *loop)
 
 inline void h2o_timer_link(h2o_evloop_t *loop, uint64_t delay_ticks, h2o_timer_t *timer)
 {
-    h2o_timerwheel_link_abs(loop->_timeouts, timer, loop->_now + delay_ticks);
+    h2o_timerwheel_link_abs(loop->_timeouts, timer, loop->_now_ms + delay_ticks);
 }
 
 #endif

--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -43,6 +43,7 @@ typedef struct st_h2o_evloop_t {
         struct st_h2o_evloop_socket_t **tail_ref;
     } _statechanged;
     uint64_t _now;
+    uint64_t _now_ns;
     struct timeval _tv_at;
     h2o_timerwheel_t *_timeouts;
     h2o_sliding_counter_t exec_time_counter;
@@ -80,6 +81,11 @@ static inline struct timeval h2o_gettimeofday(h2o_evloop_t *loop)
 static inline uint64_t h2o_now(h2o_evloop_t *loop)
 {
     return loop->_now;
+}
+
+static inline uint64_t h2o_now_nanosec(h2o_evloop_t *loop)
+{
+    return loop->_now_ns;
 }
 
 static inline uint64_t h2o_evloop_get_execution_time(h2o_evloop_t *loop)

--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -42,8 +42,8 @@ typedef struct st_h2o_evloop_t {
         struct st_h2o_evloop_socket_t *head;
         struct st_h2o_evloop_socket_t **tail_ref;
     } _statechanged;
-    uint64_t _now_ms;
-    uint64_t _now_ns;
+    uint64_t _now_millisec;
+    uint64_t _now_nanosec;
     struct timeval _tv_at;
     h2o_timerwheel_t *_timeouts;
     h2o_sliding_counter_t exec_time_counter;
@@ -80,12 +80,12 @@ static inline struct timeval h2o_gettimeofday(h2o_evloop_t *loop)
 
 static inline uint64_t h2o_now(h2o_evloop_t *loop)
 {
-    return loop->_now_ms;
+    return loop->_now_millisec;
 }
 
 static inline uint64_t h2o_now_nanosec(h2o_evloop_t *loop)
 {
-    return loop->_now_ns;
+    return loop->_now_nanosec;
 }
 
 static inline uint64_t h2o_evloop_get_execution_time(h2o_evloop_t *loop)
@@ -95,7 +95,7 @@ static inline uint64_t h2o_evloop_get_execution_time(h2o_evloop_t *loop)
 
 inline void h2o_timer_link(h2o_evloop_t *loop, uint64_t delay_ticks, h2o_timer_t *timer)
 {
-    h2o_timerwheel_link_abs(loop->_timeouts, timer, loop->_now_ms + delay_ticks);
+    h2o_timerwheel_link_abs(loop->_timeouts, timer, loop->_now_millisec + delay_ticks);
 }
 
 #endif

--- a/include/h2o/socket/uv-binding.h
+++ b/include/h2o/socket/uv-binding.h
@@ -62,6 +62,11 @@ static inline uint64_t h2o_now(h2o_loop_t *loop)
     return uv_now(loop);
 }
 
+static inline uint64_t h2o_now_nanosec(h2o_evloop_t *loop)
+{
+    return uv_hrtime();
+}
+
 inline void h2o_timer_init(h2o_timer_t *timer, h2o_timer_cb cb)
 {
     memset(timer, 0, sizeof(*timer));

--- a/include/h2o/socket/uv-binding.h
+++ b/include/h2o/socket/uv-binding.h
@@ -62,9 +62,9 @@ static inline uint64_t h2o_now(h2o_loop_t *loop)
     return uv_now(loop);
 }
 
-static inline uint64_t h2o_now_nanosec(h2o_evloop_t *loop)
+static inline uint64_t h2o_now_nanosec(h2o_loop_t *loop)
 {
-    return uv_hrtime();
+    return uv_now(loop) * 1000000;
 }
 
 inline void h2o_timer_init(h2o_timer_t *timer, h2o_timer_cb cb)

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -475,7 +475,8 @@ h2o_evloop_t *create_evloop(size_t sz)
 void update_now(h2o_evloop_t *loop)
 {
     gettimeofday(&loop->_tv_at, NULL);
-    loop->_now = (uint64_t)loop->_tv_at.tv_sec * 1000 + loop->_tv_at.tv_usec / 1000;
+    loop->_now_ns = (uint64_t)(loop->_tv_at.tv_sec * 1000000 + loop->_tv_at.tv_usec) * 1000;
+    loop->_now = loop->_now_ns / 1000000;
 }
 
 int32_t adjust_max_wait(h2o_evloop_t *loop, int32_t max_wait)

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -467,7 +467,7 @@ h2o_evloop_t *create_evloop(size_t sz)
     loop->_statechanged.tail_ref = &loop->_statechanged.head;
     update_now(loop);
     /* 3 levels * 32-slots => 1 second goes into 2nd, becomes O(N) above approx. 31 seconds */
-    loop->_timeouts = h2o_timerwheel_create(3, loop->_now_ms);
+    loop->_timeouts = h2o_timerwheel_create(3, loop->_now_millisec);
 
     return loop;
 }
@@ -475,8 +475,8 @@ h2o_evloop_t *create_evloop(size_t sz)
 void update_now(h2o_evloop_t *loop)
 {
     gettimeofday(&loop->_tv_at, NULL);
-    loop->_now_ns = (uint64_t)(loop->_tv_at.tv_sec * 1000000 + loop->_tv_at.tv_usec) * 1000;
-    loop->_now_ms = loop->_now_ns / 1000000;
+    loop->_now_nanosec = (uint64_t)(loop->_tv_at.tv_sec * 1000000 + loop->_tv_at.tv_usec) * 1000;
+    loop->_now_millisec = loop->_now_nanosec / 1000000;
 }
 
 int32_t adjust_max_wait(h2o_evloop_t *loop, int32_t max_wait)
@@ -485,10 +485,10 @@ int32_t adjust_max_wait(h2o_evloop_t *loop, int32_t max_wait)
 
     update_now(loop);
 
-    if (wake_at <= loop->_now_ms) {
+    if (wake_at <= loop->_now_millisec) {
         max_wait = 0;
     } else {
-        uint64_t delta = wake_at - loop->_now_ms;
+        uint64_t delta = wake_at - loop->_now_millisec;
         if (delta < max_wait)
             max_wait = (int32_t)delta;
     }
@@ -607,7 +607,7 @@ int h2o_evloop_run(h2o_evloop_t *loop, int32_t max_wait)
     while (1) {
         h2o_linklist_t expired;
         h2o_linklist_init_anchor(&expired);
-        h2o_timerwheel_get_expired(loop->_timeouts, loop->_now_ms, &expired);
+        h2o_timerwheel_get_expired(loop->_timeouts, loop->_now_millisec, &expired);
         if (h2o_linklist_is_empty(&expired))
             break;
         do {
@@ -623,7 +623,7 @@ int h2o_evloop_run(h2o_evloop_t *loop, int32_t max_wait)
 
     if (h2o_sliding_counter_is_running(&loop->exec_time_counter)) {
         update_now(loop);
-        h2o_sliding_counter_stop(&loop->exec_time_counter, loop->_now_ms);
+        h2o_sliding_counter_stop(&loop->exec_time_counter, loop->_now_millisec);
     }
 
     return 0;

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -475,7 +475,7 @@ h2o_evloop_t *create_evloop(size_t sz)
 void update_now(h2o_evloop_t *loop)
 {
     gettimeofday(&loop->_tv_at, NULL);
-    loop->_now_nanosec = (uint64_t)(loop->_tv_at.tv_sec * 1000000 + loop->_tv_at.tv_usec) * 1000;
+    loop->_now_nanosec = ((uint64_t)loop->_tv_at.tv_sec * 1000000 + loop->_tv_at.tv_usec) * 1000;
     loop->_now_millisec = loop->_now_nanosec / 1000000;
 }
 

--- a/lib/common/socket/evloop/epoll.c.h
+++ b/lib/common/socket/evloop/epoll.c.h
@@ -118,7 +118,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop, int32_t max_wait)
         return -1;
 
     if (nevents != 0)
-        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now);
+        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now_millisec);
 
     /* update readable flags, perform writes */
     for (i = 0; i != nevents; ++i) {

--- a/lib/common/socket/evloop/kqueue.c.h
+++ b/lib/common/socket/evloop/kqueue.c.h
@@ -124,7 +124,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop, int32_t max_wait)
         return -1;
 
     if (nevents != 0)
-        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now_ms);
+        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now_millisec);
 
     /* update readable flags, perform writes */
     for (i = 0; i != nevents; ++i) {

--- a/lib/common/socket/evloop/kqueue.c.h
+++ b/lib/common/socket/evloop/kqueue.c.h
@@ -124,7 +124,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop, int32_t max_wait)
         return -1;
 
     if (nevents != 0)
-        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now);
+        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now_ms);
 
     /* update readable flags, perform writes */
     for (i = 0; i != nevents; ++i) {

--- a/lib/common/socket/evloop/poll.c.h
+++ b/lib/common/socket/evloop/poll.c.h
@@ -110,7 +110,7 @@ int evloop_do_proceed(h2o_evloop_t *_loop, int32_t max_wait)
     /* update readable flags, perform writes */
     if (ret > 0) {
         size_t i;
-        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now);
+        h2o_sliding_counter_start(&loop->super.exec_time_counter, loop->super._now_millisec);
         for (i = 0; i != pollfds.size; ++i) {
             /* set read_ready flag before calling the write cb, since app. code invoked by the latter may close the socket, clearing
              * the former flag */


### PR DESCRIPTION
## Why

To gain better insight into the event loop latency. Nanosecond granularity will be useful.

## How

- Add a `now_ns` member to `h2o_evloop_t`, alongside the existing `now`
- Calculate `now_ns` first, and then derive `now`
- ~For [libuv](https://github.com/libuv/libuv), simply call the [uv_hrtime](http://docs.libuv.org/en/v1.x/misc.html#c.uv_hrtime) function as suggested in their documentation~

## Extra

Rename `now` to `now_ms` for clarity at a glance.