### PR TITLE
Add a USDT probe for tracing the response status

### DIFF
--- a/h2o-probes.d
+++ b/h2o-probes.d
@@ -26,4 +26,5 @@ provider h2o {
     probe receive_request(uint64_t conn_id, uint64_t req_id, int http_version);
     probe receive_request_header(uint64_t conn_id, uint64_t req_id, const char *name, size_t name_len, const char *value,
                                  size_t value_len);
+    probe send_response_status(uint64_t conn_id, uint64_t req_id, int status);
 };

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -947,6 +947,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
         } else {
             bufs[bufcnt].base = h2o_mem_alloc_pool(&conn->req.pool, char, headers_est_size);
         }
+        h2o_probe_log_response_status(&conn->req, conn->_req_index, conn->req.res.status);
         bufs[bufcnt].len = flatten_headers(bufs[bufcnt].base, &conn->req, connection);
         if (pull_mode == IS_PULL) {
             pull_mode = LASTBUF_IS_PULL;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -22,6 +22,7 @@
 #include "h2o.h"
 #include "h2o/http2.h"
 #include "h2o/http2_internal.h"
+#include "../probes_.h"
 
 static void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state);
 static void finalostream_send_informational(h2o_ostream_t *_self, h2o_req_t *req);
@@ -330,6 +331,7 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *bufs,
             send_refused_stream(conn, stream);
             return;
         }
+        h2o_probe_log_response_status(&stream->req, stream->stream_id, stream->req.res.status);
         if (send_headers(conn, stream) != 0)
             return;
     /* fallthru */

--- a/lib/probes_.h
+++ b/lib/probes_.h
@@ -98,4 +98,9 @@ static inline void h2o_probe_log_request(h2o_req_t *req, uint64_t req_index)
     }
 }
 
+static inline void h2o_probe_log_response_status(h2o_req_t *req, uint64_t req_index, int status)
+{
+    H2O_PROBE_CONN(SEND_RESPONSE_STATUS, req->conn, req_index, req->res.status);
+}
+
 #endif


### PR DESCRIPTION
Hi! This PR adds a USDT probe and its test for tracing the HTTP response status. Only H1 and H2 requests are instrumented for consistency with the other req-level probes.