### PR TITLE
add missing include

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -21,6 +21,7 @@
  */
 #include <assert.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <pthread.h>
 #include <sys/stat.h>
 #include <openssl/crypto.h>


### PR DESCRIPTION
As reported by #2223, we use UINT_MAX in src/ssl.c, therefore need to include limits.h there.