### PR TITLE
add 'H2O_EVLOOP_USE_CLOCK_MONOTONIC'

### DIFF
--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -44,7 +44,11 @@ typedef struct st_h2o_evloop_t {
     } _statechanged;
     uint64_t _now_millisec;
     uint64_t _now_nanosec;
+#ifdef H2O_EVLOOP_USE_CLOCK_MONOTONIC
+    struct timespec _ts_at;
+#else
     struct timeval _tv_at;
+#endif
     h2o_timerwheel_t *_timeouts;
     h2o_sliding_counter_t exec_time_nanosec_counter;
 } h2o_evloop_t;
@@ -75,7 +79,13 @@ static void h2o_timer_link(h2o_evloop_t *loop, uint64_t delay_ticks, h2o_timer_t
 
 static inline struct timeval h2o_gettimeofday(h2o_evloop_t *loop)
 {
+#ifdef H2O_EVLOOP_USE_CLOCK_MONOTONIC
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return tv;
+#else
     return loop->_tv_at;
+#endif
 }
 
 static inline uint64_t h2o_now(h2o_evloop_t *loop)

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -490,9 +490,15 @@ h2o_evloop_t *create_evloop(size_t sz)
 
 void update_now(h2o_evloop_t *loop)
 {
+#ifdef H2O_EVLOOP_USE_CLOCK_MONOTONIC
+    clock_gettime(CLOCK_MONOTONIC, &loop->_ts_at);
+    loop->_now_nanosec = (uint64_t)loop->_ts_at.tv_sec * 1000000000 + loop->_ts_at.tv_nsec;
+    loop->_now_millisec = loop->_now_nanosec / 1000000;
+#else
     gettimeofday(&loop->_tv_at, NULL);
     loop->_now_nanosec = ((uint64_t)loop->_tv_at.tv_sec * 1000000 + loop->_tv_at.tv_usec) * 1000;
     loop->_now_millisec = loop->_now_nanosec / 1000000;
+#endif
 }
 
 int32_t adjust_max_wait(h2o_evloop_t *loop, int32_t max_wait)


### PR DESCRIPTION
so that is possible to use 'clock_gettime' instead of 'gettimeofday'
to avoid timer issue when wall time jumps.

according to #2321