### PR TITLE
null-terminate strings in dtrace script

### DIFF
--- a/t/90dtrace.t
+++ b/t/90dtrace.t
@@ -58,10 +58,18 @@ EOT
     } else {
         exec(
             qw(unbuffer dtrace -p), $server->{pid}, "-n", <<'EOT',
-:h2o::receive_request {printf("\nXXXX*** %u:%u version %d.%d ***\n", arg0, arg1, arg2 / 256, arg2 % 256)}
+:h2o::receive_request {
+    printf("\nXXXX*** %u:%u version %d.%d ***\n", arg0, arg1, arg2 / 256, arg2 % 256);
+}
 EOT
             "-n", <<'EOT',
-:h2o::receive_request_header {printf("\nXXXX%s: %s\n", stringof(copyin(arg2, arg3)), stringof(copyin(arg4, arg5)))}
+:h2o::receive_request_header {
+    name = (char *)copyin(arg2, arg3);
+    name[arg3] = '\0';
+    value = (char *)copyin(arg4, arg5);
+    value[arg5] = '\0';
+    printf("\nXXXX%s: %s\n", stringof(name), stringof(value));
+}
 EOT
         );
         die "failed to spawn dtrace:$!";


### PR DESCRIPTION
This fixes occasional test issue in t/90dtrace.t.

Note that updated code is slightly different from the example that can be found in the DTrace book.

In Section 8, the book suggests using
```
this->foo = (char *)copyin(arg1, arg2 + 1);
this->foo[arg2] = '\0';
```

Compared to that, our code does not copy an extra byte, or use `this->`.

Our code seem to work fine on macOS 10.12, but it might become an issue on other platforms.