### PR TITLE
Avoid deprecated PTLS_OPENSSL_HAS_*.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -514,7 +514,7 @@ static const char *listener_setup_ssl_picotls(struct listener_config_t *listener
                                               SSL_CTX *ssl_ctx)
 {
     static const ptls_key_exchange_algorithm_t *key_exchanges[] = {
-#ifdef PTLS_OPENSSL_HAS_X25519
+#ifdef PTLS_OPENSSL_HAVE_X25519
         &ptls_openssl_x25519,
 #else
         &ptls_minicrypto_x25519,


### PR DESCRIPTION
[They are declared as deprecated in picotls](https://github.com/h2o/picotls/blob/5efacc294212092683207c5a873e25ddb56f9f5d/include/picotls/openssl.h#L55) and I don't see any good reason to continue to use them in h2o except they save a byte per their occurrence in each developer's workspace.