### PR TITLE
[http3] Check Transport Parameters associated to session tickets

### DIFF
--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -957,7 +957,7 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token
  * Builds authentication data for TLS session ticket. 0-RTT can be accepted only when the auth_data of the original connection and
  * the new connection are identical.
  */
-int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, quicly_context_t *ctx);
+int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, const quicly_context_t *ctx);
 /**
  *
  */

--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -938,25 +938,26 @@ void quicly_amend_ptls_context(ptls_context_t *ptls);
  *
  * @param random_bytes  PRNG
  * @param aead          the AEAD context to be used for decrypting the token
- * @param tp            Transport parameters. Used for detecting and rejecting resumption tokens associated to an incompatible set
- *                      of transport parameters. This argument is ignored when encrypting a Retry token.
  * @param buf           buffer to where the token being built is appended
  * @param start_off     Specifies the start offset of the token. When `start_off < buf->off`, the bytes in between will be
  *                      considered as part of the token and will be covered by the AEAD. Applications can use this location to embed
  *                      the identifier of the AEAD key being used.
  * @param plaintext     the token to be encrypted
  */
-int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead,
-                                 const quicly_transport_parameters_t *tp, ptls_buffer_t *buf, size_t start_off,
-                                 const quicly_address_token_plaintext_t *plaintext);
+int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead, ptls_buffer_t *buf,
+                                 size_t start_off, const quicly_address_token_plaintext_t *plaintext);
 /**
  * Decrypts an address token.
  * If decryption succeeds, returns zero. If the token is unusable due to decryption failure, returns PTLS_DECODE_ERROR. If the token
  * is unusable and the connection should be reset, returns QUICLY_ERROR_INVALID_TOKEN.
  */
-int quicly_decrypt_address_token(ptls_aead_context_t *aead, const quicly_transport_parameters_t *tp,
-                                 quicly_address_token_plaintext_t *plaintext, const void *src, size_t len, size_t prefix_len,
-                                 const char **err_desc);
+int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token_plaintext_t *plaintext, const void *src,
+                                 size_t len, size_t prefix_len, const char **err_desc);
+/**
+ * Builds authentication data for TLS session ticket. 0-RTT can be accepted only when the auth_data of the original connection and
+ * the new connection are identical.
+ */
+int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, quicly_context_t *ctx);
 /**
  *
  */

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -5750,7 +5750,7 @@ Exit:
     return ret;
 }
 
-int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, quicly_context_t *ctx)
+int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, const quicly_context_t *ctx)
 {
     int ret;
 

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -3556,8 +3556,8 @@ size_t quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encry
         memcpy(buf.base + buf.off, token_prefix.base, token_prefix.len);
         buf.off += token_prefix.len;
     }
-    if ((ret = quicly_encrypt_address_token(ctx->tls->random_bytes, token_encrypt_ctx, NULL, &buf, buf.off - token_prefix.len,
-                                            &token)) != 0)
+    if ((ret = quicly_encrypt_address_token(ctx->tls->random_bytes, token_encrypt_ctx, &buf, buf.off - token_prefix.len, &token)) !=
+        0)
         goto Exit;
 
     /* append AEAD tag */
@@ -5563,44 +5563,10 @@ void quicly_amend_ptls_context(ptls_context_t *ptls)
     ptls->update_traffic_key = &update_traffic_key;
 }
 
