### PR TITLE
Perl blackhole-ip finder

### DIFF
--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -542,6 +542,7 @@ EOT
 };
 
 subtest 'timeout' => sub {
+    my $blackhole = t::Util::find_blackhole_ip(443);
     subtest 'connect timeout' => sub {
         my $server = spawn_h2o(<< "EOT");
 proxy.timeout.connect: 100
@@ -552,7 +553,7 @@ hosts:
       /:
         mruby.handler: |
           proc {|env|
-            resp = http_request("http://192.0.2.0/").join
+            resp = http_request("http://$blackhole/").join
             if warn = resp[1].delete('client-warning')
               [504, resp[1], ["client warning: #{warn}"]]
             else

--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
-use Net::EmptyPort qw(empty_port check_port find_blackhole_ip);
+use Net::EmptyPort qw(empty_port check_port);
 use Test::More;
 use t::Util;
 
@@ -542,7 +542,7 @@ EOT
 };
 
 subtest 'timeout' => sub {
-    my $blackhole = find_blackhole_ip(443);
+    my $blackhole = t::Util::find_blackhole_ip(443);
     subtest 'connect timeout' => sub {
         my $server = spawn_h2o(<< "EOT");
 proxy.timeout.connect: 100

--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
-use Net::EmptyPort qw(empty_port check_port);
+use Net::EmptyPort qw(empty_port check_port find_blackhole_ip);
 use Test::More;
 use t::Util;
 
@@ -542,7 +542,7 @@ EOT
 };
 
 subtest 'timeout' => sub {
-    my $blackhole = t::Util::find_blackhole_ip(443);
+    my $blackhole = find_blackhole_ip(443);
     subtest 'connect timeout' => sub {
         my $server = spawn_h2o(<< "EOT");
 proxy.timeout.connect: 100

--- a/t/50mruby-redis.t
+++ b/t/50mruby-redis.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use IO::Socket::INET;
 use JSON;
-use Net::EmptyPort qw(check_port empty_port);
+use Net::EmptyPort qw(check_port empty_port find_blackhole_ip);
 use Scope::Guard qw/scope_guard/;
 use Time::HiRes;
 use Test::More;
@@ -373,7 +373,7 @@ EOT
 };
 
 subtest 'connect timeout' => sub {
-    my $blackhole = t::Util::find_blackhole_ip();
+    my $blackhole = find_blackhole_ip(6379);
     my $spawner = sub {
         my $conf = <<"EOT";
 num-threads: 1

--- a/t/50mruby-redis.t
+++ b/t/50mruby-redis.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use IO::Socket::INET;
 use JSON;
-use Net::EmptyPort qw(check_port empty_port find_blackhole_ip);
+use Net::EmptyPort qw(check_port empty_port);
 use Scope::Guard qw/scope_guard/;
 use Time::HiRes;
 use Test::More;
@@ -373,7 +373,7 @@ EOT
 };
 
 subtest 'connect timeout' => sub {
-    my $blackhole = find_blackhole_ip(6379);
+    my $blackhole = t::Util::find_blackhole_ip(6379);
     my $spawner = sub {
         my $conf = <<"EOT";
 num-threads: 1

--- a/t/50mruby-redis.t
+++ b/t/50mruby-redis.t
@@ -373,6 +373,7 @@ EOT
 };
 
 subtest 'connect timeout' => sub {
+    my $blackhole = t::Util::find_blackhole_ip();
     my $spawner = sub {
         my $conf = <<"EOT";
 num-threads: 1
@@ -383,7 +384,7 @@ hosts:
         mruby.handler: |
           proc {|env|
             # if query string is empty, wait forever
-            redis = H2O::Redis.new(:host => '192.0.2.0', :port => 6379, :connect_timeout => env['QUERY_STRING'])
+            redis = H2O::Redis.new(:host => '$blackhole', :port => 6379, :connect_timeout => env['QUERY_STRING'])
             begin
               redis.get('hoge').join
             rescue H2O::Redis::ConnectTimeoutError

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -14,7 +14,7 @@ use Protocol::HTTP2::Connection;
 use Protocol::HTTP2::Constants;
 use Scope::Guard qw(scope_guard);
 use Test::More;
-use Time::HiRes qw(sleep);
+use Time::HiRes qw(sleep gettimeofday tv_interval);
 
 use base qw(Exporter);
 our @EXPORT = qw(ASSETS_DIR DOC_ROOT bindir run_as_root server_features exec_unittest exec_mruby_unittest spawn_server spawn_h2o spawn_h2o_raw empty_ports create_data_file md5_file prog_exists run_prog openssl_can_negotiate curl_supports_http2 run_with_curl h2get_exists run_with_h2get run_with_h2get_simple one_shot_http_upstream wait_debugger spawn_forked spawn_h2_server);
@@ -521,14 +521,14 @@ sub find_blackhole_ip {
     my $port = $_[0] || 23;
     my $blackhole_ip = undef;
     my $poll = IO::Poll->new();
-    my $start = [ Time::HiRes::gettimeofday() ];
+    my $start = [ gettimeofday() ];
 
     foreach my $ip ('10.0.0.1', '192.168.0.1', '172.16.0.1', '240.0.0.1', '192.0.2.0') {
         my $sock = IO::Socket::INET->new(Blocking => 0, PeerPort => $port, PeerAddr => $ip);
         $ips{$sock} = $ip;
         $poll->mask($sock => POLLOUT|POLLIN|POLLERR|POLLHUP);
     }
-    while (scalar($poll->handles()) > 0 and Time::HiRes::tv_interval($start) < 2.00) {
+    while (scalar($poll->handles()) > 0 and tv_interval($start) < 2.00) {
         if ($poll->poll(.1) > 0) {
             foreach my $sock ($poll->handles(POLLOUT|POLLIN|POLLERR|POLLHUP)) {
                 delete($ips{$sock});


### PR DESCRIPTION
The assumption made by the test suite that certain ips will blackhole is not correct in all environments. e.g:
``` 
$ telnet 192.0.2.0 123
Trying 192.0.2.0...
telnet: Unable to connect to remote host: Network is unreachable
```
This adds a `find_blackhole_ip()` helper to help scenariis testing for
timeouts find an appropriate target ip.