### PR TITLE
remove double backslash in certain tests

### DIFF
--- a/t/50mruby.t
+++ b/t/50mruby.t
@@ -555,7 +555,7 @@ hosts:
 EOT
     my $nc = sub {
         my $path = shift;
-        my $cmd = "echo 'GET $path HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r' | nc 127.0.0.1 $server->{port}";
+        my $cmd = "echo 'GET $path HTTP/1.1\r\nHost: 127.0.0.1\r\n\r' | nc 127.0.0.1 $server->{port}";
         (undef, my $r) = run_prog($cmd);
         split(/\r\n\r\n/, $r, 2);
     };

--- a/t/50unexpected-upstream-body.t
+++ b/t/50unexpected-upstream-body.t
@@ -8,7 +8,7 @@ use t::Util;
 
 sub nc_get {
     my ($server, $path) = @_;
-    my $resp = `echo 'GET $path HTTP/1.1\\r\\n\\r\\n' | nc 127.0.0.1 $server->{port}`;
+    my $resp = `echo 'GET $path HTTP/1.1\r\n\r\n' | nc 127.0.0.1 $server->{port}`;
     (undef, my $body) = split(/\r\n\r\n/, $resp, 2);
     $body;
 }


### PR DESCRIPTION
Double backslash in some test scripts break on system w/o backslash escape interpretation, hence removing them.  
The construct of `echo "something" | nc ..` is used in a few tests, but only the two files changed it is used with double backslash.  

```
$ grep -ir --include="*.t" -E "*.echo .* \| nc .*"
..
50mruby.t:        my $cmd = "echo 'GET $path HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r' | nc 127.0.0.1 $server->{port}";
50unexpected-upstream-body.t:    my $resp = `echo 'GET $path HTTP/1.1\\r\\n\\r\\n' | nc 127.0.0.1 $server->{port}`;
..
```
