### PR TITLE
skip tests needing nghttp when nghttp is not available

### DIFF
--- a/t/50server-timing.t
+++ b/t/50server-timing.t
@@ -134,6 +134,8 @@ sub nc_get {
 }
 
 sub nghttp_get {
+    plan skip_all => 'nghttp not found'
+        unless prog_exists('nghttp');
     my ($server, $path) = @_; 
     my $out = `nghttp -vn 'https://127.0.0.1:$server->{tls_port}$path'`;
     ([map { parse_server_timing($_) } ($out =~ /recv \(stream_id=\d+\) server-timing: (.+)$/mg)], $out);

--- a/t/50suspend-body.t
+++ b/t/50suspend-body.t
@@ -14,6 +14,8 @@ sub nc_get {
 }
 
 sub nghttp_get {
+    plan skip_all => 'nghttp not found'
+        unless prog_exists('nghttp');
     my ($server, $path) = @_; 
     my $out = `nghttp -vn -t 1 'https://127.0.0.1:$server->{tls_port}$path'`;
     my $headers_size = 0;


### PR DESCRIPTION
On a system without nghttp tests in 50server-timing.t and 50suspend-body.t are failing.  This fix will skip those tests that rely on nghttp, just like it is done in other test scripts.