### PR TITLE
[h3] send and validate token

### DIFF
--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -745,7 +745,7 @@ int quicly_retry_calc_cidpair_hash(ptls_hash_algorithm_t *sha256, ptls_iovec_t c
  */
 quicly_datagram_t *quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encrypt_ctx, struct sockaddr *dest_addr,
                                      ptls_iovec_t dest_cid, struct sockaddr *src_addr, ptls_iovec_t src_cid, ptls_iovec_t odcid,
-                                     ptls_iovec_t token);
+                                     ptls_iovec_t token_prefix, ptls_iovec_t appdata);
 /**
  *
  */

--- a/deps/quicly/src/cli.c
+++ b/deps/quicly/src/cli.c
@@ -701,7 +701,8 @@ static int run_server(struct sockaddr *sa, socklen_t salen)
                         new_server_cid[0] ^= 0xff;
                         quicly_datagram_t *rp = quicly_send_retry(&ctx, address_token_aead.enc, &sa, packet.cid.src, NULL,
                                                                   ptls_iovec_init(new_server_cid, sizeof(new_server_cid)),
-                                                                  packet.cid.dest.encrypted, ptls_iovec_init(NULL, 0));
+                                                                  packet.cid.dest.encrypted, ptls_iovec_init(NULL, 0),
+                                                                  ptls_iovec_init(NULL, 0));
                         assert(rp != NULL);
                         if (send_one(fd, rp) == -1)
                             perror("sendmsg failed");

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -1186,6 +1186,7 @@
 		E9F677D21FF62228006476D3 /* 50reverse-proxy-serialize-posts-2.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50reverse-proxy-serialize-posts-2.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9F677D32004CCCA006476D3 /* 50zero-sized-timeout.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "50zero-sized-timeout.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9F677D82008686B006476D3 /* 40tls13-early-data.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40tls13-early-data.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9FC525C234B0A630076F35D /* 40http3-asroot.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40http3-asroot.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1995,6 +1996,7 @@
 				E9F677CA1FF47BD0006476D3 /* 40http2-h2spec.t */,
 				E9BCE6921FF344D4003CEA11 /* 40http2-request-window-size.t */,
 				E98041C22230C45E008B9745 /* 40http3.t */,
+				E9FC525C234B0A630076F35D /* 40http3-asroot.t */,
 				104B9A301A58F55E009EEE64 /* 40max-connections.t */,
 				10A3D3D71B4F4D0900327CF9 /* 40memcached-session-resumption.t */,
 				105534F51A460EF600627ECB /* 40protocol.t */,

--- a/include/h2o/ebpf.h
+++ b/include/h2o/ebpf.h
@@ -33,6 +33,15 @@ typedef struct st_h2o_ebpf_map_key_t {
     h2o_ebpf_address_t local, remote;
 } h2o_ebpf_map_key_t;
 
+#define H2O_EBPF_QUIC_SEND_RETRY_DEFAULT 0
+#define H2O_EBPF_QUIC_SEND_RETRY_ON 1
+#define H2O_EBPF_QUIC_SEND_RETRY_OFF 2
+
+typedef struct st_h2o_ebpf_map_value_t {
+    uint64_t skip_tracing : 1;
+    uint64_t quic_send_retry : 2;
+} h2o_ebpf_map_value_t;
+
 #define H2O_EBPF_MAP_PATH "/sys/fs/bpf/h2o_map"
 
 #endif

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -112,7 +112,7 @@ uint8_t *h2o_http3_encode_priority_frame(uint8_t *dst, const h2o_http3_priority_
 int h2o_http3_decode_priority_frame(h2o_http3_priority_frame_t *frame, const uint8_t *payload, size_t len, const char **err_desc);
 
 typedef h2o_http3_conn_t *(*h2o_http3_accept_cb)(h2o_http3_ctx_t *ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,
-                                                 quicly_decoded_packet_t *packets, size_t num_packets);
+                                                 quicly_decoded_packet_t *packet);
 typedef void (*h2o_http3_notify_connection_update_cb)(h2o_http3_ctx_t *ctx, h2o_http3_conn_t *conn);
 /**
  * Forwards a packet to given node/thread.
@@ -283,6 +283,10 @@ typedef struct st_h2o_http3_read_frame_t {
 
 extern const ptls_iovec_t h2o_http3_alpn[1];
 
+/**
+ * sends a datagram
+ */
+int h2o_http3_send_datagram(h2o_http3_ctx_t *ctx, quicly_datagram_t *p);
 /**
  * creates a unidirectional stream object
  */

