### PR TITLE
add support for openssl1.1.1 session cache resumption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,12 @@ matrix:
       before_install: *bi
       script:
         - make -f misc/docker-ci/check.mk ossl1.1.0
+    - os: linux
+      sudo: required
+      services:
+        - docker
+      env:
+        - label=openssl-1.1.1
+      before_install: *bi
+      script:
+        - make -f misc/docker-ci/check.mk ossl1.1.1

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -71,6 +71,9 @@ void h2o_sliding_counter_stop(h2o_sliding_counter_t *counter, uint64_t now);
 
 #define H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE 4096
 
+#define H2O_SESSID_CTX ((const uint8_t*)"h2o")
+#define H2O_SESSID_CTX_LEN (sizeof("h2o") - 1)
+
 typedef struct st_h2o_socket_t h2o_socket_t;
 
 typedef void (*h2o_socket_cb)(h2o_socket_t *sock, const char *err);

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -268,6 +268,7 @@ static h2o_iovec_t h2o_socket_log_ssl_session_reused(h2o_socket_t *sock, h2o_mem
 static h2o_iovec_t h2o_socket_log_ssl_cipher(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 h2o_iovec_t h2o_socket_log_ssl_cipher_bits(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 h2o_iovec_t h2o_socket_log_ssl_session_id(h2o_socket_t *sock, h2o_mem_pool_t *pool);
+int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess);
 
 /**
  * compares socket addresses

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -937,7 +937,7 @@ static void create_ossl(h2o_socket_t *sock)
 {
     sock->ssl->ossl = SSL_new(sock->ssl->ssl_ctx);
     /* set app data to be used in h2o_socket_ssl_new_session_cb */
-    assert(SSL_set_app_data(sock->ssl->ossl, sock));
+    SSL_set_app_data(sock->ssl->ossl, sock);
     setup_bio(sock);
 }
 

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -965,7 +965,8 @@ static SSL_SESSION *on_async_resumption_get(SSL *ssl,
 int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess)
 {
     h2o_socket_t *sock = (h2o_socket_t *)SSL_get_app_data(s);
-    assert(sock && sock->ssl);
+    if (sock == NULL || sock->ssl == NULL)
+        return 0;
 
     SSL_SESSION *session = NULL;
     if (!SSL_is_server(s) && sock->ssl->handshake.client.session_cache != NULL) {
@@ -986,7 +987,7 @@ int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess)
      * 0 - drop ref count
      * 1 - keep ref count
      */
-    return session ? 1 : 0;
+    return (session != NULL) ? 1 : 0;
 }
 
 static int on_async_resumption_new(SSL *ssl, SSL_SESSION *session)

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -972,16 +972,15 @@ int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess)
 
     SSL_SESSION *session = NULL;
     if (!SSL_is_server(s) && sock->ssl->handshake.client.session_cache != NULL) {
-        session = SSL_get_session(sock->ssl->ossl);
 #if OPENSSL_VERSION_NUMBER >= 0x1010100fL
-        if (SSL_SESSION_is_resumable(session))
+        if (SSL_SESSION_is_resumable(sess)) {
 #endif
+        session = sess;
         h2o_cache_set(sock->ssl->handshake.client.session_cache, h2o_now(h2o_socket_get_loop(sock)),
                      sock->ssl->handshake.client.session_cache_key, sock->ssl->handshake.client.session_cache_key_hash,
                      h2o_iovec_init(session, 1));
 #if OPENSSL_VERSION_NUMBER >= 0x1010100fL
-        else
-            session = NULL;
+        }
 #endif
     }
 

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -936,6 +936,8 @@ int32_t h2o_socket_getport(struct sockaddr *sa)
 static void create_ossl(h2o_socket_t *sock)
 {
     sock->ssl->ossl = SSL_new(sock->ssl->ssl_ctx);
+    /* set app data to be used in h2o_socket_ssl_new_session_cb */
+    assert(SSL_set_app_data(sock->ssl->ossl, sock));
     setup_bio(sock);
 }
 
