### PR TITLE
Remove an unused arg from h2o_probe_log_response_status

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -947,7 +947,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
         } else {
             bufs[bufcnt].base = h2o_mem_alloc_pool(&conn->req.pool, char, headers_est_size);
         }
-        h2o_probe_log_response_status(&conn->req, conn->_req_index, conn->req.res.status);
+        h2o_probe_log_response_status(&conn->req, conn->_req_index);
         bufs[bufcnt].len = flatten_headers(bufs[bufcnt].base, &conn->req, connection);
         if (pull_mode == IS_PULL) {
             pull_mode = LASTBUF_IS_PULL;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -331,7 +331,7 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *bufs,
             send_refused_stream(conn, stream);
             return;
         }
-        h2o_probe_log_response_status(&stream->req, stream->stream_id, stream->req.res.status);
+        h2o_probe_log_response_status(&stream->req, stream->stream_id);
         if (send_headers(conn, stream) != 0)
             return;
     /* fallthru */

--- a/lib/probes_.h
+++ b/lib/probes_.h
@@ -98,7 +98,7 @@ static inline void h2o_probe_log_request(h2o_req_t *req, uint64_t req_index)
     }
 }
 
-static inline void h2o_probe_log_response_status(h2o_req_t *req, uint64_t req_index, int status)
+static inline void h2o_probe_log_response_status(h2o_req_t *req, uint64_t req_index)
 {
     H2O_PROBE_CONN(SEND_RESPONSE_STATUS, req->conn, req_index, req->res.status);
 }


### PR DESCRIPTION
There's no need for the caller to pass the status code, because the status is obtained through `req->res.status`. Apologies for the oversight.