### PR TITLE
Add an IO timeout for http1

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -82,6 +82,8 @@ extern "C" {
 #define H2O_DEFAULT_HANDSHAKE_TIMEOUT (H2O_DEFAULT_HANDSHAKE_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_HTTP1_REQ_TIMEOUT_IN_SECS 10
 #define H2O_DEFAULT_HTTP1_REQ_TIMEOUT (H2O_DEFAULT_HTTP1_REQ_TIMEOUT_IN_SECS * 1000)
+#define H2O_DEFAULT_HTTP1_REQ_IO_TIMEOUT_IN_SECS 5
+#define H2O_DEFAULT_HTTP1_REQ_IO_TIMEOUT (H2O_DEFAULT_HTTP1_REQ_IO_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2 1
 #define H2O_DEFAULT_HTTP2_IDLE_TIMEOUT_IN_SECS 10
 #define H2O_DEFAULT_HTTP2_IDLE_TIMEOUT (H2O_DEFAULT_HTTP2_IDLE_TIMEOUT_IN_SECS * 1000)
@@ -356,6 +358,10 @@ struct st_h2o_globalconf_t {
          * request timeout (in milliseconds)
          */
         uint64_t req_timeout;
+        /**
+         * request io timeout (in milliseconds)
+         */
+        uint64_t req_io_timeout;
         /**
          * a boolean value indicating whether or not to upgrade to HTTP/2
          */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -600,6 +600,10 @@ struct st_h2o_context_t {
          * link-list of h2o_http1_conn_t
          */
         h2o_linklist_t _conns;
+        struct {
+            uint64_t request_timeouts;
+            uint64_t request_io_timeouts;
+        } events;
     } http1;
 
     struct {

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -178,6 +178,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->max_delegations = H2O_DEFAULT_MAX_DELEGATIONS;
     config->handshake_timeout = H2O_DEFAULT_HANDSHAKE_TIMEOUT;
     config->http1.req_timeout = H2O_DEFAULT_HTTP1_REQ_TIMEOUT;
+    config->http1.req_io_timeout = H2O_DEFAULT_HTTP1_REQ_IO_TIMEOUT;
     config->http1.upgrade_to_http2 = H2O_DEFAULT_HTTP1_UPGRADE_TO_HTTP2;
     config->http1.callbacks = H2O_HTTP1_CALLBACKS;
     config->http2.idle_timeout = H2O_DEFAULT_HTTP2_IDLE_TIMEOUT;

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -413,6 +413,11 @@ static int on_config_http1_request_timeout(h2o_configurator_command_t *cmd, h2o_
     return config_timeout(cmd, node, &ctx->globalconf->http1.req_timeout);
 }
 
+static int on_config_http1_request_io_timeout(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    return config_timeout(cmd, node, &ctx->globalconf->http1.req_io_timeout);
+}
+
 static int on_config_http1_upgrade_to_http2(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     ssize_t ret = h2o_configurator_get_one_of(cmd, node, "OFF,ON");
@@ -944,6 +949,9 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(&c->super, "http1-request-timeout",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http1_request_timeout);
+        h2o_configurator_define_command(&c->super, "http1-request-io-timeout",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http1_request_io_timeout);
         h2o_configurator_define_command(&c->super, "http1-upgrade-to-http2",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http1_upgrade_to_http2);

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -28,6 +28,8 @@ struct st_events_status_ctx_t {
     uint64_t h2_protocol_level_errors[H2O_HTTP2_ERROR_MAX];
     uint64_t h2_read_closed;
     uint64_t h2_write_closed;
+    uint64_t h1_request_timeout;
+    uint64_t h1_request_io_timeout;
     uint64_t ssl_errors;
     pthread_mutex_t mutex;
 };

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -50,6 +50,9 @@ static void events_status_per_thread(void *priv, h2o_context_t *ctx)
     }
     esc->h2_read_closed += ctx->http2.events.read_closed;
     esc->h2_write_closed += ctx->http2.events.write_closed;
+    esc->h1_request_timeout += ctx->http1.events.request_timeouts;
+    esc->h1_request_io_timeout += ctx->http1.events.request_io_timeouts;
+
 
     pthread_mutex_unlock(&esc->mutex);
 }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -58,6 +58,7 @@ struct st_h2o_http1_conn_t {
     /* internal structure */
     h2o_linklist_t _conns;
     h2o_timer_t _timeout_entry;
+    h2o_timer_t _io_timeout_entry;
     uint64_t _req_index;
     size_t _prevreqlen;
     size_t _unconsumed_request_size;
@@ -184,6 +185,21 @@ static void set_req_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, 
         h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_timeout_entry);
 }
 
+static void set_req_io_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, h2o_timer_cb cb)
+{
+    if (conn->_io_timeout_entry.cb != NULL)
+        h2o_timer_unlink(&conn->_io_timeout_entry);
+    conn->_io_timeout_entry.cb = cb;
+    if (cb != NULL)
+        h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_io_timeout_entry);
+}
+
+static void clear_timeouts(struct st_h2o_http1_conn_t *conn)
+{
+    set_req_timeout(conn, 0, NULL);
+    set_req_io_timeout(conn, 0, NULL);
+}
+
 static void process_request(struct st_h2o_http1_conn_t *conn)
 {
     if (conn->sock->ssl == NULL && conn->req.upgrade.base != NULL && conn->super.ctx->globalconf->http1.upgrade_to_http2 &&
@@ -203,7 +219,7 @@ static void entity_read_do_send_error(struct st_h2o_http1_conn_t *conn, int stat
 {
     conn->req.proceed_req = NULL;
     conn->_req_entity_reader = NULL;
-    set_req_timeout(conn, 0, NULL);
+    clear_timeouts(conn);
     h2o_socket_read_stop(conn->sock);
     /* FIXME We should check if `h2o_proceed_request` has been called, rather than trying to guess if we have (I'm unsure if the
      * contract is for h2o_req_t::_generator to become non-NULL immediately after `h2o_proceed_request` is being called). */
@@ -229,7 +245,7 @@ DECL_ENTITY_READ_SEND_ERROR_XXX(502)
 
 static void handle_one_body_fragment(struct st_h2o_http1_conn_t *conn, size_t fragment_size, int complete)
 {
-    set_req_timeout(conn, 0, NULL);
+    clear_timeouts(conn);
     h2o_socket_read_stop(conn->sock);
     if (conn->req.write_req.cb(conn->req.write_req.ctx, h2o_iovec_init(conn->sock->input->bytes, fragment_size), complete) != 0) {
         entity_read_send_error_502(conn, "Bad Gateway", "Bad Gateway");
@@ -508,6 +524,7 @@ static void proceed_request(h2o_req_t *req, size_t written, h2o_send_state_t sen
     }
 
     set_req_timeout(conn, conn->super.ctx->globalconf->http1.req_timeout, reqread_on_timeout);
+    set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, reqread_on_timeout);
     h2o_socket_read_start(conn->sock, reqread_on_read);
     return;
 }
@@ -585,7 +602,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
     default: // parse complete
         conn->_unconsumed_request_size = reqlen;
         if (fixup_request(conn, headers, num_headers, minor_version, &expect, &entity_body_header_index) != 0) {
-            set_req_timeout(conn, 0, NULL);
+            clear_timeouts(conn);
             send_bad_request(conn, "line folding of header fields is not supported");
             return;
         }
@@ -594,7 +611,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
             conn->req.timestamps.request_body_begin_at = h2o_gettimeofday(conn->super.ctx->loop);
             if (expect.base != NULL) {
                 if (!h2o_lcstris(expect.base, expect.len, H2O_STRLIT("100-continue"))) {
-                    set_req_timeout(conn, 0, NULL);
+                    clear_timeouts(conn);
                     h2o_socket_read_stop(conn->sock);
                     h2o_send_error_417(&conn->req, "Expectation Failed", "unknown expectation",
                                        H2O_SEND_ERROR_HTTP1_CLOSE_CONNECTION);
@@ -618,7 +635,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
             }
             conn->_req_entity_reader->handle_incoming_entity(conn);
         } else {
-            set_req_timeout(conn, 0, NULL);
+            clear_timeouts(conn);
             h2o_socket_read_stop(conn->sock);
             process_request(conn);
         }
@@ -663,6 +680,7 @@ void reqread_on_read(h2o_socket_t *sock, const char *err)
         return;
     }
 
+    set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, reqread_on_timeout);
     if (conn->_req_entity_reader == NULL)
         handle_incoming_request(conn);
     else
@@ -688,6 +706,7 @@ static void reqread_on_timeout(h2o_timer_t *entry)
 static inline void reqread_start(struct st_h2o_http1_conn_t *conn)
 {
     set_req_timeout(conn, conn->super.ctx->globalconf->http1.req_timeout, reqread_on_timeout);
+    set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, reqread_on_timeout);
     h2o_socket_read_start(conn->sock, reqread_on_read);
     if (conn->sock->input->size != 0)
         handle_incoming_request(conn);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -175,7 +175,7 @@ static void cleanup_connection(struct st_h2o_http1_conn_t *conn)
 /**
  * timer is activated if cb != NULL, disactivated otherwise
  */
-static void set_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, h2o_timer_cb cb)
+static void set_req_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, h2o_timer_cb cb)
 {
     if (conn->_timeout_entry.cb != NULL)
         h2o_timer_unlink(&conn->_timeout_entry);
@@ -203,7 +203,7 @@ static void entity_read_do_send_error(struct st_h2o_http1_conn_t *conn, int stat
 {
     conn->req.proceed_req = NULL;
     conn->_req_entity_reader = NULL;
-    set_timeout(conn, 0, NULL);
+    set_req_timeout(conn, 0, NULL);
     h2o_socket_read_stop(conn->sock);
     /* FIXME We should check if `h2o_proceed_request` has been called, rather than trying to guess if we have (I'm unsure if the
      * contract is for h2o_req_t::_generator to become non-NULL immediately after `h2o_proceed_request` is being called). */
@@ -229,7 +229,7 @@ DECL_ENTITY_READ_SEND_ERROR_XXX(502)
 
 static void handle_one_body_fragment(struct st_h2o_http1_conn_t *conn, size_t fragment_size, int complete)
 {
-    set_timeout(conn, 0, NULL);
+    set_req_timeout(conn, 0, NULL);
     h2o_socket_read_stop(conn->sock);
     if (conn->req.write_req.cb(conn->req.write_req.ctx, h2o_iovec_init(conn->sock->input->bytes, fragment_size), complete) != 0) {
         entity_read_send_error_502(conn, "Bad Gateway", "Bad Gateway");
@@ -507,7 +507,7 @@ static void proceed_request(h2o_req_t *req, size_t written, h2o_send_state_t sen
         return;
     }
 
-    set_timeout(conn, conn->super.ctx->globalconf->http1.req_timeout, reqread_on_timeout);
+    set_req_timeout(conn, conn->super.ctx->globalconf->http1.req_timeout, reqread_on_timeout);
     h2o_socket_read_start(conn->sock, reqread_on_read);
     return;
 }
@@ -585,7 +585,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
     default: // parse complete
         conn->_unconsumed_request_size = reqlen;
         if (fixup_request(conn, headers, num_headers, minor_version, &expect, &entity_body_header_index) != 0) {
-            set_timeout(conn, 0, NULL);
+            set_req_timeout(conn, 0, NULL);
             send_bad_request(conn, "line folding of header fields is not supported");
             return;
         }
@@ -594,7 +594,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
             conn->req.timestamps.request_body_begin_at = h2o_gettimeofday(conn->super.ctx->loop);
             if (expect.base != NULL) {
                 if (!h2o_lcstris(expect.base, expect.len, H2O_STRLIT("100-continue"))) {
-                    set_timeout(conn, 0, NULL);
+                    set_req_timeout(conn, 0, NULL);
                     h2o_socket_read_stop(conn->sock);
                     h2o_send_error_417(&conn->req, "Expectation Failed", "unknown expectation",
                                        H2O_SEND_ERROR_HTTP1_CLOSE_CONNECTION);
@@ -618,7 +618,7 @@ static void handle_incoming_request(struct st_h2o_http1_conn_t *conn)
             }
             conn->_req_entity_reader->handle_incoming_entity(conn);
         } else {
-            set_timeout(conn, 0, NULL);
+            set_req_timeout(conn, 0, NULL);
             h2o_socket_read_stop(conn->sock);
             process_request(conn);
         }
@@ -687,7 +687,7 @@ static void reqread_on_timeout(h2o_timer_t *entry)
 
 static inline void reqread_start(struct st_h2o_http1_conn_t *conn)
 {
-    set_timeout(conn, conn->super.ctx->globalconf->http1.req_timeout, reqread_on_timeout);
+    set_req_timeout(conn, conn->super.ctx->globalconf->http1.req_timeout, reqread_on_timeout);
     h2o_socket_read_start(conn->sock, reqread_on_read);
     if (conn->sock->input->size != 0)
         handle_incoming_request(conn);
@@ -995,7 +995,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
     if (bufcnt != 0) {
         h2o_socket_write(conn->sock, bufs, bufcnt, h2o_send_state_is_in_progress(send_state) ? on_send_next : on_send_complete);
     } else {
-        set_timeout(conn, 0, on_delayed_send_complete);
+        set_req_timeout(conn, 0, on_delayed_send_complete);
     }
 }
 

--- a/t/40http1-timeouts.t
+++ b/t/40http1-timeouts.t
@@ -1,0 +1,64 @@
+use strict;
+use warnings;
+use IO::Socket::INET;
+use Test::More;
+use Time::HiRes qw(sleep);
+use t::Util;
+use Net::EmptyPort qw(check_port empty_port);
+use File::Temp qw(tempfile);
+
+my $upstream_port = empty_port({ host => '0.0.0.0' });
+my $upstream = spawn_server(
+    argv => [
+        qw(
+            plackup -s Standalone --ssl=1 --ssl-key-file=examples/h2o/server.key --ssl-cert-file=examples/h2o/server.crt --port
+        ),
+        $upstream_port, ASSETS_DIR . "/upstream.psgi"
+    ],
+    is_ready => sub {
+        check_port($upstream_port);
+    },
+);
+
+my $server = spawn_h2o(<< "EOT");
+http1-request-io-timeout: 2
+http1-request-timeout: 5
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: https://127.0.0.1:$upstream_port
+        proxy.ssl.verify-peer: OFF
+        proxy.timeout.io: 1000000
+EOT
+
+my $port = $server->{port};
+sub build_test {
+    my $times = shift;
+    my $sleep = shift;
+    my $t = "";
+    foreach (1 .. $times) {
+        $t = $t."\n".'$writer->write("lorem ipsum dolor sit amet");';
+        $t = $t."\n".'sleep '.$sleep.";\n";
+    }
+    my $prefix = 'return sub {
+        my $responder = shift;
+        my $writer = $responder->([ 200, [ "content-type" => "text/plain" ] ]);';
+   my $suffix = '
+        $writer->close;
+};';
+    my ($conffh, $conffn) = tempfile(UNLINK => 1);
+    print $conffh $prefix.$t.$suffix;
+    close($conffh);
+    return $conffn;
+}
+
+my $conffn = build_test(1, 3);
+my $res = `curl -X POST -d \@$conffn -svo /dev/null http://127.0.0.1:$port/custom-perl 2>&1 > /dev/null`;
+like $res, qr{transfer closed with outstanding read data remaining}, "connection was closed";
+
+$conffn = build_test(8, 1);
+$res = `curl -X POST -d \@$conffn -svo /dev/null http://127.0.0.1:$port/custom-perl 2>&1 > /dev/null`;
+like $res, qr{Connection.*to host 127.0.0.1 left intact}, "connection was closed";
+
+done_testing();


### PR DESCRIPTION
This PR adds a new `http1-request-io-timeout` parameter, in
milliseconds.

This allows to have a finer grained control on the activity on the http1 socket. 