### PR TITLE
Use PRIu64 to interpolate the content-length value

### DIFF
--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -136,7 +136,7 @@ static h2o_iovec_t build_content_length(h2o_mem_pool_t *pool, size_t cl)
 {
     h2o_iovec_t cl_buf;
     cl_buf.base = h2o_mem_alloc_pool(pool, char, sizeof(H2O_UINT64_LONGEST_STR) - 1);
-    cl_buf.len = sprintf(cl_buf.base, "%zu", cl);
+    cl_buf.len = sprintf(cl_buf.base, "%" PRIu64, cl);
     return cl_buf;
 }
 


### PR DESCRIPTION
Submitting this before I forget. As suggested by [this review](https://github.com/h2o/h2o/pull/2194#discussion_r357467148) in another PR, use the `PRIu64` literal as the format specifier to interpolate the content-length value. It's basically the same code, bounded by `H2O_UINT64_LONGEST_STR`.