### PR TITLE
socket: Add h2o_socket_get_ssl_server_name()

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -262,6 +262,7 @@ int h2o_socket_get_ssl_session_reused(h2o_socket_t *sock);
 const char *h2o_socket_get_ssl_cipher(h2o_socket_t *sock);
 int h2o_socket_get_ssl_cipher_bits(h2o_socket_t *sock);
 h2o_iovec_t h2o_socket_get_ssl_session_id(h2o_socket_t *sock);
+const char *h2o_socket_get_ssl_server_name(const h2o_socket_t *sock);
 static h2o_iovec_t h2o_socket_log_ssl_protocol_version(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 static h2o_iovec_t h2o_socket_log_ssl_session_reused(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 static h2o_iovec_t h2o_socket_log_ssl_cipher(h2o_socket_t *sock, h2o_mem_pool_t *pool);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -838,6 +838,21 @@ h2o_iovec_t h2o_socket_get_ssl_session_id(h2o_socket_t *sock)
     return h2o_iovec_init(NULL, 0);
 }
 
+const char *h2o_socket_get_ssl_server_name(const h2o_socket_t *sock)
+{
+  if (sock->ssl != NULL) {
+#if H2O_USE_PICOTLS
+      if (sock->ssl->ptls != NULL) {
+          return ptls_get_server_name(sock->ssl->ptls);
+      } else
+#endif
+      if (sock->ssl->ossl != NULL) {
+          return SSL_get_servername(sock->ssl->ossl, TLSEXT_NAMETYPE_host_name);
+      }
+  }
+  return NULL;
+}
+
 h2o_iovec_t h2o_socket_log_ssl_session_id(h2o_socket_t *sock, h2o_mem_pool_t *pool)
 {
     h2o_iovec_t base64id, rawid = h2o_socket_get_ssl_session_id(sock);


### PR DESCRIPTION
It looks like there is currently no way to retrieve the TLS Server Name Indication value sent by the client, if any, from the existing libh2o API. This new function provides access to this value when it is present.