### PR TITLE
Turning dry_run off for CIFuzz

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         oss-fuzz-project-name: 'h2o'
-        dry-run: true
+        dry-run: false
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'h2o'
         fuzz-seconds: 600
-        dry-run: true
+        dry-run: false
     - name: Upload Crash
       uses: actions/upload-artifact@v1
       if: failure()


### PR DESCRIPTION
Allows CIFuzz to report bugs that it has uncovered. 