@@ -965,8 +967,8 @@ static SSL_SESSION *on_async_resumption_get(SSL *ssl,
 int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess)
 {
     h2o_socket_t *sock = (h2o_socket_t *)SSL_get_app_data(s);
-    if (sock == NULL || sock->ssl == NULL)
-        return 0;
+    assert(sock != NULL);
+    assert(sock->ssl != NULL);
 
     SSL_SESSION *session = NULL;
     if (!SSL_is_server(s) && sock->ssl->handshake.client.session_cache != NULL) {

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -970,25 +970,18 @@ int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess)
     assert(sock != NULL);
     assert(sock->ssl != NULL);
 
-    SSL_SESSION *session = NULL;
-    if (!SSL_is_server(s) && sock->ssl->handshake.client.session_cache != NULL) {
+    if (!SSL_is_server(s) && sock->ssl->handshake.client.session_cache != NULL
 #if OPENSSL_VERSION_NUMBER >= 0x1010100fL
-        if (SSL_SESSION_is_resumable(sess)) {
+        && SSL_SESSION_is_resumable(sess)
 #endif
-        session = sess;
+    ) {
         h2o_cache_set(sock->ssl->handshake.client.session_cache, h2o_now(h2o_socket_get_loop(sock)),
-                     sock->ssl->handshake.client.session_cache_key, sock->ssl->handshake.client.session_cache_key_hash,
-                     h2o_iovec_init(session, 1));
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
-        }
-#endif
+                      sock->ssl->handshake.client.session_cache_key, sock->ssl->handshake.client.session_cache_key_hash,
+                      h2o_iovec_init(sess, 1));
+        return 1; /* retain ref count */
     }
 
-    /*
-     * 0 - drop ref count
-     * 1 - keep ref count
-     */
-    return (session != NULL) ? 1 : 0;
+    return 0; /* drop ref count */
 }
 
 static int on_async_resumption_new(SSL *ssl, SSL_SESSION *session)

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -971,7 +971,7 @@ int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess)
     assert(sock->ssl != NULL);
 
     if (!SSL_is_server(s) && sock->ssl->handshake.client.session_cache != NULL
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010100fL
         && SSL_SESSION_is_resumable(sess)
 #endif
     ) {

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -116,7 +116,7 @@ static int on_config_websocket(h2o_configurator_command_t *cmd, h2o_configurator
 static SSL_CTX *create_ssl_ctx(void)
 {
     long options;
-    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+    SSL_CTX *ctx = SSL_CTX_new(SSLv23_client_method());
     options = SSL_CTX_get_options(ctx) | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
 #ifdef SSL_OP_NO_RENEGOTIATION
     /* introduced in openssl 1.1.0h */

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -123,7 +123,7 @@ static SSL_CTX *create_ssl_ctx(void)
     options |= SSL_OP_NO_RENEGOTIATION;
 #endif
     SSL_CTX_set_options(ctx, options);
-    SSL_CTX_set_session_id_context(ctx, (const uint8_t*)"h2o", sizeof("h2o") - 1);
+    SSL_CTX_set_session_id_context(ctx, H2O_SESSID_CTX, H2O_SESSID_CTX_LEN);
     SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL_STORE);
     SSL_CTX_sess_set_new_cb(ctx, h2o_socket_ssl_new_session_cb);
     return ctx;
@@ -159,7 +159,7 @@ static void update_ssl_ctx(SSL_CTX **ctx, X509_STORE *cert_store, int verify_mod
 
     /* create new ctx */
     *ctx = create_ssl_ctx();
-    SSL_CTX_set_session_id_context(*ctx, (const uint8_t*)"h2o", sizeof("h2o") - 1);
+    SSL_CTX_set_session_id_context(*ctx, H2O_SESSID_CTX, H2O_SESSID_CTX_LEN);
     SSL_CTX_set_cert_store(*ctx, cert_store);
     SSL_CTX_set_verify(*ctx, verify_mode, NULL);
     if (new_session_cache != NULL)

--- a/misc/docker-ci/Dockerfile
+++ b/misc/docker-ci/Dockerfile
@@ -18,14 +18,23 @@ ENV PATH=/usr/lib/llvm-4.0/bin:$PATH
 RUN wget --no-verbose -O - https://curl.haxx.se/download/curl-7.57.0.tar.gz | tar xzf -
 RUN (cd curl-7.57.0 && ./configure --prefix=/usr/local --with-nghttp2 --disable-shared && make && sudo make install)
 
-# openssl 1.1.0
 ARG OPENSSL_URL="https://www.openssl.org/source/"
+# openssl 1.1.0
 ARG OPENSSL_VERSION="1.1.0i"
 ARG OPENSSL_SHA1="6713f8b083e4c0b0e70fd090bf714169baf3717c"
 RUN curl -O ${OPENSSL_URL}openssl-${OPENSSL_VERSION}.tar.gz
 RUN (echo "${OPENSSL_SHA1} openssl-${OPENSSL_VERSION}.tar.gz" | sha1sum -c - && tar xf openssl-${OPENSSL_VERSION}.tar.gz)
 RUN (cd openssl-${OPENSSL_VERSION} && \
 	./config --prefix=/opt/openssl-1.1.0 --openssldir=/opt/openssl-1.1.0 shared enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers && \
+	make -j $(nproc) && make -j install_sw install_ssldirs)
+
+# openssl 1.1.1
+ARG OPENSSL_VERSION="1.1.1c"
+ARG OPENSSL_SHA1="71b830a077276cbeccc994369538617a21bee808"
+RUN curl -O ${OPENSSL_URL}openssl-${OPENSSL_VERSION}.tar.gz
+RUN (echo "${OPENSSL_SHA1} openssl-${OPENSSL_VERSION}.tar.gz" | sha1sum -c - && tar xf openssl-${OPENSSL_VERSION}.tar.gz)
+RUN (cd openssl-${OPENSSL_VERSION} && \
+	./config --prefix=/opt/openssl-1.1.1 --openssldir=/opt/openssl-1.1.1 shared enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers && \
 	make -j $(nproc) && make -j install_sw install_ssldirs)
 
 # cpan modules

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -14,6 +14,9 @@ fuzz:
 ossl1.1.0:
 	docker run $(DOCKER_RUN_OPTS) $(CONTAINER_NAME) make -f /h2o/misc/docker-ci/check.mk _ossl1.1.0
 
+ossl1.1.1:
+	docker run $(DOCKER_RUN_OPTS) $(CONTAINER_NAME) make -f /h2o/misc/docker-ci/check.mk _ossl1.1.1
+
 _check:
 	mkdir -p build
 	$(MAKE) -f $(CHECK_MK) -C build _do-check CMAKE_ARGS=$(CMAKE_ARGS)

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -27,6 +27,9 @@ _do-check:
 _ossl1.1.0:
 	$(MAKE) -f $(CHECK_MK) _check CMAKE_ARGS=-DOPENSSL_ROOT_DIR=/opt/openssl-1.1.0
 
+_ossl1.1.1:
+	$(MAKE) -f $(CHECK_MK) _check CMAKE_ARGS=-DOPENSSL_ROOT_DIR=/opt/openssl-1.1.1
+
 _fuzz:
 	$(FUZZ_ASAN) CC=clang CXX=clang++ $(MAKE) -f $(CHECK_MK) _check CMAKE_ARGS=-DBUILD_FUZZER=ON
 	$(FUZZ_ASAN) $(MAKE) -f $(CHECK_MK) -C build _do-fuzz-extra

--- a/src/main.c
+++ b/src/main.c
@@ -695,7 +695,7 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
 #endif
 
     /* setup */
-    ssl_ctx = SSL_CTX_new(TLS_server_method());
+    ssl_ctx = SSL_CTX_new(SSLv23_server_method());
     SSL_CTX_set_options(ssl_ctx, ssl_options);
 
     SSL_CTX_set_session_id_context(ssl_ctx, (const uint8_t*)"h2o", sizeof("h2o") - 1);

--- a/src/main.c
+++ b/src/main.c
@@ -690,9 +690,15 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
     ssl_options |= SSL_OP_NO_COMPRESSION;
 #endif
 
+#ifdef SSL_OP_NO_RENEGOTIATION
+    ssl_options |= SSL_OP_NO_RENEGOTIATION;
+#endif
+
     /* setup */
-    ssl_ctx = SSL_CTX_new(SSLv23_server_method());
+    ssl_ctx = SSL_CTX_new(TLS_server_method());
     SSL_CTX_set_options(ssl_ctx, ssl_options);
+
+    SSL_CTX_set_session_id_context(ssl_ctx, (const uint8_t*)"h2o", sizeof("h2o") - 1);
 
     setup_ecc_key(ssl_ctx);
     if (SSL_CTX_use_certificate_chain_file(ssl_ctx, (*certificate_file)->data.scalar) != 1) {

--- a/src/main.c
+++ b/src/main.c
@@ -698,7 +698,7 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
     ssl_ctx = SSL_CTX_new(SSLv23_server_method());
     SSL_CTX_set_options(ssl_ctx, ssl_options);
 
-    SSL_CTX_set_session_id_context(ssl_ctx, (const uint8_t*)"h2o", sizeof("h2o") - 1);
+    SSL_CTX_set_session_id_context(ssl_ctx, H2O_SESSID_CTX, H2O_SESSID_CTX_LEN);
 
     setup_ecc_key(ssl_ctx);
     if (SSL_CTX_use_certificate_chain_file(ssl_ctx, (*certificate_file)->data.scalar) != 1) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -130,6 +130,7 @@ static void setup_cache_enable(SSL_CTX **contexts, size_t num_contexts, int asyn
     size_t i;
     for (i = 0; i != num_contexts; ++i) {
         SSL_CTX_set_session_cache_mode(contexts[i], SSL_SESS_CACHE_SERVER | SSL_SESS_CACHE_NO_AUTO_CLEAR);
+        SSL_CTX_set_session_id_context(contexts[i], (const uint8_t*)"h2o", sizeof("h2o") - 1);
         SSL_CTX_set_timeout(contexts[i], conf.lifetime);
         if (async_resumption)
             h2o_socket_ssl_async_resumption_setup_ctx(contexts[i]);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -130,7 +130,7 @@ static void setup_cache_enable(SSL_CTX **contexts, size_t num_contexts, int asyn
     size_t i;
     for (i = 0; i != num_contexts; ++i) {
         SSL_CTX_set_session_cache_mode(contexts[i], SSL_SESS_CACHE_SERVER | SSL_SESS_CACHE_NO_AUTO_CLEAR);
-        SSL_CTX_set_session_id_context(contexts[i], (const uint8_t*)"h2o", sizeof("h2o") - 1);
+        SSL_CTX_set_session_id_context(contexts[i], H2O_SESSID_CTX, H2O_SESSID_CTX_LEN);
         SSL_CTX_set_timeout(contexts[i], conf.lifetime);
         if (async_resumption)
             h2o_socket_ssl_async_resumption_setup_ctx(contexts[i]);


### PR DESCRIPTION
hi, this PR enables ossl-1.1.1 session cache resumption support by moving from the get1 session api to the the new_session callback. Also sets the session cache context and the explicit client session behavior when creating new ossl CTXs (proxy).

this should make `t/50reverse-proxy-session-resumption.t` happy when linking against openssl-1.1.0 and openssl1.1.1

Note that Dockerfile has changed and the CI image will need an update to install openssl-1.1.1c in `/opt/openssl-1.1.1`