### PR TITLE
make sock->bytes_read cumulative

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -113,11 +113,11 @@ struct st_h2o_socket_t {
     /**
      * total bytes read (above the TLS layer)
      */
-    size_t bytes_read;
+    uint64_t bytes_read;
     /**
      * total bytes written (above the TLS layer)
      */
-    size_t bytes_written;
+    uint64_t bytes_written;
     /**
      * boolean flag to indicate if sock is NOT being traced
      */

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -60,6 +60,7 @@ struct st_h2o_http1client_t {
     char _chunk_len_str[(sizeof(H2O_UINT64_LONGEST_HEX_STR) - 1) + 2 + 1]; /* SIZE_MAX in hex + CRLF + '\0' */
     h2o_buffer_t *_body_buf;
     h2o_buffer_t *_body_buf_in_flight;
+    size_t _last_bytes_read;
     unsigned _is_chunked : 1;
     unsigned _body_buf_is_done : 1;
     unsigned _seen_at_least_one_chunk : 1;
@@ -134,11 +135,13 @@ static void on_body_until_close(h2o_socket_t *sock, const char *err)
         close_response(client);
         return;
     }
+    size_t size = sock->bytes_read - client->_last_bytes_read;
+    client->_last_bytes_read = sock->bytes_read;
 
-    client->super.bytes_read.body += sock->bytes_read;
-    client->super.bytes_read.total += sock->bytes_read;
+    client->super.bytes_read.body += size;
+    client->super.bytes_read.total += size;
 
-    if (sock->bytes_read != 0) {
+    if (size != 0) {
         if (client->super._cb.on_body(&client->super, NULL) != 0) {
             close_client(client);
             return;
@@ -159,23 +162,25 @@ static void on_body_content_length(h2o_socket_t *sock, const char *err)
         on_error(client, h2o_httpclient_error_io);
         return;
     }
+    size_t size = sock->bytes_read - client->_last_bytes_read;
+    client->_last_bytes_read = sock->bytes_read;
 
-    client->super.bytes_read.body += sock->bytes_read;
-    client->super.bytes_read.total += sock->bytes_read;
+    client->super.bytes_read.body += size;
+    client->super.bytes_read.total += size;
 
-    if (sock->bytes_read != 0 || client->_body_decoder.content_length.bytesleft == 0) {
+    if (size != 0 || client->_body_decoder.content_length.bytesleft == 0) {
         int ret;
-        if (client->_body_decoder.content_length.bytesleft <= sock->bytes_read) {
-            if (client->_body_decoder.content_length.bytesleft < sock->bytes_read) {
+        if (client->_body_decoder.content_length.bytesleft <= size) {
+            if (client->_body_decoder.content_length.bytesleft < size) {
                 /* remove the trailing garbage from buf, and disable keepalive */
-                client->sock->input->size -= sock->bytes_read - client->_body_decoder.content_length.bytesleft;
+                client->sock->input->size -= size - client->_body_decoder.content_length.bytesleft;
                 client->_do_keepalive = 0;
             }
             client->_body_decoder.content_length.bytesleft = 0;
             client->state.res = STREAM_STATE_CLOSED;
             client->super.timings.response_end_at = h2o_gettimeofday(client->super.ctx->loop);
         } else {
-            client->_body_decoder.content_length.bytesleft -= sock->bytes_read;
+            client->_body_decoder.content_length.bytesleft -= size;
         }
         ret = client->super._cb.on_body(&client->super,
                                         client->state.res == STREAM_STATE_CLOSED ? h2o_httpclient_error_is_eos : NULL);
@@ -218,19 +223,21 @@ static void on_body_chunked(h2o_socket_t *sock, const char *err)
         }
         return;
     }
+    size_t size = sock->bytes_read - client->_last_bytes_read;
+    client->_last_bytes_read = sock->bytes_read;
 
-    client->super.bytes_read.body += sock->bytes_read;
-    client->super.bytes_read.total += sock->bytes_read;
+    client->super.bytes_read.body += size;
+    client->super.bytes_read.total += size;
 
     inbuf = client->sock->input;
-    if (sock->bytes_read != 0) {
+    if (size != 0) {
         const char *errstr;
         int cb_ret;
-        size_t newsz = sock->bytes_read;
+        size_t newsz = size;
 
         switch (phr_decode_chunked(&client->_body_decoder.chunked.decoder, inbuf->bytes + inbuf->size - newsz, &newsz)) {
         case -1: /* error */
-            newsz = sock->bytes_read;
+            newsz = size;
             client->_do_keepalive = 0;
             errstr = h2o_httpclient_error_http1_parse_failed;
             break;
@@ -246,7 +253,7 @@ static void on_body_chunked(h2o_socket_t *sock, const char *err)
             client->super.timings.response_end_at = h2o_gettimeofday(client->super.ctx->loop);
             break;
         }
-        inbuf->size -= sock->bytes_read - newsz;
+        inbuf->size -= size - newsz;
         if (inbuf->size > 0)
             client->_seen_at_least_one_chunk = 1;
         cb_ret = client->super._cb.on_body(&client->super, errstr);
@@ -417,7 +424,8 @@ static void on_head(h2o_socket_t *sock, const char *err)
 
     h2o_buffer_consume(&sock->input, client->bytes_to_consume);
     client->bytes_to_consume = 0;
-    client->sock->bytes_read = client->sock->input->size;
+    client->_last_bytes_read = client->sock->bytes_read - client->sock->input->size;
+//    client->sock->bytes_read = client->sock->input->size;
 
     client->super._timeout.cb = on_body_timeout;
     h2o_socket_read_start(sock, reader);

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -60,7 +60,7 @@ struct st_h2o_http1client_t {
     char _chunk_len_str[(sizeof(H2O_UINT64_LONGEST_HEX_STR) - 1) + 2 + 1]; /* SIZE_MAX in hex + CRLF + '\0' */
     h2o_buffer_t *_body_buf;
     h2o_buffer_t *_body_buf_in_flight;
-    size_t _last_bytes_read;
+    uint64_t _last_bytes_read;
     unsigned _is_chunked : 1;
     unsigned _body_buf_is_done : 1;
     unsigned _seen_at_least_one_chunk : 1;
@@ -135,7 +135,7 @@ static void on_body_until_close(h2o_socket_t *sock, const char *err)
         close_response(client);
         return;
     }
-    size_t size = sock->bytes_read - client->_last_bytes_read;
+    uint64_t size = sock->bytes_read - client->_last_bytes_read;
     client->_last_bytes_read = sock->bytes_read;
 
     client->super.bytes_read.body += size;
@@ -162,7 +162,7 @@ static void on_body_content_length(h2o_socket_t *sock, const char *err)
         on_error(client, h2o_httpclient_error_io);
         return;
     }
-    size_t size = sock->bytes_read - client->_last_bytes_read;
+    uint64_t size = sock->bytes_read - client->_last_bytes_read;
     client->_last_bytes_read = sock->bytes_read;
 
     client->super.bytes_read.body += size;
@@ -223,7 +223,7 @@ static void on_body_chunked(h2o_socket_t *sock, const char *err)
         }
         return;
     }
-    size_t size = sock->bytes_read - client->_last_bytes_read;
+    uint64_t size = sock->bytes_read - client->_last_bytes_read;
     client->_last_bytes_read = sock->bytes_read;
 
     client->super.bytes_read.body += size;
@@ -425,7 +425,6 @@ static void on_head(h2o_socket_t *sock, const char *err)
     h2o_buffer_consume(&sock->input, client->bytes_to_consume);
     client->bytes_to_consume = 0;
     client->_last_bytes_read = client->sock->bytes_read - client->sock->input->size;
-//    client->sock->bytes_read = client->sock->input->size;
 
     client->super._timeout.cb = on_body_timeout;
     h2o_socket_read_start(sock, reader);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -619,7 +619,8 @@ size_t h2o_socket_do_prepare_for_latency_optimized_write(h2o_socket_t *sock,
 
 void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb)
 {
-    size_t i, prev_bytes_written = sock->bytes_written;
+    size_t i;
+    uint64_t prev_bytes_written = sock->bytes_written;
 
     assert(bufcnt > 0);
     for (i = 0; i != bufcnt; ++i) {

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -228,7 +228,7 @@ Complete:
 static void read_on_ready(struct st_h2o_evloop_socket_t *sock)
 {
     const char *err = 0;
-    size_t prev_bytes_read = sock->super.input->size;
+    size_t prev_size = sock->super.input->size;
 
     if ((sock->_flags & H2O_SOCKET_FLAG_DONT_READ) != 0)
         goto Notify;
@@ -244,7 +244,7 @@ Notify:
      * behavior is intentional; it is designed as such so that the applications
      * can update their timeout counters when a partial SSL record arrives.
      */
-    sock->super.bytes_read = sock->super.input->size - prev_bytes_read;
+    sock->super.bytes_read += sock->super.input->size - prev_size;
     sock->super._cb.read(&sock->super, err);
 }
 

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -65,20 +65,19 @@ static void on_read_tcp(uv_stream_t *stream, ssize_t nread, const uv_buf_t *_unu
     struct st_h2o_uv_socket_t *sock = stream->data;
 
     if (nread < 0) {
-        sock->super.bytes_read = 0;
         sock->super._cb.read(&sock->super, h2o_socket_error_closed);
         return;
     }
 
     sock->super.input->size += nread;
-    sock->super.bytes_read = nread;
+    sock->super.bytes_read += nread;
     sock->super._cb.read(&sock->super, NULL);
 }
 
 static void on_read_ssl(uv_stream_t *stream, ssize_t nread, const uv_buf_t *_unused)
 {
     struct st_h2o_uv_socket_t *sock = stream->data;
-    size_t prev_bytes_read = sock->super.input->size;
+    size_t prev_size = sock->super.input->size;
     const char *err = h2o_socket_error_io;
 
     if (nread > 0) {
@@ -88,7 +87,7 @@ static void on_read_ssl(uv_stream_t *stream, ssize_t nread, const uv_buf_t *_unu
         else
             err = NULL;
     }
-    sock->super.bytes_read = sock->super.input->size - prev_bytes_read;
+    sock->super.bytes_read += sock->super.input->size - prev_size;
     sock->super._cb.read(&sock->super, err);
 }
 

--- a/lib/tunnel.c
+++ b/lib/tunnel.c
@@ -68,7 +68,7 @@ static void on_read(h2o_socket_t *sock, const char *err)
         return;
     }
 
-    if (sock->bytes_read == 0)
+    if (sock->input->size == 0)
         return;
 
     h2o_socket_read_stop(sock);


### PR DESCRIPTION
Follow up of https://github.com/h2o/h2o/pull/2197

As https://github.com/h2o/h2o/pull/2197#discussion_r356912066 stated, `sock->bytes_read` was contradicting to [the API comment](https://github.com/h2o/h2o/blob/master/include/h2o/socket.h#L114): it was delta from previous callback invocation, not total value. This PR makes it be real total size of bytes the socket ever read.