### PR TITLE
Add code format checker job for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,13 @@ matrix:
       script:
         - uname -a
         - make -f misc/docker-ci/check.mk dtrace CONTAINER_NAME=kazuho/h2o-ci:ubuntu1904
+    - os: linux
+      sudo: required
+      dist: bionic
+      services:
+        - docker
+      env:
+        - label=format-check
+      before_install: *bi
+      script:
+        - make -f misc/docker-ci/check.mk format-check CONTAINER_NAME=hajimefu/clang-format:latest

--- a/misc/docker-ci/Dockerfile.clang-format
+++ b/misc/docker-ci/Dockerfile.clang-format
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get --yes update
+RUN apt-get install --yes \
+	make \
+	clang-format-9 \
+	curl \
+	git \
+	sudo \
+	wget
+
+# use dumb-init
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 \
+ && chmod +x /usr/local/bin/dumb-init
+
+# create user
+RUN useradd --create-home ci
+RUN echo 'ci ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+WORKDIR /home/ci
+USER ci
+
+ENTRYPOINT ["/usr/local/bin/dumb-init"]

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -22,6 +22,9 @@ ossl1.1.1:
 dtrace:
 	docker run $(DOCKER_RUN_OPTS) $(CONTAINER_NAME) env DTRACE_TESTS=1 make -f $(SRC_DIR)/misc/docker-ci/check.mk _check
 
+format-check:
+	docker run $(DOCKER_RUN_OPTS) $(CONTAINER_NAME) make -f $(SRC_DIR)/misc/docker-ci/check.mk -C $(SRC_DIR) _do-format-check
+
 _check:
 	mkdir -p build
 	sudo mount -t tmpfs tmpfs build
@@ -43,10 +46,13 @@ _do-fuzz-extra:
 	./h2o-fuzzer-http2 -close_fd_mask=3 -runs=1 -max_len=16384 $(SRC_DIR)/fuzz/http2-corpus < /dev/null
 	./h2o-fuzzer-url -close_fd_mask=3 -runs=1 -max_len=16384 $(SRC_DIR)/fuzz/url-corpus < /dev/null
 
+_do-format-check:
+	bash $(SRC_DIR)/misc/format-checker.sh -f clang-format-9 -r origin/master
+
 enter:
 	docker run $(DOCKER_RUN_OPTS) -it $(CONTAINER_NAME) bash
 
 pull:
 	docker pull $(CONTAINER_NAME)
 
-.PHONY: fuzz _check _do-check _fuzz _do-fuzz-extra enter pull
+.PHONY: fuzz _check _do-check _fuzz _do-fuzz-extra enter pull format-check _do-format_check

--- a/misc/format-checker.sh
+++ b/misc/format-checker.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+rev=HEAD^
+clang_format=clang-format
+
+while getopts ":f:r:" opt; do
+	case $opt in
+	f)
+		clang_format=$OPTARG
+		;;
+	r)
+		rev=$OPTARG
+		;;
+	\?)
+		echo "Usage: $0 [options]"
+		echo ""
+		echo "Options:"
+		echo "  -f  Specify a command to use as a formatter [default=clang-format]"
+		echo "  -r  Specify rev to use as a base commit (any file changed after rev will be checked) [default=HEAD^]"
+		exit 1
+	esac
+done
+
+cd `git rev-parse --show-toplevel`
+files=`git diff --cached --name-only ${rev} | egrep -v '(^deps/|/_|^handler/mimemap/defaults\.c\.h)' | grep -e '.*\.[ch]\(\.in\)\?$'`
+
+if [ ! $( command -v ${clang_format} ) ]; then
+	echo "Cannot execute ${clang_format}"
+	exit 1
+fi
+
+tmpdir=`mktemp --tmpdir -d h2o-format-checker.XXXXXX`
+if [ $? != 0 ]; then
+	echo "Failed to create a temp directory"
+    exit 1
+fi
+
+# Copy the style file under tmpdir, otherwise clang-format may not pick up the style
+# (even though it is located in the current directory)
+cp .clang-format ${tmpdir}/
+
+ret=0
+
+# Verify code formatting using clang-format
+for f in $files; do
+	git checkout-index --prefix=${tmpdir}/ $f
+	index=${tmpdir}/$f # File from current index
+	correct=$tmpdir/${f}.correct # File with correct format
+	${clang_format} -style=file $index > $correct
+	diff -u $index $correct
+	if [ $? != 0 ]; then
+		ret=1
+	fi
+done
+
+rm -rf $tmpdir
+
+exit $ret


### PR DESCRIPTION
This PR adds a code format checker job for Travis CI. It adds a new CI job "format-check".

Some features (some might require more discussion before merging):
* Currently uses clang-format 9.0
    * There might be a subtle different in code formatting if we move to a different clang-format version, so would be nice to stick to a particular version for a long period of time.
    * 9.0 is the one currently available through Homebrew
* Checks only the final state (top) of the PR's branch
    * Say, a PR consists of three commits, A, B, and C. A and B introduce bad formattings but C fixes them. In this case this checker would pass.
    * We could perform a patch-by-patch check instead (the checker would fail in this case because of A and B). However, given how we handle PRs (i.e. discouraging rebasing/patch cleaning), I think the current model would suffice.
    * In any case, files touched in A, B, and C are checked.
* Relies on `hajimefu/clang-format` Docker image
    * I had to use Ubuntu 18.04-based image to easily get clang-format 9.0. (clang-format-9 is not available on either 16.04 or 19.04's official repo, where we already have Docker images for CI)
    * We could instead directly install clang-format from LLVM's official APT repository for 16.04 or 19.04.
    * I'm happy to move the image under `kazuho/` namespace once we settle this PR.
