### PR TITLE
fix resource leak in file handler

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -404,6 +404,7 @@ inline void h2o_mem_addref_shared(void *p)
 inline int h2o_mem_release_shared(void *p)
 {
     struct st_h2o_mem_pool_shared_entry_t *entry = H2O_STRUCT_FROM_MEMBER(struct st_h2o_mem_pool_shared_entry_t, bytes, p);
+    assert(entry->refcnt != 0);
     if (--entry->refcnt == 0) {
         if (entry->dispose != NULL)
             entry->dispose(entry->bytes);


### PR DESCRIPTION
#1992, merged as part of #1846, introduced a resource leak in the file handler where the sendvec submitted with `send_state` set to final was not released when the protocol implementation did not send the contents of the sendvec.

This was causing memory and file descriptor leak on h2o.examp1e.net, as the website uses push, that gets cancelled without sending any data when the same resourec is attempted to be pushed for the second time on the same connection. This has been identified as the cause of #2134.

This PR fixes the issue by using the destruction of `h2o_req_t::pool` as the trigger to destruct the generator.