### PR TITLE
sort out httpclient errors

### DIFF
--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -206,7 +206,7 @@ extern const char h2o_httpclient_error_flow_control[];
 extern const char h2o_httpclient_error_http1_line_folding[];
 extern const char h2o_httpclient_error_http1_unexpected_transfer_encoding[];
 extern const char h2o_httpclient_error_http1_parse_failed[];
-extern const char h2o_httpclient_error_http2_upstream_protocol[];
+extern const char h2o_httpclient_error_http2_protocol_violation[];
 extern const char h2o_httpclient_error_internal[];
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool);

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -201,12 +201,12 @@ extern const char h2o_httpclient_error_io[];
 extern const char h2o_httpclient_error_connection_timeout[];
 extern const char h2o_httpclient_error_first_byte_timeout[];
 extern const char h2o_httpclient_error_io_timeout[];
+extern const char h2o_httpclient_error_invalid_content_length[];
+extern const char h2o_httpclient_error_flow_control[];
 extern const char h2o_httpclient_error_http1_line_folding[];
 extern const char h2o_httpclient_error_http1_unexpected_transfer_encoding[];
-extern const char h2o_httpclient_error_http1_invalid_content_length[];
 extern const char h2o_httpclient_error_http1_parse_failed[];
 extern const char h2o_httpclient_error_http2_upstream_protocol[];
-extern const char h2o_httpclient_error_flow_control[];
 extern const char h2o_httpclient_error_internal[];
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool);

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -198,7 +198,7 @@ extern const char h2o_httpclient_error_is_eos[];
 extern const char h2o_httpclient_error_refused_stream[];
 extern const char h2o_httpclient_error_unknown_alpn_protocol[];
 extern const char h2o_httpclient_error_io[];
-extern const char h2o_httpclient_error_connection_timeout[];
+extern const char h2o_httpclient_error_connect_timeout[];
 extern const char h2o_httpclient_error_first_byte_timeout[];
 extern const char h2o_httpclient_error_io_timeout[];
 extern const char h2o_httpclient_error_invalid_content_length[];

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -206,7 +206,6 @@ extern const char h2o_httpclient_error_http1_unexpected_transfer_encoding[];
 extern const char h2o_httpclient_error_http1_invalid_content_length[];
 extern const char h2o_httpclient_error_http1_parse_failed[];
 extern const char h2o_httpclient_error_http2_upstream_protocol[];
-extern const char h2o_httpclient_error_http2_goaway_received[];
 extern const char h2o_httpclient_error_http2_flow_control_window_overflow[];
 extern const char h2o_httpclient_error_internal[];
 

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -206,7 +206,7 @@ extern const char h2o_httpclient_error_http1_unexpected_transfer_encoding[];
 extern const char h2o_httpclient_error_http1_invalid_content_length[];
 extern const char h2o_httpclient_error_http1_parse_failed[];
 extern const char h2o_httpclient_error_http2_upstream_protocol[];
