### PR TITLE
fix mruby middleware issues

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1629,6 +1629,10 @@ void h2o_send_informational(h2o_req_t *req);
  */
 static int h2o_req_can_stream_request(h2o_req_t *req);
 /**
+ * resolves internal redirect url for dest regarding req's hostconf
+ */
+int h2o_req_resolve_internal_redirect_url(h2o_req_t *req, h2o_iovec_t dest, h2o_url_t *resolved);
+/**
  * logs an error
  */
 void h2o_req_log_error(h2o_req_t *req, const char *module, const char *fmt, ...) __attribute__((format(printf, 3, 4)));

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -409,13 +409,8 @@ static int handle_header_raw_key(h2o_mruby_shared_context_t *shared_ctx, h2o_iov
     if (name.base == NULL)
         return 0;
 
-    if ((token = h2o_lookup_token(name.base, name.len)) != NULL) {
-        value = h2o_strdup(&req->pool, value.base, value.len);
-        h2o_add_header(&req->pool, &req->headers, token, NULL, value.base, value.len);
-    } else {
-        value = h2o_strdup(&req->pool, value.base, value.len);
-        h2o_add_header_by_str(&req->pool, &req->headers, name.base, name.len, 0, NULL, value.base, value.len);
-    }
+    value = h2o_strdup(&req->pool, value.base, value.len);
+    h2o_add_header_by_str(&req->pool, &req->headers, name.base, name.len, 1, NULL, value.base, value.len);
 
     return 0;
 }

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -837,7 +837,11 @@ static mrb_value middleware_request_method(mrb_state *mrb, mrb_value self)
 
     h2o_req_t *super = &subreq->super;
     if (mrb_bool(reprocess)) {
-        h2o_reprocess_request_deferred(super, super->method, super->scheme, super->authority, super->path, super->overrides, 1);
+        h2o_url_t resolved;
+        if (h2o_req_resolve_internal_redirect_url(super, super->path, &resolved) != 0) {
+            mrb_exc_raise(mrb, mrb_exc_new_str_lit(mrb, E_RUNTIME_ERROR, "failed to resolve reprocess uri"));
+        }
+        h2o_reprocess_request_deferred(super, super->method, resolved.scheme, resolved.authority, resolved.path, super->overrides, 1);
     } else {
         h2o_delegate_request_deferred(super);
     }

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -558,6 +558,7 @@ static int retrieve_env(mrb_state *mrb, mrb_value key, mrb_value value, void *_d
     } else if (CHECK_KEY("rack.run_once")) {
     } else if (CHECK_KEY("rack.url_scheme")) {
         RETRIEVE_ENV_STR(data->env.scheme);
+    } else if (CHECK_KEY("rack.early_hints")) {
     } else if (keystr_len >= 5 && memcmp(keystr, "HTTP_", 5) == 0) {
         mrb_value http_header = mrb_nil_value();
         RETRIEVE_ENV_STR(http_header);

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -119,21 +119,23 @@ static void on_gc_dispose_app_input_stream(mrb_state *mrb, void *_subreq)
 const static struct mrb_data_type app_request_type = {"app_request_type", on_gc_dispose_app_request};
 const static struct mrb_data_type app_input_stream_type = {"app_input_stream", on_gc_dispose_app_input_stream};
 
-static h2o_iovec_t convert_env_to_header_name(h2o_mem_pool_t *pool, const char *name, size_t len)
+static h2o_iovec_t convert_env_key_to_header_name(h2o_mem_pool_t *pool, const char *name, size_t len, int has_key_prefix)
 {
 #define KEY_PREFIX "HTTP_"
 #define KEY_PREFIX_LEN (sizeof(KEY_PREFIX) - 1)
-    if (len < KEY_PREFIX_LEN || !h2o_memis(name, KEY_PREFIX_LEN, KEY_PREFIX, KEY_PREFIX_LEN)) {
+    if (has_key_prefix && (len < KEY_PREFIX_LEN || !h2o_memis(name, KEY_PREFIX_LEN, KEY_PREFIX, KEY_PREFIX_LEN))) {
         return h2o_iovec_init(NULL, 0);
     }
 
     h2o_iovec_t ret;
 
-    ret.len = len - KEY_PREFIX_LEN;
+    ret.len = has_key_prefix ? len - KEY_PREFIX_LEN : len;
     ret.base = h2o_mem_alloc_pool(pool, char, ret.len);
 
-    name += KEY_PREFIX_LEN;
-    len -= KEY_PREFIX_LEN;
+    if (has_key_prefix) {
+        name += KEY_PREFIX_LEN;
+        len -= KEY_PREFIX_LEN;
+    }
 
     char *d = ret.base;
     for (; len != 0; ++name, --len)
@@ -398,19 +400,40 @@ static int skip_tracing(h2o_conn_t *conn)
     return 1;
 }
 
+static int handle_header_raw_key(h2o_mruby_shared_context_t *shared_ctx, h2o_iovec_t *raw_key, h2o_iovec_t value, void *_req)
+{
+    h2o_req_t *req = _req;
+    const h2o_token_t *token;
+
+    h2o_iovec_t name = convert_env_key_to_header_name(&req->pool, raw_key->base, raw_key->len, 0);
+    if (name.base == NULL)
+        return 0;
+
+    if ((token = h2o_lookup_token(name.base, name.len)) != NULL) {
+        value = h2o_strdup(&req->pool, value.base, value.len);
+        h2o_add_header(&req->pool, &req->headers, token, NULL, value.base, value.len);
+    } else {
+        value = h2o_strdup(&req->pool, value.base, value.len);
+        h2o_add_header_by_str(&req->pool, &req->headers, name.base, name.len, 0, NULL, value.base, value.len);
+    }
+
+    return 0;
+}
+
 static int handle_header_env_key(h2o_mruby_shared_context_t *shared_ctx, h2o_iovec_t *env_key, h2o_iovec_t value, void *_req)
 {
     h2o_req_t *req = _req;
     const h2o_token_t *token;
 
-    /* convert env key to header name (lower case) */
-    h2o_iovec_t name = convert_env_to_header_name(&req->pool, env_key->base, env_key->len);
+    h2o_iovec_t name = convert_env_key_to_header_name(&req->pool, env_key->base, env_key->len, 1);
     if (name.base == NULL)
         return 0;
 
     if ((token = h2o_lookup_token(name.base, name.len)) != NULL) {
         if (token == H2O_TOKEN_CONTENT_LENGTH) {
             /* skip. use CONTENT_LENGTH instead of HTTP_CONTENT_LENGTH */
+        } else if (token == H2O_TOKEN_CONTENT_TYPE) {
+            /* ditto */
         } else {
             value = h2o_strdup(&req->pool, value.base, value.len);
             h2o_add_header(&req->pool, &req->headers, token, NULL, value.base, value.len);
@@ -521,6 +544,11 @@ static int retrieve_env(mrb_state *mrb, mrb_value key, mrb_value value, void *_d
         RETRIEVE_ENV_NUM(content_length);
         if (!mrb_nil_p(content_length))
             data->subreq->super.content_length = mrb_fixnum(content_length);
+    } else if (CHECK_KEY("CONTENT_TYPE")) {
+        mrb_value content_type = mrb_nil_value();
+        RETRIEVE_ENV_STR(content_type);
+        if (!mrb_nil_p(content_type))
+            h2o_mruby_iterate_header_values(data->ctx->shared, key, content_type, handle_header_raw_key, &data->subreq->super);
     } else if (CHECK_KEY("HTTP_HOST")) {
         RETRIEVE_ENV_STR(data->env.http_host);
     } else if (CHECK_KEY("PATH_INFO")) {

--- a/t/50mruby-middleware.t
+++ b/t/50mruby-middleware.t
@@ -868,4 +868,40 @@ EOT
     is $body, 'bar';
 };
 
+subtest 'both H2O.next and H2O.reprocess preserve content-type header' => sub {
+    my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        << "EOT";
+hosts:
+  default:
+    paths:
+      /1:
+        - mruby.handler: |
+            proc {|env|
+              H2O.next.call(env)
+            }
+        - mruby.handler: |
+            proc {|env|
+              next_ct = "#{env['CONTENT_TYPE']}1"
+              env['NEXT_CT'] = next_ct
+              env['SCRIPT_NAME'] = "/2"
+              H2O.reprocess.call(env)
+            }
+      /2:
+        # there was a bug that CONTENT_TYPE is unexpectedly added to env, not headers
+        # so unset env here to check that the header is correctly forwarded as a header
+        - unsetenv:
+          - CONTENT_TYPE
+        - mruby.handler: |
+            proc {|env|
+              reprocess_ct = "#{env['CONTENT_TYPE']}2"
+              [200, {}, [env['NEXT_CT'], reprocess_ct]]
+            }
+EOT
+    });
+    my ($status, $headers, $body);
+    ($status, $headers, $body) = get('http', $server->{port}, 'curl', '/1', +{ headers => ['content-type: OK'] });
+    is $body, 'OK1OK2';
+};
+
 done_testing();


### PR DESCRIPTION
Thanks to https://github.com/h2o/h2o/issues/2255 reported by @utrenkner, I found and fixed several issues around `H2O.next` and `H2O.reprocess`.

1. H2O.reprocess didn't actively use internal redirect. If the authority of the sub request (which is generally constructed by host header) doesn't match to hostconf's name, it does proxying, which establishes a TCP connection. This PR applies the same logic as redirect handler to resolve authority, which uses `req->hostconf->authority` in a base url for resolving.
2. `rack.early_hints` was not removed when constructing sub request. As the result, it was set in env. This PR removes it.
3. Samely, `CONTENT_TYPE` was not handled correctly. It's a special env key that has no `HTTP_` prefix, but current implementation doesn't treat it specially, so it is set in env too. This PR adds special handling for that header.

1 and 3 can explain why https://github.com/h2o/h2o/issues/2255 happened: Due to 3, `CONTENT_TYPE` is not forwarded as a header but set in env. `H2O.next.call` invokes the next handler taking over the env including `CONTENT_TYPE`, so the next handler can see it in env hash. But then the handler does 
`H2O.reprocess.call`, which end up proxing due to 1, then that env is not visible from the reprocessed handler.