### PR TITLE
[http3] process incoming packets by group of (path, DCID), fix broken path comparison logic

### DIFF
--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -5173,6 +5173,8 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     uint64_t pn, offending_frame_type = QUICLY_FRAME_TYPE_PADDING;
     int is_ack_only, ret;
 
+    assert(src_addr->sa_family == AF_INET || src_addr->sa_family == AF_INET6);
+
     lock_now(conn, 0);
 
     QUICLY_PROBE(RECEIVE, conn, conn->stash.now,

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -773,7 +773,8 @@ void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock)
                 ++packet_index;
             }
             ++dgram_index;
-            /* if we have enough room for the next datagram, that is, the expected worst case of 4 packets in a coalesced datagram, continue */
+            /* if we have enough room for the next datagram, that is, the expected worst case of 4 packets in a coalesced datagram,
+             * continue */
             if (packet_index + 4 < PTLS_ELEMENTSOF(packets))
                 continue;
 

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -725,7 +725,8 @@ void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock)
         size_t packet_index = 0;
         dgram_index = 0;
         while (dgram_index < num_dgrams) {
-            int has_decoded = 0;
+            int has_decoded = 0; /* indicates if a decoded packet belonging to a different connection is stored at
+                                  * `packets[packet_index]` */
             /* dispatch packets in `packets`, if the datagram at dgram_index is from a different path */
             if (packet_index != 0) {
                 assert(dgram_index != 0);
@@ -753,8 +754,7 @@ void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock)
                 ++dgram_index;
                 goto ProcessPackets;
             }
-            /* dispatch packets in `packets` if the DCID is different, adjusting packets and packet_index to retain the newly
-             * decoded packet */
+            /* dispatch packets in `packets` if the DCID is different, setting the `has_encoded` flag */
             if (packet_index != 0) {
                 const ptls_iovec_t *prev_dcid = &packets[packet_index - 1].cid.dest.encrypted,
                                    *cur_dcid = &packets[packet_index].cid.dest.encrypted;

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -774,7 +774,7 @@ void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock)
                 ++packet_index;
             }
             ++dgram_index;
-            /* if we have enough room for (i.e. can store 4 packets that consist) next datagram, continue */
+            /* if we have enough room for the next datagram, that is, the expected worst case of 4 packets in a coalesced datagram, continue */
             if (packet_index + 4 < PTLS_ELEMENTSOF(packets))
                 continue;
 

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -763,9 +763,8 @@ void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock)
                     ++dgram_index;
                     goto ProcessPackets;
                 }
-            } else {
-                ++packet_index;
             }
+            ++packet_index;
             /* add rest of the packets */
             while (payload_off < dgrams[dgram_index].vec.iov_len && packet_index < PTLS_ELEMENTSOF(packets)) {
                 if (quicly_decode_packet(ctx->quic, packets + packet_index, dgrams[dgram_index].vec.iov_base,

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -743,7 +743,7 @@ void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock)
                 } else {
                     goto ProcessPackets;
                 }
-                /* check TTL */
+                /* TTL should be same for dispatched packets */
                 if (dgrams[dgram_index - 1].ttl != dgrams[dgram_index].ttl)
                     goto ProcessPackets;
             }

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -779,13 +779,15 @@ void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock)
                 continue;
 
         ProcessPackets:
-            process_packets(ctx, &dgrams[dgram_index - 1].destaddr, &dgrams[dgram_index - 1].srcaddr, dgrams[dgram_index - 1].ttl,
-                            packets, packet_index);
-            if (has_decoded) {
-                packets[0] = packets[packet_index];
-                packet_index = 1;
-            } else {
-                packet_index = 0;
+            if (packet_index != 0) {
+                process_packets(ctx, &dgrams[dgram_index - 1].destaddr, &dgrams[dgram_index - 1].srcaddr,
+                                dgrams[dgram_index - 1].ttl, packets, packet_index);
+                if (has_decoded) {
+                    packets[0] = packets[packet_index];
+                    packet_index = 1;
+                } else {
+                    packet_index = 0;
+                }
             }
         }
         if (packet_index != 0)

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -754,7 +754,7 @@ void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock)
                 ++dgram_index;
                 goto ProcessPackets;
             }
-            /* dispatch packets in `packets` if the DCID is different, setting the `has_encoded` flag */
+            /* dispatch packets in `packets` if the DCID is different, setting the `has_decoded` flag */
             if (packet_index != 0) {
                 const ptls_iovec_t *prev_dcid = &packets[packet_index - 1].cid.dest.encrypted,
                                    *cur_dcid = &packets[packet_index].cid.dest.encrypted;


### PR DESCRIPTION
Makes one design change and one bug fix.

The design change is that incoming QUIC packets are grouped by a tuple of (path, DCID) and then dispatched, rather than just using the path as the key. The resolution of https://github.com/quicwg/base-drafts/issues/2844 was to prohibit such a design.

The bug fix is that the code used for comparing the paths of two incoming packets was broken, leading to something that looks like packet losses, as packets were misrouted to incorrect paths or to incorrect connection contexts. This PR addresses that bug.

Closes https://github.com/h2o/quicly/issues/345.