### PR TITLE
avoid setting SO_REUSEADDR on UDP sockets

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1064,7 +1064,8 @@ static int open_inet_listener(h2o_configurator_command_t *cmd, yoml_t *node, con
     if ((fd = socket(domain, type, protocol)) == -1)
         goto Error;
     set_cloexec(fd);
-    { /* set reuseaddr */
+    /* if the socket is TCP, set SO_REUSEADDR flag to avoid TIME_WAIT after shutdown */
+    if (type == SOCK_STREAM) {
         int flag = 1;
         if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) != 0)
             goto Error;


### PR DESCRIPTION
Setting the SO_REUSEADDR socket option is essential for TCP listen ports, in order to avoid TIME_WAIT.

However, we should not set the socket option for UDP sockets, because there is no TIME_WAIT phase in UDP, and because it has a different meaning. Quoting from http://www.kohala.com/start/mcast.api.txt:

```
More than one process may bind to the same SOCK_DGRAM UDP port if the bind()
is preceded by:

	int one = 1;
	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one))

In this case, every incoming multicast or broadcast UDP datagram destined to
the shared port is delivered to all sockets bound to the port.  For backwards
compatibility reasons, THIS DOES NOT APPLY TO INCOMING UNICAST DATAGRAMS --
unicast datagrams are never delivered to more than one socket, regardless of
how many sockets are bound to the datagram's destination port.  SOCK_RAW
sockets do not require the SO_REUSEADDR option to share a single IP protocol
type.
```