### PR TITLE
fix chunk size accumulation in reverse proxy serialize post 3 test

### DIFF
--- a/t/50reverse-proxy-serialize-posts-3.t
+++ b/t/50reverse-proxy-serialize-posts-3.t
@@ -80,7 +80,7 @@ ok($chunked_header_found == 1, "TE:chunked header found");
 my @chunks = split /\r\n/, $body;
 
 my $chunk_len = 0;
-for (my $i = 0; $i < scalar(@chunks); $i+=3) {
+for (my $i = 0; $i < scalar(@chunks); $i+=2) {
     $chunk_len += hex($chunks[$i]);
 }
 


### PR DESCRIPTION
I ran the tests on several systems including running locally (Fedora), on GitHub runners (Ubuntu), Alpine (docker and native) and last but not least via docker locally on kazuho/h2o-ci:latest. On all but running kazuho/h2o-ci:latest via docker on Travis CI the 50reverse-proxy-serialize-posts-3.t test script fails with an `Integer overflow in hexadecimal number` respectively `Hexadecimal number > 0xffffffff non-portable` error. Why?
The pattern of the chunked `body` tested is \<size in hex\>\r\n\<payload\>\r\n\<size in hex\>\r\n\<payload>... with a body size of 5000 bytes in the test scripts. On kazuho/h2o-ci:latest via docker on Travis CI it comes as `1388\r\naaaaaaaaa..` and succeeds (so basically it comes as one and only one chunk, so element 0, which is 1388 is the size (hex 1388 = decimal 5000), so basically as one chunk, but on other systems, the payload is broken up into multiple chunks (mostly I have seen multiples of 1000, so like 1x4000+1x1000 or 1x1000+1x2000+1x1000, and so on).  
The script tries to read the size of the chunks and accumulate them, which is every **second** element starting at index 0, but it advances 3 instead of 2.  
`for (my $i = 0; $i < scalar(@chunks); $i+=3)`  
So with that it tries to read the chunk of data respectively the payload itself and that fails with above error, when the payload is broken into more than one chunk.

This PR corrects the test script to reading every second element instead of every third element.





  