--- a/include/h2o/http3_server.h
+++ b/include/h2o/http3_server.h
@@ -30,6 +30,7 @@
 typedef struct st_h2o_http3_server_ctx_t {
     h2o_http3_ctx_t super;
     h2o_accept_ctx_t *accept_ctx;
+    unsigned send_retry : 1;
 } h2o_http3_server_ctx_t;
 
 extern const h2o_protocol_callbacks_t H2O_HTTP3_SERVER_CALLBACKS;
@@ -38,9 +39,9 @@ extern const h2o_http3_conn_callbacks_t H2O_HTTP3_CONN_CALLBACKS;
 /**
  * the acceptor callback to be used together with h2o_http3_server_ctx_t
  */
-h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_ctx_t *_ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,
-                                          quicly_decoded_packet_t *packets, size_t num_packets,
-                                          const h2o_http3_conn_callbacks_t *h3_callbacks);
+h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,
+                                          quicly_decoded_packet_t *packet, quicly_address_token_plaintext_t *address_token,
+                                          int skip_tracing, const h2o_http3_conn_callbacks_t *h3_callbacks);
 /**
  *
  */

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -31,6 +31,7 @@ extern "C" {
 #include <openssl/ssl.h>
 #include "picotls.h"
 #include "h2o/cache.h"
+#include "h2o/ebpf.h"
 #include "h2o/memory.h"
 #include "h2o/openssl_backport.h"
 #include "h2o/string_.h"
@@ -285,7 +286,7 @@ int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess);
 /**
  * compares socket addresses
  */
-int h2o_socket_compare_address(struct sockaddr *x, struct sockaddr *y);
+int h2o_socket_compare_address(struct sockaddr *x, struct sockaddr *y, int check_port);
 /**
  * getnameinfo (buf should be NI_MAXHOST in length), returns SIZE_MAX if failed
  */
@@ -362,7 +363,8 @@ struct st_h2o_ebpf_map_key_t;
 /**
  * function to lookup if the connection is tagged for special treatment. At the moment, the results are: 0 - no, 1 - trace.
  */
-int h2o_socket_ebpf_lookup(h2o_loop_t *loop, int (*init_key)(struct st_h2o_ebpf_map_key_t *key, void *cbdata), void *cbdata);
+h2o_ebpf_map_value_t h2o_socket_ebpf_lookup(h2o_loop_t *loop, int (*init_key)(struct st_h2o_ebpf_map_key_t *key, void *cbdata),
+                                            void *cbdata);
 /**
  * callback for initializing the ebpf lookup key from raw information
  */

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -452,7 +452,7 @@ h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *_listener)
 
     if (peeraddr != NULL && *peeraddrlen <= sizeof(*peeraddr))
         h2o_socket_setpeername(sock, (struct sockaddr *)peeraddr, *peeraddrlen);
-    if (!h2o_socket_ebpf_lookup(listener->loop, h2o_socket_ebpf_init_key, sock))
+    if (h2o_socket_ebpf_lookup(listener->loop, h2o_socket_ebpf_init_key, sock).skip_tracing)
         sock->_skip_tracing = 1;
     return sock;
 }

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -274,7 +274,7 @@ h2o_socket_t *h2o_uv_socket_create(uv_handle_t *handle, uv_close_cb close_cb)
     sock->handle = handle;
     sock->close_cb = close_cb;
     sock->handle->data = sock;