-extern const char h2o_httpclient_error_http2_flow_control_window_overflow[];
+extern const char h2o_httpclient_error_flow_control[];
 extern const char h2o_httpclient_error_internal[];
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool);

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -196,6 +196,19 @@ typedef struct st_h2o_httpclient__h2_conn_t {
 
 extern const char h2o_httpclient_error_is_eos[];
 extern const char h2o_httpclient_error_refused_stream[];
+extern const char h2o_httpclient_error_unknown_alpn_protocol[];
+extern const char h2o_httpclient_error_io[];
+extern const char h2o_httpclient_error_connection_timeout[];
+extern const char h2o_httpclient_error_first_byte_timeout[];
+extern const char h2o_httpclient_error_io_timeout[];
+extern const char h2o_httpclient_error_http1_line_folding[];
+extern const char h2o_httpclient_error_http1_unexpected_transfer_encoding[];
+extern const char h2o_httpclient_error_http1_invalid_content_length[];
+extern const char h2o_httpclient_error_http1_parse_failed[];
+extern const char h2o_httpclient_error_http2_upstream_protocol[];
+extern const char h2o_httpclient_error_http2_goaway_received[];
+extern const char h2o_httpclient_error_http2_flow_control_window_overflow[];
+extern const char h2o_httpclient_error_internal[];
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool);
 

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -338,7 +338,7 @@ static void on_head(h2o_socket_t *sock, const char *err)
         } else if (headers[i].name == &H2O_TOKEN_CONTENT_LENGTH->buf) {
             if ((client->_body_decoder.content_length.bytesleft = h2o_strtosize(headers[i].value.base, headers[i].value.len)) ==
                 SIZE_MAX) {
-                on_error_before_head(client, h2o_httpclient_error_http1_invalid_content_length);
+                on_error_before_head(client, h2o_httpclient_error_invalid_content_length);
                 return;
             }
             if (reader != on_req_chunked)

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -85,7 +85,7 @@ static void on_body_error(struct st_h2o_http1client_t *client, const char *errst
 static void on_body_timeout(h2o_timer_t *entry)
 {
     struct st_h2o_http1client_t *client = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1client_t, super._timeout, entry);
-    on_body_error(client, "I/O timeout");
+    on_body_error(client, h2o_httpclient_error_io_timeout);
 }
 
 static void do_update_window(h2o_httpclient_t *_client);
@@ -120,7 +120,7 @@ static void on_body_content_length(h2o_socket_t *sock, const char *err)
     h2o_timer_unlink(&client->super._timeout);
 
     if (err != NULL) {
-        on_body_error(client, "I/O error (body; content-length)");
+        on_body_error(client, h2o_httpclient_error_io);
         return;
     }
 
@@ -174,7 +174,7 @@ static void on_req_chunked(h2o_socket_t *sock, const char *err)
             client->super._cb.on_body(&client->super, h2o_httpclient_error_is_eos);
             close_client(client);
         } else {
-            on_body_error(client, "I/O error (body; chunked)");
+            on_body_error(client, h2o_httpclient_error_io);
         }
         return;
     }
@@ -189,7 +189,7 @@ static void on_req_chunked(h2o_socket_t *sock, const char *err)
         case -1: /* error */
             newsz = sock->bytes_read;
             client->_do_keepalive = 0;
-            errstr = "failed to parse the response (chunked)";
+            errstr = h2o_httpclient_error_http1_parse_failed;
             break;
         case -2: /* incomplete */
             errstr = NULL;
@@ -241,7 +241,7 @@ static void on_head(h2o_socket_t *sock, const char *err)
     h2o_timer_unlink(&client->super._timeout);
 
     if (err != NULL) {
-        on_error_before_head(client, "I/O error (head)");
+        on_error_before_head(client, h2o_httpclient_error_io);
         return;
     }
 
@@ -257,7 +257,7 @@ static void on_head(h2o_socket_t *sock, const char *err)
                                   &num_headers, 0);
         switch (rlen) {
         case -1: /* error */
-            on_error_before_head(client, "failed to parse the response");
+            on_error_before_head(client, h2o_httpclient_error_http1_parse_failed);
             return;
         case -2: /* incomplete */
             h2o_timer_link(client->super.ctx->loop, client->super.ctx->io_timeout, &client->super._timeout);
@@ -270,7 +270,7 @@ static void on_head(h2o_socket_t *sock, const char *err)
         for (i = 0; i != num_headers; ++i) {
             if (src_headers[i].name_len == 0) {
                 /* reject multiline header */
-                on_error_before_head(client, "line folding of header fields is not supported");
+                on_error_before_head(client, h2o_httpclient_error_http1_line_folding);
                 return;
             }
             const h2o_token_t *token;
@@ -324,13 +324,13 @@ static void on_head(h2o_socket_t *sock, const char *err)
             } else if (h2o_memis(headers[i].value.base, headers[i].value.len, H2O_STRLIT("identity"))) {
                 /* continue */
             } else {
-                on_error_before_head(client, "unexpected type of transfer-encoding");
+                on_error_before_head(client, h2o_httpclient_error_http1_unexpected_transfer_encoding);
                 return;
             }
         } else if (headers[i].name == &H2O_TOKEN_CONTENT_LENGTH->buf) {
             if ((client->_body_decoder.content_length.bytesleft = h2o_strtosize(headers[i].value.base, headers[i].value.len)) ==
                 SIZE_MAX) {
-                on_error_before_head(client, "invalid content-length");
+                on_error_before_head(client, h2o_httpclient_error_http1_invalid_content_length);
                 return;
             }
             if (reader != on_req_chunked)
@@ -377,7 +377,7 @@ static void on_head(h2o_socket_t *sock, const char *err)
 static void on_head_timeout(h2o_timer_t *entry)
 {
     struct st_h2o_http1client_t *client = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1client_t, super._timeout, entry);
-    on_error_before_head(client, "I/O timeout");
+    on_error_before_head(client, h2o_httpclient_error_io_timeout);
 }
 
 static void on_send_request(h2o_socket_t *sock, const char *err)
