### PR TITLE
Change process name of neverbleed

### DIFF
--- a/deps/neverbleed/README.md
+++ b/deps/neverbleed/README.md
@@ -1,7 +1,7 @@
 Neverbleed
 ===============
 
-Neverbleed is an [OpenSSL engine](https://www.openssl.org/docs/manmaster/crypto/engine.html) that runs RSA private key operations in an isolated process, thereby minimizing the risk of private key leak in case of vulnerability such as [Heartbleed](http://heartbleed.com/).
+Neverbleed is an [OpenSSL engine](https://www.openssl.org/docs/man1.0.2/crypto/engine.html) that runs RSA private key operations in an isolated process, thereby minimizing the risk of private key leak in case of vulnerability such as [Heartbleed](http://heartbleed.com/).
 
 The engine is known to work together with existing versions of OpenSSL or LibreSSL, with minimal changes to the server source code.
 

--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -32,24 +32,78 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
-#include <openssl/rand.h>
-#include <openssl/ssl.h>
-#include <openssl/rsa.h>
-#include <openssl/bn.h>
-#ifdef __linux__
-#include <sys/prctl.h>
-#endif
-#include "neverbleed.h"
 
-#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
-#define OPENSSL_1_1_API 1
-#else
-#define OPENSSL_1_1_API 0
+#include <openssl/opensslconf.h>
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
+/* RSA_METHOD is opaque, so RSA_meth* are used. */
+#define NEVERBLEED_OPAQUE_RSA_METHOD
 #endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(OPENSSL_NO_EC) \
+    && (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x2090100fL)
+/* EC_KEY_METHOD and related APIs are avaliable, so ECDSA is enabled. */
+#define NEVERBLEED_ECDSA
+#endif
+
+#include <openssl/bn.h>
+#ifdef NEVERBLEED_ECDSA
+#include <openssl/ec.h>
+#endif
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+#include <openssl/ssl.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL \
+    || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+
+static void RSA_get0_key(const RSA *rsa, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+{
+    if (n) {
+        *n = rsa->n;
+    }
+
+    if (e) {
+        *e = rsa->e;
+    }
+
+    if (d) {
+        *d = rsa->d;
+    }
+}
+
+static int RSA_set0_key(RSA *rsa, BIGNUM *n, BIGNUM *e, BIGNUM *d)
+{
+    if (n == NULL || e == NULL) {
+        return 0;
+    }
+
+    BN_free(rsa->n);
+    BN_free(rsa->e);
+    BN_free(rsa->d);
+    rsa->n = n;
+    rsa->e = e;
+    rsa->d = d;
+
+    return 1;
+}
+
+static void RSA_set_flags(RSA *r, int flags)
+{
+    r->flags |= flags;
+}
+
+#endif
+
+#include "neverbleed.h"
 
 enum neverbleed_type { NEVERBLEED_TYPE_ERROR, NEVERBLEED_TYPE_RSA, NEVERBLEED_TYPE_ECDSA };
 
@@ -630,45 +684,6 @@ static int sign_stub(struct expbuf_t *buf)
     return 0;
 }
 
-#if !OPENSSL_1_1_API && (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER < 0x2070000fL)
-
-static void RSA_get0_key(const RSA *rsa, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
-{
-    if (n) {
-        *n = rsa->n;
-    }
-
-    if (e) {
-        *e = rsa->e;
-    }
-
-    if (d) {
-        *d = rsa->d;
-    }
-}
-
-static int RSA_set0_key(RSA *rsa, BIGNUM *n, BIGNUM *e, BIGNUM *d)
-{
-    if (n == NULL || e == NULL) {
-        return 0;
-    }
-
-    BN_free(rsa->n);
-    BN_free(rsa->e);
-    BN_free(rsa->d);
-    rsa->n = n;
-    rsa->e = e;
-    rsa->d = d;
-
-    return 1;
-}
-
-static void RSA_set_flags(RSA *r, int flags)
-{
-    r->flags |= flags;
-}
-#endif
-
 static EVP_PKEY *create_pkey(neverbleed_t *nb, size_t key_index, const char *ebuf, const char *nbuf)
 {
     struct st_neverbleed_rsa_exdata_t *exdata;
@@ -703,7 +718,7 @@ static EVP_PKEY *create_pkey(neverbleed_t *nb, size_t key_index, const char *ebu
     return pkey;
 }
 
-#if OPENSSL_1_1_API
+#ifdef NEVERBLEED_ECDSA
 
 static EC_KEY *daemon_get_ecdsa(size_t key_index)
 {
@@ -969,7 +984,7 @@ int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char 
         pkey = create_pkey(nb, index, estr, nstr);
         break;
     }
-#if OPENSSL_1_1_API
+#ifdef NEVERBLEED_ECDSA
     case NEVERBLEED_TYPE_ECDSA: {
         char *ec_pubkeystr;
         size_t curve_name;
@@ -978,7 +993,7 @@ int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char 
             errno = 0;
             dief("failed to parse response");
         }
-        pkey = ecdsa_create_pkey(nb, index, curve_name, ec_pubkeystr);
+        pkey = ecdsa_create_pkey(nb, index, (int)curve_name, ec_pubkeystr);
         break;
     }
 #endif
@@ -1016,9 +1031,11 @@ static int load_key_stub(struct expbuf_t *buf)
     char *estr = NULL, *nstr = NULL, errbuf[NEVERBLEED_ERRBUF_SIZE] = "";
     size_t type = NEVERBLEED_TYPE_ERROR;
     EVP_PKEY *pkey = NULL;
+#ifdef NEVERBLEED_ECDSA
     const EC_GROUP *ec_group;
     BIGNUM *ec_pubkeybn = NULL;
     char *ec_pubkeystr = NULL;
+#endif
 
     if ((fn = expbuf_shift_str(buf)) == NULL) {
         warnf("%s: failed to parse request", __FUNCTION__);
@@ -1048,7 +1065,7 @@ static int load_key_stub(struct expbuf_t *buf)
         break;
     }
     case EVP_PKEY_EC: {
-#if OPENSSL_1_1_API
+#ifdef NEVERBLEED_ECDSA
         const EC_POINT *ec_pubkey;
         EC_KEY *ec_key;
 
@@ -1066,7 +1083,7 @@ static int load_key_stub(struct expbuf_t *buf)
         ec_pubkeystr = BN_bn2hex(ec_pubkeybn);
         break;
 #else
-        snprintf(errbuf, sizeof(errbuf), "ECDSA support requires OpenSSL >= 1.1.0");
+        snprintf(errbuf, sizeof(errbuf), "ECDSA support requires OpenSSL >= 1.1.0 or LibreSSL >= 2.9.1");
         goto Respond;
 #endif
     }
@@ -1084,10 +1101,12 @@ Respond:
         expbuf_push_str(buf, estr != NULL ? estr : "");
         expbuf_push_str(buf, nstr != NULL ? nstr : "");
         break;
+#ifdef NEVERBLEED_ECDSA
     case NEVERBLEED_TYPE_ECDSA:
         expbuf_push_num(buf, EC_GROUP_get_curve_name(ec_group));
         expbuf_push_str(buf, ec_pubkeystr);
         break;
+#endif
     default:
         expbuf_push_str(buf, errbuf);
     }
@@ -1099,10 +1118,12 @@ Respond:
         OPENSSL_free(estr);
     if (nstr != NULL)
         OPENSSL_free(nstr);
+#ifdef NEVERBLEED_ECDSA
     if (ec_pubkeystr != NULL)
         OPENSSL_free(ec_pubkeystr);
     if (ec_pubkeybn != NULL)
         BN_free(ec_pubkeybn);
+#endif
     if (fp != NULL)
         fclose(fp);
 
@@ -1311,7 +1332,7 @@ static void *daemon_conn_thread(void *_sock_fd)
         } else if (strcmp(cmd, "sign") == 0) {
             if (sign_stub(&buf) != 0)
                 break;
-#if OPENSSL_1_1_API
+#ifdef NEVERBLEED_ECDSA
         } else if (strcmp(cmd, "ecdsa_sign") == 0) {
             if (ecdsa_sign_stub(&buf) != 0)
                 break;
@@ -1375,7 +1396,7 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
     }
 }
 
