### PR TITLE
Add the ability to specify address family for proxy connections

### DIFF
--- a/doc/configure/proxy_directives.html
+++ b/doc/configure/proxy_directives.html
@@ -168,6 +168,20 @@ Forwards the requests to the specified backends, and proxies the response.
 </code></pre>
 </div>
 
+<p>
+When the <code>family</code> key is used, the address family for the backend specification can be controlled. Legal values
+for are <code>inet</code> and <code>inet6</code>. If nothing is specified, an address family of <code>PF_UNSPEC</code> is
+used, which will result in both IP and IPv6 (if present) being used.
+</p>
+
+<div class="example">
+<div class="caption">Example. Forwarding the requests to multiple application server using specified address family</div>
+<pre><code>proxy.reverse.url:
+  - url: http://some.host.com:8080
+    family: inet
+</code></pre>
+</div>
+
 <div class="example">
 <div class="caption">Example. Forwarding the requests to multiple application server with different weight</div>
 <pre><code>proxy.reverse.url:

--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -47,11 +47,16 @@ typedef struct st_h2o_socketpool_target_conf_t {
      * weight - 1 for load balancer, where weight is an integer within range [1, 256]
      */
     uint8_t weight_m1;
+    int family;
 } h2o_socketpool_target_conf_t;
 
 #define H2O_SOCKETPOOL_TARGET_MAX_WEIGHT 256
 
 typedef struct st_h2o_socketpool_target_t {
+    /**
+     * Address family of the backend. Defaults to PF_UNSPEC
+     */
+    int family;
     /**
      * target URL
      */

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -194,6 +194,10 @@ h2o_socketpool_target_t *h2o_socketpool_create_target(h2o_url_t *origin, h2o_soc
         target->peer.sockaddr.len = salen;
         break;
     }
+    /*
+     * Copy the address family to use for getaddrinfo(3) hints.
+     */
+    target->family = lb_target_conf->family;
     target->_shared.leased_count = 0;
     if (lb_target_conf != NULL)
         target->conf.weight_m1 = lb_target_conf->weight_m1;
@@ -334,7 +338,7 @@ static void try_connect(h2o_socketpool_connect_request_t *req)
     switch (target->type) {
     case H2O_SOCKETPOOL_TYPE_NAMED:
         /* resolve the name, and connect */
-        req->getaddr_req = h2o_hostinfo_getaddr(req->getaddr_receiver, target->url.host, target->peer.named_serv, AF_UNSPEC,
+        req->getaddr_req = h2o_hostinfo_getaddr(req->getaddr_receiver, target->url.host, target->peer.named_serv, target->family,
                                                 SOCK_STREAM, IPPROTO_TCP, AI_ADDRCONFIG | AI_NUMERICSERV, on_getaddr, req);
         break;
     case H2O_SOCKETPOOL_TYPE_SOCKADDR:


### PR DESCRIPTION
When the family key is used, the address family for the backend specification
can be controlled. Legal values for are inet and inet6. If nothing is specified,
an address family of PF_UNSPEC is used, which will result in both IP and
IPv6 (if present) being used.

Example:

proxy.reverse.url:
  - url: http://some.host.com:8080
    family: inet