### PR TITLE
Expand "openssl_backport.h" to include BIO_meth_free() and BIO_meth_set_*()

### DIFF
--- a/include/h2o/openssl_backport.h
+++ b/include/h2o/openssl_backport.h
@@ -45,10 +45,25 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
     return bm;
 }
 
-#define BIO_meth_set_write(bm, cb) ((bm)->bwrite = cb)
-#define BIO_meth_set_read(bm, cb) ((bm)->bread = cb)
-#define BIO_meth_set_puts(bm, cb) ((bm)->bputs = cb)
-#define BIO_meth_set_ctrl(bm, cb) ((bm)->ctrl = cb)
+#define BIO_meth_free(bm) free(bm)
+
+#define BIO_meth_set_write(bm, cb) ((bm)->bwrite = (cb))
+#define BIO_meth_set_read(bm, cb) ((bm)->bread = (cb))
+#define BIO_meth_set_puts(bm, cb) ((bm)->bputs = (cb))
+#define BIO_meth_set_gets(bm, cb) ((bm)->bgets = (cb))
+#define BIO_meth_set_ctrl(bm, cb) ((bm)->ctrl = (cb))
+#define BIO_meth_set_create(bm, cb) ((bm)->create = (cb))
+#define BIO_meth_set_destroy(bm, cb) ((bm)->destroy = (cb))
+#define BIO_meth_set_callback_ctrl(bm, cb) ((bm)->callback_ctrl = (cb))
+
+#define BIO_meth_get_write(bm) ((bm)->bwrite)
+#define BIO_meth_get_read(bm) ((bm)->bread)
+#define BIO_meth_get_puts(bm) ((bm)->bputs)
+#define BIO_meth_get_gets(bm) ((bm)->bgets)
+#define BIO_meth_get_ctrl(bm) ((bm)->ctrl)
+#define BIO_meth_get_create(bm) ((bm)->create)
+#define BIO_meth_get_destroy(bm) ((bm)->destroy)
+#define BIO_meth_get_callback_ctrl(bm) ((bm)->callback_ctrl)
 
 #ifndef OPENSSL_IS_BORINGSSL
 #define SSL_CTX_up_ref(ctx) CRYPTO_add(&(ctx)->references, 1, CRYPTO_LOCK_SSL_CTX)


### PR DESCRIPTION
These macros aren't used by h2o, but this header file is the first search engine hit for someone looking to polyfill OpenSSL 1.0.2 so that a single program can work portably against either 1.0.2 or 1.1.0. Therefore, it is helpful to the wider community if this header file contains the *full* polyfill for `BIO_METHOD` setters added in 1.1.0.

(The two methods I needed polyfills for, personally, were `BIO_meth_free` and `BIO_meth_set_create`. The rest, such as `BIO_meth_set_gets`, are only for completeness, following the logic above.)

OpenSSL 1.1.0 also adds getters such as `BIO_meth_get_ctrl(bm)`. I have no need for them myself, but the same logic applies: this useful header file should be a full polyfill for the benefit of the wider community.

https://www.openssl.org/docs/man1.1.1/man3/BIO_meth_new.html
(The documented `BIO_meth_{get,set}_read_ex` and `BIO_meth_{get,set}_write_ex` are new in 1.1.0 and therefore code that wants also to work with 1.0.2 shouldn't be using those.)