-    if (!h2o_socket_ebpf_lookup(sock->handle->loop, h2o_socket_ebpf_init_key, &sock->super))
+    if (h2o_socket_ebpf_lookup(sock->handle->loop, h2o_socket_ebpf_init_key, &sock->super).skip_tracing)
         sock->super._skip_tracing = 1;
     return &sock->super;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1114,82 +1114,120 @@ void init_openssl(void)
     conf.lifetime = 3600; /* default value for session timeout is 1 hour */
 }
 
-struct st_quic_cid_key_t {
+struct st_quic_keyset_t {
     uint8_t name;
-    quicly_cid_encryptor_t *encryptor;
+    quicly_cid_encryptor_t *cid;
+    struct {
+        ptls_aead_context_t *enc;
+        ptls_aead_context_t *dec;
+    } address_token;
 };
 
 static __thread struct {
     unsigned generation;
-    H2O_VECTOR(struct st_quic_cid_key_t) keys;
-} quic_cid_keys = {UINT_MAX /* the value needs to be one smaller than session_tickets.generation */};
+    H2O_VECTOR(struct st_quic_keyset_t) keys;
+} quic_keys = {UINT_MAX /* the value needs to be one smaller than session_tickets.generation */};
 
-static void update_cid_keys(void)
+static void init_keyset(struct st_quic_keyset_t *keyset, uint8_t name, ptls_iovec_t master_secret)
+{
+    uint8_t master_digestbuf[PTLS_MAX_DIGEST_SIZE], keybuf[PTLS_MAX_SECRET_SIZE];
+    int ret;
+
+    if (master_secret.len > PTLS_SHA256_DIGEST_SIZE) {
+        ptls_calc_hash(&ptls_openssl_sha256, master_digestbuf, master_secret.base, master_secret.len);
+        master_secret = ptls_iovec_init(master_digestbuf, PTLS_SHA256_DIGEST_SIZE);
+    }
+
+    keyset->name = name;
+    keyset->cid =
+        quicly_new_default_cid_encryptor(&ptls_openssl_bfecb, &ptls_openssl_aes128ecb, &ptls_openssl_sha256, master_secret);
+    assert(keyset->cid != NULL);
+    ret = ptls_hkdf_expand_label(&ptls_openssl_sha256, keybuf, ptls_openssl_aes128gcm.key_size, master_secret, "address-token",
+                                 ptls_iovec_init(NULL, 0), "");
+    assert(ret == 0);
+    keyset->address_token.enc = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 1, keybuf, "");
+    assert(keyset->address_token.enc != NULL);
+    keyset->address_token.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, keybuf, "");
+    assert(keyset->address_token.dec != NULL);
+
+    ptls_clear_memory(master_digestbuf, sizeof(master_digestbuf));
+    ptls_clear_memory(keybuf, sizeof(keybuf));
+}
+
+static void dispose_keyset(struct st_quic_keyset_t *keyset)
+{
+    quicly_free_default_cid_encryptor(keyset->cid);
+    keyset->cid = NULL;
+    ptls_aead_free(keyset->address_token.enc);
+    keyset->address_token.enc = NULL;
+    ptls_aead_free(keyset->address_token.dec);
+    keyset->address_token.dec = NULL;
+}
+
+/**
+ * updates the quic keysets, returning the active one
+ */
+static struct st_quic_keyset_t *update_quic_keys(void)
 {
     unsigned new_generation;
 
-    while ((new_generation = session_tickets.generation) != quic_cid_keys.generation) {
-        /* we need to update. first, release all entries from quic_cid_keys */
-        while (quic_cid_keys.keys.size != 0)
-            quicly_free_default_cid_encryptor(quic_cid_keys.keys.entries[--quic_cid_keys.keys.size].encryptor);
+    while ((new_generation = session_tickets.generation) != quic_keys.generation) {
+        /* we need to update. first, release all entries from quic_keys */
+        while (quic_keys.keys.size != 0)
+            dispose_keyset(quic_keys.keys.entries + --quic_keys.keys.size);
 
-        /* build quic_cid_keys while taking the read lock */
+        /* build quic_keys while taking the read lock */
         pthread_rwlock_rdlock(&session_tickets.rwlock);
         assert(session_tickets.tickets.size != 0);
-        h2o_vector_reserve(NULL, &quic_cid_keys.keys, session_tickets.tickets.size);
-        for (; quic_cid_keys.keys.size != session_tickets.tickets.size; ++quic_cid_keys.keys.size) {
-            struct st_session_ticket_t *ticket = session_tickets.tickets.entries[quic_cid_keys.keys.size];
-            struct st_quic_cid_key_t *slot = quic_cid_keys.keys.entries + quic_cid_keys.keys.size;
-            slot->name = ticket->name[0];
-            slot->encryptor = quicly_new_default_cid_encryptor(
-                &ptls_openssl_bfecb, &ptls_openssl_aes128ecb, &ptls_openssl_sha256,
-                ptls_iovec_init(ticket->keybuf, EVP_CIPHER_key_length(ticket->cipher) + EVP_MD_block_size(ticket->hmac)));
-            assert(slot->encryptor != NULL);
+        h2o_vector_reserve(NULL, &quic_keys.keys, session_tickets.tickets.size);
+        for (; quic_keys.keys.size != session_tickets.tickets.size; ++quic_keys.keys.size) {
+            struct st_session_ticket_t *ticket = session_tickets.tickets.entries[quic_keys.keys.size];
+            init_keyset(quic_keys.keys.entries + quic_keys.keys.size, ticket->name[0],
+                        ptls_iovec_init(ticket->keybuf, EVP_CIPHER_key_length(ticket->cipher) + EVP_MD_block_size(ticket->hmac)));
         }
         pthread_rwlock_unlock(&session_tickets.rwlock);
 
         /* update our counter */
-        quic_cid_keys.generation = new_generation;
+        quic_keys.generation = new_generation;
     }
+
+    return quic_keys.keys.entries;
 }
 
-static void encrypt_cid(quicly_cid_encryptor_t *self, quicly_cid_t *encrypted, void *stateless_reset_token,
-                        const quicly_cid_plaintext_t *plaintext)
-{
-    struct st_quic_cid_key_t *key;
-    quicly_cid_t tmp_cid;
-
-    update_cid_keys();
-
-    key = quic_cid_keys.keys.entries;
-    key->encryptor->encrypt_cid(key->encryptor, &tmp_cid, stateless_reset_token, plaintext);
-    assert(tmp_cid.len < sizeof(tmp_cid.cid));
-    encrypted->cid[0] = key->name;
-    memcpy(encrypted->cid + 1, tmp_cid.cid, tmp_cid.len);
-    encrypted->len = tmp_cid.len + 1;
-}
-
-static struct st_quic_cid_key_t *find_cid_key(uint8_t key_id)
+static struct st_quic_keyset_t *find_keyset(uint8_t key_id)
 {
     size_t i;
-    for (i = 0; i != quic_cid_keys.keys.size; ++i) {
-        struct st_quic_cid_key_t *key = quic_cid_keys.keys.entries + i;
+    for (i = 0; i != quic_keys.keys.size; ++i) {
+        struct st_quic_keyset_t *key = quic_keys.keys.entries + i;
         if (key->name == key_id)
             return key;
     }
     return NULL;
 }
 
+static void encrypt_cid(quicly_cid_encryptor_t *self, quicly_cid_t *encrypted, void *stateless_reset_token,
+                        const quicly_cid_plaintext_t *plaintext)
+{
+    struct st_quic_keyset_t *keyset = update_quic_keys();
+    quicly_cid_t tmp_cid;
+
+    keyset->cid->encrypt_cid(keyset->cid, &tmp_cid, stateless_reset_token, plaintext);
+    assert(tmp_cid.len < sizeof(tmp_cid.cid));
+    encrypted->cid[0] = keyset->name;
+    memcpy(encrypted->cid + 1, tmp_cid.cid, tmp_cid.len);
+    encrypted->len = tmp_cid.len + 1;
+}
+
 static size_t decrypt_cid(quicly_cid_encryptor_t *self, quicly_cid_plaintext_t *plaintext, const void *_encrypted, size_t len)
 {
     const uint8_t *encrypted = _encrypted;
-    struct st_quic_cid_key_t *key;
+    struct st_quic_keyset_t *keyset;
 
-    update_cid_keys();
+    update_quic_keys();
 
-    if ((key = find_cid_key(encrypted[0])) == NULL)
+    if ((keyset = find_keyset(encrypted[0])) == NULL)
         return SIZE_MAX;
-    if ((len = key->encryptor->decrypt_cid(key->encryptor, plaintext, encrypted + 1, len != 0 ? len - 1 : 0)) == SIZE_MAX)
+    if ((len = keyset->cid->decrypt_cid(keyset->cid, plaintext, encrypted + 1, len != 0 ? len - 1 : 0)) == SIZE_MAX)
         return SIZE_MAX;
     return 1 + len;
 }
@@ -1197,13 +1235,46 @@ static size_t decrypt_cid(quicly_cid_encryptor_t *self, quicly_cid_plaintext_t *
 static int generate_stateless_reset_token(quicly_cid_encryptor_t *self, void *token, const void *_encrypted)
 {
     const uint8_t *encrypted = _encrypted;
-    struct st_quic_cid_key_t *key;
+    struct st_quic_keyset_t *keyset;
 
-    update_cid_keys();
+    update_quic_keys();
 
-    if ((key = find_cid_key(encrypted[0])) == NULL)
+    if ((keyset = find_keyset(encrypted[0])) == NULL)
         return 0;
-    return key->encryptor->generate_stateless_reset_token(key->encryptor, token, encrypted + 1);
+    return keyset->cid->generate_stateless_reset_token(keyset->cid, token, encrypted + 1);
 }
 
 quicly_cid_encryptor_t quic_cid_encryptor = {encrypt_cid, decrypt_cid, generate_stateless_reset_token};
+
+int quic_decrypt_address_token(quicly_address_token_plaintext_t *pt, ptls_iovec_t input)
+{
+    struct st_quic_keyset_t *keyset;
+
+    update_quic_keys();
+
+    if ((keyset = find_keyset(input.base[0])) == NULL)
+        return PTLS_ERROR_INCOMPATIBLE_KEY; /* TODO consider error code */
+    return quicly_decrypt_address_token(keyset->address_token.dec, pt, input.base, input.len, 1);
+}
+
+ptls_aead_context_t *quic_get_address_token_encryptor(uint8_t *prefix)
+{
+    struct st_quic_keyset_t *keyset = update_quic_keys();
+    *prefix = keyset->name;
+    return keyset->address_token.enc;
+}
+
+static int generate_resumption_token(quicly_generate_resumption_token_t *self, quicly_conn_t *conn, ptls_buffer_t *buf,
+                                     quicly_address_token_plaintext_t *token)
+{
+    uint8_t prefix;
+    ptls_aead_context_t *aead = quic_get_address_token_encryptor(&prefix);
+    int ret;
+
+    if ((ret = ptls_buffer_reserve(buf, 1)) != 0)
+        return ret;
+    buf->base[buf->off++] = prefix;
+    return quicly_encrypt_address_token(ptls_openssl_random_bytes, aead, buf, buf->off - 1, token);
+}
+
+quicly_generate_resumption_token_t quic_resumption_token_generator = {generate_resumption_token};

--- a/src/standalone.h
+++ b/src/standalone.h
@@ -37,5 +37,8 @@ int ssl_session_resumption_on_config(h2o_configurator_command_t *cmd, h2o_config
 void ssl_session_ticket_register_setup_barrier(h2o_barrier_t *barrier);
 
 extern quicly_cid_encryptor_t quic_cid_encryptor;
+int quic_decrypt_address_token(quicly_address_token_plaintext_t *pt, ptls_iovec_t input);
+ptls_aead_context_t *quic_get_address_token_encryptor(uint8_t *prefix);
+extern quicly_generate_resumption_token_t quic_resumption_token_generator;
 
 #endif

--- a/t/40http3-asroot.t
+++ b/t/40http3-asroot.t
@@ -1,0 +1,95 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use Net::EmptyPort qw(empty_port wait_port);
+use File::Temp qw(tempdir);
+use Test::More;
+use t::Util;
+
+run_as_root();
+
+my $client_prog = bindir() . "/h2o-httpclient";
+plan skip_all => "$client_prog not found"
+    unless -e $client_prog;
+
+plan skip_all => 'dtrace not found'
+    unless prog_exists('dtrace');
+plan skip_all => 'bpftrace is not supported'
+    if $^O eq 'linux';
+plan skip_all => 'unbuffer not found'
+    unless prog_exists('unbuffer');
+plan skip_all => 'server is not compiled with dtrace support'
+    unless server_features()->{dtrace};
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+my $quic_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
+
+subtest 'retry' => sub {
+    subtest 'off' => sub {
+        my $server = spawn_retry_server('OFF');
+        my @lines = fetch("https://127.0.0.1:$quic_port");
+        like join("", @lines), qr{^HTTP/3 200}m;
+        unlike join("", @lines), qr{^first-byte: f}m;
+    };
+    subtest 'on' => sub {
+        my $server = spawn_retry_server('ON');
+        my @lines = fetch("https://127.0.0.1:$quic_port");
+        like join("", @lines), qr{^HTTP/3 200}m;
+        like +(grep {/^first-byte: /} @lines)[0], qr/^first-byte: f[0-9a-f]$/m;
+    };
+};
+
+done_testing;
+
+sub spawn_retry_server {
+    my $boolflag = shift;
+    my $server = spawn_h2o(<< "EOT");
+listen:
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+  quic:
+    retry: $boolflag
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: t/assets/doc_root
+EOT
+    wait_port({port => $quic_port, proto => 'udp'});
+    $server;
+}
+
+sub fetch {
+    my $progargs = shift;
+    pipe my $readfh, my $writefh
+        or die "pipe failed:$!";
+    my $pid = fork;
+    die "fork failed:$!"
+        unless defined $pid;
+    if ($pid == 0) {
+        # child process
+        close $readfh;
+        open STDOUT, ">&", $writefh
+            or die "failed to redirect stdout to pipe:$!";
+        open STDERR, ">&", $writefh
+            or die "failed to redirect stderr to pipe:$!";
+        exec qw(dtrace -q -c), "$client_prog -3 $progargs", "-n", <<'EOT';
+quicly$target:::receive {
+    bytes = (uint8_t *)copyin(arg3, arg4);
+    printf("first-byte: %02x\n", bytes[0]);
+}
+EOT
+        die "falied to exec dtrace:$!";
+    }
+    # parent process
+    close $writefh;
+    my @lines = <$readfh>;
+    while (wait() != $pid) {}
+    @lines;
+}


### PR DESCRIPTION
* send and receive AEAD-encrypted tokens (incl. resumption tokens)
* add configuration knob to enforce retry
* as well as expanding the EBPF map value to 64-bit bitmap for fine-grained control of retries
* add dtrace-based test (for retries)

ToDo:
* [ ] add test for the use of resumption tokens