### PR TITLE
two phase path configure

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -266,7 +266,7 @@ struct st_h2o_hostconf_t {
     /**
      * list of path configurations
      */
-    H2O_VECTOR(h2o_pathconf_t) paths;
+    H2O_VECTOR(h2o_pathconf_t *) paths;
     /**
      * catch-all path configuration
      */

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -50,8 +50,9 @@ static void destroy_hostconf(h2o_hostconf_t *hostconf)
         free(hostconf->authority.hostport.base);
     free(hostconf->authority.host.base);
     for (i = 0; i != hostconf->paths.size; ++i) {
-        h2o_pathconf_t *pathconf = hostconf->paths.entries + i;
+        h2o_pathconf_t *pathconf = hostconf->paths.entries[i];
         h2o_config_dispose_pathconf(pathconf);
+        free(pathconf);
     }
     free(hostconf->paths.entries);
     h2o_config_dispose_pathconf(&hostconf->fallback_path);
@@ -204,12 +205,11 @@ void h2o_config_init(h2o_globalconf_t *config)
 
 h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *path, int flags)
 {
-    h2o_pathconf_t *pathconf;
+    h2o_pathconf_t *pathconf = h2o_mem_alloc(sizeof(*pathconf));
+    h2o_config_init_pathconf(pathconf, hostconf->global, path, hostconf->mimemap);
 
     h2o_vector_reserve(NULL, &hostconf->paths, hostconf->paths.size + 1);
-    pathconf = hostconf->paths.entries + hostconf->paths.size++;
-
-    h2o_config_init_pathconf(pathconf, hostconf->global, path, hostconf->mimemap);
+    hostconf->paths.entries[hostconf->paths.size++] = pathconf;
 
     return pathconf;
 }

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -329,12 +329,19 @@ static int on_config_paths(h2o_configurator_command_t *cmd, h2o_configurator_con
     }
     qsort(node->data.mapping.elements, node->data.mapping.size, sizeof(node->data.mapping.elements[0]),
           (int (*)(const void *, const void *))sort_from_longer_paths);
