### PR TITLE
[http3] fix resource leak

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -425,7 +425,7 @@ static void on_send_shift(quicly_stream_t *qs, size_t delta)
     }
     delta -= bytes_avail_in_first_vec;
     stream->sendbuf.off_within_first_vec = 0;
-    if (stream->sendbuf.min_index_to_addref != 0)
+    if (stream->sendbuf.vecs.entries[0].callbacks->update_refcnt != NULL)
         stream->sendbuf.vecs.entries[0].callbacks->update_refcnt(stream->sendbuf.vecs.entries, &stream->req, 0);
 
     for (i = 1; delta != 0; ++i) {
@@ -435,7 +435,7 @@ static void on_send_shift(quicly_stream_t *qs, size_t delta)
             break;
         }
         delta -= stream->sendbuf.vecs.entries[i].len;
-        if (i < stream->sendbuf.min_index_to_addref)
+        if (stream->sendbuf.vecs.entries[i].callbacks->update_refcnt != NULL)
             stream->sendbuf.vecs.entries[i].callbacks->update_refcnt(stream->sendbuf.vecs.entries + i, &stream->req, 0);
     }
     memmove(stream->sendbuf.vecs.entries, stream->sendbuf.vecs.entries + i,


### PR DESCRIPTION
Consider the following scenario:

1. handler provides data
2. the data gets sent
3. proceed callback is called and `H2O_SEND_STATE_FINAL` is delivered immediately
4. ACK is received

This behavior was observed when running t/40http3.t on macOS.