### PR TITLE
use Host header when `:authority` is absent

### DIFF
--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -539,10 +539,8 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                     if (token->flags.http2_should_reject) {
                         if (token == H2O_TOKEN_HOST) {
                             /* HTTP2 allows the use of host header (in place of :authority) */
-                            if (authority->base == NULL) {
+                            if (authority->base == NULL)
                                 *authority = value;
-                                *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS;
-                            }
                             goto Next;
                         } else if (token == H2O_TOKEN_TE && h2o_lcstris(value.base, value.len, H2O_STRLIT("trailers"))) {
                             /* do not reject */

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -495,7 +495,6 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
             if (pseudo_header_exists_map != NULL) {
                 /* FIXME validate the chars in the value (e.g. reject SP in path) */
                 if (name == &H2O_TOKEN_AUTHORITY->buf) {
-                    /* FIXME should we perform this check? */
                     if (authority->base != NULL)
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     *authority = value;
@@ -539,7 +538,11 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                     /* reject headers as defined in draft-16 8.1.2.2 */
                     if (token->flags.http2_should_reject) {
                         if (token == H2O_TOKEN_HOST) {
-                            /* just skip (and :authority is used) */
+                            /* HTTP2 allows the use of host header (in place of :authority) */
+                            if (authority->base == NULL) {
+                                *authority = value;
+                                *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS;
+                            }
                             goto Next;
                         } else if (token == H2O_TOKEN_TE && h2o_lcstris(value.base, value.len, H2O_STRLIT("trailers"))) {
                             /* do not reject */


### PR DESCRIPTION
[Section 8.1.2.3 of RFC 7540](https://httpwg.org/specs/rfc7540.html#HttpRequest) states that _clients that generate HTTP/2 requests directly SHOULD use the :authority pseudo-header field instead of the Host header field_.

However, H2O simply drops the Host header field.

This PR fixes the problem. The logic is intentionally lax, as it is about dealing with intermediaries that possibly forwards a HTTP/1.0 request to a HTTP/2 (or HTTP/3) server.

Thanks to @martinduke for recognizing the interop issue, thanks to @mikebishop for explaining what is the correct behavior.