### PR TITLE
add 'user: root' to h2o conf in tests when running as root

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -204,6 +204,7 @@ listen:
     key-file: examples/h2o/server.key
     certificate-file: examples/h2o/server.crt
     @{[$max_ssl_version ? "max-version: $max_ssl_version" : ""]}
+@{[$< == 0 ? "user: root" : ""]}
 EOT
 
     my $ret = spawn_h2o_raw($conf, [$port, $tls_port], \@opts);


### PR DESCRIPTION
When the tests are run as root, then tests where h2o connects to an upstream server via a unix socket are failing.  The upstream server creates the socket 'file' as root, but h2o running as 'nobody' is not be able to access it, hence the tests are failing with an upstream connection error.  This change adds `user: root` to the h2o config used in tests, if the tests are run under root.

For example [GitHub Actions runners using Docker require running as root](https://help.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user).  
