### PR TITLE
Introduce H2O_SIZE_T_LONGEST_STR

### DIFF
--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -41,6 +41,10 @@ extern "C" {
 #define H2O_UINT64_LONGEST_STR "18446744073709551615"
 #define H2O_UINT64_LONGEST_HEX_STR "FFFFFFFFFFFFFFFF"
 
+#define H2O_SIZE_T_LONGEST_STR                                                                                                     \
+    H2O_UINT64_LONGEST_STR /* As it is hard to define a macro based on the actual size of size_t, we hard-code it to 64-bits and   \
+                              assert that in string.c */
+
 /**
  * duplicates given string
  * @param pool memory pool (or NULL to use malloc)

--- a/lib/common/string.c
+++ b/lib/common/string.c
@@ -28,6 +28,9 @@
 
 h2o_iovec_t h2o_strdup(h2o_mem_pool_t *pool, const char *s, size_t slen)
 {
+    /* We do not need this check to be here, but it needs to be somewhere, see the definition of H2O_SIZE_T_LONGEST_STR */
+    H2O_BUILD_ASSERT(sizeof(size_t) <= sizeof(uint64_t));
+
     h2o_iovec_t ret;
 
     if (slen == SIZE_MAX)

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -135,7 +135,7 @@ static int req_requires_content_length(h2o_req_t *req)
 static h2o_iovec_t build_content_length(h2o_mem_pool_t *pool, size_t cl)
 {
     h2o_iovec_t cl_buf;
-    cl_buf.base = h2o_mem_alloc_pool(pool, char, sizeof(H2O_UINT64_LONGEST_STR) - 1);
+    cl_buf.base = h2o_mem_alloc_pool(pool, char, sizeof(H2O_SIZE_T_LONGEST_STR));
     cl_buf.len = sprintf(cl_buf.base, "%zu", cl);
     return cl_buf;
 }

--- a/lib/handler/mruby/http_request.c
+++ b/lib/handler/mruby/http_request.c
@@ -595,7 +595,7 @@ static mrb_value http_request_method(mrb_state *mrb, mrb_value self)
             // FIXME: how to handle fastpath and who frees this?
             ctx->req.body = h2o_strdup(&ctx->pool, RSTRING_PTR(body), RSTRING_LEN(body));
             if (!ctx->req.has_transfer_encoding) {
-                char *buf = h2o_mem_alloc_pool(&ctx->pool, char, sizeof(H2O_UINT64_LONGEST_STR) - 1);
+                char *buf = h2o_mem_alloc_pool(&ctx->pool, char, sizeof(H2O_SIZE_T_LONGEST_STR));
                 size_t l = (size_t)sprintf(buf, "%zu", ctx->req.body.len);
                 h2o_add_header(&ctx->pool, &ctx->req.headers, H2O_TOKEN_CONTENT_LENGTH, NULL, buf, l);
             }

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -30,7 +30,7 @@
 #define HEADER_TABLE_ENTRY_SIZE_OFFSET 32
 #define STATUS_HEADER_MAX_SIZE 5
 #define CONTENT_LENGTH_HEADER_MAX_SIZE                                                                                             \
-    (3 + sizeof(H2O_UINT64_LONGEST_STR) - 1) /* uses Literal Header Field without Indexing (RFC7541 6.2.2) */
+    (3 + sizeof(H2O_SIZE_T_LONGEST_STR) - 1) /* uses Literal Header Field without Indexing (RFC7541 6.2.2) */
 
 #include "hpack_huffman_table.h"
 

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -1300,10 +1300,10 @@ void h2o_qpack_flatten_response(h2o_qpack_encoder_t *_qpack, h2o_mem_pool_t *_po
         if (content_length == 0) {
             flatten_static_indexed(&ctx, 4);
         } else {
-            char cl_str[sizeof(H2O_UINT64_LONGEST_STR)];
-            sprintf(cl_str, "%" PRIu64, (uint64_t)content_length);
+            char cl_str[sizeof(H2O_SIZE_T_LONGEST_STR)];
+            size_t cl_len = (size_t)sprintf(cl_str, "%zu", content_length);
             do_flatten_header(&ctx, 4, 0, H2O_TOKEN_CONTENT_LENGTH->flags.likely_to_repeat, &H2O_TOKEN_CONTENT_LENGTH->buf,
-                              h2o_iovec_init(cl_str, strlen(cl_str)), (h2o_header_flags_t){0});
+                              h2o_iovec_init(cl_str, cl_len), (h2o_header_flags_t){0});
         }
     }
 


### PR DESCRIPTION
Until now, we have used `H2O_UINT64_LONGEST_STR`, because it is hard to define `H2O_SIZE_T_LONGEST_STR` as a string constant, as it is impossible do `#if sizeof(size_t) == x`.

However, that has caused confusion and have led to inconsistent coding pattern.

Therefore, we will introduce `H2O_SIZE_T_LONGEST_STR`. It is defined as `H2O_UINT64_LONGEST_STR`, along with a guard that generates a compiler error when sizeof(size_t) exceeds 64 bits. We will be wasting some space when sizeof(size_t) == 4, but it is no worse than status quo.