### PR TITLE
add -u switch to memcached when tests run as root

### DIFF
--- a/t/40memcached-session-resumption.t
+++ b/t/40memcached-session-resumption.t
@@ -23,8 +23,9 @@ sub doit {
     subtest $memc_proto => sub {
         # start memcached
         my $memc_port = empty_port();
+        my $memc_user = getlogin || getpwuid($<);
         my $memc_guard = spawn_server(
-            argv     => [ qw(memcached -l 127.0.0.1 -p), $memc_port, "-B", $memc_proto ],
+            argv     => [ qw(memcached -l 127.0.0.1 -p), $memc_port, "-B", $memc_proto, "-u", $memc_user ],
             is_ready => sub {
                 check_port($memc_port);
             },

--- a/t/40session-ticket.t
+++ b/t/40session-ticket.t
@@ -75,10 +75,11 @@ subtest "memcached" => sub {
     plan skip_all => "memcached not found"
         unless prog_exists("memcached");
     my $memc_port = empty_port();
+    my $memc_user = getlogin || getpwuid($<);
     my $doit = sub {
         my $memc_proto = shift;
         my $memc_guard = spawn_server(
-            argv     => [ qw(memcached -l 127.0.0.1 -p), $memc_port, "-B", $memc_proto ],
+            argv     => [ qw(memcached -l 127.0.0.1 -p), $memc_port, "-B", $memc_proto, "-u", $memc_user ],
             is_ready => sub {
                 check_port($memc_port);
             },

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -59,7 +59,11 @@ sub exec_unittest {
             close $wfh;
             POSIX::dup2($rfh->fileno, 5)
                 or die "dup2 failed:$!";
-            exec qw(share/h2o/kill-on-close -- memcached -l 127.0.0.1 -p), $port;
+            if ($< == 0) {
+                exec qw(share/h2o/kill-on-close -- memcached -u root -l 127.0.0.1 -p), $port;
+            } else {
+                exec qw(share/h2o/kill-on-close -- memcached -l 127.0.0.1 -p), $port;
+            }
             exit 1;
         }
         close $rfh;


### PR DESCRIPTION
This is a continuation of #2337 to allow tests to run on systems when root is required to run the tests. The tests involving memcached otherwise have error:  
`spawning memcached... can't run as root without the -u switch`.  

For example [GitHub Actions runners using Docker require running as root](https://help.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user).