### PR TITLE
Update the comment for posix_spawnp

### DIFF
--- a/lib/common/serverutil.c
+++ b/lib/common/serverutil.c
@@ -146,7 +146,7 @@ pid_t h2o_spawnp(const char *cmd, char *const *argv, const int *mapped_fds, int 
     extern int pipe2(int pipefd[2], int flags);
 #endif
 
-    /* posix_spawnp of Linux does not return error if the executable does not exist, see
+    /* Before glibc 2.24, posix_spawnp of Linux does not return error if the executable does not exist, see
      * https://gist.github.com/kazuho/0c233e6f86d27d6e4f09
      */
     extern char **environ;


### PR DESCRIPTION
posix_spawnp can return ENOENT directory since glibc 2.24.
https://sourceware.org/bugzilla/show_bug.cgi?id=10354#c12