### PR TITLE
main: replace deprecated OpenSSL APIs

### DIFF
--- a/include/h2o/openssl_backport.h
+++ b/include/h2o/openssl_backport.h
@@ -56,6 +56,9 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
 #define X509_STORE_up_ref(store) CRYPTO_add(&(store)->references, 1, CRYPTO_LOCK_X509_STORE)
 #endif
 
+#define OPENSSL_VERSION SSLEAY_VERSION
+#define OpenSSL_version SSLeay_version
+
 #endif
 
 /* backports for OpenSSL 1.0.1 and LibreSSL */

--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,7 @@
 #include <sys/un.h>
 #include <sys/wait.h>
 #include <openssl/crypto.h>
+#include <openssl/dh.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #ifdef LIBC_HAS_BACKTRACE
@@ -2477,7 +2478,7 @@ static h2o_iovec_t on_extra_status(void *unused, h2o_globalconf_t *_conf, h2o_re
                        " \"listeners\": %zu,\n"
                        " \"worker-threads\": %zu,\n"
                        " \"num-sessions\": %lu",
-                       SSLeay_version(SSLEAY_VERSION), current_time, restart_time, (uint64_t)(now - conf.launch_time), generation,
+                       OpenSSL_version(OPENSSL_VERSION), current_time, restart_time, (uint64_t)(now - conf.launch_time), generation,
                        num_connections(0), conf.max_connections, conf.num_listeners, conf.thread_map.size, num_sessions(0));
     assert(ret.len < BUFSIZE);
 
@@ -2673,7 +2674,7 @@ int main(int argc, char **argv)
                 break;
             case 'v':
                 printf("h2o version " H2O_VERSION "\n");
-                printf("OpenSSL: %s\n", SSLeay_version(SSLEAY_VERSION));
+                printf("OpenSSL: %s\n", OpenSSL_version(OPENSSL_VERSION));
 #if H2O_USE_MRUBY
                 printf(
                     "mruby: YES\n"); /* TODO determine the way to obtain the version of mruby (that is being linked dynamically) */


### PR DESCRIPTION
Otherwise compilation fails.

The dh.h header is for DH_free. It's normally implicit with ssl.h.