-/* builds AAD, from the plaintext data we'd have on wire and the transport parameter */
-static int build_aad_of_address_token(ptls_buffer_t *aad, const quicly_transport_parameters_t *tp, const void *plaintext_on_wire,
-                                      size_t plaintext_on_wire_len)
+int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead, ptls_buffer_t *buf,
+                                 size_t start_off, const quicly_address_token_plaintext_t *plaintext)
 {
     int ret;
-
-    ptls_buffer_push_block(aad, -1, { ptls_buffer_pushv(aad, plaintext_on_wire, plaintext_on_wire_len); });
-#define PUSH_TP(id, block)                                                                                                         \
-    do {                                                                                                                           \
-        ptls_buffer_push_quicint(aad, id);                                                                                         \
-        ptls_buffer_push_block(aad, -1, block);                                                                                    \
-    } while (0)
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_ACTIVE_CONNECTION_ID_LIMIT,
-            { ptls_buffer_push_quicint(aad, tp->active_connection_id_limit); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_DATA, { ptls_buffer_push_quicint(aad, tp->max_data); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL,
-            { ptls_buffer_push_quicint(aad, tp->max_stream_data.bidi_local); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE,
-            { ptls_buffer_push_quicint(aad, tp->max_stream_data.bidi_remote); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_UNI, { ptls_buffer_push_quicint(aad, tp->max_stream_data.uni); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_BIDI, { ptls_buffer_push_quicint(aad, tp->max_streams_bidi); });
-    PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_UNI, { ptls_buffer_push_quicint(aad, tp->max_streams_uni); });
-#undef PUSH_TP
-
-    ret = 0;
-Exit:
-    return ret;
-}
-
-int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead_context_t *aead,
-                                 const quicly_transport_parameters_t *tp, ptls_buffer_t *buf, size_t start_off,
-                                 const quicly_address_token_plaintext_t *plaintext)
-{
-    ptls_iovec_t aad;
-    ptls_buffer_t resumption_aad;
-    int ret;
-
-    ptls_buffer_init(&resumption_aad, "", 0);
 
     /* type and IV */
     if ((ret = ptls_buffer_reserve(buf, 1 + aead->algo->iv_size)) != 0)
@@ -5632,7 +5598,6 @@ int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead
         });
         ptls_buffer_push16(buf, port);
     }
