### PR TITLE
Reinitiate OCSP stapling.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -861,10 +861,6 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
     ssl_config->certificate_file = h2o_strdup(NULL, (*certificate_file)->data.scalar, SIZE_MAX).base;
     ssl_config->http2_origin_frame = http2_origin_frame;
 
-#if !H2O_USE_OCSP
-    if (ocsp_update_interval != 0)
-        fprintf(stderr, "[OCSP Stapling] disabled (not support by the SSL library)\n");
-#else
 #ifndef OPENSSL_NO_OCSP
     SSL_CTX_set_tlsext_status_cb(ssl_ctx, on_staple_ocsp_ossl);
     SSL_CTX_set_tlsext_status_arg(ssl_ctx, ssl_config);
@@ -904,7 +900,6 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
         } break;
         }
     }
-#endif
 
     if (use_picotls) {
         const char *errstr = listener_setup_ssl_picotls(listener, ssl_config, ssl_ctx);


### PR DESCRIPTION
The commit a42769ce4dceee6c57e9453e59af5e67ab9d267f removed H2O_USE_OCSP but it was still refered to, so OCSP stapling was always 'not used'. The [other piece where H2O_USE_OCSP was used](https://github.com/h2o/h2o/blob/572ba09118ecb84fe4daf530b3302a8997146b73/src/main.c#L93-L104) is now [enabled unconditionally](https://github.com/h2o/h2o/blob/47814cd5a7cf9ed76137d623d3bf91d3397b71c4/src/main.c#L91-L100), so I did the same.