### PR TITLE
Fix h2olog to follow the latest quicly-probes.d (st_quicly_stats_t)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -900,6 +900,7 @@ IF (WITH_H2OLOG)
     SET(H2OLOG_GEN_DEPS
         "h2o-probes.d"
         "deps/quicly/quicly-probes.d"
+        "h2olog/quic.h"
     )
 
     ADD_CUSTOM_COMMAND(

--- a/h2olog/quic.h
+++ b/h2olog/quic.h
@@ -48,6 +48,11 @@ struct st_quicly_address_token_plaintext_t {
     int dummy;
 };
 
+
+struct st_quicly_stats_t {
+    int dummy;
+};
+
 struct st_h2o_conn_t {
     int dummy;
 };


### PR DESCRIPTION
Reported by @syohex  at https://github.com/h2o/h2o/pull/2353#issuecomment-650887319

@kazuho `st_quicly_stats_t` is empty and thus `conn_stats` event is useless, but if you need some fields, I'll add them.