-    aad = ptls_iovec_init(buf->base + start_off, enc_start - start_off);
     switch (plaintext->type) {
     case QUICLY_ADDRESS_TOKEN_TYPE_RETRY:
         ptls_buffer_push_block(buf, 1,
@@ -5644,9 +5609,6 @@ int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead
         break;
     case QUICLY_ADDRESS_TOKEN_TYPE_RESUMPTION:
         ptls_buffer_push_block(buf, 1, { ptls_buffer_pushv(buf, plaintext->resumption.bytes, plaintext->resumption.len); });
-        if ((ret = build_aad_of_address_token(&resumption_aad, tp, aad.base, aad.len)) != 0)
-            goto Exit;
-        aad = ptls_iovec_init(resumption_aad.base, resumption_aad.off);
         break;
     default:
         assert(!"unexpected token type");
@@ -5657,19 +5619,17 @@ int quicly_encrypt_address_token(void (*random_bytes)(void *, size_t), ptls_aead
     /* encrypt, abusing the internal API to supply full IV */
     if ((ret = ptls_buffer_reserve(buf, aead->algo->tag_size)) != 0)
         goto Exit;
-    aead->do_encrypt_init(aead, buf->base + enc_start - aead->algo->iv_size, aad.base, aad.len);
+    aead->do_encrypt_init(aead, buf->base + enc_start - aead->algo->iv_size, buf->base + start_off, enc_start - start_off);
     ptls_aead_encrypt_update(aead, buf->base + enc_start, buf->base + enc_start, buf->off - enc_start);
     ptls_aead_encrypt_final(aead, buf->base + buf->off);
     buf->off += aead->algo->tag_size;
 
 Exit:
-    ptls_buffer_dispose(&resumption_aad);
     return ret;
 }
 
-int quicly_decrypt_address_token(ptls_aead_context_t *aead, const quicly_transport_parameters_t *tp,
-                                 quicly_address_token_plaintext_t *plaintext, const void *_token, size_t len, size_t prefix_len,
-                                 const char **err_desc)
+int quicly_decrypt_address_token(ptls_aead_context_t *aead, quicly_address_token_plaintext_t *plaintext, const void *_token,
+                                 size_t len, size_t prefix_len, const char **err_desc)
 {
     const uint8_t *const token = _token;
     uint8_t ptbuf[QUICLY_MIN_CLIENT_INITIAL_SIZE];
@@ -5701,20 +5661,12 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, const quicly_transpo
     }
 
     /* `goto Exit` can only happen below this line, and that is guaranteed by declaring `ret` here */
-    ptls_iovec_t aad = ptls_iovec_init(token, prefix_len + 1 + aead->algo->iv_size);
-    ptls_buffer_t resumption_aad;
-    ptls_buffer_init(&resumption_aad, "", 0);
     int ret;
 
     /* decrypt */
-    if (plaintext->type == QUICLY_ADDRESS_TOKEN_TYPE_RESUMPTION) {
-        if ((ret = build_aad_of_address_token(&resumption_aad, tp, aad.base, aad.len)) != 0)
-            goto Exit;
-        aad = ptls_iovec_init(resumption_aad.base, resumption_aad.off);
-    }
     if ((ptlen = aead->do_decrypt(aead, ptbuf, token + prefix_len + 1 + aead->algo->iv_size,
-                                  len - (prefix_len + 1 + aead->algo->iv_size), token + prefix_len + 1, aad.base, aad.len)) ==
-        SIZE_MAX) {
+                                  len - (prefix_len + 1 + aead->algo->iv_size), token + prefix_len + 1, token,
+                                  prefix_len + 1 + aead->algo->iv_size)) == SIZE_MAX) {
         ret = PTLS_ALERT_DECRYPT_ERROR;
         *err_desc = "token decryption failure";
         goto Exit;
@@ -5788,7 +5740,6 @@ int quicly_decrypt_address_token(ptls_aead_context_t *aead, const quicly_transpo
     ret = 0;
 
 Exit:
-    ptls_buffer_dispose(&resumption_aad);
     if (ret != 0) {
         if (*err_desc == NULL)
             *err_desc = "token decode error";
@@ -5796,6 +5747,40 @@ Exit:
         if (plaintext->type == QUICLY_ADDRESS_TOKEN_TYPE_RETRY)
             ret = QUICLY_TRANSPORT_ERROR_INVALID_TOKEN;
     }
+    return ret;
+}
+
+int quicly_build_session_ticket_auth_data(ptls_buffer_t *auth_data, quicly_context_t *ctx)
+{
+    int ret;
+
+#define PUSH_TP(id, block)                                                                                                         \
+    do {                                                                                                                           \
+        ptls_buffer_push_quicint(auth_data, id);                                                                                   \
+        ptls_buffer_push_block(auth_data, -1, block);                                                                              \
+    } while (0)
+
+    ptls_buffer_push_block(auth_data, -1, {
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_ACTIVE_CONNECTION_ID_LIMIT,
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.active_connection_id_limit); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_DATA,
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_data); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL,
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_stream_data.bidi_local); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE,
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_stream_data.bidi_remote); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAM_DATA_UNI,
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_stream_data.uni); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_BIDI,
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_streams_bidi); });
+        PUSH_TP(QUICLY_TRANSPORT_PARAMETER_ID_INITIAL_MAX_STREAMS_UNI,
+                { ptls_buffer_push_quicint(auth_data, ctx->transport_params.max_streams_uni); });
+    });
+
+#undef PUSH_TP
+
+    ret = 0;
+Exit:
     return ret;
 }
 

