### PR TITLE
new checkdepends convenience target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -738,12 +738,16 @@ IF (LIBUV_FOUND)
     TARGET_LINK_LIBRARIES(t-00unit-libuv.t ${LIBUV_LIBRARIES} ${OPENSSL_LIBRARIES} ${EXTRA_LIBS})
 ENDIF (LIBUV_FOUND)
 
-ADD_CUSTOM_TARGET(check env H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -I. -v t/*.t
+ADD_CUSTOM_TARGET(checkdepends
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS h2o t-00unit-evloop.t lib-examples-evloop ${OPTIONAL_TEST})
 IF (LIBUV_FOUND)
-    ADD_DEPENDENCIES(check t-00unit-libuv.t lib-examples)
+    ADD_DEPENDENCIES(checkdepends t-00unit-libuv.t lib-examples)
 ENDIF ()
+
+ADD_CUSTOM_TARGET(check env H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -I. -v t/*.t
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS checkdepends)
 
 ADD_CUSTOM_TARGET(doc ${CMAKE_MAKE_PROGRAM} -f ../misc/doc.mk all BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doc
@@ -764,7 +768,7 @@ IF (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/misc/h2get/CMakeLists.txt)
                         BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
                         INSTALL_COMMAND true)
     SET_TARGET_PROPERTIES(h2get PROPERTIES EXCLUDE_FROM_ALL TRUE)
-    ADD_DEPENDENCIES(check h2get)
+    ADD_DEPENDENCIES(checkdepends h2get)
 ENDIF ()
 
 ExternalProject_Add(picotls-cli
@@ -774,13 +778,13 @@ ExternalProject_Add(picotls-cli
                     BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} cli
                     INSTALL_COMMAND true)
 SET_TARGET_PROPERTIES(picotls-cli PROPERTIES EXCLUDE_FROM_ALL TRUE)
-ADD_DEPENDENCIES(check picotls-cli)
+ADD_DEPENDENCIES(checkdepends picotls-cli)
 
 ADD_CUSTOM_TARGET(check-valgrind env H2O_VALGRIND=./misc/h2o_valgrind/ H2O_ROOT=. BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} prove -I. -v t/*.t
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS h2o t-00unit-evloop.t)
 IF (LIBUV_FOUND)
-    ADD_DEPENDENCIES(check t-00unit-libuv.t lib-examples)
+    ADD_DEPENDENCIES(checkdepends t-00unit-libuv.t lib-examples)
 ENDIF ()
 
 IF (BUILD_FUZZER)


### PR DESCRIPTION
This change introduces a convenience target 'checkdepends'.
A usual sequence to build and test currently looks like this after running cmake (args omitted for brevity):  
`$ make`  
`$ make check`  
In this case `make check` still *builds* some dependencies before starting the actual test scripts.  This change will allow to run the tests in parallel by adding a target that builds all remaining dependencies for check:  
`$ make`  
`$ make checkdepends`  
After that one can run tests in parallel:  
`$ env H2O_ROOT=. BINARY_DIR=<bindir> prove -I. -v t/<filtersometestscripts>.t`  
I was able to cut the build+test time drastically running like eight test runners in parallel - see screenshot in the attachment.
In my current approach I am figuring out the remaining `make check` dependencies after running `make` using a [shell script filtering the result of a make check dry run](https://stackoverflow.com/questions/60828698/print-targets-that-need-to-be-remade/60828699#60828). Adding this new target is to replace said shell script.
The sequence:  
`$ make`  
`$ make check`  
will continue to function as usual.
![h2ogithubactionsparalleltests](https://user-images.githubusercontent.com/1248912/83578926-e4c8b600-a505-11ea-819e-e1aef8588f3b.png)
