### PR TITLE
mention to -DCMAKE_BUILD_TYPE=Debug

### DIFF
--- a/srcdoc/install.mt
+++ b/srcdoc/install.mt
@@ -72,6 +72,12 @@ It is turned on by default if the prerequisites (<a href="https://www.gnu.org/so
 This option can be used to add or override the compile options being passed to the C compiler.
 As an example, <a href="https://en.wikipedia.org/wiki/AddressSanitizer">AddressSanitizer (ASan)</a> can be enabled when using recent versions of GCC or Clang, by passing <code>-DCMAKE_C_FLAGS="-fsanitize=address -fno-stack-protector -fno-omit-frame-pointer"</code>.
 </dd>
+<dt><code>-DCMAKE_BUILD_TYPE=Release|Debug</code></dt>
+<dd>
+This option specifies the build type, <code>Release</code> or <code>Debug</code>.
+The default is <code>Release</code>.
+You'd like to add some more debugging flags to `CMAKE_C_FLAGS` on <code>Debug</code> build, for example <code>-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-g3</code> if you use <code>gdb</code>.
+</dd>
 </p>
 
 <h3>Installing from Source, using OpenSSL</h3>

--- a/srcdoc/install.mt
+++ b/srcdoc/install.mt
@@ -76,7 +76,6 @@ As an example, <a href="https://en.wikipedia.org/wiki/AddressSanitizer">AddressS
 <dd>
 This option specifies the build type, <code>Release</code> or <code>Debug</code>.
 The default is <code>Release</code>.
-You'd like to add some more debugging flags to `CMAKE_C_FLAGS` on <code>Debug</code> build, for example <code>-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-g3</code> if you use <code>gdb</code>.
 </dd>
 </p>
 


### PR DESCRIPTION
I think this is worth adding to the doc because (1) `-DCMAKE_BUILD_TYPE=Release` is not the cmake default (2) the copy-and-paste-ready snippet `-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-g3` is useful for everyone who uses gdb for H2O.