--- a/deps/quicly/misc/probe2trace.pl
+++ b/deps/quicly/misc/probe2trace.pl
@@ -144,7 +144,7 @@ for my $probe (@probes) {
                 }
             } elsif ($type =~ /\s+\*$/) {
                 # emit the address for other pointers
-                push @fmt, qq!"name":"0x%llx"!;
+                push @fmt, qq!"$name":"0x%llx"!;
                 push @ap, "(unsigned long long)arg$i";
             } else {
                 die "can't handle type: $type";

--- a/deps/quicly/src/cli.c
+++ b/deps/quicly/src/cli.c
@@ -394,8 +394,7 @@ static quicly_closed_by_remote_t closed_by_remote = {&on_closed_by_remote};
 static int on_generate_resumption_token(quicly_generate_resumption_token_t *self, quicly_conn_t *conn, ptls_buffer_t *buf,
                                         quicly_address_token_plaintext_t *token)
 {
-    return quicly_encrypt_address_token(tlsctx.random_bytes, address_token_aead.enc, &quicly_get_context(conn)->transport_params,
-                                        buf, buf->off, token);
+    return quicly_encrypt_address_token(tlsctx.random_bytes, address_token_aead.enc, buf, buf->off, token);
 }
 
 static quicly_generate_resumption_token_t generate_resumption_token = {&on_generate_resumption_token};
@@ -773,8 +772,8 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                         quicly_address_token_plaintext_t *token = NULL, token_buf;
                         if (packet.token.len != 0) {
                             const char *err_desc = NULL;
-                            int ret = quicly_decrypt_address_token(address_token_aead.dec, &ctx.transport_params, &token_buf,
-                                                                   packet.token.base, packet.token.len, 0, &err_desc);
+                            int ret = quicly_decrypt_address_token(address_token_aead.dec, &token_buf, packet.token.base,
+                                                                   packet.token.len, 0, &err_desc);
                             if (ret == 0 && validate_token(&sa, packet.cid.src, packet.cid.dest.encrypted, &token_buf, &err_desc)) {
                                 token = &token_buf;
                             } else if (enforce_retry && (ret == QUICLY_TRANSPORT_ERROR_INVALID_TOKEN ||

--- a/deps/quicly/t/test.c
+++ b/deps/quicly/t/test.c
@@ -402,11 +402,11 @@ static void test_address_token_codec(void)
     input.appdata.len = strlen((char *)input.appdata.bytes);
     ptls_buffer_init(&buf, "", 0);
 
-    ok(quicly_encrypt_address_token(ptls_openssl_random_bytes, enc, NULL, &buf, 0, &input) == 0);
+    ok(quicly_encrypt_address_token(ptls_openssl_random_bytes, enc, &buf, 0, &input) == 0);
 
     /* check that the output is ok */
     ptls_openssl_random_bytes(&output, sizeof(output));
-    ok(quicly_decrypt_address_token(dec, NULL, &output, buf.base, buf.off, 0, &err_desc) == 0);
+    ok(quicly_decrypt_address_token(dec, &output, buf.base, buf.off, 0, &err_desc) == 0);
     ok(input.type == output.type);
     ok(input.issued_at == output.issued_at);
     ok(input.remote.sa.sa_family == output.remote.sa.sa_family);
@@ -422,13 +422,13 @@ static void test_address_token_codec(void)
     /* failure to decrypt a Retry token is a hard error */
     ptls_openssl_random_bytes(&output, sizeof(output));
     buf.base[buf.off - 1] ^= 0x80;
-    ok(quicly_decrypt_address_token(dec, NULL, &output, buf.base, buf.off, 0, &err_desc) == QUICLY_TRANSPORT_ERROR_INVALID_TOKEN);
+    ok(quicly_decrypt_address_token(dec, &output, buf.base, buf.off, 0, &err_desc) == QUICLY_TRANSPORT_ERROR_INVALID_TOKEN);
     buf.base[buf.off - 1] ^= 0x80;
 
     /* failure to decrypt a token that is not a Retry is a soft error */
     ptls_openssl_random_bytes(&output, sizeof(output));
     buf.base[0] ^= 0x80;
-    ok(quicly_decrypt_address_token(dec, NULL, &output, buf.base, buf.off, 0, &err_desc) == PTLS_ALERT_DECODE_ERROR);
+    ok(quicly_decrypt_address_token(dec, &output, buf.base, buf.off, 0, &err_desc) == PTLS_ALERT_DECODE_ERROR);
     buf.base[0] ^= 0x80;
 
     ptls_buffer_dispose(&buf);

--- a/src/main.c
+++ b/src/main.c
@@ -2316,7 +2316,7 @@ static h2o_http3_conn_t *on_http3_accept(h2o_http3_ctx_t *_ctx, quicly_address_t
     if (packet->token.len != 0) {
         int ret;
         const char *err_desc = NULL;
-        if ((ret = quic_decrypt_address_token(&token_buf, packet->token, &ctx->super.quic->transport_params, &err_desc)) == 0) {
+        if ((ret = quic_decrypt_address_token(&token_buf, packet->token, &err_desc)) == 0) {
             if (validate_token(ctx, &srcaddr->sa, packet->cid.src, packet->cid.dest.encrypted, &token_buf))
                 token = &token_buf;
         } else if (ret == QUICLY_TRANSPORT_ERROR_INVALID_TOKEN) {

--- a/src/main.c
+++ b/src/main.c
@@ -3124,6 +3124,13 @@ int main(int argc, char **argv)
         }
         ssl_setup_session_resumption(ssl_contexts.entries, ssl_contexts.size, quic_args, sync_barrier);
         free(ssl_contexts.entries);
+        for (i = 0; i != conf.num_listeners; ++i) {
+            for (j = 0; j != conf.listeners[i]->ssl.size; ++j) {
+                ptls_context_t *ptls = h2o_socket_ssl_get_picotls_context(conf.listeners[i]->ssl.entries[j]->ctx);
+                if (ptls != NULL)
+                    ssl_setup_session_resumption_ptls(ptls, conf.listeners[i]->quic.ctx);
+            }
+        }
     }
 
     /* all setup should be complete by now */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -350,7 +350,7 @@ static int encrypt_ticket_ptls(ptls_encrypt_ticket_t *_self, ptls_t *tls, int is
     int ret;
 
     if (is_encrypt) {
-        /* encrypt given data, witch the QUIC tag appended if necessary */
+        /* encrypt given data, with the QUIC tag appended if necessary */
         uint8_t srcbuf[src.len + sizeof(self->quic_tag)];
         if (self->is_quic) {
             memcpy(srcbuf, src.base, src.len);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1253,8 +1253,7 @@ static int generate_stateless_reset_token(quicly_cid_encryptor_t *self, void *to
 
 quicly_cid_encryptor_t quic_cid_encryptor = {encrypt_cid, decrypt_cid, generate_stateless_reset_token};
 
-int quic_decrypt_address_token(quicly_address_token_plaintext_t *pt, ptls_iovec_t input, const quicly_transport_parameters_t *tp,
-                               const char **err_desc)
+int quic_decrypt_address_token(quicly_address_token_plaintext_t *pt, ptls_iovec_t input, const char **err_desc)
 {
     struct st_quic_keyset_t *keyset;
 
@@ -1262,7 +1261,7 @@ int quic_decrypt_address_token(quicly_address_token_plaintext_t *pt, ptls_iovec_
 
     if ((keyset = find_quic_keyset(input.base[0])) == NULL)
         return PTLS_ERROR_INCOMPATIBLE_KEY; /* TODO consider error code */
-    return quicly_decrypt_address_token(keyset->address_token.dec, tp, pt, input.base, input.len, 1, err_desc);
+    return quicly_decrypt_address_token(keyset->address_token.dec, pt, input.base, input.len, 1, err_desc);
 }
 
 ptls_aead_context_t *quic_get_address_token_encryptor(uint8_t *prefix)
@@ -1282,8 +1281,7 @@ static int generate_resumption_token(quicly_generate_resumption_token_t *self, q
     if ((ret = ptls_buffer_reserve(buf, 1)) != 0)
         return ret;
     buf->base[buf->off++] = prefix;
-    return quicly_encrypt_address_token(ptls_openssl_random_bytes, aead, &quicly_get_context(conn)->transport_params, buf,
-                                        buf->off - 1, token);
+    return quicly_encrypt_address_token(ptls_openssl_random_bytes, aead, buf, buf->off - 1, token);
 }
 
 quicly_generate_resumption_token_t quic_resumption_token_generator = {generate_resumption_token};

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -320,9 +320,59 @@ static int ticket_key_callback_ossl(SSL *ssl, unsigned char *key_name, unsigned 
     return ticket_key_callback(key_name, iv, ctx, hctx, enc);
 }
 
-static int encrypt_ticket_key_ptls(ptls_encrypt_ticket_t *self, ptls_t *tls, int is_encrypt, ptls_buffer_t *dst, ptls_iovec_t src)
+static void calculate_quic_tp_tag(uint8_t *tag64, quicly_context_t *ctx)
 {
-    return (is_encrypt ? ptls_openssl_encrypt_ticket : ptls_openssl_decrypt_ticket)(dst, src, ticket_key_callback);
+    ptls_buffer_t buf;
+    uint8_t full_digest[PTLS_SHA256_DIGEST_SIZE];
+
+    /* calculate sha256 hash of remembered tp */
+    ptls_buffer_init(&buf, "", 0);
+    if (quicly_build_session_ticket_auth_data(&buf, ctx) != 0 ||
+        ptls_calc_hash(&ptls_openssl_sha256, full_digest, buf.base, buf.off) != 0)
+        h2o_fatal("failed to calculate sha256 of remembered TPs");
+    ptls_buffer_dispose(&buf);
+
+    /* use the first 64-bit */
+    memcmp(tag64, full_digest, 8);
+}
+
+
+
+struct encrypt_ticket_ptls_t {
+    ptls_encrypt_ticket_t super;
+    uint8_t is_quic : 1;
+    uint8_t quic_tag[8];
+};
+
+static int encrypt_ticket_ptls(ptls_encrypt_ticket_t *_self, ptls_t *tls, int is_encrypt, ptls_buffer_t *dst, ptls_iovec_t src)
+{
+    struct encrypt_ticket_ptls_t *self = (void *)_self;
+    int ret;
+
+    if (is_encrypt) {
+        /* encrypt given data, witch the QUIC tag appended if necessary */
+        uint8_t srcbuf[src.len + sizeof(self->quic_tag)];
+        if (self->is_quic) {
+            memcpy(srcbuf, src.base, src.len);
+            memcpy(srcbuf + src.len, self->quic_tag, sizeof(self->quic_tag));
+            src.base = srcbuf;
+            src.len += sizeof(self->quic_tag);
+        }
+        return ptls_openssl_encrypt_ticket(dst, src, ticket_key_callback);
+    } else {
+        /* decrypt given data, then if necessary, check and remove the QUIC tag */
+        size_t dst_start_off = dst->off;
+        if ((ret = ptls_openssl_decrypt_ticket(dst, src, ticket_key_callback)) != 0)
+            return ret;
+        if (self->is_quic) {
+            if (dst->off - dst_start_off < sizeof(self->quic_tag))
+                return PTLS_ALERT_DECODE_ERROR;
+            dst->off -= sizeof(self->quic_tag);
+            if (memcmp(dst->base + dst->off, self->quic_tag, sizeof(self->quic_tag)) != 0)
+                return PTLS_ERROR_REJECT_EARLY_DATA;
+        }
+        return 0;
+    }
 }
 
 static int update_tickets(session_ticket_vector_t *tickets, uint64_t now)
@@ -1055,12 +1105,7 @@ void ssl_setup_session_resumption(SSL_CTX **contexts, size_t num_contexts, struc
         for (i = 0; i != num_contexts; ++i) {
             SSL_CTX *ctx = contexts[i];
             SSL_CTX_set_tlsext_ticket_key_cb(ctx, ticket_key_callback_ossl);
-            ptls_context_t *pctx = h2o_socket_ssl_get_picotls_context(ctx);
-            if (pctx != NULL) {
-                static ptls_encrypt_ticket_t encryptor = {encrypt_ticket_key_ptls};
-                pctx->ticket_lifetime = 86400 * 7; // FIXME conf.lifetime;
-                pctx->encrypt_ticket = &encryptor;
-            }
+            /* accompanying ptls context is initialized in ssl_setup_session_resumption_ptls */
         }
     } else {
         size_t i;
@@ -1068,6 +1113,20 @@ void ssl_setup_session_resumption(SSL_CTX **contexts, size_t num_contexts, struc
             SSL_CTX_set_options(contexts[i], SSL_CTX_get_options(contexts[i]) | SSL_OP_NO_TICKET);
     }
 #endif
+}
+
+void ssl_setup_session_resumption_ptls(ptls_context_t *ptls, quicly_context_t *quic)
+{
+    if (conf.ticket.update_thread != NULL) {
+        struct encrypt_ticket_ptls_t *encryptor = malloc(sizeof(*encryptor));
+        *encryptor = (struct encrypt_ticket_ptls_t){{encrypt_ticket_ptls}};
+        if (quic != NULL) {
+            encryptor->is_quic = 1;
+            calculate_quic_tp_tag(encryptor->quic_tag, quic);
+        }
+        ptls->ticket_lifetime = 86400 * 7; // FIXME conf.lifetime
+        ptls->encrypt_ticket = &encryptor->super;
+    }
 }
 
 static pthread_mutex_t *mutexes;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -333,10 +333,8 @@ static void calculate_quic_tp_tag(uint8_t *tag64, quicly_context_t *ctx)
     ptls_buffer_dispose(&buf);
 
     /* use the first 64-bit */
-    memcmp(tag64, full_digest, 8);
+    memcpy(tag64, full_digest, 8);
 }
-
-
 
 struct encrypt_ticket_ptls_t {
     ptls_encrypt_ticket_t super;

--- a/src/standalone.h
+++ b/src/standalone.h
@@ -39,6 +39,7 @@ struct st_h2o_quic_resumption_args_t {
 
 void ssl_setup_session_resumption(SSL_CTX **contexts, size_t num_contexts, struct st_h2o_quic_resumption_args_t *quic_args,
                                   h2o_barrier_t *startup_barrier);
+void ssl_setup_session_resumption_ptls(ptls_context_t *ptls, quicly_context_t *quic);
 int ssl_session_resumption_on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node);
 
 extern quicly_cid_encryptor_t quic_cid_encryptor;

--- a/src/standalone.h
+++ b/src/standalone.h
@@ -42,8 +42,7 @@ void ssl_setup_session_resumption(SSL_CTX **contexts, size_t num_contexts, struc
 int ssl_session_resumption_on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node);
 
 extern quicly_cid_encryptor_t quic_cid_encryptor;
-int quic_decrypt_address_token(quicly_address_token_plaintext_t *pt, ptls_iovec_t input, const quicly_transport_parameters_t *tp,
-                               const char **err_desc);
+int quic_decrypt_address_token(quicly_address_token_plaintext_t *pt, ptls_iovec_t input, const char **err_desc);
 ptls_aead_context_t *quic_get_address_token_encryptor(uint8_t *prefix);
 extern quicly_generate_resumption_token_t quic_resumption_token_generator;
 


### PR DESCRIPTION
As stated in https://github.com/h2o/quicly/pull/356, our support for draft-28 came with a code that associates certain TPs to NEW_TOKEN tokens and validates them. This is incorrect.

What we should be doing is associate the TPs to TLS session tickets, and upon mismatch, reject 0-RTT.

This PR is the H2O-side of the fix (quicly-side fix is https://github.com/h2o/quicly/pull/356).