### PR TITLE
FIX: SSL_shutdown returns 0 on partial shutdown case

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -395,7 +395,7 @@ static void shutdown_ssl(h2o_socket_t *sock, const char *err)
     if (sock->ssl->output.bufs.size != 0) {
         h2o_socket_read_stop(sock);
         flush_pending_ssl(sock, ret == 1 ? dispose_socket : shutdown_ssl);
-    } else if (ret == 2 && SSL_get_error(sock->ssl->ossl, ret) == SSL_ERROR_WANT_READ) {
+    } else if (ret == 0 && SSL_get_error(sock->ssl->ossl, ret) == SSL_ERROR_WANT_READ) {
         h2o_socket_read_start(sock, shutdown_ssl);
     } else {
         goto Close;


### PR DESCRIPTION
Hi, Kazhuho-san,

I'm afraid that we should check the the return code of SSL_shutdown against 0 to handle partial shutdown case. That code resides there for 5 near years so I use the word `afraid', not `sure'.  

Thank you for your works.

Kind regards,
Chul-Woong