### PR TITLE
implement our own "once" function

### DIFF
--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -85,7 +85,7 @@ void h2o_multithread_create_thread(pthread_t *tid, const pthread_attr_t *attr, v
 /**
  * a variant of pthread_once, that does not require you to declare a callback, nor have a global variable
  */
-#define H2O_MULTITRHEAD_ONCE(block)                                                                                                \
+#define H2O_MULTITHREAD_ONCE(block)                                                                                                \
     do {                                                                                                                           \
         static volatile int lock = 0;                                                                                              \
         int lock_loaded = lock;                                                                                                    \

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -82,6 +82,28 @@ void h2o_multithread_send_message(h2o_multithread_receiver_t *receiver, h2o_mult
  */
 void h2o_multithread_create_thread(pthread_t *tid, const pthread_attr_t *attr, void *(*func)(void *), void *arg);
 
+/**
+ * a variant of pthread_once, that does not require you to declare a callback, nor have a global variable
+ */
+#define H2O_MULTITRHEAD_ONCE(block)                                                                                                \
+    do {                                                                                                                           \
+        static volatile int lock = 0;                                                                                              \
+        int lock_loaded = lock;                                                                                                    \
+        __sync_synchronize();                                                                                                      \
+        if (!lock_loaded) {                                                                                                        \
+            static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;                                                              \
+            pthread_mutex_lock(&mutex);                                                                                            \
+            if (!lock) {                                                                                                           \
+                do {                                                                                                               \
+                    block                                                                                                          \
+                } while (0);                                                                                                       \
+                __sync_synchronize();                                                                                              \
+                lock = 1;                                                                                                          \
+            }                                                                                                                      \
+            pthread_mutex_unlock(&mutex);                                                                                          \
+        }                                                                                                                          \
+    } while (0)
+
 void h2o_sem_init(h2o_sem_t *sem, ssize_t capacity);
 void h2o_sem_destroy(h2o_sem_t *sem);
 void h2o_sem_wait(h2o_sem_t *sem);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -212,7 +212,7 @@ static long ctrl_bio(BIO *b, int cmd, long num, void *ptr)
 
 static void setup_bio(h2o_socket_t *sock)
 {
-    static BIO_METHOD *bio_methods = NULL;
+    static volatile BIO_METHOD *bio_methods = NULL;
     H2O_MULTITRHEAD_ONCE({
         bio_methods = BIO_meth_new(BIO_TYPE_FD, "h2o_socket");
         BIO_meth_set_write(bio_methods, write_bio);
@@ -1302,7 +1302,7 @@ void h2o_socket_ssl_async_resumption_setup_ctx(SSL_CTX *ctx)
 
 static int get_ptls_index(void)
 {
-    static int index;
+    static volatile int index;
     H2O_MULTITRHEAD_ONCE({ index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL); });
     return index;
 }
@@ -1328,7 +1328,7 @@ static void on_dispose_ssl_ctx_session_cache(void *parent, void *ptr, CRYPTO_EX_
 
 static int get_ssl_session_cache_index(void)
 {
-    static int index;
+    static volatile int index;
     H2O_MULTITRHEAD_ONCE({ index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, on_dispose_ssl_ctx_session_cache); });
     return index;
 }

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -213,7 +213,7 @@ static long ctrl_bio(BIO *b, int cmd, long num, void *ptr)
 static void setup_bio(h2o_socket_t *sock)
 {
     static volatile BIO_METHOD *bio_methods = NULL;
-    H2O_MULTITRHEAD_ONCE({
+    H2O_MULTITHREAD_ONCE({
         bio_methods = BIO_meth_new(BIO_TYPE_FD, "h2o_socket");
         BIO_meth_set_write(bio_methods, write_bio);
         BIO_meth_set_read(bio_methods, read_bio);
@@ -1303,7 +1303,7 @@ void h2o_socket_ssl_async_resumption_setup_ctx(SSL_CTX *ctx)
 static int get_ptls_index(void)
 {
     static volatile int index;
-    H2O_MULTITRHEAD_ONCE({ index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL); });
+    H2O_MULTITHREAD_ONCE({ index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL); });
     return index;
 }
 
@@ -1329,7 +1329,7 @@ static void on_dispose_ssl_ctx_session_cache(void *parent, void *ptr, CRYPTO_EX_
 static int get_ssl_session_cache_index(void)
 {
     static volatile int index;
-    H2O_MULTITRHEAD_ONCE({ index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, on_dispose_ssl_ctx_session_cache); });
+    H2O_MULTITHREAD_ONCE({ index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, on_dispose_ssl_ctx_session_cache); });
     return index;
 }
 

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -37,6 +37,7 @@
 #include "picotls.h"
 #endif
 #include "h2o/socket.h"
+#include "h2o/multithread.h"
 
 #if defined(__APPLE__) && defined(__clang__)
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -212,20 +213,13 @@ static long ctrl_bio(BIO *b, int cmd, long num, void *ptr)
 static void setup_bio(h2o_socket_t *sock)
 {
     static BIO_METHOD *bio_methods = NULL;
-    if (bio_methods == NULL) {
-        static pthread_mutex_t init_lock = PTHREAD_MUTEX_INITIALIZER;
-        pthread_mutex_lock(&init_lock);
-        if (bio_methods == NULL) {
-            BIO_METHOD *biom = BIO_meth_new(BIO_TYPE_FD, "h2o_socket");
-            BIO_meth_set_write(biom, write_bio);
-            BIO_meth_set_read(biom, read_bio);
-            BIO_meth_set_puts(biom, puts_bio);
-            BIO_meth_set_ctrl(biom, ctrl_bio);
-            __sync_synchronize();
-            bio_methods = biom;
-        }
-        pthread_mutex_unlock(&init_lock);
-    }
+    H2O_MULTITRHEAD_ONCE({
+        bio_methods = BIO_meth_new(BIO_TYPE_FD, "h2o_socket");
+        BIO_meth_set_write(bio_methods, write_bio);
+        BIO_meth_set_read(bio_methods, read_bio);
+        BIO_meth_set_puts(bio_methods, puts_bio);
+        BIO_meth_set_ctrl(bio_methods, ctrl_bio);
+    });
 
     BIO *bio = BIO_new(bio_methods);
     if (bio == NULL)
@@ -1308,18 +1302,8 @@ void h2o_socket_ssl_async_resumption_setup_ctx(SSL_CTX *ctx)
 
 static int get_ptls_index(void)
 {
-    static int index = -1;
-
-    if (index == -1) {
-        static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-        pthread_mutex_lock(&mutex);
-        if (index == -1) {
-            index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
-            assert(index != -1);
-        }
-        pthread_mutex_unlock(&mutex);
-    }
-
+    static int index;
+    H2O_MULTITRHEAD_ONCE({ index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL); });
     return index;
 }
 
@@ -1344,14 +1328,8 @@ static void on_dispose_ssl_ctx_session_cache(void *parent, void *ptr, CRYPTO_EX_
 
 static int get_ssl_session_cache_index(void)
 {
-    static int index = -1;
-    static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-    pthread_mutex_lock(&mutex);
-    if (index == -1) {
-        index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, on_dispose_ssl_ctx_session_cache);
-        assert(index != -1);
-    }
-    pthread_mutex_unlock(&mutex);
+    static int index;
+    H2O_MULTITRHEAD_ONCE({ index = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, on_dispose_ssl_ctx_session_cache); });
     return index;
 }
 


### PR DESCRIPTION
My affection to using closures instead of declaring callbacks (and global variables) is strong enough to define a replacement for `pthread_once` function that takes a closure as an argument.

Actually, this PR fixes theoretical race conditions in some of the initialization code that we run. 9c06f68 addresses two cases where an "index" might be used by a different thread, before the objects that are being referred to by that "index" is being written to memory.