### PR TITLE
Add support for packet timestamping on Linux.

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -105,6 +105,10 @@ struct st_h2o_socket_t {
     void *data;
     struct st_h2o_socket_ssl_t *ssl;
     h2o_buffer_t *input;
+    int timestamping;
+    long long timestamping_rate;
+    long long *timestamping_rate_counter;
+
     /**
      * total bytes read (above the TLS layer)
      */
@@ -195,6 +199,10 @@ void h2o_socket_dispose_export(h2o_socket_export_t *info);
  * closes the socket
  */
 void h2o_socket_close(h2o_socket_t *sock);
+/**
+ * Handles a packet timestamp from an h2o socket on platforms which support it
+ */
+void h2o_socket_handle_timestamp(struct st_h2o_evloop_socket_t *sock, struct msghdr *msg);
 /**
  * Schedules a callback to be notify we the socket can be written to
  */

--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -47,6 +47,7 @@ typedef struct st_h2o_evloop_t {
     struct timeval _tv_at;
     h2o_timerwheel_t *_timeouts;
     h2o_sliding_counter_t exec_time_nanosec_counter;
+    h2o_sliding_counter_t packet_latency_nanosec_counter;
 } h2o_evloop_t;
 
 typedef h2o_evloop_t h2o_loop_t;
@@ -96,6 +97,11 @@ static inline uint64_t h2o_evloop_get_execution_time_millisec(h2o_evloop_t *loop
 static inline uint64_t h2o_evloop_get_execution_time_nanosec(h2o_evloop_t *loop)
 {
     return loop->exec_time_nanosec_counter.average;
+}
+
+static inline uint64_t h2o_evloop_get_packet_kernel_latency_nanosec(h2o_evloop_t *loop)
+{
+    return loop->packet_latency_nanosec_counter.average;
 }
 
 inline void h2o_timer_link(h2o_evloop_t *loop, uint64_t delay_ticks, h2o_timer_t *timer)


### PR DESCRIPTION
This change allows the user to specify the option "packet-timestamping" to turn
on packet timestamping on supported platforms (this change implements this for
Linux).

The user may also specify a "packet-timestamping-sample-rate" to determine how
often to read the packet timestamping information and compute the average.

The data is exported in nanoseconds per thread via "duration-stats" (if enabled).