### PR TITLE
Make sure several threads are not accessing the timerwheel

### DIFF
--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -113,13 +113,9 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);
 
     static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-    static int once = 0;
     pthread_mutex_lock(&mutex);
 
-    if (once == 0) {
-        once++;
-        h2o_socketpool_register_loop(&ctx->globalconf->proxy.global_socketpool, loop);
-    }
+    h2o_socketpool_register_loop(&ctx->globalconf->proxy.global_socketpool, loop);
 
     for (i = 0; config->hosts[i] != NULL; ++i) {
         h2o_hostconf_t *hostconf = config->hosts[i];

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -113,9 +113,13 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     memset(ctx->_module_configs, 0, sizeof(*ctx->_module_configs) * config->_num_config_slots);
 
     static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+    static int once = 0;
     pthread_mutex_lock(&mutex);
 
-    h2o_socketpool_register_loop(&ctx->globalconf->proxy.global_socketpool, loop);
+    if (once == 0) {
+        once++;
+        h2o_socketpool_register_loop(&ctx->globalconf->proxy.global_socketpool, loop);
+    }
 
     for (i = 0; config->hosts[i] != NULL; ++i) {
         h2o_hostconf_t *hostconf = config->hosts[i];


### PR DESCRIPTION
We ensure this by only letting one thread update the timers: the first
one that called `h2o_socketpool_register_loop`. The other threads can
still expire sockets, just not adjust the timer for the next expiration.