### PR TITLE
Add a USDT probe to detect H3 accept failure

### DIFF
--- a/h2o-probes.d
+++ b/h2o-probes.d
@@ -25,6 +25,7 @@ provider h2o {
     probe h1_close(uint64_t conn_id);
     probe h2_unknown_frame_type(uint64_t conn_id, uint8_t frame_type);
     probe h3_accept(uint64_t conn_id, struct st_h2o_conn_t *conn, struct st_quicly_conn_t *quic);
+    probe h3_accept_error(uint64_t conn_id, int errno);
     probe h3_close(uint64_t conn_id);
     probe h3_stream_create(uint64_t conn_id, uint64_t req_id);
     probe h3_stream_destroy(uint64_t conn_id, uint64_t req_id);

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1471,6 +1471,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
     ptls_default_skip_tracing = orig_skip_tracing;
 #endif
     if (accept_ret != 0) {
+        H2O_PROBE_CONN(H3_ACCEPT_ERROR, &conn->super, accept_ret);
         h2o_http3_dispose_conn(&conn->h3);
         free(conn);
         return NULL;


### PR DESCRIPTION
My motive here is to help client developers identify mistakes in their implementation. The probe is intentionally minimal because hopefully in most cases, Quicly's error code is adequate to point developers to the right direction.