### PR TITLE
Use closefrom(2) if available in the OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,18 +114,6 @@ IF (LIBC_HAS_BACKTRACE)
     ENDIF ()
 ENDIF ()
 
-CHECK_C_SOURCE_COMPILES("
-#include <unistd.h>
-int main(void) {
-closefrom(0);
-return 0;
-}" LIBC_HAS_CLOSEFROM)
-CMAKE_POP_CHECK_STATE()
-
-IF(LIBC_HAS_CLOSEFROM)
-  ADD_DEFINITIONS("-DLIBC_HAS_CLOSEFROM")
-ENDIF()
-
 OPTION(WITHOUT_LIBS "skip building libs even when possible" OFF)
 OPTION(BUILD_SHARED_LIBS "whether to build a shared library" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,18 @@ IF (LIBC_HAS_BACKTRACE)
     ENDIF ()
 ENDIF ()
 
+CHECK_C_SOURCE_COMPILES("
+#include <unistd.h>
+int main(void) {
+closefrom(0);
+return 0;
+}" LIBC_HAS_CLOSEFROM)
+CMAKE_POP_CHECK_STATE()
+
+IF(LIBC_HAS_CLOSEFROM)
+  ADD_DEFINITIONS("-DLIBC_HAS_CLOSEFROM")
+ENDIF()
+
 OPTION(WITHOUT_LIBS "skip building libs even when possible" OFF)
 OPTION(BUILD_SHARED_LIBS "whether to build a shared library" OFF)
 

--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -1349,7 +1349,7 @@ Exit:
 
 static void cleanup_fds(int listen_fd, int close_notify_fd)
 {
-#ifdef LIBC_HAS_CLOSEFROM
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
     int maxfd, k;
 
     maxfd = 0;

--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -1347,7 +1347,7 @@ Exit:
 }
 
 
-static void neverbleed_cleanup_fds(int listen_fd, int close_notify_fd)
+static void cleanup_fds(int listen_fd, int close_notify_fd)
 {
 #ifdef LIBC_HAS_CLOSEFROM
     int maxfd, k;
@@ -1390,7 +1390,7 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
     pthread_attr_t thattr;
     int sock_fd;
 
-    neverbleed_cleanup_fds(listen_fd, close_notify_fd);
+    cleanup_fds(listen_fd, close_notify_fd);
 
     pthread_attr_init(&thattr);
     pthread_attr_setdetachstate(&thattr, 1);


### PR DESCRIPTION
Currently, when the neverbleed process is forked we query `_SC_OPEN_MAX` and
iterate through every file descriptor above `STDERR` (skipping listen and
close notify file descriptors) and call the `close(2)` syscall on the fd.
Each syscall is a context switch, and depending on the audit/debug state of
the system during this time, roughly 231,000 syscalls will be executed.
On security audited, traced or otherwise hooked (kprobes, ebpf, perf)
processes, this will generate 231,000 records being committed to disk.

This change introduces an optimization which determines the highest file
descriptor value currently in the process, uses the standard `close(2)` syscall
for anything less than (excluding stdout, stderr, and stdin) then executes
`closefrom(2)` on the highest fd plus one. This substantially decreases the number
of context switches during the bootstrap phase of the neverbleed process (from
231,000 to roughly 9. This change also includes the necessary cmake changes to
detect the functionality. Tested and verified on FreeBSD:

```
 [..]
 52544: close(3)                                  = 0 (0x0)
 52544: close(4)                                  = 0 (0x0)
 52544: close(5)                                  = 0 (0x0)
 52544: close(6)                                  = 0 (0x0)
 52544: close(7)                                  = 0 (0x0)
 52544: close(8)                                  = 0 (0x0)
 52544: close(9)                                  = 0 (0x0)
 52544: close(11)                                 ERR#9 'Bad file descriptor'
 52544: closefrom(13)                             = 0 (0x0)
 [..]
```