### PR TITLE
Keep track of mmap failures

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -335,6 +335,7 @@ void h2o_dump_memory(FILE *fp, const char *buf, size_t len);
 void h2o_append_to_null_terminated_list(void ***list, void *element);
 
 extern __thread h2o_mem_recycle_t h2o_mem_pool_allocator;
+extern size_t mmap_errors;
 
 /* inline defs */
 

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -335,7 +335,7 @@ void h2o_dump_memory(FILE *fp, const char *buf, size_t len);
 void h2o_append_to_null_terminated_list(void ***list, void *element);
 
 extern __thread h2o_mem_recycle_t h2o_mem_pool_allocator;
-extern size_t mmap_errors;
+extern size_t h2o_mmap_errors;
 
 /* inline defs */
 

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -69,6 +69,7 @@ struct st_h2o_mem_pool_shared_ref_t {
 void *(*volatile h2o_mem__set_secure)(void *, int, size_t) = memset;
 
 __thread h2o_mem_recycle_t h2o_mem_pool_allocator = {16};
+size_t mmap_errors = 0;
 
 void h2o__fatal(const char *file, int line, const char *msg, ...)
 {
@@ -331,6 +332,7 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
     return ret;
 
 MapError:
+    __sync_add_and_fetch(&mmap_errors, 1);
     ret.base = NULL;
     ret.len = 0;
     return ret;

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -69,7 +69,7 @@ struct st_h2o_mem_pool_shared_ref_t {
 void *(*volatile h2o_mem__set_secure)(void *, int, size_t) = memset;
 
 __thread h2o_mem_recycle_t h2o_mem_pool_allocator = {16};
-size_t mmap_errors = 0;
+size_t h2o_mmap_errors = 0;
 
 void h2o__fatal(const char *file, int line, const char *msg, ...)
 {
@@ -332,7 +332,7 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
     return ret;
 
 MapError:
-    __sync_add_and_fetch(&mmap_errors, 1);
+    __sync_add_and_fetch(&h2o_mmap_errors, 1);
     ret.base = NULL;
     ret.len = 0;
     return ret;

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -98,13 +98,13 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        " \"http2.read-closed\": %" PRIu64 ", \n"
                        " \"http2.write-closed\": %" PRIu64 ", \n"
                        " \"ssl.errors\": %" PRIu64 ", \n"
-                       " \"memory.mmap_errors\": %" PRIu64 "\n",
+                       " \"memory.mmap_errors\": %zu\n",
                        H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
                        H1_AGG_ERR(500), H1_AGG_ERR(502), H1_AGG_ERR(503), H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL),
                        H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT), H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE),
                        H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL), H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT),
                        H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY), esc->h2_read_closed, esc->h2_write_closed,
-                       esc->ssl_errors, (uint64_t)mmap_errors);
+                       esc->ssl_errors, mmap_errors);
     pthread_mutex_destroy(&esc->mutex);
     free(esc);
     return ret;

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -104,7 +104,7 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT), H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE),
                        H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL), H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT),
                        H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY), esc->h2_read_closed, esc->h2_write_closed,
-                       esc->ssl_errors, mmap_errors);
+                       esc->ssl_errors, h2o_mmap_errors);
     pthread_mutex_destroy(&esc->mutex);
     free(esc);
     return ret;

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -97,13 +97,14 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        " \"http2-errors.inadequate-security\": %" PRIu64 ", \n"
                        " \"http2.read-closed\": %" PRIu64 ", \n"
                        " \"http2.write-closed\": %" PRIu64 ", \n"
-                       " \"ssl.errors\": %" PRIu64 "\n",
+                       " \"ssl.errors\": %" PRIu64 ", \n"
+                       " \"memory.mmap_errors\": %" PRIu64 "\n",
                        H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
                        H1_AGG_ERR(500), H1_AGG_ERR(502), H1_AGG_ERR(503), H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL),
                        H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT), H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE),
                        H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL), H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT),
                        H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY), esc->h2_read_closed, esc->h2_write_closed,
-                       esc->ssl_errors);
+                       esc->ssl_errors, (uint64_t)mmap_errors);
     pthread_mutex_destroy(&esc->mutex);
     free(esc);
     return ret;


### PR DESCRIPTION
## Objective

Maintain a count of mmap failures, and make it accessible through the H2O Status API.

## How

Declare a global `size_t` and operate on it using the `__sync_add_and_fetch` atomic built-in function. Code is added to a hot function but given that the error is rare, there should be no performance impact.

## Demonstration

Native Response:

```
$ curl -s localhost:8080/status/json | grep mmap
 "memory.mmap_errors": 0
```

Prometheus Response [via mruby](https://github.com/h2o/h2o/pull/1892):

```
$ curl -s localhost:8080/metrics | grep mmap
# HELP h2o_memory_mmap_errors memory.mmap_errors
# TYPE h2o_memory_mmap_errors counter
h2o_memory_mmap_errors{version="2.3.0-DEV@3aa238b1"} 0
```