-#if !OPENSSL_1_1_API
+#ifndef NEVERBLEED_OPAQUE_RSA_METHOD
 
 static RSA_METHOD static_rsa_method = {
     "privsep RSA method", /* name */
@@ -1400,38 +1421,39 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf)
 {
     int pipe_fds[2] = {-1, -1}, listen_fd = -1;
     char *tempdir = NULL;
-#if OPENSSL_1_1_API
-    const RSA_METHOD *default_method = RSA_PKCS1_OpenSSL();
-    EC_KEY_METHOD *ecdsa_method;
+    const RSA_METHOD *rsa_default_method;
+    RSA_METHOD *rsa_method;
+#ifdef NEVERBLEED_ECDSA
     const EC_KEY_METHOD *ecdsa_default_method;
-    RSA_METHOD *rsa_method = RSA_meth_new("privsep RSA method", 0);
+    EC_KEY_METHOD *ecdsa_method;
+#endif
 
+#ifdef NEVERBLEED_OPAQUE_RSA_METHOD
+    rsa_default_method = RSA_PKCS1_OpenSSL();
+    rsa_method = RSA_meth_dup(rsa_default_method);
+
+    RSA_meth_set1_name(rsa_method, "privsep RSA method");
     RSA_meth_set_priv_enc(rsa_method, priv_enc_proxy);
     RSA_meth_set_priv_dec(rsa_method, priv_dec_proxy);
     RSA_meth_set_sign(rsa_method, sign_proxy);
-
-    RSA_meth_set_pub_enc(rsa_method, RSA_meth_get_pub_enc(default_method));
-    RSA_meth_set_pub_dec(rsa_method, RSA_meth_get_pub_dec(default_method));
-    RSA_meth_set_verify(rsa_method, RSA_meth_get_verify(default_method));
-
     RSA_meth_set_finish(rsa_method, priv_rsa_finish);
+#else
+    rsa_default_method = RSA_PKCS1_SSLeay();
+    rsa_method = &static_rsa_method;
 
-    /* setup EC_KEY_METHOD for ECDSA */
+    rsa_method->rsa_pub_enc = rsa_default_method->rsa_pub_enc;
+    rsa_method->rsa_pub_dec = rsa_default_method->rsa_pub_dec;
+    rsa_method->rsa_verify = rsa_default_method->rsa_verify;
+    rsa_method->bn_mod_exp = rsa_default_method->bn_mod_exp;
+#endif
+
+#ifdef NEVERBLEED_ECDSA
     ecdsa_default_method = EC_KEY_get_default_method();
     ecdsa_method = EC_KEY_METHOD_new(ecdsa_default_method);
 
-    EC_KEY_METHOD_set_keygen(ecdsa_method, NULL);
-    EC_KEY_METHOD_set_compute_key(ecdsa_method, NULL);
     /* it seems sign_sig and sign_setup is not used in TLS ECDSA. */
     EC_KEY_METHOD_set_sign(ecdsa_method, ecdsa_sign_proxy, NULL, NULL);
     EC_KEY_METHOD_set_init(ecdsa_method, NULL, priv_ecdsa_finish, NULL, NULL, NULL, NULL);
-#else
-    const RSA_METHOD *default_method = RSA_PKCS1_SSLeay();
-    RSA_METHOD *rsa_method = &static_rsa_method;
-
-    rsa_method->rsa_pub_enc = default_method->rsa_pub_enc;
-    rsa_method->rsa_pub_dec = default_method->rsa_pub_dec;
-    rsa_method->rsa_verify = default_method->rsa_verify;
 #endif
 
     /* setup the daemon */
@@ -1474,6 +1496,8 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf)
 #ifdef __linux__
         prctl(PR_SET_DUMPABLE, 0, 0, 0, 0);
 #endif
