### PR TITLE
Fix the outdated non-Linux dtrace test setup

### DIFF
--- a/t/90dtrace.t
+++ b/t/90dtrace.t
@@ -78,6 +78,15 @@ EOT
     printf("\nXXXX%u:%u status:%u\n", arg0, arg1, arg2);
 }
 EOT
+            "-n", <<'EOT',
+:h2o::send_response_header {
+    name = (char *)copyin(arg2, arg3);
+    name[arg3] = '\0';
+    value = (char *)copyin(arg4, arg5);
+    value[arg5] = '\0';
+    printf("\nXXXX%s: %s\n", stringof(name), stringof(value));
+}
+EOT
         );
         die "failed to spawn dtrace:$!";
     }


### PR DESCRIPTION
In #2194, I had neglected to update the test code for non-Linux platforms (in practice,  disrupting macOS users). The fix is a shameless copy of `receive_request_header` probe attachment, but it is sufficient to satisfy the failing test cases.
