### PR TITLE
[http2] Remove debug printf on unknown frame type

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1068,8 +1068,6 @@ ssize_t expect_default(h2o_http2_conn_t *conn, const uint8_t *src, size_t len, c
         int hret = FRAME_HANDLERS[frame.type](conn, &frame, err_desc);
         if (hret != 0)
             ret = hret;
-    } else {
-        h2o_error_printf("skipping frame (type:%d)\n", frame.type);
     }
 
     return ret;


### PR DESCRIPTION
This patch removes a debug printf on receiving unknown frame
type, which could flood system log when a client sends a lot of
unknown frame types.