### PR TITLE
Detect NEXTPROTONEG (NPN) support on OpenSSL

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -29,6 +29,7 @@ extern "C" {
 #include <stdint.h>
 #include <sys/socket.h>
 #include <openssl/ssl.h>
+#include <openssl/opensslconf.h>
 #include "picotls.h"
 #include "h2o/cache.h"
 #include "h2o/ebpf.h"
@@ -46,7 +47,11 @@ extern "C" {
 
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L
 #define H2O_USE_ALPN 1
+#ifndef OPENSSL_NO_NEXTPROTONEG
 #define H2O_USE_NPN 1
+#else
+#define H2O_USE_NPN 0
+#endif
 #elif OPENSSL_VERSION_NUMBER >= 0x10001000L
 #define H2O_USE_ALPN 0
 #define H2O_USE_NPN 1


### PR DESCRIPTION
OpenSSL exposes OPENSSL_NO_NEXTPROTONEG when the no-nextprotoneg flag is passed at build time which has the effect of disabling NPN support. ALPN is hard-coded on and cannot be disabled, so this flag shouldn't affect that at all.

Fixes #2056

Signed-off-by: James Taylor <james@jtaylor.id.au>