-
+    
+    /* At first regsiter all paths before configure, because hostconf->paths may be reallocated */
     for (i = 0; i != node->data.mapping.size; ++i) {
-        yoml_t *key = node->data.mapping.elements[i].key, *value;
+        yoml_t *key = node->data.mapping.elements[i].key;
+        h2o_config_register_path(ctx->hostconf, key->data.scalar, 0);
+    }
+
+    /* Then configure all paths with corresponding values */
+    for (i = 0; i != node->data.mapping.size; ++i) {
+        yoml_t *value;
         if ((value = convert_path_config_node(cmd, node->data.mapping.elements[i].value)) == NULL)
             return -1;
-        h2o_pathconf_t *pathconf = h2o_config_register_path(ctx->hostconf, key->data.scalar, 0);
+        h2o_pathconf_t *pathconf = ctx->hostconf->paths.entries + i;
         int cmd_ret = config_path(ctx, pathconf, value);
         yoml_free(value, NULL);
         if (cmd_ret != 0)

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -329,20 +329,12 @@ static int on_config_paths(h2o_configurator_command_t *cmd, h2o_configurator_con
     }
     qsort(node->data.mapping.elements, node->data.mapping.size, sizeof(node->data.mapping.elements[0]),
           (int (*)(const void *, const void *))sort_from_longer_paths);
-    
-    /* At first regsiter all paths before configure, because hostconf->paths may be reallocated */
-    size_t prev_paths_size = ctx->hostconf->paths.size;
-    for (i = 0; i != node->data.mapping.size; ++i) {
-        yoml_t *key = node->data.mapping.elements[i].key;
-        h2o_config_register_path(ctx->hostconf, key->data.scalar, 0);
-    }
 
-    /* Then configure all paths with corresponding values */
     for (i = 0; i != node->data.mapping.size; ++i) {
-        yoml_t *value;
+        yoml_t *key = node->data.mapping.elements[i].key, *value;
         if ((value = convert_path_config_node(cmd, node->data.mapping.elements[i].value)) == NULL)
             return -1;
-        h2o_pathconf_t *pathconf = ctx->hostconf->paths.entries + prev_paths_size + i;
+        h2o_pathconf_t *pathconf = h2o_config_register_path(ctx->hostconf, key->data.scalar, 0);
         int cmd_ret = config_path(ctx, pathconf, value);
         yoml_free(value, NULL);
         if (cmd_ret != 0)

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -331,6 +331,7 @@ static int on_config_paths(h2o_configurator_command_t *cmd, h2o_configurator_con
           (int (*)(const void *, const void *))sort_from_longer_paths);
     
     /* At first regsiter all paths before configure, because hostconf->paths may be reallocated */
+    size_t prev_paths_size = ctx->hostconf->paths.size;
     for (i = 0; i != node->data.mapping.size; ++i) {
         yoml_t *key = node->data.mapping.elements[i].key;
         h2o_config_register_path(ctx->hostconf, key->data.scalar, 0);
@@ -341,7 +342,7 @@ static int on_config_paths(h2o_configurator_command_t *cmd, h2o_configurator_con
         yoml_t *value;
         if ((value = convert_path_config_node(cmd, node->data.mapping.elements[i].value)) == NULL)
             return -1;
-        h2o_pathconf_t *pathconf = ctx->hostconf->paths.entries + i;
+        h2o_pathconf_t *pathconf = ctx->hostconf->paths.entries + prev_paths_size + i;
         int cmd_ret = config_path(ctx, pathconf, value);
         yoml_free(value, NULL);
         if (cmd_ret != 0)

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -120,7 +120,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     for (i = 0; config->hosts[i] != NULL; ++i) {
         h2o_hostconf_t *hostconf = config->hosts[i];
         for (j = 0; j != hostconf->paths.size; ++j) {
-            h2o_pathconf_t *pathconf = hostconf->paths.entries + j;
+            h2o_pathconf_t *pathconf = hostconf->paths.entries[j];
             h2o_context_init_pathconf_context(ctx, pathconf);
         }
         h2o_context_init_pathconf_context(ctx, &hostconf->fallback_path);
@@ -139,7 +139,7 @@ void h2o_context_dispose(h2o_context_t *ctx)
     for (i = 0; config->hosts[i] != NULL; ++i) {
         h2o_hostconf_t *hostconf = config->hosts[i];
         for (j = 0; j != hostconf->paths.size; ++j) {
-            h2o_pathconf_t *pathconf = hostconf->paths.entries + j;
+            h2o_pathconf_t *pathconf = hostconf->paths.entries[j];
             h2o_context_dispose_pathconf_context(ctx, pathconf);
         }
         h2o_context_dispose_pathconf_context(ctx, &hostconf->fallback_path);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -165,7 +165,7 @@ static void setup_pathconf(h2o_req_t *req, h2o_hostconf_t *hostconf)
 
     /* setup pathconf, or redirect to "path/" */
     for (i = 0; i != hostconf->paths.size; ++i) {
-        h2o_pathconf_t *candidate = hostconf->paths.entries + i;
+        h2o_pathconf_t *candidate = hostconf->paths.entries[i];
         if (req->path_normalized.len >= candidate->path.len &&
             memcmp(req->path_normalized.base, candidate->path.base, candidate->path.len) == 0 &&
             (candidate->path.base[candidate->path.len - 1] == '/' || req->path_normalized.len == candidate->path.len ||

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -272,7 +272,7 @@ static mrb_value build_constants(mrb_state *mrb, const char *server_name, size_t
             mrb_ary_set(mrb, ary, i, lit);
         }
         for (; i != H2O_MAX_TOKENS * 2; ++i) {
-            const h2o_token_t *token = h2o__tokens + i - H2O_MAX_TOKENS;
+            const h2o_token_t *token = h2o__tokens + (i - H2O_MAX_TOKENS);
             mrb_value lit = mrb_nil_value();
             if (token == H2O_TOKEN_CONTENT_TYPE) {
                 lit = mrb_str_new_lit(mrb, "CONTENT_TYPE");

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -219,8 +219,8 @@ void h2o_duration_stats_register(h2o_globalconf_t *conf)
         hconf = conf->hosts[k];
         for (i = 0; i < hconf->paths.size; i++) {
             int j;
-            for (j = 0; j < hconf->paths.entries[i].handlers.size; j++) {
-                h2o_pathconf_t *pathconf = &hconf->paths.entries[i];
+            for (j = 0; j < hconf->paths.entries[i]->handlers.size; j++) {
+                h2o_pathconf_t *pathconf = hconf->paths.entries[i];
                 h2o_vector_reserve(NULL, &pathconf->_loggers, pathconf->_loggers.size + 1);
                 pathconf->_loggers.entries[pathconf->_loggers.size++] = (void *)logger;
             }

--- a/t/00unit/lib/handler/fastcgi.c
+++ b/t/00unit/lib/handler/fastcgi.c
@@ -84,7 +84,7 @@ static void test_build_request(void)
     conn->req.query_at = SIZE_MAX;
     conn->req.version = 0x101;
     conn->req.hostconf = *ctx.globalconf->hosts;
-    conn->req.pathconf = conn->req.hostconf->paths.entries;
+    conn->req.pathconf = conn->req.hostconf->paths.entries[0];
     h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_COOKIE, NULL, H2O_STRLIT("foo=bar"));
     h2o_add_header(&conn->req.pool, &conn->req.headers, H2O_TOKEN_USER_AGENT, NULL,
                    H2O_STRLIT("Mozilla/5.0 (X11; Linux) KHTML/4.9.1 (like Gecko) Konqueror/4.9"));


### PR DESCRIPTION
Fix https://github.com/h2o/h2o/issues/2234

`hostconf->paths` may be reallocated in `h2o_config_register_path`, but currently mruby handler has its reference. This PR fixes it by registering all paths at first, then configuring all paths
