### PR TITLE
Prevent crash in PRIORITY frame handling

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -675,6 +675,11 @@ static void set_priority(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream, con
                      * This entire logic assumes Chromium-type dependency tree, thus guarded by
                      * `chromium_dependency_tree` */
                     parent_sched = h2o_http2_scheduler_find_parent_by_weight(&conn->scheduler, priority->weight);
+                    if (parent_sched == &stream->_scheduler.node) {
+                        /* h2o_http2_scheduler_find_parent_by_weight may return the current node itself.
+                         * In such a case, correct parent should be the parent of the current node. */
+                        parent_sched = &current_parent_stream->_scheduler.node;
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a dependency stream has already been closed, current priority
handling code would crash by an assertion failure, because under a
certain condition h2o_http2_scheduler_find_parent_by_weight may
return the current node itself as a parent, and simply passing it to
h2o_http2_scheduler_rebind later is an incorrect behavior.

This patch adds a check for the return value of
h2o_http2_scheduler_find_parent_by_weight, just like we already do
in send_headers (lib/http2/stream.c).

Input sequence to reproduce the crash (by h2get) is:

    h2g.send_priority(7, 0, 1, 1)
    h2g.send_priority(9, 7, 1, 0)
    h2g.send_data(7, 0x2, "00000")
    h2g.send_priority(7, 0, 1, 0)
    h2g.send_priority(9, 7, 1, 0)

Credit to OSS-Fuzz: This bug was found by OSS-Fuzz
(https://github.com/google/oss-fuzz)