### PR TITLE
[doc] recommend out-of-source build, explain H2O_ROOT

### DIFF
--- a/srcdoc/install.mt
+++ b/srcdoc/install.mt
@@ -25,7 +25,9 @@ Download a release version from <a href="https://github.com/h2o/h2o/releases">th
 </p>
 
 <?= $ctx->{code}->(<< 'EOT')
-% cmake .
+% mkdir -p build
+% cd build
+% cmake ..
 % make
 % sudo make install
 EOT
@@ -95,7 +97,9 @@ CMake will search for OpenSSL by looking at the default search paths.
 </p>
 
 <?= $ctx->{code}->(<< 'EOT')
-% cmake .
+% mkdir -p build
+% cd build
+% cmake ..
 % make
 % sudo make install
 EOT
@@ -107,7 +111,9 @@ The preferred approach is to use the <code>PKG_CONFIG_PATH</code> environment va
 </p>
 
 <?= $ctx->{code}->(<< 'EOT')
-% PKG_CONFIG_PATH=/usr/local/openssl-1.0.2/lib/pkgconfig cmake .
+% mkdir -p build
+% cd build
+% PKG_CONFIG_PATH=/usr/local/openssl-1.0.2/lib/pkgconfig cmake ..
 % make
 % sudo make install
 EOT
@@ -118,7 +124,9 @@ In case your OpenSSL installation does not have the <code>lib/pkgconfig</code> d
 </p>
 
 <?= $ctx->{code}->(<< 'EOT')
-% OPENSSL_ROOT_DIR=/usr/local/openssl-1.0.2 cmake .
+% mkdir -p build
+% cd build
+% OPENSSL_ROOT_DIR=/usr/local/openssl-1.0.2 cmake ..
 % make
 % sudo make install
 EOT

--- a/srcdoc/install.mt
+++ b/srcdoc/install.mt
@@ -47,6 +47,15 @@ EOT
 ?>
 
 <p>
+Or if you'd like to start H2O without installing it, you can use the <code>H2O_ROOT</code> environment variable.
+</p>
+
+<?= $ctx->{code}->(<< 'EOT')
+% H2O_ROOT=$PWD build/h2o -c examples/h2o/h2o.conf
+EOT
+?>
+
+<p>
 The example configuration starts a server that listens to port 8080 (HTTP) and port 8081 (HTTPS).  Try to access the ports using the protocols respectively (note: when accessing via HTTPS it is likely that you would see hostname mismatch errors reported by the web browsers).
 </p>
 


### PR DESCRIPTION
The [out-of-source build](https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#what-is-an-out-of-source-build) is officially recommended, and it makes us avoid some kinds of build errors like https://github.com/h2o/h2o/issues/2093 by removing the build directory easily.

Also, I've explained `H2O_ROOT` in the doc to run H2O on the project directory without installing it. 