+        if (neverbleed_post_fork_cb != NULL)
+            neverbleed_post_fork_cb();
         daemon_vars.nb = nb;
         daemon_main(listen_fd, pipe_fds[0], tempdir);
         break;
@@ -1488,7 +1512,7 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf)
     /* setup engine */
     if ((nb->engine = ENGINE_new()) == NULL || !ENGINE_set_id(nb->engine, "neverbleed") ||
         !ENGINE_set_name(nb->engine, "privilege separation software engine") || !ENGINE_set_RSA(nb->engine, rsa_method)
-#if OPENSSL_1_1_API
+#ifdef NEVERBLEED_ECDSA
         || !ENGINE_set_EC(nb->engine, ecdsa_method)
 #endif
             ) {
@@ -1519,3 +1543,5 @@ Fail:
     }
     return -1;
 }
+
+void (*neverbleed_post_fork_cb)(void) = NULL;

--- a/deps/neverbleed/neverbleed.h
+++ b/deps/neverbleed/neverbleed.h
@@ -53,6 +53,11 @@ int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char 
  * setuidgid (also changes the file permissions so that `user` can connect to the daemon, if change_socket_ownership is non-zero)
  */
 int neverbleed_setuidgid(neverbleed_t *nb, const char *user, int change_socket_ownership);
+/**
+ * an optional callback that can be registered by the application for doing stuff immediately after the neverbleed process is being
+ * spawned
+ */
+extern void (*neverbleed_post_fork_cb)(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Previously, the only way that we could distinguish the h2o process serving requests and the neverbleed process was by checking their relationship (i.e. parent vs. child). This PR sets the name of the neverbleed process to "neverbleed" by overwriting `argv`. Doing so helps people using `pidof`.

The feature is currently limited to linux. Even though `argv` rewrite is a popular technique, it is not known to be safe or work across multiple platforms. As an example, it is impossible to change the command name detected by `pidof` of homebrew, by rewriting `argv` (or by changing the vector by calling `_NSGetArgv`).