### PR TITLE
DTrace: Consistently use uint64_t for req_index 

### DIFF
--- a/h2o-probes.d
+++ b/h2o-probes.d
@@ -23,7 +23,7 @@
 provider h2o {
     probe h1_accept(uint64_t conn_id, struct st_h2o_socket_t *sock, struct st_h2o_conn_t *conn);
     probe h1_close(uint64_t conn_id);
-    probe receive_request(uint64_t conn_id, int64_t req_id, int http_version);
+    probe receive_request(uint64_t conn_id, uint64_t req_id, int http_version);
     probe receive_request_header(uint64_t conn_id, uint64_t req_id, const char *name, size_t name_len, const char *value,
                                  size_t value_len);
 };


### PR DESCRIPTION
Hello! I noticed a trivial oversight while working on request-layer USDT probing. It's going to take me a bit longer to complete that work, so I'm submitting this nit-of-a-change ahead of time.