### PR TITLE
[build] Find OpenSSL in macOS with `brew --prefix openssl` automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,11 +59,11 @@ IF ((CMAKE_SYSTEM_NAME STREQUAL "Darwin") AND NOT (DEFINED OPENSSL_ROOT_DIR OR D
     )
     IF (NOT EXISTS ${OPENSSL_ROOT_DIR})
         MESSAGE(STATUS "*************************************************************************\n"
-                    "   * Setting OPENSSL_ROOT_DIR to /usr/local/opt/openssl. On macOS, OpenSSL *\n"
+                    "   * Setting OPENSSL_ROOT_DIR to /usr/local. On macOS, OpenSSL *\n"
                     "   * should be installed using homebrew or OPENSSL_ROOT_DIR must be set to *\n"
                     "   * the path that has OpenSSL installed.                                  *\n"
                     "   *************************************************************************")
-        SET(OPENSSL_ROOT_DIR, "/usr/local/opt/openssl")
+        SET(OPENSSL_ROOT_DIR "/usr/local")
     ENDIF ()
 ENDIF ()
 FIND_PACKAGE(OpenSSL REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,9 @@ IF ((CMAKE_SYSTEM_NAME STREQUAL "Darwin") AND NOT (DEFINED OPENSSL_ROOT_DIR OR D
     )
     IF (NOT EXISTS ${OPENSSL_ROOT_DIR})
         MESSAGE(STATUS "*************************************************************************\n"
-                    "   * Setting OPENSSL_ROOT_DIR to /usr/local. On macOS, OpenSSL *\n"
-                    "   * should be installed using homebrew or OPENSSL_ROOT_DIR must be set to *\n"
-                    "   * the path that has OpenSSL installed.                                  *\n"
+                    "   * Setting OPENSSL_ROOT_DIR to /usr/local. On macOS, OpenSSL should be   *\n"
+                    "   * installed using homebrew or OPENSSL_ROOT_DIR must be set to the path  *\n"
+                    "   * that has OpenSSL installed.                                           *\n"
                     "   *************************************************************************")
         SET(OPENSSL_ROOT_DIR "/usr/local")
     ENDIF ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ IF ((CMAKE_SYSTEM_NAME STREQUAL "Darwin") AND NOT (DEFINED OPENSSL_ROOT_DIR OR D
         OUTPUT_STRIP_TRAILING_WHITESPACE
         ERROR_QUIET
     )
-    IF (OPENSSL_ROOT_DIR STREQUAL "")
+    IF (NOT EXISTS ${OPENSSL_ROOT_DIR})
         MESSAGE(STATUS "*************************************************************************\n"
                     "   * Setting OPENSSL_ROOT_DIR to /usr/local/opt/openssl. On macOS, OpenSSL *\n"
                     "   * should be installed using homebrew or OPENSSL_ROOT_DIR must be set to *\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,20 @@ FIND_PACKAGE(PkgConfig)
 FIND_PACKAGE(Threads REQUIRED)
 
 IF ((CMAKE_SYSTEM_NAME STREQUAL "Darwin") AND NOT (DEFINED OPENSSL_ROOT_DIR OR DEFINED ENV{OPENSSL_ROOT_DIR}))
-    MESSAGE(STATUS "*************************************************************************\n"
-                "   * Setting OPENSSL_ROOT_DIR to /usr/local/opt/openssl. On macOS, OpenSSL *\n"
-                "   * should be installed using homebrew or OPENSSL_ROOT_DIR must be set to *\n"
-                "   * the path that has OpenSSL installed.                                  *\n"
-                "   *************************************************************************")
-    SET(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+    EXECUTE_PROCESS(
+        COMMAND brew --prefix openssl
+        OUTPUT_VARIABLE OPENSSL_ROOT_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    IF (OPENSSL_ROOT_DIR STREQUAL "")
+        MESSAGE(STATUS "*************************************************************************\n"
+                    "   * Setting OPENSSL_ROOT_DIR to /usr/local/opt/openssl. On macOS, OpenSSL *\n"
+                    "   * should be installed using homebrew or OPENSSL_ROOT_DIR must be set to *\n"
+                    "   * the path that has OpenSSL installed.                                  *\n"
+                    "   *************************************************************************")
+        SET(OPENSSL_ROOT_DIR, "/usr/local/opt/openssl")
+    ENDIF ()
 ENDIF ()
 FIND_PACKAGE(OpenSSL REQUIRED)
 FIND_PACKAGE(ZLIB REQUIRED)


### PR DESCRIPTION
The OpenSSL root path on macOS might not be `/usr/local/opt/openssl` _as of May 2020_ because:

* The basename of homebrew-provided OpenSSL is `openssl@1.1` by default, not `openssl`
  * See https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl@1.1.rb or `brew info openssl`
* Some people use a non-default homebrew root path

So I believe CMakeLists.txt should use `brew --prefix openssl` as the default. 