### PR TITLE
[CI] Add macOS build to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,24 @@ matrix:
       script:
         - uname -a
         - make -f misc/docker-ci/check.mk dtrace CONTAINER_NAME=kazuho/h2o-ci:ubuntu1904
+    - os: osx
+      osx_image: xcode11.3
+      env:
+        - label=macOS
+      cache: ccache
+      addons:
+        homebrew:
+          update: true
+          packages:
+            - expect
+            - nghttp2
+            - ccache
+      before_install:
+        - curl -L https://cpanmin.us | perl - --nootest --self-upgrade --sudo
+        - cpanm --sudo --installdeps --notest .
+      script:
+        - mkdir -p build
+        - make -f misc/docker-ci/check.mk SRC_DIR="$PWD" _do-check
+  fast_finish: true
+  allow_failures:
+      env: label=macOS

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,18 @@
+#!perl
+# cpanm --installdeps --notest .
+
+requires "FCGI";
+requires "FCGI::ProcManager";
+requires "IPC::Signal";
+requires "JSON";
+requires "List::MoreUtils";
+requires "Plack";
+requires "Scope::Guard";
+requires "Test::Exception";
+requires "LWP";
+requires "IO::Socket::SSL";
+requires "Starlet";
+requires "Protocol::HTTP2";
+requires "Test::TCP", "2.21";
+requires "Path::Tiny";
+requires "CGI";

--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,6 @@ requires "LWP";
 requires "IO::Socket::SSL";
 requires "Starlet";
 requires "Protocol::HTTP2";
-requires "Test::TCP", "2.21";
+requires "Test::TCP", "== 2.21";
 requires "Path::Tiny";
 requires "CGI";

--- a/misc/docker-ci/Dockerfile
+++ b/misc/docker-ci/Dockerfile
@@ -38,13 +38,9 @@ RUN (cd openssl-${OPENSSL_VERSION} && \
 	make -j $(nproc) && make -j install_sw install_ssldirs)
 
 # cpan modules
-RUN apt-get install --yes cpanminus
-RUN apt-get install --yes libfcgi-perl libfcgi-procmanager-perl libipc-signal-perl libjson-perl liblist-moreutils-perl libplack-perl libscope-guard-perl libtest-exception-perl libwww-perl libio-socket-ssl-perl
-ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN sudo cpanm --notest Starlet Protocol::HTTP2
+RUN curl -L https://cpanmin.us | perl - --nootest --self-upgrade --sudo
+RUN cpanm --sudo --notest .
 
-# Test-TCP 2.21
-RUN sudo cpanm --notest https://github.com/tokuhirom/Test-TCP.git@2.21
 # h2spec
 RUN curl -Ls https://github.com/i110/h2spec/releases/download/v2.2.0-4e8cc7e/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin
 

--- a/misc/docker-ci/Dockerfile.ubuntu1904
+++ b/misc/docker-ci/Dockerfile.ubuntu1904
@@ -32,22 +32,9 @@ RUN apt-get install --yes \
 	systemtap-sdt-dev \
 	wget
 
-# perl
-RUN apt-get install --yes \
-	cpanminus \
-	libfcgi-perl \
-	libfcgi-procmanager-perl \
-	libipc-signal-perl \
-	libjson-perl \
-	liblist-moreutils-perl \
-	libplack-perl \
-	libscope-guard-perl \
-	libtest-exception-perl \
-	libwww-perl \
-	libio-socket-ssl-perl
-ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN sudo cpanm --notest Starlet Protocol::HTTP2
-RUN sudo cpanm --notest https://github.com/tokuhirom/Test-TCP.git@2.21
+# cpan modules
+RUN curl -L https://cpanmin.us | perl - --nootest --self-upgrade --sudo
+RUN cpanm --sudo --notest .
 
 # h2spec
 RUN curl -Ls https://github.com/i110/h2spec/releases/download/v2.2.0-4e8cc7e/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin


### PR DESCRIPTION
This PR adds a macOS build for Travis. This is also an executable instruction to setup test dependencies for macOS, since `cpanfile` is more portable than `apt-get`.

By the way, macOS build doesn't 100% pass in Travis. In my macOS environment, all the tests can pass, but some tests are very fragile. So I'd like to add the `allow_failures` flag to macOS build.

## Refs

* `xcode11.3` is the [latest development environment](https://docs.travis-ci.com/user/reference/osx/#macos-version) in Travis
* https://github.com/travis-ci/travis-ci/issues/7824#issuecomment-437242430
* https://github.com/h2o/h2o/issues/2148 
