### PR TITLE
Disable TLS v1.3 properly (when configured as such)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -683,8 +683,12 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
         ssl_options |= SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
     }
     if (max_version != NULL) {
-        if (strcasecmp((*max_version)->data.scalar, "tlsv1.3") < 0)
+        if (strcasecmp((*max_version)->data.scalar, "tlsv1.3") < 0) {
+#ifdef SSL_OP_NO_TLSv1_3
+            ssl_options |= SSL_OP_NO_TLSv1_3;
+#endif
             use_picotls = 0;
+        }
     }
     if (ocsp_update_interval_node != NULL) {
         if (h2o_configurator_scanf(cmd, *ocsp_update_interval_node, "%" PRIu64, &ocsp_update_interval) != 0)


### PR DESCRIPTION
When TLS 1.3 is request to be disabled, we need to set the flag of OpenSSL (in addition to disabling picotls) now that OpenSSL supports 1.3.