### PR TITLE
fix data corruption when on-the-fly compression is used

### DIFF
--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -385,7 +385,7 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
     } else if (nextbuf != stream->_data.entries) {
         /* adjust the buffer */
         size_t newsize = stream->_data.size - (nextbuf - stream->_data.entries);
-        memmove(stream->_data.entries, nextbuf, sizeof(h2o_iovec_t) * newsize);
+        memmove(stream->_data.entries, nextbuf, sizeof(stream->_data.entries[0]) * newsize);
         stream->_data.size = newsize;
     }
 


### PR DESCRIPTION
The on-the-fly compressor typically emits multiple vectors.

In #1992 that got merged as part of #1846, we switched the vector type being used for sending response chunks from `h2o_iovec_t` to `h2o_sendvec_t`. The size of the structs are different.

However, we failed to make the corresponding change in HTTP/2 handler, resulting in corrupt list of vectors when multiple vectors are split into different calls to writev.

Reported in #2135.

PS. This is a good (bad) example in showing the danger of using `typeof(typename)` in memory-related function calls (e.g., malloc, memcpy, memmove). Do we want to do a review and rewrite those?