### PR TITLE
Add workaround for CIFuzz build bug [WIP]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,21 +3,23 @@ on: [pull_request]
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
-    steps:
-    - name: Build Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'h2o'
-        dry-run: false
-    - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-      with:
-        oss-fuzz-project-name: 'h2o'
-        fuzz-seconds: 600
-        dry-run: false
-    - name: Upload Crash
-      uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: artifacts
-        path: ./out/artifacts
+    # Workaround for https://github.com/google/oss-fuzz/issues/3731
+    if: github.repository == 'h2o/h2o'
+      steps:
+      - name: Build Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'h2o'
+          dry-run: false
+      - name: Run Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'h2o'
+          fuzz-seconds: 600
+          dry-run: false
+      - name: Upload Crash
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: artifacts
+          path: ./out/artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,21 +5,21 @@ jobs:
     runs-on: ubuntu-latest
     # Workaround for https://github.com/google/oss-fuzz/issues/3731
     if: github.repository == 'h2o/h2o'
-      steps:
-      - name: Build Fuzzers
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
-        with:
-          oss-fuzz-project-name: 'h2o'
-          dry-run: false
-      - name: Run Fuzzers
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
-        with:
-          oss-fuzz-project-name: 'h2o'
-          fuzz-seconds: 600
-          dry-run: false
-      - name: Upload Crash
-        uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: artifacts
-          path: ./out/artifacts
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'h2o'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'h2o'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
CIFuzz currently does not support fuzzing of forks. See https://github.com/google/oss-fuzz/issues/3731. This changes the configuration so that CIFuzz does not run on forks, i.e. does not run on PRs from forked repos. I believe https://github.com/h2o/h2o/pull/2356 (presently) shows an example failure.

Note that I copied this approach from [systemd's CIFuzz configuration](https://github.com/systemd/systemd/blob/master/.github/workflows/cifuzz.yml).

This change should be rolled back when the CIFuzz bug is fixed.