### PR TITLE
Remove wrong assertion of defer_timeout of http2client

### DIFF
--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -762,8 +762,6 @@ static ssize_t expect_settings(struct st_h2o_http2client_conn_t *conn, const uin
 
 static void close_connection_now(struct st_h2o_http2client_conn_t *conn)
 {
-    assert(!h2o_timer_is_linked(&conn->output.defer_timeout));
-
     free(conn->super.origin_url.authority.base);
     free(conn->super.origin_url.host.base);
     free(conn->super.origin_url.path.base);


### PR DESCRIPTION
Fixes https://github.com/h2o/h2o/issues/2180. It can be still linked when either IO error or IO timeout happen. It's hard to write a test for this case, because defer_timeout is zero-timeout

