### PR TITLE
Refactor request streaming API

### DIFF
--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -123,6 +123,10 @@ struct st_h2o_http2_stream_t {
      */
     h2o_send_state_t send_state;
     /**
+     * request body buffer
+     */
+    h2o_buffer_t *req_body;
+    /**
      * the request object; placed at last since it is large and has it's own ctor
      */
     h2o_req_t req;

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -322,9 +322,6 @@ void h2o_dispose_request(h2o_req_t *req)
     if (req->error_logs != NULL)
         h2o_buffer_dispose(&req->error_logs);
 
-    if (req->_req_body.body != NULL)
-        h2o_buffer_dispose(&req->_req_body.body);
-
     h2o_mem_clear_pool(&req->pool);
 }
 
@@ -834,20 +831,3 @@ Clear:
     req->res.headers = (h2o_headers_t){NULL, 0, 0};
 }
 
-int h2o_write_req_first(void *_req, h2o_iovec_t payload, int is_end_entity)
-{
-    h2o_req_t *req = _req;
-    h2o_handler_t *first_handler;
-
-    /* if possible, switch to either streaming request body mode */
-    if (!is_end_entity && (first_handler = h2o_get_first_handler(req)) != NULL && first_handler->supports_request_streaming) {
-        if (!h2o_buffer_try_append(&req->_req_body.body, payload.base, payload.len))
-            return -1;
-        req->entity = h2o_iovec_init(req->_req_body.body->bytes, req->_req_body.body->size);
-        req->write_req.on_streaming_selected(req, 1);
-        return 0;
-    }
-
-    req->write_req.on_streaming_selected(req, 0);
-    return req->write_req.cb(req->write_req.ctx, payload, is_end_entity);
-}

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -432,16 +432,16 @@ static int update_stream_output_window(h2o_http2_stream_t *stream, ssize_t delta
 
 static void handle_request_body_chunk(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, h2o_iovec_t payload, int is_end_stream)
 {
-    stream->req._req_body.bytes_received += payload.len;
+    stream->req.req_body_bytes_received += payload.len;
 
     /* check size */
-    if (stream->req._req_body.bytes_received > conn->super.ctx->globalconf->max_request_entity_size) {
+    if (stream->req.req_body_bytes_received > conn->super.ctx->globalconf->max_request_entity_size) {
         stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_REFUSED_STREAM);
         h2o_http2_stream_reset(conn, stream);
         return;
     }
     if (stream->req.content_length != SIZE_MAX) {
-        size_t received = stream->req._req_body.bytes_received, cl = stream->req.content_length;
+        size_t received = stream->req.req_body_bytes_received, cl = stream->req.content_length;
         if (is_end_stream ? (received != cl) : (received > cl)) {
             stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_PROTOCOL);
             h2o_http2_stream_reset(conn, stream);
@@ -518,7 +518,7 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     }
 
     /* handle the request */
-    if (stream->req._req_body.body == NULL) {
+    if (stream->req_body == NULL) {
         execute_or_enqueue_request(conn, stream);
     } else {
         h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_RECV_BODY);
@@ -682,12 +682,12 @@ static int write_req_non_streaming(void *_req, h2o_iovec_t payload, int is_end_s
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
 
-    if (h2o_buffer_try_append(&stream->req._req_body.body, payload.base, payload.len) == 0)
+    if (h2o_buffer_try_append(&stream->req_body, payload.base, payload.len) == 0)
         return -1;
     proceed_request(&stream->req, payload.len, is_end_stream ? H2O_SEND_STATE_FINAL : H2O_SEND_STATE_IN_PROGRESS);
 
     if (is_end_stream) {
-        stream->req.entity = h2o_iovec_init(stream->req._req_body.body->bytes, stream->req._req_body.body->size);
+        stream->req.entity = h2o_iovec_init(stream->req_body->bytes, stream->req_body->size);
         execute_or_enqueue_request((h2o_http2_conn_t *)stream->req.conn, stream);
     }
     return 0;
@@ -696,9 +696,9 @@ static int write_req_non_streaming(void *_req, h2o_iovec_t payload, int is_end_s
 static int write_req_streaming_pre_dispatch(void *_req, h2o_iovec_t payload, int is_end_stream)
 {
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
-    if (!h2o_buffer_try_append(&stream->req._req_body.body, payload.base, payload.len))
+    if (!h2o_buffer_try_append(&stream->req_body, payload.base, payload.len))
         return -1;
-    stream->req.entity = h2o_iovec_init(stream->req._req_body.body->bytes, stream->req._req_body.body->size);
+    stream->req.entity = h2o_iovec_init(stream->req_body->bytes, stream->req_body->size);
 
     /* mark that we have seen eos */
     if (is_end_stream)
@@ -707,23 +707,29 @@ static int write_req_streaming_pre_dispatch(void *_req, h2o_iovec_t payload, int
     return 0;
 }
 
-static void on_request_streaming_selected(h2o_req_t *req, int is_streaming)
+static int write_req_first(void *_req, h2o_iovec_t payload, int is_end_stream)
 {
-    h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, req);
+    h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, req, _req);
     h2o_http2_conn_t *conn = (h2o_http2_conn_t *)stream->req.conn;
 
-    if (is_streaming) {
-        req->write_req.cb = write_req_streaming_pre_dispatch;
-        req->proceed_req = proceed_request;
+    /* if possible, switch streaming request body mode */
+    if (!is_end_stream && h2o_req_can_stream_request(&stream->req)) {
+        if (!h2o_buffer_try_append(&stream->req_body, payload.base, payload.len))
+            return -1;
+        stream->req.entity = h2o_iovec_init(stream->req_body->bytes, stream->req_body->size);
+        stream->req.write_req.cb = write_req_streaming_pre_dispatch;
+        stream->req.proceed_req = proceed_request;
         if (!reset_stream_if_disregarded(conn, stream))
             execute_or_enqueue_request_core(conn, stream);
-        return;
+        return 0;
     }
+
     /* TODO elect input streams one by one for non-streaming case as well? */
     update_stream_input_window(conn, stream,
                                conn->super.ctx->globalconf->http2.active_stream_window_size -
                                    H2O_HTTP2_SETTINGS_HOST_STREAM_INITIAL_WINDOW_SIZE);
-    req->write_req.cb = write_req_non_streaming;
+    stream->req.write_req.cb = write_req_non_streaming;
+    return write_req_non_streaming(&stream->req, payload, is_end_stream);
 }
 
 static int handle_data_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame, const char **err_desc)
@@ -820,13 +826,12 @@ static int handle_headers_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *frame
         set_priority(conn, stream, &payload.priority, 0);
     }
     h2o_http2_stream_prepare_for_request(conn, stream);
-    stream->req.write_req.cb = h2o_write_req_first;
-    stream->req.write_req.on_streaming_selected = on_request_streaming_selected;
+    stream->req.write_req.cb = write_req_first;
     stream->req.write_req.ctx = &stream->req;
 
     /* setup container for request body if it is expected to arrive */
     if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_STREAM) == 0)
-        h2o_buffer_init(&stream->req._req_body.body, &h2o_socket_buffer_prototype);
+        h2o_buffer_init(&stream->req_body, &h2o_socket_buffer_prototype);
 
     if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_HEADERS) != 0) {
         /* request headers are complete, handle it */

--- a/lib/http2/http2_debug_state.c
+++ b/lib/http2/http2_debug_state.c
@@ -156,7 +156,7 @@ h2o_http2_debug_state_t *h2o_http2_get_debug_state(h2o_req_t *req, int hpack_ena
                          "      \"created\": %" PRIu64 "\n"
                          "    },",
                          stream->stream_id, state_string, h2o_http2_window_get_avail(&stream->input_window.window),
-                         h2o_http2_window_get_avail(&stream->output_window), stream->req._req_body.bytes_received,
+                         h2o_http2_window_get_avail(&stream->output_window), stream->req.req_body_bytes_received,
                          stream->req.bytes_sent, (uint64_t)stream->req.timestamps.request_begin_at.tv_sec);
         });
 

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -68,6 +68,8 @@ void h2o_http2_stream_close(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
     h2o_http2_conn_unregister_stream(conn, stream);
     if (stream->cache_digests != NULL)
         h2o_cache_digests_destroy(stream->cache_digests);
+    if (stream->req_body != NULL)
+        h2o_buffer_dispose(&stream->req_body);
     h2o_dispose_request(&stream->req);
     if (stream->stream_id == 1 && conn->_http1_req_input != NULL)
         h2o_buffer_dispose(&conn->_http1_req_input);


### PR DESCRIPTION
At the moment, the request streaming API is designed as a series of callbacks, and every protocol implementation is expected to use them in one particular way.

To be specific, the protocol implementations are expected to pass received data (i.e. chunk or a DATA frame payload) as a vector, which is either passed to the generator (when in streaming mode) or back to a callback provided by the protocol implementation (when not in streaming mode). Only one vector is inflight at a time.

This design does not fit well for H3, as the flattened input it obtains is as tiny as a fraction of a packet. To keep the number of interactions between the protocol handler and the generator low, and to keep the BDP reasonably large, the H3 implementation needs to concatenate the payload received in multiple packets, then pass them to the streaming API.

This raises the following question: why does the H3 implementation need to use the callback-based API even when streaming mode is _not_ used? As stated, it would have the buffer to hold payload post-concatenation.

To paraphrase, it now seems that the callback-based design of the current request streaming API is too restrictive. Therefore this PR changes the design to an approach based on composition.

An utility function called `h2o_req_can_stream_request` is provided, that returns a boolean indicating if a request can be streamed. It is up to each protocol implementation to call the function, then do whatever it wants.

There is no change in how generators deal with request streaming. The change is totally on how the protocol implementation uses the API.