### PR TITLE
Unlink the requests from pending if the stream goes to close_wait

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -269,6 +269,9 @@ static void set_state(struct st_h2o_http3_server_stream_t *stream, enum h2o_http
         assert(conn->delayed_streams.recv_body_blocked.prev == &stream->link || !"stream is not registered to the recv_body list?");
         break;
     case H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT: {
+        if (h2o_linklist_is_linked(&stream->link))
+            h2o_linklist_unlink(&stream->link);
+
         dispose_request(stream);
         static const quicly_stream_callbacks_t close_wait_callbacks = {on_stream_destroy,
                                                                        quicly_stream_noop_on_send_shift,


### PR DESCRIPTION
We might hit the following assert otherwise `stream->state == H2O_HTTP3_SERVER_STREAM_STATE_REQ_PENDING` in `run_delayed`.