@@ -387,7 +387,7 @@ static void on_send_request(h2o_socket_t *sock, const char *err)
     h2o_timer_unlink(&client->super._timeout);
 
     if (err != NULL) {
-        on_error_before_head(client, "I/O error (send request)");
+        on_error_before_head(client, h2o_httpclient_error_io);
         return;
     }
 
@@ -501,7 +501,7 @@ static int do_write_req(h2o_httpclient_t *_client, h2o_iovec_t chunk, int is_end
 static void on_send_timeout(h2o_timer_t *entry)
 {
     struct st_h2o_http1client_t *client = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http1client_t, super._timeout, entry);
-    on_error_before_head(client, "I/O timeout");
+    on_error_before_head(client, h2o_httpclient_error_io_timeout);
 }
 
 static h2o_iovec_t build_request(struct st_h2o_http1client_t *client, h2o_iovec_t method, h2o_url_t url, h2o_iovec_t connection,
@@ -612,7 +612,7 @@ static void on_connection_ready(struct st_h2o_http1client_t *client)
         if (body.base != NULL) {
             h2o_buffer_init(&client->_body_buf, &h2o_socket_buffer_prototype);
             if (!h2o_buffer_try_append(&client->_body_buf, body.base, body.len)) {
-                on_send_request(client->sock, "Internal error");
+                on_error_before_head(client, h2o_httpclient_error_internal);
                 return;
             }
         }

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -655,8 +655,6 @@ static int handle_goaway_frame(struct st_h2o_http2client_conn_t *conn, h2o_http2
     kh_foreach_value(conn->streams, stream, {
         if (stream->stream_id > payload.last_stream_id) {
             call_callback_with_error(stream, h2o_httpclient_error_refused_stream);
-        } else {
-            call_callback_with_error(stream, h2o_httpclient_error_http2_goaway_received);
         }
     });
 

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -860,7 +860,7 @@ static void on_connect_error(struct st_h2o_http2client_stream_t *stream, const c
 static void do_stream_timeout(struct st_h2o_http2client_stream_t *stream)
 {
     if (stream->conn == NULL) {
-        on_connect_error(stream, h2o_httpclient_error_connection_timeout);
+        on_connect_error(stream, h2o_httpclient_error_connect_timeout);
         return;
     }
     const char *errstr = stream->state == H2O_HTTP2CLIENT_STREAM_STATE_RECV_HEADERS ? h2o_httpclient_error_first_byte_timeout : h2o_httpclient_error_io_timeout;

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -334,7 +334,7 @@ static int on_head(struct st_h2o_http2client_conn_t *conn, struct st_h2o_http2cl
 
 Failed:
     assert(ret == H2O_HTTP2_ERROR_PROTOCOL);
-    call_callback_with_error(stream, h2o_httpclient_error_http2_upstream_protocol);
+    call_callback_with_error(stream, h2o_httpclient_error_http2_protocol_violation);
 SendRSTStream:
     stream_send_error(conn, stream->stream_id, ret);
     close_stream(stream);
@@ -409,7 +409,7 @@ static int handle_data_frame(struct st_h2o_http2client_conn_t *conn, h2o_http2_f
 
     if (stream->state != H2O_HTTP2CLIENT_STREAM_STATE_RECV_BODY) {
         stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
-        call_callback_with_error(stream, h2o_httpclient_error_http2_upstream_protocol);
+        call_callback_with_error(stream, h2o_httpclient_error_http2_protocol_violation);
         close_stream(stream);
         return 0;
     }
@@ -487,7 +487,7 @@ static int handle_headers_frame(struct st_h2o_http2client_conn_t *conn, h2o_http
         return 0;
     default:
         stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
-        call_callback_with_error(stream, h2o_httpclient_error_http2_upstream_protocol);
+        call_callback_with_error(stream, h2o_httpclient_error_http2_protocol_violation);
         close_stream(stream);
         return 0;
     }
@@ -675,7 +675,7 @@ static int handle_window_update_frame(struct st_h2o_http2client_conn_t *conn, h2
             stream_send_error(conn, frame->stream_id, ret);
             struct st_h2o_http2client_stream_t *stream = get_stream(conn, frame->stream_id);
             if (stream != NULL) {
-                call_callback_with_error(stream, h2o_httpclient_error_http2_upstream_protocol);
+                call_callback_with_error(stream, h2o_httpclient_error_http2_protocol_violation);
                 close_stream(stream);
             }
             return 0;
@@ -905,7 +905,7 @@ static int parse_input(struct st_h2o_http2client_conn_t *conn)
                 enqueue_goaway(conn, (int)ret,
                                err_desc != NULL ? (h2o_iovec_t){(char *)err_desc, strlen(err_desc)} : (h2o_iovec_t){NULL});
             }
-            call_stream_callbacks_with_error(conn, h2o_httpclient_error_http2_upstream_protocol);
+            call_stream_callbacks_with_error(conn, h2o_httpclient_error_http2_protocol_violation);
             return close_connection(conn);
         }
         /* advance to the next frame */

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -416,7 +416,7 @@ static int handle_data_frame(struct st_h2o_http2client_conn_t *conn, h2o_http2_f
 
     size_t max_size = get_max_buffer_size(stream->super.ctx);
     if (stream->input.body->size + payload.length > max_size) {
-        stream->super._cb.on_body(&stream->super, h2o_httpclient_error_http2_upstream_protocol);
+        stream->super._cb.on_body(&stream->super, h2o_httpclient_error_flow_control);
         stream_send_error(stream->conn, stream->stream_id, H2O_HTTP2_ERROR_FLOW_CONTROL);
         close_stream(stream);
         return 0;
@@ -694,7 +694,7 @@ static int handle_window_update_frame(struct st_h2o_http2client_conn_t *conn, h2
         if (stream != NULL) {
             if (update_stream_output_window(stream, payload.window_size_increment) != 0) {
                 stream_send_error(conn, frame->stream_id, H2O_HTTP2_ERROR_FLOW_CONTROL);
-                call_callback_with_error(stream, h2o_httpclient_error_http2_flow_control_window_overflow);
+                call_callback_with_error(stream, h2o_httpclient_error_flow_control);
                 close_stream(stream);
                 return 0;
             }

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -34,7 +34,7 @@ const char h2o_httpclient_error_flow_control[] = "flow control error";
 const char h2o_httpclient_error_http1_line_folding[] = "line folding of header fields is not supported";
 const char h2o_httpclient_error_http1_unexpected_transfer_encoding[] = "unexpected type of transfer-encoding";
 const char h2o_httpclient_error_http1_parse_failed[] = "failed to parse the response";
-const char h2o_httpclient_error_http2_upstream_protocol[] = "upstream protocol error";
+const char h2o_httpclient_error_http2_protocol_violation[] = "protocol violation";
 const char h2o_httpclient_error_internal[] = "internal error";
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool)

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -34,7 +34,6 @@ const char h2o_httpclient_error_http1_unexpected_transfer_encoding[] = "unexpect
 const char h2o_httpclient_error_http1_invalid_content_length[] = "invalid content-length";
 const char h2o_httpclient_error_http1_parse_failed[] = "failed to parse the response";
 const char h2o_httpclient_error_http2_upstream_protocol[] = "upstream protocol error";
-const char h2o_httpclient_error_http2_goaway_received[] = "GOAWAY received";
 const char h2o_httpclient_error_http2_flow_control_window_overflow[] = "flow control window overflow";
 const char h2o_httpclient_error_internal[] = "internal error";
 

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -29,12 +29,12 @@ const char h2o_httpclient_error_io[] = "I/O error";
 const char h2o_httpclient_error_connection_timeout[] = "connection timeout";
 const char h2o_httpclient_error_first_byte_timeout[] = "first byte timeout";
 const char h2o_httpclient_error_io_timeout[] = "I/O timeout";
+const char h2o_httpclient_error_invalid_content_length[] = "invalid content-length";
+const char h2o_httpclient_error_flow_control[] = "flow control error";
 const char h2o_httpclient_error_http1_line_folding[] = "line folding of header fields is not supported";
 const char h2o_httpclient_error_http1_unexpected_transfer_encoding[] = "unexpected type of transfer-encoding";
-const char h2o_httpclient_error_http1_invalid_content_length[] = "invalid content-length";
 const char h2o_httpclient_error_http1_parse_failed[] = "failed to parse the response";
 const char h2o_httpclient_error_http2_upstream_protocol[] = "upstream protocol error";
-const char h2o_httpclient_error_flow_control[] = "flow control error";
 const char h2o_httpclient_error_internal[] = "internal error";
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool)

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -24,6 +24,19 @@
 
 const char h2o_httpclient_error_is_eos[] = "end of stream";
 const char h2o_httpclient_error_refused_stream[] = "refused stream";
+const char h2o_httpclient_error_unknown_alpn_protocol[] = "unknown alpn protocol";
+const char h2o_httpclient_error_io[] = "I/O error";
+const char h2o_httpclient_error_connection_timeout[] = "connection timeout";
+const char h2o_httpclient_error_first_byte_timeout[] = "first byte timeout";
+const char h2o_httpclient_error_io_timeout[] = "I/O timeout";
+const char h2o_httpclient_error_http1_line_folding[] = "line folding of header fields is not supported";
+const char h2o_httpclient_error_http1_unexpected_transfer_encoding[] = "unexpected type of transfer-encoding";
+const char h2o_httpclient_error_http1_invalid_content_length[] = "invalid content-length";
+const char h2o_httpclient_error_http1_parse_failed[] = "failed to parse the response";
+const char h2o_httpclient_error_http2_upstream_protocol[] = "upstream protocol error";
+const char h2o_httpclient_error_http2_goaway_received[] = "GOAWAY received";
+const char h2o_httpclient_error_http2_flow_control_window_overflow[] = "flow control window overflow";
+const char h2o_httpclient_error_internal[] = "internal error";
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool)
 {

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -34,7 +34,7 @@ const char h2o_httpclient_error_http1_unexpected_transfer_encoding[] = "unexpect
 const char h2o_httpclient_error_http1_invalid_content_length[] = "invalid content-length";
 const char h2o_httpclient_error_http1_parse_failed[] = "failed to parse the response";
 const char h2o_httpclient_error_http2_upstream_protocol[] = "upstream protocol error";
-const char h2o_httpclient_error_http2_flow_control_window_overflow[] = "flow control window overflow";
+const char h2o_httpclient_error_flow_control[] = "flow control error";
 const char h2o_httpclient_error_internal[] = "internal error";
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool)

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -26,7 +26,7 @@ const char h2o_httpclient_error_is_eos[] = "end of stream";
 const char h2o_httpclient_error_refused_stream[] = "refused stream";
 const char h2o_httpclient_error_unknown_alpn_protocol[] = "unknown alpn protocol";
 const char h2o_httpclient_error_io[] = "I/O error";
-const char h2o_httpclient_error_connection_timeout[] = "connection timeout";
+const char h2o_httpclient_error_connect_timeout[] = "connection timeout";
 const char h2o_httpclient_error_first_byte_timeout[] = "first byte timeout";
 const char h2o_httpclient_error_io_timeout[] = "I/O timeout";
 const char h2o_httpclient_error_invalid_content_length[] = "invalid content-length";
@@ -66,7 +66,7 @@ static void on_connect_error(h2o_httpclient_t *client, const char *errstr)
 static void on_connect_timeout(h2o_timer_t *entry)
 {
     h2o_httpclient_t *client = H2O_STRUCT_FROM_MEMBER(h2o_httpclient_t, _timeout, entry);
-    on_connect_error(client, "connection timeout");
+    on_connect_error(client, h2o_httpclient_error_connect_timeout);
 }
 
 static void do_cancel(h2o_httpclient_t *_client)
@@ -121,7 +121,7 @@ static void on_pool_connect(h2o_socket_t *sock, const char *errstr, void *data, 
         } else if (memcmp(alpn_proto.base, "http/1.1", alpn_proto.len) == 0) {
             h2o_httpclient__h1_on_connect(client, sock, origin);
         } else {
-            on_connect_error(client, "unknown alpn protocol");
+            on_connect_error(client, h2o_httpclient_error_unknown_alpn_protocol);
         }
     }
 }

--- a/t/50mruby-error-log.t
+++ b/t/50mruby-error-log.t
@@ -253,7 +253,7 @@ EOT
             is scalar(@$access_logs), 1, 'access log count';
             isnt scalar(@$error_logs), 0, 'error log count';
             is $access_logs->[0], '', 'access log';
-            is $error_logs->[-1], '[lib/core/proxy.c] in request:/:failed to parse the response (chunked)', 'error log';
+            is $error_logs->[-1], '[lib/core/proxy.c] in request:/:failed to parse the response', 'error log';
 
             live_check($proto, $port, $curl);
         });

--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -588,7 +588,7 @@ EOT
 
         my ($headers, $body) = run_prog("curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/");
         like $headers, qr{HTTP/[^ ]+ 504\s}is;
-        is $body, 'client warning: I/O timeout';
+        is $body, 'client warning: first byte timeout';
     };
 };
 

