### PR TITLE
propagate detailed information of response body

### DIFF
--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -38,8 +38,12 @@ typedef struct st_h2o_httpclient_properties_t {
     h2o_iovec_t *connection_header;
 } h2o_httpclient_properties_t;
 
+typedef struct st_h2o_httpclient_body_hints_t {
+    size_t *bytes_left_in_chunk;
+} h2o_httpclient_body_hints_t;
+
 typedef void (*h2o_httpclient_proceed_req_cb)(h2o_httpclient_t *client, size_t written, int is_end_stream);
-typedef int (*h2o_httpclient_body_cb)(h2o_httpclient_t *client, const char *errstr);
+typedef int (*h2o_httpclient_body_cb)(h2o_httpclient_t *client, h2o_httpclient_body_hints_t *hints, const char *errstr);
 typedef h2o_httpclient_body_cb (*h2o_httpclient_head_cb)(h2o_httpclient_t *client, const char *errstr, int version, int status,
                                                          h2o_iovec_t msg, h2o_header_t *headers, size_t num_headers,
                                                          int header_requires_dup);

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -75,10 +75,16 @@ static void close_client(struct st_h2o_http1client_t *client)
     free(client);
 }
 
+static int call_on_body_with_no_hints(struct st_h2o_http1client_t *client, const char *errstr)
+{
+    h2o_httpclient_body_hints_t hints = (h2o_httpclient_body_hints_t){NULL};
+    return client->super._cb.on_body(&client->super, &hints, errstr);
+}
+
 static void on_body_error(struct st_h2o_http1client_t *client, const char *errstr)
 {
     client->_do_keepalive = 0;
-    client->super._cb.on_body(&client->super, errstr);
+    call_on_body_with_no_hints(client, errstr);
     close_client(client);
 }
 
@@ -97,13 +103,13 @@ static void on_body_until_close(h2o_socket_t *sock, const char *err)
 
     if (err != NULL) {
         client->super.timings.response_end_at = h2o_gettimeofday(client->super.ctx->loop);
-        client->super._cb.on_body(&client->super, h2o_httpclient_error_is_eos);
+        call_on_body_with_no_hints(client, h2o_httpclient_error_is_eos);
         close_client(client);
         return;
     }
 
     if (sock->bytes_read != 0) {
-        if (client->super._cb.on_body(&client->super, NULL) != 0) {
+        if (call_on_body_with_no_hints(client, NULL) != 0) {
             close_client(client);
             return;
         }
@@ -140,7 +146,7 @@ static void on_body_content_length(h2o_socket_t *sock, const char *err)
             client->_body_decoder.content_length.bytesleft -= sock->bytes_read;
             errstr = NULL;
         }
-        ret = client->super._cb.on_body(&client->super, errstr);
+        ret = call_on_body_with_no_hints(client, errstr);
         if (errstr == h2o_httpclient_error_is_eos) {
             close_client(client);
             return;
@@ -171,7 +177,7 @@ static void on_req_chunked(h2o_socket_t *sock, const char *err)
              */
             client->_do_keepalive = 0;
             client->super.timings.response_end_at = h2o_gettimeofday(client->super.ctx->loop);
-            client->super._cb.on_body(&client->super, h2o_httpclient_error_is_eos);
+            call_on_body_with_no_hints(client, h2o_httpclient_error_is_eos);
             close_client(client);
         } else {
             on_body_error(client, "I/O error (body; chunked)");
@@ -205,7 +211,10 @@ static void on_req_chunked(h2o_socket_t *sock, const char *err)
         inbuf->size -= sock->bytes_read - newsz;
         if (inbuf->size > 0)
             client->_seen_at_least_one_chunk = 1;
-        cb_ret = client->super._cb.on_body(&client->super, errstr);
+
+        size_t bytes_left_in_chunk = client->_body_decoder.chunked.decoder.bytes_left_in_chunk;
+        h2o_httpclient_body_hints_t hints = (h2o_httpclient_body_hints_t){&bytes_left_in_chunk};
+        cb_ret = client->super._cb.on_body(&client->super, &hints, errstr);
         if (errstr != NULL) {
             close_client(client);
             return;

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -382,7 +382,7 @@ static void copy_stats(struct rp_generator_t *self)
     self->src_req->proxy_stats.bytes_written.body = self->client->bytes_written.body;
 }
 
-static int on_body(h2o_httpclient_t *client, const char *errstr)
+static int on_body(h2o_httpclient_t *client, h2o_httpclient_body_hints_t *hints, const char *errstr)
 {
     struct rp_generator_t *self = client->data;
 

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -361,7 +361,7 @@ static mrb_value build_chunk(struct st_h2o_mruby_http_request_context_t *ctx)
     return chunk;
 }
 
-static int do_on_body(h2o_httpclient_t *client, const char *errstr)
+static int do_on_body(h2o_httpclient_t *client, h2o_httpclient_body_hints_t *hints, const char *errstr)
 {
     struct st_h2o_mruby_http_request_context_t *ctx = client->data;
 
@@ -387,7 +387,7 @@ static int do_on_body(h2o_httpclient_t *client, const char *errstr)
     return 0;
 }
 
-static int on_body(h2o_httpclient_t *client, const char *errstr)
+static int on_body(h2o_httpclient_t *client, h2o_httpclient_body_hints_t *hints, const char *errstr)
 {
     struct st_h2o_mruby_http_request_context_t *ctx = client->data;
     if (try_dispose_context(ctx))
@@ -396,7 +396,7 @@ static int on_body(h2o_httpclient_t *client, const char *errstr)
     int gc_arena = mrb_gc_arena_save(ctx->ctx->shared->mrb);
     mrb_gc_protect(ctx->ctx->shared->mrb, ctx->refs.input_stream);
 
-    int ret = do_on_body(client, errstr);
+    int ret = do_on_body(client, hints, errstr);
 
     mrb_gc_arena_restore(ctx->ctx->shared->mrb, gc_arena);
 

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -118,7 +118,7 @@ static void start_request(h2o_httpclient_ctx_t *ctx)
     h2o_httpclient_connect(NULL, &pool, url_parsed, ctx, connpool, url_parsed, on_connect);
 }
 
-static int on_body(h2o_httpclient_t *client, const char *errstr)
+static int on_body(h2o_httpclient_t *client, h2o_httpclient_body_hints_t *hints, const char *errstr)
 {
     if (errstr != NULL && errstr != h2o_httpclient_error_is_eos) {
         on_error(client->ctx, errstr);


### PR DESCRIPTION
Sometimes it's useful to know the remaining chunk length while reading chunked response body. By knowing that the users can bail out earlier when they found that the receiving chunk or the whole response body exceed a limit they defined.
This PR introduces `h2o_httpclient_body_hints_t` and let httpclient pass it to on_body callack. As you see chunked matters are only in HTTP/1, so other clients (ex: http2client) should set NULL pointer to `bytes_left_in_chunk` variable.