### PR TITLE
Prevent an assertion if proceed_request needs to send an error while the http2 connection is shutting down

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -719,10 +719,10 @@ static void proceed_request(h2o_req_t *req, size_t written, h2o_send_state_t sen
 
     if (send_state == H2O_SEND_STATE_ERROR) {
         finish_body_streaming(stream);
-        stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
-        if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM) {
+        if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING)
+            stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
+        if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM)
             h2o_http2_stream_close(conn, stream);
-        }
         return;
     }
 


### PR DESCRIPTION
Here is the path that's causing this:
```
    stream_send_error lib/http2/connection.c
    proceed_request lib/http2/connection.c
    on_head lib/core/proxy.c
    on_error lib/common/http1client.c
    on_send_timeout lib/common/http1client.c
```