--- a/t/50reverse-proxy-http2.t
+++ b/t/50reverse-proxy-http2.t
@@ -41,7 +41,7 @@ subtest 'no :status header' => sub {
     my $server = create_h2o($upstream_port);
     my ($headers, $body) = run_prog("curl -s --dump-header /dev/stderr http://127.0.0.1:@{[$server->{port}]}");
     like $headers, qr{^HTTP/[0-9.]+ 502}is;
-    like $body, qr/upstream error \(connection level\)/;
+    like $body, qr/upstream protocol error/;
     ok check_port($server->{port}), 'live check';
 };
 

--- a/t/50reverse-proxy-http2.t
+++ b/t/50reverse-proxy-http2.t
@@ -41,7 +41,7 @@ subtest 'no :status header' => sub {
     my $server = create_h2o($upstream_port);
     my ($headers, $body) = run_prog("curl -s --dump-header /dev/stderr http://127.0.0.1:@{[$server->{port}]}");
     like $headers, qr{^HTTP/[0-9.]+ 502}is;
-    like $body, qr/upstream protocol error/;
+    like $body, qr/protocol violation/;
     ok check_port($server->{port}), 'live check';
 };
 


### PR DESCRIPTION
httpclient error strings are a bit messy, and hard to handle because the users have to strcmp the error string to know what actual error happened. This PR exports all httpclient specific errors like existing `h2o_httpclient_error_is_eos` and allows the users to compare the errstr pointer to them.

As a preliminary work to it, I sorted out existing error messages as the following:

- There were some variants of `I/O error`, but I merged them into one `I/O error`
- In H1, there were two types of parsing errors, `failed to parse the response` and `failed to parse the response (chunked)`, but I merged the latter to the former.
- In H2, there were many types of errors caused by the upstream like `invalid DATA frame`, `buffered data size exceeds input window`, etc.. but I put them all together into `upstream protocol error`.

Additionaly, In H1, I made it able to distinguish `first byte timeout` from other I/O timeouts, just like H2.