### PR TITLE
## Implement privsep sandbox for H2O

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,12 @@ SET(LIB_SOURCE_FILES
     lib/common/memcached.c
     lib/common/memory.c
     lib/common/multithread.c
+    lib/common/privsep.c
+    lib/common/privsep_dispatch.c
+    lib/common/privsep_sandbox_linux.c
+    lib/common/privsep_sandbox_freebsd.c
+    lib/common/allpriv.c
+    lib/common/priv_wrapper.c
     lib/common/redis.c
     lib/common/serverutil.c
     lib/common/socket.c
@@ -561,6 +567,14 @@ TARGET_INCLUDE_DIRECTORIES(libh2o PUBLIC ${OPENSSL_INCLUDE_DIR})
 TARGET_INCLUDE_DIRECTORIES(libh2o-evloop PUBLIC ${OPENSSL_INCLUDE_DIR})
 TARGET_LINK_LIBRARIES(libh2o ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS})
 TARGET_LINK_LIBRARIES(libh2o-evloop ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS})
+
+IF (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    ADD_LIBRARY(sandboxc SHARED
+        deps/fcgi/lib/libsandboxc.c)
+    INSTALL(TARGETS sandboxc DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ENDIF()
+ADD_EXECUTABLE(fcgi deps/fcgi/fcgi.c deps/fcgi/sandbox.c)
+INSTALL(TARGETS fcgi DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o)
 
 ADD_EXECUTABLE(t-qif t/qif.c)
 SET_TARGET_PROPERTIES(t-qif PROPERTIES

--- a/deps/fcgi/fcgi.c
+++ b/deps/fcgi/fcgi.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/syscall.h>
+
+#include <stdio.h>
+#include <getopt.h>
+#include <grp.h>
+#include <unistd.h>
+#include <errno.h>
+#include <err.h>
+#include <pwd.h>
+#include <stdlib.h>
+#include <sysexits.h>
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include <libgen.h>
+
+#include "fcgi.h"
+#include "sandbox.h"
+
+static struct option long_options[] = {
+    { "unlink-sock-path",   required_argument, 0, 'P' },
+    { "setuidgid",          required_argument, 0, 'u' },
+    { "help",               no_argument, 0, 'h' },
+    { "wait-fd",            required_argument, 0, 'f' },
+    { "sandbox",            no_argument, 0, 's' },
+    { "libc-wrapper",       required_argument, 0, 'w' },
+    { NULL, 0, 0, 0 }
+};
+
+static void usage(void) {
+
+    (void) fprintf(stderr,
+      "Usage: fcgi [OPTIONS] -- COMMAND\n\n"
+      "Options\n"
+        " -h, --help                    Display program usage\n"
+        " -P, --unlink-sock-path=PATH   Directory containing fcgi socket\n"
+        " -u, --setuidgid=USER          User/group for setuid operation\n"
+        " -f, --wait-fd=FD              FD to wait on for parent termination\n"
+        " -s, --sandbox                 Run process in a sandbox\n"
+        " -w, --libc-wrapper=LIB        libc wrapper in sandbox\n\n"
+        "Example:\n"
+        " fcgi -P /tmp/fastcgi -u nobody -f 5 -e 10 -- /usr/bin/php-cgi\n"
+        "\n");
+    exit(EX_OSERR);
+}
+
+static void setuidgid(char *user)
+{
+    struct passwd *pwd;
+
+    errno = 0;
+    if ((pwd = getpwnam(user)) == NULL) {
+        if (errno == 0) {
+            errx(EX_CONFIG, "unknown user:%s\n", user);
+        } else {
+            err(EX_OSERR, "getpwnam");
+        }
+    }
+    if (getuid() == pwd->pw_uid && getgid() == pwd->pw_gid) {
+        endpwent();
+        return;
+    }
+    if (setgid(pwd->pw_gid) != 0) {
+        err(EX_OSERR, "setgid failed");
+    }
+    if (initgroups(pwd->pw_name, pwd->pw_gid) != 0) {
+        err(EX_OSERR, "initgroups failed");
+    }
+    if (setuid(pwd->pw_uid) != 0) {
+        err(EX_OSERR, "setuid failed");
+    }
+    endpwent();
+}
+
+static void *wait_for_parent(void *arg)
+{
+    struct wait_params *wp;
+    char path[1024];
+    ssize_t cc;
+    char b;
+
+    wp = (struct wait_params *) arg;
+    while (1) {
+        cc = read(wp->wait_fd, &b, 1);
+        if (cc == -1 && errno == EINTR) {
+            continue;
+        }
+        if (cc == -1) {
+            err(EX_OSERR, "read wait_fd failed");
+        }
+        break;
+    }
+    warnx("h2o disapeared. cleaning up");
+    warnx("sending SIGTERM to child");
+    if (kill(wp->fcgi_pid, SIGTERM) == -1) {
+        err(EX_OSERR, "kill failed");
+    }
+    if (wp->sock_path == NULL) {
+        return (NULL);
+    }
+    warnx("removing socket %s/_", wp->sock_path);
+    sprintf(path, "%s/_", wp->sock_path);
+    (void) unlink(path);
+    (void) unlink(wp->sock_path);
+    return (NULL);
+}
+
+int main(int argc, char *argv [], char *env [])
+{
+    int option_index, c, ret, status;
+    struct wait_params wp;
+    pthread_t thr;
+    char *user;
+    pid_t pid;
+
+    bzero(&wp, sizeof(wp));
+    wp.wait_fd = -1;
+    wp.sock_path = NULL;
+    wp.do_sandbox = 0;
+    user = "nobody";
+    c = 0;
+    while (c >= 0) {
+        c = getopt_long(argc, argv, "f:hP:su:w:", long_options,
+          &option_index);
+        switch (c) {
+        case 'w':
+            wp.libc_wrapper = optarg;
+            break;
+        case 'f':
+            wp.wait_fd = atoi(optarg);
+            break;
+        case 'h':
+            usage();
+            break;  /* NOTREACHED */
+        case 'P':
+            wp.sock_path = optarg;
+            break;
+        case 's':
+            wp.do_sandbox = 1;
+            break;
+        case 'u':
+            user = optarg;
+            break;
+        }
+    }
+    argc -= optind;
+    argv += optind;
+    if (argc == 0) {
+        usage();
+        /* NOTREACHED */
+    }
+    setuidgid(user);
+    pid = fork();
+    if (pid == -1) {
+        err(EX_OSERR, "fork failed");
+    }
+    if (pid == 0) {
+        sandbox_exec(&wp, argv, env);
+        err(EX_OSERR, "execve failed");
+    }
+    wp.fcgi_pid = pid;
+    if (wp.wait_fd >= 0) {
+        if (pthread_create(&thr, NULL, wait_for_parent, &wp) == -1) {
+            err(EX_OSERR, "pthread_create failed");
+        }
+    }
+    while (1) {
+        ret = waitpid(pid, &status, 0);
+        if (ret == -1 && errno == EINTR) {
+            continue;
+        }
+        if (ret == -1) {
+            err(EX_OSERR, "waitpid(%d) failed", pid);
+        }
+        break;
+    }
+    warnx("collected exit status (%d) from child (%d)", status, pid);
+    return (0);
+}

--- a/deps/fcgi/fcgi.h
+++ b/deps/fcgi/fcgi.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef FCGI_DOT_H_
+#define	FCGI_DOT_H_
+
+
+struct wait_params {
+    int          wait_fd;
+    pid_t        fcgi_pid;
+    char        *sock_path;
+    int          do_sandbox;
+    char        *libc_wrapper;
+};
+
+#endif /* FCGI_DOT_H_ */

--- a/deps/fcgi/lib/libsandboxc.c
+++ b/deps/fcgi/lib/libsandboxc.c
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <sys/types.h>
+#include <sys/event.h>
+#include <sys/procdesc.h>
+#include <sys/queue.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+
+#include <stdarg.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <assert.h>
+#include <errno.h>
+
+static int rootfd = -1;
+
+struct proc_map {
+	int			proc_fd;
+	pid_t			proc_pid;
+	TAILQ_ENTRY(proc_map)	proc_glue;
+};
+
+static TAILQ_HEAD( , proc_map)	proc_map_head;
+pthread_mutex_t map_mutex;
+static int nprocs;
+
+static int sandbox_get_root_fd(void)
+{
+	char *fd_string;
+
+	if (rootfd > -1) {
+		return (rootfd);
+	}
+	fd_string = getenv("H2O_SANDBOX_ROOT_FD");
+	if (fd_string == NULL) {
+		return (-1);
+	}
+	rootfd = atoi(fd_string);
+	return (rootfd);
+}
+
+static pid_t
+lookup_map_by_fd(int fd)
+{
+	struct proc_map *pm;
+
+	pthread_mutex_lock(&map_mutex);
+	TAILQ_FOREACH(pm, &proc_map_head, proc_glue) {
+		if (pm->proc_fd == fd) {
+			pthread_mutex_unlock(&map_mutex);
+			return (pm->proc_pid);
+		}
+	}
+	pthread_mutex_unlock(&map_mutex);
+	return (-1);
+}
+
+static void
+remove_map(pid_t pid)
+{
+	struct proc_map *pm, *pm_temp;
+
+	pthread_mutex_lock(&map_mutex);
+	TAILQ_FOREACH_SAFE(pm, &proc_map_head, proc_glue, pm_temp) {
+		if (pm->proc_pid != pid) {
+			continue;
+		}
+		nprocs--;
+		TAILQ_REMOVE(&proc_map_head, pm, proc_glue);
+		pthread_mutex_unlock(&map_mutex);
+		free(pm);
+		return;
+        }
+        pthread_mutex_unlock(&map_mutex);
+}
+
+static int
+lookup_map_by_pid(pid_t pid)
+{
+	struct proc_map *pm;
+
+	pthread_mutex_lock(&map_mutex);
+	TAILQ_FOREACH(pm, &proc_map_head, proc_glue) {
+		if (pm->proc_pid == pid) {
+			pthread_mutex_unlock(&map_mutex);
+			return (pm->proc_fd);
+		}
+	}
+	pthread_mutex_unlock(&map_mutex);
+	return (-1);
+}
+
+static pid_t
+waitpid_all(pid_t pid, int *status, int options)
+{
+	struct kevent *kev, *kp;
+	struct proc_map *pm;
+	int kq, ret, k, ents;
+	pid_t p;
+
+	kq = kqueue();
+	if (kq == -1) {
+		return (-1);
+	}
+	ents = nprocs;
+	kev = calloc(ents, sizeof(*kev));
+	if (kev == NULL) {
+		return (-1);
+	}
+	k = 0;
+	pthread_mutex_lock(&map_mutex);
+	TAILQ_FOREACH(pm, &proc_map_head, proc_glue) {
+		kp = &kev[k++];
+		EV_SET(kp, pm->proc_fd, EVFILT_PROCDESC, EV_ADD, NOTE_EXIT,
+		    0, NULL);
+		if (k == ents) {
+			break;
+		}
+	}
+	pthread_mutex_unlock(&map_mutex);
+	ret = kevent(kq, kev, ents, NULL, 0, NULL);
+	if (ret == -1) {
+		return (-1);
+	}
+	while (1) {
+		ret = kevent(kq, NULL, 0, kev, ents, NULL);
+		if (ret == -1) {
+			return (-1);
+		}
+		kp = &kev[0];
+		p = lookup_map_by_fd(kp->ident);
+		remove_map(p);
+		*status = kev->data;
+		break;
+	}
+	return (p);
+}
+
+pid_t
+waitpid(pid_t pid, int *status, int options)
+{
+	struct kevent kev;
+	int kq, ret, pidfd;
+
+	if (pid == -1) {
+		return (waitpid_all(pid, status, options));
+	}
+	kq = kqueue();
+	if (kq == -1) {
+		return (-1);
+	}
+	pidfd = lookup_map_by_pid(pid);
+	if (pidfd == -1) {
+		/*
+		 * Do we need to return ESRCH here?
+		 */
+		errno = EINVAL;
+		return (-1);
+	}
+	EV_SET(&kev, pidfd, EVFILT_PROCDESC, EV_ADD, NOTE_EXIT, 0, NULL);
+	ret = kevent(kq, &kev, 1, NULL, 0, NULL);
+	if (ret == -1) {
+		return (-1);
+	}
+	while (1) {
+		ret = kevent(kq, NULL, 0, &kev, 1, NULL);
+		if (ret == -1) {
+			return (-1);
+		}
+		remove_map(pid);
+		*status = kev.data;
+		break;
+	}
+        return (pid);
+}
+
+pid_t
+fork(void)
+{
+	struct proc_map *pm;
+	pid_t pid;
+	int fd;
+
+	pm = calloc(1, sizeof(*pm));
+	if (pm == NULL) {
+		return (-1);
+	}
+	pid = pdfork(&fd, 0);
+	if (pid == 0 || pid == -1) {
+		free(pm);
+		return (pid);
+	}
+	pm->proc_fd = fd;
+	pm->proc_pid = pid;
+	pthread_mutex_lock(&map_mutex);
+	TAILQ_INSERT_HEAD(&proc_map_head, pm, proc_glue);
+	nprocs++;
+	pthread_mutex_unlock(&map_mutex);
+	return (pid);
+}
+
+pid_t
+vfork(void)
+{
+
+	return (fork());
+}
+
+int
+kill(pid_t pid, int sig)
+{
+	int fd;
+
+	fd = lookup_map_by_pid(pid);
+	if (fd == -1) {
+		errno = ESRCH;
+		return (-1);
+	}
+	return (pdkill(fd, sig));
+}
+
+int
+access(const char *path, int mode)
+{
+	int fd;
+
+	if (*path == '/') {
+		path++;
+	}
+	fd = sandbox_get_root_fd();
+	if (fd == -1) {
+		return (-1);
+	}
+	return (faccessat(fd, path, mode, 0));
+}
+
+int
+eaccess(const char *path, int mode)
+{
+	int fd;
+
+        if (*path == '/') {
+                path++;
+        }
+	fd = sandbox_get_root_fd();
+	if (fd == -1) {
+		return (-1);
+	}
+	return (faccessat(fd, path, mode, 0));
+}
+
+int
+stat(const char *path, struct stat *st)
+{
+	int fd;
+
+        if (*path == '/') {
+                path++;
+        }
+	fd = sandbox_get_root_fd();
+	if (fd == -1) {
+		return (-1);
+	}
+	return (fstatat(fd, path, st, AT_SYMLINK_NOFOLLOW));
+}
+
+int
+lstat(const char *path, struct stat *st)
+{
+	int fd;
+
+        if (*path == '/') {
+                path++;
+        }
+	fd = sandbox_get_root_fd();
+	if (fd == -1) {
+		return (-1);
+	}
+	return (fstatat(fd, path, st, AT_SYMLINK_NOFOLLOW));
+}
+
+int
+_open(const char *path, int flags, ...)
+{
+	va_list args;
+	int fd, mode;
+
+        if (*path == '/') {
+                path++;
+        }
+	va_start(args, flags);
+	mode = va_arg(args, int);
+	fd = sandbox_get_root_fd();
+	if (fd == -1) {
+		return (-1);
+	}
+	return (openat(fd, path, flags, mode));
+}
+
+int
+open(const char *path, int flags, ...)
+{
+	va_list args;
+	int mode;
+
+        if (*path == '/') {
+                path++;
+        }
+	va_start(args, flags);
+	mode = va_arg(args, int);
+	return (_open(path, flags, mode));
+}
+
+pid_t
+wait(int *status)
+{
+
+	return (waitpid(-1, status, 0));
+}
+
+pid_t
+wait4(pid_t pid, int *status, int options, struct rusage *rusage)
+{
+
+	return (waitpid(pid, status, options));
+}

--- a/deps/fcgi/sandbox.c
+++ b/deps/fcgi/sandbox.c
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifdef __linux__
+#ifdef SANDBOX_SECCOMP_FILTER_DEBUG
+# include <asm/siginfo.h>
+# define __have_siginfo_t 1
+# define __have_sigval_t 1
+# define __have_sigevent_t 1
+#endif
+
+#define SECCOMP_AUDIT_ARCH AUDIT_ARCH_X86_64
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/resource.h>
+#include <sys/prctl.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+
+#include <linux/net.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <elf.h>
+
+#include <asm/unistd.h>
+
+#include <sysexits.h>
+#include <errno.h>
+#include <assert.h>
+#include <err.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stddef.h>  /* for offsetof */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <libgen.h>
+
+#include "fcgi.h"
+#include "sandbox.h"
+
+#define H2O_SECCOMP_DEBUG 1
+#ifdef H2O_SECCOMP_DEBUG
+#define SECCOMP_FILTER_FAIL SECCOMP_RET_TRAP
+#else
+#define SECCOMP_FILTER_FAIL SECCOMP_RET_KILL
+#endif
+
+static const struct sock_filter basic_deny_insns[] = {
+    /* 
+     * Begin BPF filter program specification.
+     */
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
+        offsetof(struct seccomp_data, arch)),
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
+        offsetof(struct seccomp_data, nr)),
+#ifdef _NR_execveat
+    SC_ALLOW(__execveat),
+#endif
+#ifdef __NR_execve
+    SC_DENY(__NR_execve, EACCES),
+#endif
+#ifdef __NR_socketcall
+    SC_ALLOW_ARG(__NR_socketcall, 0, SYS_SHUTDOWN),
+    SC_DENY(__NR_socketcall, EACCES),
+#endif
+#ifdef __NR_socket
+    SC_DENY(__NR_socket, EACCES),
+#endif
+#ifdef __NR_ptrace
+    SC_DENY(__NR_ptrace, EACCES),
+#endif
+#ifdef __NR_kexec_load
+    SC_DENY(__NR_kexec_load, EACCES),
+#endif
+#ifdef __NR_exec_file_load
+    SC_DENY(__NR_exec_file_load, EACCES),
+#endif
+#ifdef __NR_shmget
+    SC_DENY(__NR_shmget, EACCES),
+#endif
+#ifdef __NR_shmat
+    SC_DENY(__NR_shmat, EACCES),
+#endif
+#ifdef __NR_shmctl
+    SC_DENY(__NR_shmctl, EACCES),
+#endif
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW),
+};  
+
+static const struct sock_fprog h2o_basic_program = {
+    .len = (sizeof(basic_deny_insns) / sizeof(basic_deny_insns[0])),
+    .filter = (struct sock_filter *)basic_deny_insns,
+};
+
+static int disect_path(char *orig, char **dir, char **base)
+{
+    char *dir_copy, *base_copy;
+
+    dir_copy = strdup(orig);
+    if (dir_copy == NULL) {
+        return (-1);
+    }
+    (void) dirname(dir_copy);
+    *dir = dir_copy;
+    if (*dir == NULL) {
+        return (-1);
+    }
+    base_copy = strdup(orig);
+    if (base_copy == NULL) {
+        free(dir_copy);
+        return (-1);
+    }
+    (void) basename(base_copy);
+    *base = base_copy;
+    if (*base == NULL) {
+        free(dir_copy);
+        free(base_copy);
+        return (-1);
+    }
+    return (0);
+}
+
+void sandbox_bind(int flags)
+{
+    const struct sock_fprog *fprog;
+
+    fprog = &h2o_basic_program;
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == -1) {
+        err(1, "prctl(PR_SET_NO_NEW_PRIVS)");
+    }
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, fprog) == -1) {
+        err(1, "prctl(PR_SET_SECCOMP)");
+    }
+    printf("[SANDBOX] fastcgi: type: Linux SECCOMP-BPF bound to process\n");
+}
+
+void sandbox_exec(struct wait_params *wp, char **argv, char **env)
+{
+    char *base, *dir;
+    int fd;
+
+    base = NULL;
+    fd = -1;
+    if (wp->do_sandbox) {
+        if (disect_path(*argv, &dir, &base)) {
+            errx(EX_OSERR, "failed to process supplied path");
+        }
+        fd = open(dir, O_RDONLY | O_DIRECTORY);
+        if (fd == -1) {
+            free(base);
+            free(dir);
+            err(1, "open('%s') failed", dir);
+        }
+        free(dir);
+    }
+    sandbox_bind(0);
+    switch (wp->do_sandbox) {
+    case 0:
+        execve(*argv, argv, env);
+        break;
+    default:
+        assert(base != NULL && fd >= 0);
+        syscall(__NR_execveat, fd, base, argv, env, 0);
+        break;
+    }
+    if (wp->do_sandbox) {
+        free(base);
+    }
+    err(EX_OSERR, "execveat failed: sandbox=%d", wp->do_sandbox);
+}
+#endif  /* __linux__ */
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/capsicum.h>
+
+#include <stdio.h>
+#include <assert.h>
+#include <err.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sysexits.h>
+
+#include "fcgi.h"
+#include "sandbox.h"
+
+/*
+ * Standard directories for runtime shared objects. We should probably make
+ * this tunable so the users can specify alternative paths if they want.
+ *
+ * NOTE: These paths must be relative to the sandbox root.
+ */
+static char *static_lib_dirs[] = {
+    "lib",
+    "usr/lib",
+    "usr/local/lib",
+    NULL
+};
+
+/*
+ * Construct the argv vector that will be used to execute the ELF laoder
+ * with the FastCGI handler + args.
+ */
+static char **rtld_argv(char **argv, int binfd)
+{
+    char **ret, **copy, *f, *p, namebuf[128];
+    size_t nalloc;
+    int counter;
+
+    assert(argv != NULL);
+    counter = 0;
+    copy = argv;
+    while ((p = *copy++)) {
+        counter++;
+    }
+    /*
+     * Allocate pointers for the number of fields in the original vector plus
+     * the 4 (described above), plus 1 for the terminating NULL pointer.
+     */
+    nalloc = counter + 4 + 1;
+    ret = calloc(nalloc, sizeof(p));
+    if (ret == NULL) {
+        err(1, "sandbox: failed to allocate memory");
+    }
+    (void) snprintf(namebuf, sizeof(namebuf), "[fcgi-sandbox] %s", *argv);
+    counter = 0;
+    p = strdup(namebuf);
+    if (p == NULL) {
+        err(1, "sandbox: failed to allocate memory");
+    }
+    ret[counter++] = p;
+    ret[counter++] = "-f";
+    (void) snprintf(namebuf, sizeof(namebuf), "%d", binfd);
+    p = strdup(namebuf);
+    if (p == NULL) {
+        err(1, "sandbox: failed to allocate memory");
+    }
+    ret[counter++] = p;
+    ret[counter++] = "--";
+    copy = argv;
+    while ((f = *copy++)) {
+        ret[counter++] = f;
+    }
+    ret[counter] = NULL;
+    return (ret);
+}
+
+/*
+ * Loop through a list containing all the standard lib directories relative
+ * to the sandbox root and obtain file descriptors for these directories.
+ * These file descriptors will be used by the runtime linker to load any
+ * runtime libraries. This is required because in capability mode, the
+ * linker will not have traditional access to the file system namespace.
+ */
+static char *emit_library_path_fds(void)
+{
+    char **lib_dirs, *dir, fdbuf[8], ret[1024], *ptr;
+    size_t total, count;
+    int fd;
+
+    count = 0;
+    total = sizeof(static_lib_dirs) / sizeof(static_lib_dirs[0]);
+    lib_dirs = static_lib_dirs;
+    bzero(ret, sizeof(ret));
+    while ((dir = *lib_dirs++)) {
+        count++;
+        fd = openat(AT_FDCWD, dir, O_DIRECTORY | O_RDONLY);
+        if (fd == -1) {
+            err(1, "sandbox: openat(%s) failed", dir);
+        }
+        snprintf(fdbuf, sizeof(fdbuf), "%d", fd);
+        strcat(ret, fdbuf);
+        if (count < total) {
+            strcat(ret, ":");
+        }
+    }
+    ptr = strdup(ret);
+    if (ptr == NULL) {
+        err(1, "sandbox: failed to alloc memory");
+    }
+    return (ptr);
+}
+
+/*
+ * Execute the FastCGI handler in the context of a Capsicum sandbox.
+ */
+void sandbox_exec(struct wait_params *wp, char **argv, char **env)
+{
+    char *lib_path_fds, **rtld_vec, fdbuf[8];
+    int rtld_fd, bin_fd, root_fd;
+    extern char **environ;
+
+    if (wp->do_sandbox == 0) {
+        execve(*argv, argv, env);
+        err(1, "execve(%s) failed: sandbox disabled", *argv);
+    }
+    /*
+     * We are in the chrooted sandbox, move to the root of the
+     * outer sandbox because our openat(2) operations will be
+     * relative to the root of the sandbox.
+     *
+     * In capability mode, we need to execute ELF using the
+     * ELF interpreter directly (rtld-elf). Open a file descritor
+     * to the interpreter first.
+     */
+    if (chdir("/") == -1) {
+        err(1, "sandbox: failed to chdir to sandbox root");
+    }
+    rtld_fd = openat(AT_FDCWD, "/libexec/ld-elf.so.1", O_RDONLY);
+    if (rtld_fd == -1) {
+        err(1, "sandbox: failed to open the ELF runtime linker");
+    }
+    /*
+     * In capability (sandbox) mode, we do not have access to the global
+     * file system namespace. If our executable is dynamically linked the
+     * runtime linker will need to know where to find the shared objects.
+     *
+     * Open a bunch of file descriptors for standard libraries containing
+     * the shared objects and stuff them into the LD_LIBRARY_PATH_FDS
+     * environment variable. The runtime linker will use these file descriptors
+     * to mmap(2) in the code instead of the pathnames.
+     */
+    lib_path_fds = emit_library_path_fds();
+    assert(lib_path_fds != NULL);
+    if (setenv("LD_LIBRARY_PATH_FDS", lib_path_fds, 1) != 0) {
+        err(1, "setenv(LD_LIBRARY_PATH_FDS) failed");
+    }
+    /*
+     * We want to faciliate some basic operations within the sandbox. We will
+     * set an environment variable telling the wrapper library where the
+     * sandbox file descriptor is.
+     *
+     * We will also specify the libc wrapper to preload. Otherwise fastcgi
+     * handlers that do not know they are running in a sandbox will attempt
+     * to access the global file system namespace, and this will not work
+     * when the process is in capability mode.
+     */
+    if (wp->libc_wrapper) {
+        root_fd = openat(AT_FDCWD, "/", O_RDONLY | O_DIRECTORY);
+        if (root_fd == -1) {
+            err(1, "openat(root fd) failed");
+        }
+        (void) snprintf(fdbuf, sizeof(fdbuf), "%d", root_fd);
+        if (setenv("H2O_SANDBOX_ROOT_FD", fdbuf, 1) != 0) {
+            err(1, "setenv(H2O_SANDBOX_ROOT_FD) failed");
+        }
+        if (setenv("LD_PRELOAD", wp->libc_wrapper, 1) != 0) {
+            err(1, "setenv(LD_PRELOAD) failed");
+        }
+    }
+    /*
+     * Now we need to get a file descriptor for the FastCGI handler itself.
+     * For example (/usr/local/bin/php-cgi). This process will be handling
+     * request data containing potentially malicious payloads.
+     *
+     * We will convert it to a string so we can pass it on the "command line"
+     * of the runtime when we activate the executable.
+     */
+    bin_fd = openat(AT_FDCWD, *argv, O_RDONLY);
+    if (bin_fd == -1) {
+        err(1, "openat(%s) failed", *argv);
+    }
+    rtld_vec = rtld_argv(argv, bin_fd);
+    sandbox_bind(0);
+    fexecve(rtld_fd, rtld_vec, environ);
+    err(EX_OSERR, "fexecve failed: sandbox enabled");
+}
+
+void sandbox_bind(int flags)
+{
+
+    if (cap_enter() == -1) {
+        err(1, "cap_enter() failed");
+    }
+    printf("[SANDBOX] fastcgi: type: FreeBSD CAPSICUM bound to process\n");
+}
+#endif  /* __FreeBSD */

--- a/deps/fcgi/sandbox.h
+++ b/deps/fcgi/sandbox.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020 Christian Peron
+ *
+ * This largely came from the OpenSSH seccomp filter code.
+ * There are obviously changes in the syscall execution profle
+ * so the policies have been updated to reflect that.
+ *
+ * Copyright (c) 2012 Will Drewry <wad@dataspill.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef SANDBOX_LINUX_DOT_H_
+#define SANDBOX_LINUX_DOT_H_
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+# define ARG_LO_OFFSET  0
+# define ARG_HI_OFFSET  sizeof(uint32_t)
+#elif __BYTE_ORDER == __BIG_ENDIAN
+# define ARG_LO_OFFSET  sizeof(uint32_t)
+# define ARG_HI_OFFSET  0
+#else
+#error "Unknown endianness"
+#endif
+
+/* Simple helpers to avoid manual errors (but larger BPF programs). */
+#define SC_DENY(_nr, _errno) \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 1), \
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ERRNO|(_errno))
+#define SC_ALLOW(_nr) \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 1), \
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW)
+#define SC_ALLOW_ARG(_nr, _arg_nr, _arg_val) \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 6), \
+    /* load and test syscall argument, low word */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_LO_OFFSET), \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, \
+        ((_arg_val) & 0xFFFFFFFF), 0, 3), \
+    /* load and test syscall argument, high word */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_HI_OFFSET), \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, \
+        (((uint32_t)((uint64_t)(_arg_val) >> 32)) & 0xFFFFFFFF), 0, 1), \
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW), \
+    /* reload syscall number; all rules expect it in accumulator */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, nr))
+
+#define SC_DENY_ARG_MASK(_nr, _arg_nr, _arg_mask) \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 8), \
+    /* load, mask and test syscall argument, low word */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_LO_OFFSET), \
+    BPF_STMT(BPF_ALU+BPF_AND+BPF_K, ~((_arg_mask) & 0xFFFFFFFF)), \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0, 0, 4), \
+    /* load, mask and test syscall argument, high word */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_HI_OFFSET), \
+    BPF_STMT(BPF_ALU+BPF_AND+BPF_K, \
+        ~(((uint32_t)((uint64_t)(_arg_mask) >> 32)) & 0xFFFFFFFF)), \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0, 0, 1), \
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL), \
+    /* reload syscall number; all rules expect it in accumulator */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, nr))
+
+/*
+ BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ERRNO|(_errno)),
+ BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
+ */
+/* Allow if syscall argument contains only values in mask */
+#define SC_ALLOW_ARG_MASK(_nr, _arg_nr, _arg_mask) \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, (_nr), 0, 8), \
+    /* load, mask and test syscall argument, low word */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_LO_OFFSET), \
+    BPF_STMT(BPF_ALU+BPF_AND+BPF_K, ~((_arg_mask) & 0xFFFFFFFF)), \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0, 0, 4), \
+    /* load, mask and test syscall argument, high word */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, args[(_arg_nr)]) + ARG_HI_OFFSET), \
+    BPF_STMT(BPF_ALU+BPF_AND+BPF_K, \
+        ~(((uint32_t)((uint64_t)(_arg_mask) >> 32)) & 0xFFFFFFFF)), \
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0, 0, 1), \
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ALLOW), \
+    /* reload syscall number; all rules expect it in accumulator */ \
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS, \
+        offsetof(struct seccomp_data, nr))
+
+void        sandbox_bind(int);
+void        sandbox_exec(struct wait_params *, char **, char **);
+
+#endif  /* SANDBOX_LINUX_DOT_H_ */

--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -104,6 +104,8 @@ static void RSA_set_flags(RSA *r, int flags)
 #endif
 
 #include "neverbleed.h"
+#include "h2o.h"
+#include "h2o/privsep.h"
 
 enum neverbleed_type { NEVERBLEED_TYPE_ERROR, NEVERBLEED_TYPE_RSA, NEVERBLEED_TYPE_ECDSA };
 
@@ -391,17 +393,15 @@ struct st_neverbleed_thread_data_t *get_thread_data(neverbleed_t *nb)
     }
 
     thdata->self_pid = self_pid;
-#ifdef SOCK_CLOEXEC
-    if ((thdata->fd = socket(PF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0)) == -1)
-        dief("socket(2) failed");
-#else
-    if ((thdata->fd = socket(PF_UNIX, SOCK_STREAM, 0)) == -1)
-        dief("socket(2) failed");
-    set_cloexec(thdata->fd);
-#endif
-    while (connect(thdata->fd, (void *)&nb->sun_, sizeof(nb->sun_)) != 0)
-        if (errno != EINTR)
-            dief("failed to connect to privsep daemon");
+    /*
+     * This code is running in the context of the non-privileged, sandboxed
+     * h2o main process. Because of this we must use the privsep interface
+     * to access the neverbleed socket so we can offload our operations.
+     */
+    thdata->fd = h2o_priv_get_neverbleed_sock(&nb->sun_);
+    if (thdata->fd == -1) {
+        dief("failed to get neverbleed connection via privsep");
+    }
     while ((r = write(thdata->fd, nb->auth_token, sizeof(nb->auth_token))) == -1 && errno == EINTR)
         ;
     if (r != sizeof(nb->auth_token))
@@ -1042,7 +1042,7 @@ static int load_key_stub(struct expbuf_t *buf)
         return -1;
     }
 
-    if ((fp = fopen(fn, "rt")) == NULL) {
+    if ((fp = h2o_priv_fopen(fn, "rt")) == NULL) {
         strerror_r(errno, errbuf, sizeof(errbuf));
         goto Respond;
     }
@@ -1201,6 +1201,11 @@ static int setuidgid_stub(struct expbuf_t *buf)
         warnf("%s: setuid(%d) failed\n", __FUNCTION__, (int)pw->pw_uid);
         goto Respond;
     }
+    /*
+     * Now that we have successfully setuid, changed socket permissions etc
+     * we can enter sandbox mode.
+     */
+    h2o_priv_bind_sandbox(SANDBOX_POLICY_NEVERBLEED);
     ret = 0;
 
 Respond:
@@ -1367,6 +1372,39 @@ Exit:
     return NULL;
 }
 
+static void set_privsep_socket(void)
+{
+    extern char *privsep_sock_path;
+    struct sockaddr_un sun;
+    int sock, ret;
+
+    /*
+     * Activate the neverbleed sandbox policy. We already have our socket
+     * descriptor that h2o will use for cryptographic operations. The only
+     * additional access we will need into the global namespace(s) is to
+     * access TLS certificate data. Create and connect a socket to the
+     * privsep process, and use this for any subsequent file system operations.
+     */
+    sock = socket(PF_UNIX, SOCK_STREAM, 0);
+    if (sock == -1) {
+        abort();
+    }
+    assert(privsep_sock_path != NULL);
+    bzero(&sun, sizeof(sun));
+    sun.sun_family = PF_UNIX;
+    snprintf(sun.sun_path, sizeof(sun.sun_path), "%s", privsep_sock_path);
+    while (1) {
+        ret = connect(sock, (struct sockaddr *)&sun, sizeof(sun));
+        if (ret == -1 && errno == EINTR) {
+            continue;
+        } else if (ret == -1) {
+            abort();
+        }
+        break;
+    }
+    h2o_privsep_set_global_sock(sock);
+}
+
 __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notify_fd, const char *tempdir)
 {
     pthread_t tid;
@@ -1384,6 +1422,12 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
 
     pthread_attr_init(&thattr);
     pthread_attr_setdetachstate(&thattr, 1);
+
+    /*
+     * Setup the global serialized socket for privsep operations. Make sure
+     * this stays after we close all the file descriptors in the process.
+     */
+    set_privsep_socket();
 
     if (pthread_create(&tid, &thattr, daemon_close_notify_thread, (char *)NULL + close_notify_fd) != 0)
         dief("pthread_create failed");
@@ -1486,6 +1530,7 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf)
         snprintf(errbuf, NEVERBLEED_ERRBUF_SIZE, "listen(2) failed:%s", strerror(errno));
         goto Fail;
     }
+    h2o_priv_set_neverbleed_path(nb->sun_.sun_path);
     nb->daemon_pid = fork();
     switch (nb->daemon_pid) {
     case -1:

--- a/deps/picotls/lib/cifra/random.c
+++ b/deps/picotls/lib/cifra/random.c
@@ -34,6 +34,9 @@
 #include "drbg.h"
 #include "picotls.h"
 #include "picotls/minicrypto.h"
+#include "h2o.h"
+#include "h2o/privsep.h"
+
 #include <stdio.h>
 #ifdef _WINDOWS
 #ifdef _WINDOWS_XP
@@ -86,8 +89,8 @@ static void read_entropy(uint8_t *entropy, size_t size)
 {
     int fd;
 
-    if ((fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC)) == -1) {
-        if ((fd = open("/dev/random", O_RDONLY | O_CLOEXEC)) == -1) {
+    if ((fd = h2o_priv_open("/dev/urandom", O_RDONLY | O_CLOEXEC)) == -1) {
+        if ((fd = h2o_priv_open("/dev/random", O_RDONLY | O_CLOEXEC)) == -1) {
             perror("ptls_minicrypto_random_bytes: could not open neither /dev/random or /dev/urandom");
             abort();
         }

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -324,6 +324,11 @@ typedef enum h2o_send_informational_mode {
 
 struct st_h2o_globalconf_t {
     /**
+     * Chroot path for outer sandbox if we aren't running in a container
+     * or jail.
+     */
+    char    *privsep_dir;
+    /**
      * a NULL-terminated list of host contexts (h2o_hostconf_t)
      */
     h2o_hostconf_t **hosts;

--- a/include/h2o/privsep.h
+++ b/include/h2o/privsep.h
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef PRIVSEP_DOT_H_
+#define PRIVSEP_DOT_H_
+#include <sys/types.h>
+#include <pwd.h>
+
+#include "h2o.h"
+
+#define H2O_CMD_BUF 1024
+#define H2O_TZ_BUF  32
+
+struct h2o_privsep_watpid {
+    int                 pid;
+    int                 options;
+};
+typedef struct h2o_privsep_watpid h2o_privsep_watpid_t;
+
+struct h2o_fd_mapping {
+    int     type;
+#define H2O_FDMAP_WRITE_TO_PROC     1
+#define H2O_FDMAP_READ_FROM_PROC    2
+#define H2O_FDMAP_SEND_TO_PROC      3
+#define H2O_FDMAP_BASIC             4
+    int     from;
+    int     to;
+    int     pipefds[2];
+};
+typedef struct h2o_fd_mapping h2o_fd_mapping_t;
+
+struct h2o_exec_context {
+    struct h2o_fd_mapping   *fdmaps;
+    int                      maps_alloc;
+    int                      maps_used;
+};
+typedef struct h2o_exec_context h2o_exec_context_t;
+
+struct h2o_privsep_sendmsg {
+    size_t              msg_namelen;
+    size_t              msg_iovlen;
+    size_t              msg_controllen;
+    int                 flags;
+};
+typedef struct h2o_privsep_sendmsg h2o_privsep_sendmsg_t;
+
+struct h2o_privsep_open_listener {
+    int                         domain;
+    int                         type;
+    int                         protocol;
+    struct sockaddr_storage     sas;
+    socklen_t                   addrlen;
+    int                         reuseport;
+};
+typedef struct h2o_privsep_open_listener h2o_privsep_open_listener_t;
+
+struct h2o_privsep_socket_worker {
+    h2o_globalconf_t    *gcp;
+    int                  sock;
+};
+typedef struct h2o_privsep_socket_worker h2o_privsep_socket_worker_t;
+
+struct privsep_worker {
+    pthread_t            thr;
+    int                  sock;
+    h2o_globalconf_t    *gcp;
+};
+
+typedef struct privsep_worker privsep_worker_t;
+
+int     privsep_init(h2o_globalconf_t *);
+int     privsep_set_neverbleed_path(const char *);
+void    privsep_bind_sandbox(int);
+
+
+struct h2o_privsep_neverbleed_path {
+    char                    path[512];
+};
+typedef struct h2o_privsep_neverbleed_path h2o_privsep_neverbleed_path_t;
+
+struct h2o_privsep_open {
+    char                    path[512];
+    int                     flags;
+    mode_t                  mode;
+};
+typedef struct h2o_privsep_open h2o_privsep_open_t;
+
+struct h2o_privsep_getaddrinfo {
+    char                    hostname[256];
+    char                    servname[256];
+    struct addrinfo         hints;
+};
+typedef struct h2o_privsep_getaddrinfo h2o_privsep_getaddrinfo_t;
+
+struct h2o_privsep_getaddrinfo_result {
+    int                     ai_flags;
+	int                     ai_family;
+	int                     ai_socktype;
+	int                     ai_protocol;
+	socklen_t               ai_addrlen;
+	struct sockaddr_storage sas;
+	char                    ai_canonname[256];
+};
+typedef struct h2o_privsep_getaddrinfo_result h2o_privsep_getaddrinfo_result_t;
+
+struct h2o_privsep {
+    int     ps_sock;
+};
+typedef struct h2o_privsep h2o_privsep_t;
+
+#define PRIVSEP_STATE_ACTIVE    1
+#define PRIVSEP_STATE_OFF       2
+
+/*
+ * Define a set of privsep features. These flags will control OS specific
+ * aspects of the sandboxing operations.
+ */
+#define SANDBOX_ALLOWS_SENDMSG  0x0000000000000001
+#define PRIVSEP_PRIVILEGED      0x0000000000000002
+#define PRIVSEP_NON_PRIVILEGED  0x0000000000000004
+
+enum {
+    SANDBOX_POLICY_NONE,
+    SANDBOX_POLICY_NEVERBLEED,
+    SANDBOX_POLICY_H2OMAIN
+};
+
+enum {
+    PRIV_NONE,
+    PRIV_OPEN,
+    PRIV_PRIVSEP_SOCK,
+    PRIV_NEVERBLEED_SOCK,
+    PRIV_SET_NEVERBLEED_PATH,
+    PRIV_GETADDRINFO,
+    PRIV_CONNECT,
+    PRIV_DROP_PRIVS,
+    PRIV_OPEN_LISTENER,
+    PRIV_SENDMSG,
+    PRIV_FD_MAPPED_EXEC,
+    PRIV_WAITPID,
+    PRIV_GMTIME,
+    PRIV_LOCALTIME
+};
+
+/*
+ * Wrapper functions for privsep/regular mode.
+ */
+int              h2o_priv_init(h2o_globalconf_t *);
+void             h2o_priv_bind_sandbox(int);
+int              h2o_priv_get_neverbleed_sock(struct sockaddr_un *);
+int              h2o_priv_open(const char *, int, ...);
+int              h2o_priv_getaddrinfo(const char *, const char *,
+                   const struct addrinfo *, struct addrinfo **);
+int              h2o_priv_connect_sock_noblock(struct sockaddr_storage *, int *, int *);
+void             h2o_priv_set_neverbleed_path(const char *);
+int              h2o_priv_open_listener(int, int, int, struct sockaddr_storage *,
+                   socklen_t, int);
+ssize_t          h2o_priv_sendmsg(int, struct msghdr *, int);
+void             h2o_priv_freeaddrinfo(struct addrinfo *);
+void             h2o_priv_init_exec_context(h2o_exec_context_t *);
+void             h2o_priv_cleanup_exec_context(h2o_exec_context_t *);
+void             h2o_priv_bind_fd(h2o_exec_context_t *, int, int, int);
+pid_t            h2o_priv_exec(h2o_exec_context_t *, const char *, char *const [], int);
+pid_t            h2o_priv_waitpid(pid_t, int *, int);
+void             h2o_priv_sandbox_hints(char *);
+char **          h2o_priv_init_fastcgi(char *, char *, char *);
+char **          h2o_priv_gen_env(void);
+struct tm *      h2o_priv_gmtime_r(const time_t *, struct tm *);
+void             h2o_priv_gmtime_cleanup(struct tm *);
+struct tm *      h2o_priv_localtime_r(const time_t *, struct tm *);
+void             h2o_priv_localtime_cleanup(struct tm *);
+FILE *           h2o_priv_fopen(const char * restrict, const char * restrict);
+/*
+ * All privilege operation prototypes
+ */
+void             h2o_allpriv_bind_sandbox(int);
+int              h2o_allpriv_get_neverbleed_sock(struct sockaddr_un *);
+int              h2o_allpriv_open(const char *, int, ...);
+int              h2o_allpriv_getaddrinfo(const char *, const char *,
+                   const struct addrinfo *, struct addrinfo **);
+int              h2o_allpriv_connect_sock_noblock(struct sockaddr_storage *, int *, int *);
+int              h2o_allpriv_init(h2o_globalconf_t *);
+int              h2o_allpriv_open_listener(int, int, int, struct sockaddr_storage *,
+                  socklen_t, int);
+ssize_t          h2o_allpriv_sendmsg(int, struct msghdr *, int);
+pid_t            h2o_allpriv_exec(h2o_exec_context_t *, const char *, char *const [],
+                   char **, int);
+char **          h2o_allpriv_init_fastcgi(char *, char *, char *);
+/*
+ * Privsep operation prototypes
+ */
+FILE            *h2o_privsep_fopen(const char * restrict,
+                   const char * restrict);
+struct tm *      h2o_privsep_dotime_r(const time_t *, struct tm *, int);
+pid_t            h2o_privsep_waitpid(pid_t, int *, int);
+void             h2o_privsep_bind_sandbox(int);
+int              h2o_privsep_init(h2o_globalconf_t *);
+int              h2o_privsep_activate(void);
+int              h2o_privsep_may_read(int, void *, size_t);
+void             h2o_privsep_must_readv(int, const struct iovec *, int);
+void             h2o_privsep_must_writev(int, const struct iovec *, int);
+void             h2o_privsep_must_read(int, void *, size_t);
+void             h2o_privsep_must_write(int, void *, size_t);
+void             h2o_privsep_send_fd(int, int);
+int              h2o_privsep_receive_fd(int);
+h2o_privsep_t   *h2o_get_tsd(void);
+int              h2o_privsep_set_global_sock(int);
+int              h2o_privsep_open(const char *, int, ...);
+int              h2o_privsep_get_neverbleed_sock(void);
+void             h2o_privsep_set_neverbleed_path(const char *);
+int              h2o_privsep_getaddrinfo(const char *, const char *,
+                   const struct addrinfo *, struct addrinfo **);
+int              h2o_privsep_connect_sock_noblock(struct sockaddr_storage *,
+                   int *, int *);
+int              h2o_privsep_drop_privs(void);
+void             h2o_privsep_event_loop(h2o_globalconf_t *, int, int);
+int              h2o_privsep_open_listener(int, int, int,
+                   struct sockaddr_storage *, socklen_t, int);
+ssize_t          h2o_privsep_sendmsg(int, struct msghdr *, int);
+void             h2o_privsep_freeaddrinfo(struct addrinfo *);
+pid_t            h2o_privsep_exec(h2o_exec_context_t *, const char *,
+                   char *const [],
+                   char **, int);
+char            *h2o_privsep_marshal_vec(char *const [], size_t *);
+char            **h2o_privsep_unmarshal_vec(char *, size_t);
+void             h2o_privsep_sandbox_hints(char *);
+char **          h2o_privsep_init_fastcgi(char *, char *, char *);
+FILE *           h2o_privsep_fopen(const char * restrict,
+                   const char * restrict);
+
+void             sandbox_bind_linux(int);
+void             sandbox_bind_freebsd(int);
+void             sandbox_emit_linux_hints(char *);
+void             sandbox_emit_freebsd_hints(char *);
+
+#endif /* PRIVSEP_DOT_H_ */

--- a/lib/common/allpriv.c
+++ b/lib/common/allpriv.c
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <sysexits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "h2o.h"
+#include "h2o/configurator.h"
+#include "h2o/privsep.h"
+
+/*
+ * NB: We need to move this to a central location so it can be sucked in by
+ * main.c and allpriv.c
+ */
+#if defined(__linux) && defined(SO_REUSEPORT)
+#define H2O_HTTP3_USE_REUSEPORT 1
+#define H2O_SO_REUSEPORT SO_REUSEPORT
+#elif defined(SO_REUSEPORT_LB) /* FreeBSD */
+#define H2O_HTTP3_USE_REUSEPORT 1
+#define H2O_SO_REUSEPORT SO_REUSEPORT_LB
+#else
+#define H2O_HTTP3_USE_REUSEPORT 0
+#endif
+
+char **h2o_allpriv_init_fastcgi(char *sock_dir, char *spawn_user,
+    char *spawn_cmd)
+{
+    char **argv, *kill_on_close_cmd_path, *setuidgid_cmd_path;
+    size_t index, alloc;
+
+    alloc = 32;
+    argv = calloc(alloc, sizeof(argv));
+    if (argv == NULL) {
+        return (NULL);
+    }
+    index = 0;
+    kill_on_close_cmd_path = h2o_configurator_get_cmd_path("share/h2o/kill-on-close");
+    argv[index++] = kill_on_close_cmd_path;
+    argv[index++] = "--rm";
+    argv[index++] = sock_dir;
+    argv[index++] = "--";
+    if (spawn_user != NULL) {
+        setuidgid_cmd_path = h2o_configurator_get_cmd_path("share/h2o/setuidgid");
+        argv[index++] = setuidgid_cmd_path;
+        argv[index++] = spawn_user;
+    }
+    argv[index++] = "/bin/sh";
+    argv[index++] = "-c";
+    argv[index++] = spawn_cmd;
+    argv[index++] = NULL;
+    assert(index < 32);
+    return (argv);
+}
+
+pid_t h2o_allpriv_exec(h2o_exec_context_t *ec, const char *cmd,
+  char *const argv[], char **env, int policy)
+{
+    int error_pipe[2], ecode, ret, k;
+    extern char **environ;
+    char **envp;
+    ssize_t cc;
+    pid_t pid;
+
+    if (pipe2(error_pipe, O_CLOEXEC) == -1) {
+        return (-1);
+    }
+    pid = fork();
+    if (pid == -1) {
+        return (-1);
+    }
+    if (pid == 0) {
+        /*
+         * Overlay the file descriptors per the mapping specification in the
+         * the caller. h2o_read_command() has a different mapping specification
+         * than the backtrace producer. I think we have captured all the use
+         * cases for this feature.
+         */
+        for (k = 0; k < ec->maps_used; k++) {
+            dup2(ec->fdmaps[k].from, ec->fdmaps[k].to);
+        }
+        envp = h2o_priv_gen_env();
+        if (envp != NULL) {
+            environ = envp;
+        }
+        (void) execvp(cmd, argv);
+        ecode = errno;
+        (void) write(error_pipe[1], &ecode, sizeof(ecode));
+        _exit(EX_SOFTWARE);
+    }
+    close(error_pipe[1]);
+    while (1) {
+        cc = read(error_pipe[0], &ecode, sizeof(ecode));
+        if (cc == -1 && errno == EINTR) {
+            continue;
+        }
+        /*
+         * EOF on this file descriptor is what we want to see. It means that
+         * the exec(2) was successful, and the file descriptor was closed as
+         * as a result. If this is the case, break from the loop and deliver
+         * the PID to the caller.
+         */
+        if (cc == 0) {
+            break;
+        }
+        /*
+         * If we received data, it was the child process informing us that the
+         * exec(2) operation was not successful. Copy the error code and and
+         * send it to the caller. Call waitpid(2) to collect the exit status
+         * since it's invariant that the process is dead.
+         */
+        while (1) {
+            ret = waitpid(pid, NULL, 0);
+            if (ret == -1 && errno == EINTR) {
+                continue;
+            } else if (ret == -1) {
+                ecode = errno;
+            }
+            break;
+        }
+        errno = ecode;
+        return (-1);
+    }
+    return (pid);
+}
+
+ssize_t h2o_allpriv_sendmsg(int sock, struct msghdr *msg, int flag)
+{
+
+    return (sendmsg(sock, msg, flag));
+}
+
+int h2o_allpriv_open_listener(int domain, int type, int protocol,
+  struct sockaddr_storage *addr, socklen_t addrlen, int reuseport)
+{
+    int fd, flag;
+
+    /*
+     * NB: we need to propagate the specific error back to the caller.
+     */
+    if ((fd = socket(domain, type, protocol)) == -1) {
+        return (-1);
+    }
+    if (fcntl(fd, F_SETFD, O_CLOEXEC) == -1) {
+        close(fd);
+        return (-1);
+    }
+    /* if the socket is TCP, set SO_REUSEADDR flag to avoid TIME_WAIT after shutdown */
+    if (type == SOCK_STREAM) {
+        flag = 1;
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) != 0) {
+            close(fd);
+            return (-1);
+        }
+    }
+#ifdef IPV6_V6ONLY
+    /* set IPv6only */
+    if (domain == AF_INET6) {
+        flag = 1;
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &flag, sizeof(flag)) != 0) {
+            close(fd);
+            return (-1);
+        }
+    }
+#endif
+    if (reuseport) {
+#if H2O_HTTP3_USE_REUSEPORT
+        flag = 1;
+        if (setsockopt(fd, SOL_SOCKET, H2O_SO_REUSEPORT, &flag, sizeof(flag)) != 0) {
+            fprintf(stderr, "[warning] setsockopt(SO_REUSEPORT) failed:%s\n", strerror(errno));
+        }
+#endif
+    }
+    if (bind(fd, (struct sockaddr *)addr, addrlen) != 0) {
+        close(fd);
+        return (-1);
+    }
+
+    /* TCP-specific actions */
+    if (protocol == IPPROTO_TCP) {
+        /* listen */
+        if (listen(fd, H2O_SOMAXCONN) != 0) {
+            close(fd);
+            return (-1);
+        }
+    }
+    return (fd);
+}
+
+void h2o_allpriv_bind_sandbox(int policy)
+{
+}
+
+int h2o_allpriv_init(h2o_globalconf_t *gcp)
+{
+
+    return (0);
+}
+
+int h2o_allpriv_get_neverbleed_sock(struct sockaddr_un *sun)
+{
+    int sock;
+
+#ifdef SOCK_CLOEXEC
+    sock = socket(PF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+#else
+    sock = socket(PF_UNIX, SOCK_STREAM, 0);
+#endif
+    if (sock == -1) {
+        return (-1);
+    }
+#ifndef SOCK_CLOEXEC
+    if (fcntl(sock, F_SETFD, O_CLOEXEC) == -1) {
+        return (-1);
+    }
+#endif
+    while (connect(sock, (void *)sun, sizeof(*sun)) != 0)    
+        if (errno != EINTR) 
+            return (-1);
+    return (sock);
+}
+
+int h2o_allpriv_open(const char *path, int flags, ...)
+{
+    /*
+     * NB: need to use va_args to extract mode if present.
+     */
+    return (open(path, flags, 0));
+}
+
+int h2o_allpriv_getaddrinfo(const char *hostname, const char *servname,
+  const struct addrinfo *hints, struct addrinfo **res)
+{
+
+    return (getaddrinfo(hostname, servname, hints, res));
+}
+
+int h2o_allpriv_connect_sock_noblock(struct sockaddr_storage *sas,
+    int *sock_ret, int *connect_ret)
+{
+    socklen_t sl;
+    int sock;
+
+#ifdef SOCK_CLOEXEC
+    sock = socket(PF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+#else
+    sock = socket(PF_UNIX, SOCK_STREAM, 0);
+#endif 
+    if (sock == -1) {
+        *sock_ret = sock;
+        return (-1);
+    }
+    (void) fcntl(sock, F_SETFL, O_NONBLOCK);
+    switch (sas->ss_family) {
+    case PF_UNIX:
+        sl = sizeof(struct sockaddr_un);
+        break;
+    case PF_INET:
+        sl = sizeof(struct sockaddr_in);
+        break;
+    case PF_INET6:
+        sl = sizeof(struct sockaddr_in6);
+        break;
+    default:
+        abort();
+    }
+    *connect_ret = connect(sock, (void *)sas, sl);
+    return (sock);
+}

--- a/lib/common/priv_wrapper.c
+++ b/lib/common/priv_wrapper.c
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <err.h>
+
+#include "h2o.h"
+#include "h2o/privsep.h"
+
+static int privsep_state = PRIVSEP_STATE_OFF;
+
+FILE *h2o_priv_fopen(const char * restrict path, const char * restrict mode)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_fopen(path, mode));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (fopen(path, mode));
+        break;
+    }
+    return (NULL);
+}
+
+void h2o_priv_localtime_cleanup(struct tm *result)
+{
+
+    /* NB: storage for the timezone data */
+}
+
+void h2o_priv_gmtime_cleanup(struct tm *result)
+{
+
+    /* NB: storage for the timezone data */
+}
+
+struct tm *h2o_priv_localtime_r(const time_t *clock, struct tm *result)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_dotime_r(clock, result, PRIV_LOCALTIME));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (localtime_r(clock, result));
+        break;
+    default:
+        abort();
+    }
+    return (NULL);
+}
+
+struct tm *h2o_priv_gmtime_r(const time_t *clock, struct tm *result)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_dotime_r(clock, result, PRIV_GMTIME));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (gmtime_r(clock, result));
+        break;
+    default:
+        abort();
+    }
+    return (NULL);
+}
+
+char **h2o_priv_init_fastcgi(char *sock_dir, char *spawn_user,
+    char *spawn_cmd)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_init_fastcgi(sock_dir, spawn_user, spawn_cmd));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (h2o_allpriv_init_fastcgi(sock_dir, spawn_user, spawn_cmd));
+        break;
+    default:
+        abort();
+    }
+    return (NULL);
+}
+
+char **h2o_priv_gen_env(void)
+{
+    extern char **environ;
+    size_t num;
+
+    /* calculate number of envvars, as well as looking for H2O_ROOT= */
+    for (num = 0; environ[num] != NULL; ++num)
+        if (strncmp(environ[num], "H2O_ROOT=", sizeof("H2O_ROOT=") - 1) == 0)
+            return (NULL);
+    /* not found */
+    char **newenv = h2o_mem_alloc(sizeof(*newenv) * (num + 2) + sizeof("H2O_ROOT=" H2O_TO_STR(H2O_ROOT)));
+    memcpy(newenv, environ, sizeof(*newenv) * num);
+    newenv[num] = (char *)(newenv + num + 2);
+    newenv[num + 1] = NULL;
+    strcpy(newenv[num], "H2O_ROOT=" H2O_TO_STR(H2O_ROOT));
+    return (newenv);
+}
+
+pid_t h2o_priv_waitpid(pid_t pid, int *stat_loc, int options)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_waitpid(pid, stat_loc, options));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (waitpid(pid, stat_loc, options));
+        break;
+    default:
+        abort();
+    }
+}
+
+pid_t h2o_priv_exec(h2o_exec_context_t *ec, const char *cmd,
+  char *const argv[], int policy)
+{
+    char **env;
+
+    env = h2o_priv_gen_env();
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_exec(ec, cmd, argv, env, policy));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (h2o_allpriv_exec(ec, cmd, argv, env, policy));
+        break;
+    default:
+        abort();
+    }
+    /* NB: need to know whether h2o_priv_gen_env allocated a new env */
+}
+
+void h2o_priv_cleanup_exec_context(h2o_exec_context_t *ec)
+{
+
+    assert(ec->fdmaps != NULL);
+    free(ec->fdmaps);
+}
+
+void h2o_priv_bind_fd(h2o_exec_context_t *ec, int from, int to, int type)
+{
+    h2o_fd_mapping_t *map;
+
+    if (ec->maps_alloc == 0) {
+        ec->fdmaps = calloc(4, sizeof(h2o_fd_mapping_t));
+        ec->maps_alloc = 4;
+    } else if (ec->maps_used == ec->maps_alloc) {
+        ec->maps_alloc += 2;
+        ec->fdmaps = realloc(ec->fdmaps,
+            ec->maps_alloc * sizeof(h2o_fd_mapping_t));
+    }
+    assert(ec != NULL);
+    assert(from >= 0);
+    assert(to >= 0);
+    map = &ec->fdmaps[ec->maps_used++];
+    map->from = from;
+    map->to = to;
+    map->type = type;
+}
+
+void h2o_priv_init_exec_context(h2o_exec_context_t *ec)
+{
+
+    assert(ec != NULL);
+    ec->maps_alloc = 0;
+    ec->maps_used = 0;
+    ec->fdmaps = NULL;
+}
+
+/*
+ * The privsep constructed addrinfo structures use a bit more heap storage than
+ * the libc versions. As a result, the the privsep constructed addrinfo needs
+ * it's own destuctor, as using freeaddrinfo(3) will miss the socket addr
+ * storage.
+ */
+void h2o_priv_freeaddrinfo(struct addrinfo *ai)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        h2o_privsep_freeaddrinfo(ai);
+        break;
+    case PRIVSEP_STATE_OFF:
+        freeaddrinfo(ai);
+        break;
+    default:
+        abort();
+    }
+}
+
+void h2o_priv_sandbox_hints(char *root)
+{
+
+    h2o_privsep_sandbox_hints(root);
+}
+
+/*
+ * We are currently using sendmsg(2) to transmit H3 UDP packets. Because of the
+ * arbitrary connectionless peer specification, it has been considered a
+ * dangerous syscall. We need to implement a privilege for it.
+ */
+ssize_t h2o_priv_sendmsg(int sock, struct msghdr *msg, int flags)
+{
+
+    /*
+     * NB: depending on the operating system, we may allow sendmsg() in
+     * sandbox mode. We need a flag that is specified to control whether
+     * or not we want to use the privsep version of this function.
+     */
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_sendmsg(sock, msg, flags));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (h2o_allpriv_sendmsg(sock, msg, flags));
+        break;
+    default:
+        abort();
+    }
+}
+
+/*
+ * We need to define a privilege to setup listeners. This is primarily for the
+ * H2O_HTTP3_USE_REUSEPORT case in the run_loop when the sandbox has been bound
+ * to the thread.
+ */
+int h2o_priv_open_listener(int domain, int type, int protocol,
+  struct sockaddr_storage *addr, socklen_t addrlen, int reuseport)
+{
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_open_listener(domain, type, protocol, addr,
+          addrlen, reuseport));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (h2o_allpriv_open_listener(domain, type, protocol, addr,
+          addrlen, reuseport));
+        break;
+    default:
+        abort();
+    }
+}
+
+int h2o_priv_init(h2o_globalconf_t *gcp)
+{
+
+    assert(privsep_state == PRIVSEP_STATE_OFF);
+    if (gcp->privsep_dir == NULL) {
+        privsep_state = PRIVSEP_STATE_OFF;
+        h2o_allpriv_init(gcp);
+        return (0);
+    }
+    privsep_state = PRIVSEP_STATE_ACTIVE;
+    return (h2o_privsep_init(gcp));
+}
+
+void h2o_priv_bind_sandbox(int policy)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        h2o_privsep_bind_sandbox(policy);
+        break;
+    case PRIVSEP_STATE_OFF:
+        h2o_allpriv_bind_sandbox(policy);
+        break;
+    default:
+        abort();
+    }
+}
+
+void h2o_priv_set_neverbleed_path(const char *path)
+{
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        h2o_privsep_set_neverbleed_path(path);
+        break;
+    case PRIVSEP_STATE_OFF:
+        break;
+    default:
+        abort();
+    }
+}
+
+int h2o_priv_get_neverbleed_sock(struct sockaddr_un *sun)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_get_neverbleed_sock());
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (h2o_allpriv_get_neverbleed_sock(sun));
+        break;
+    default:
+        abort();
+    }
+    /* NOTREACHED */
+    return (-1);
+}
+
+int h2o_priv_open(const char *path, int flag, ...)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_open(path, flag, 0));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (h2o_allpriv_open(path, flag, 0));
+        break;
+    default:
+        abort();
+    }
+    /* NOTREACHED */
+    return (-1);
+}
+
+int h2o_priv_getaddrinfo(const char *host, const char *servname,
+  const struct addrinfo *hints, struct addrinfo **res)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_getaddrinfo(host, servname, hints, res));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (h2o_allpriv_getaddrinfo(host, servname, hints, res));
+        break;
+    default:
+        abort();
+    }
+    /* NOTREACHED */
+    return (-1);
+
+}
+
+int h2o_priv_connect_sock_noblock(struct sockaddr_storage *sas,
+  int *sock_ret, int *connect_ret)
+{
+
+    assert(privsep_state != 0);
+    switch (privsep_state) {
+    case PRIVSEP_STATE_ACTIVE:
+        return (h2o_privsep_connect_sock_noblock(sas, sock_ret, connect_ret));
+        break;
+    case PRIVSEP_STATE_OFF:
+        return (h2o_allpriv_connect_sock_noblock(sas, sock_ret, connect_ret));
+        break;
+    default:
+        abort();
+    }
+    /* NOTREACHED */
+    return (-1);
+}

--- a/lib/common/privsep.c
+++ b/lib/common/privsep.c
@@ -1,0 +1,944 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <sys/uio.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <err.h>
+
+#include "h2o.h"
+#include "h2o/configurator.h"
+#include "h2o/privsep.h"
+
+/*
+ * New threads will be created in the sandbox. To get their thread specific
+ * socket for the privsep operations, serialize them on the socket-pair.
+ * This serialization only happens to get the initial socket to bind in
+ * thread specific data. All subsequent operations will be parallelized.
+ */
+static pthread_mutex_t privsep_mutex;
+static pthread_key_t privsep_key;
+extern int privsep_global_sock;
+static int privsep_active;
+extern int privsep_flags;
+
+/*
+ * This function was largely lifted from FreeBSD which distributes
+ * this file/function under the BSD-3-Clause license.
+ */
+static int h2o_priv_mode_to_flags(const char *mode, int *flagsptr)
+{
+    int m, o, known;
+
+    switch (*mode++) {
+    case 'r':   /* open for reading */
+        m = O_RDONLY;
+        o = 0;
+        break;
+    case 'w':   /* open for writing */
+        m = O_WRONLY;
+        o = O_CREAT | O_TRUNC;
+        break;
+    case 'a':   /* open for appending */
+        m = O_WRONLY;
+        o = O_CREAT | O_APPEND;
+        break;
+    default:    /* illegal mode */
+        errno = EINVAL;
+        return (-1);
+    }
+    do {
+        known = 1;
+        switch (*mode++) {
+        case 'b':
+            /* 'b' (binary) is ignored */
+            break;
+        case '+':
+            m = O_RDWR;
+            break;
+        case 'x':
+            /* 'x' means exclusive (fail if the file exists) */
+            o |= O_EXCL;
+            break;
+#ifdef O_CLOEXEC
+        case 'e':
+            /* set close-on-exec */
+            o |= O_CLOEXEC;
+            break;
+#endif
+        default:
+            known = 0;
+            break;
+        }
+    } while (known);
+    if ((o & O_EXCL) != 0 && m == O_RDONLY) {
+        errno = EINVAL;
+        return (-1);
+    }
+    *flagsptr = m | o;
+    return (0);
+}
+
+FILE *h2o_privsep_fopen(const char * restrict path, const char * restrict mode)
+{
+    int flags, fd;
+    FILE *fp;
+
+    if (h2o_priv_mode_to_flags(mode, &flags)) {
+        return (NULL);
+    }
+    fd = h2o_privsep_open(path, flags);
+    if (fd == -1) {
+        return (NULL);
+    }
+    fp = fdopen(fd, mode);
+    return (fp);
+}
+
+struct tm *h2o_privsep_dotime_r(const time_t *clock,
+  struct tm *result, int type)
+{
+    char tzbuf[H2O_TZ_BUF];
+    h2o_privsep_t *psd;
+    int time_type;
+    uint32_t cmd;
+
+    time_type = type;
+    assert(time_type == PRIV_LOCALTIME || time_type == PRIV_GMTIME);
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    cmd = PRIV_GMTIME;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    h2o_privsep_must_write(psd->ps_sock, &time_type, sizeof(time_type));
+    h2o_privsep_must_write(psd->ps_sock, (void *)clock, sizeof(*clock));
+    h2o_privsep_must_read(psd->ps_sock, tzbuf, sizeof(tzbuf));
+    h2o_privsep_must_read(psd->ps_sock, result, sizeof(*result));
+    /*
+     * NB: we need to figure out how important the timezone is and
+     * determine how we want to manage the storage. Possibly thread
+     * stack?.
+     */
+    return (result);
+}
+
+char **h2o_privsep_init_fastcgi(char *sock_dir, char *spawn_user,
+    char *spawn_cmd)
+{
+    char **argv, buf[512], *dir, *fcgi_cmd_path, *copy;
+    size_t index, alloc;
+
+    alloc = 32;
+    argv = calloc(alloc, sizeof(argv));
+    if (argv == NULL) {
+        return (NULL);
+    }
+    copy = strdup(spawn_cmd);
+    dir = dirname(copy);
+    if (dir == NULL) {
+        free(argv);
+        return (NULL);
+    }
+    index = 0;
+    fcgi_cmd_path = h2o_configurator_get_cmd_path("share/h2o/fcgi");
+    argv[index++] = fcgi_cmd_path;
+#ifdef __FreeBSD__
+    /*
+     * NB: Implement sandbox wrappers for Linux
+     * NB: We do not have a general purpopse libc wrapper for Linux.
+     * Sandbox policies are allowing open(2) within the outer sandbox
+     * but we may want to further lock down the FCGI stuff and
+     * implement the sandbox wrappers under Linux too.
+     */
+    argv[index++] = "--libc-wrapper";
+    argv[index++] = "libsandboxc.so";
+#endif
+    argv[index++] = "--sandbox";
+    argv[index++] = "--unlink-sock-path";
+    argv[index++] = sock_dir;
+    argv[index++] = "--wait-fd";
+    sprintf(buf, "%d", 5);
+    argv[index++] = strdup(buf);
+    if (spawn_user != NULL) {
+        argv[index++] = "--setuidgid";
+        argv[index++] = spawn_user;
+    }
+    argv[index++] = "--";
+    argv[index++] = spawn_cmd;
+    /*
+     * NB: Currently any command line arguments are being passed in as a single
+     * vector entry. We need to split each field up into an element and pass
+     * it in.
+     */
+    argv[index++] = NULL;
+    assert(index < alloc);
+    return (argv);
+}
+
+pid_t h2o_privsep_waitpid(pid_t pid, int *status, int options)
+{
+    h2o_privsep_watpid_t args;
+    h2o_privsep_t *psd;
+    uint32_t cmd;
+    pid_t ret_pid;
+    int ecode;
+
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    cmd = PRIV_WAITPID;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    args.pid = pid;
+    args.options = options;
+    h2o_privsep_must_write(psd->ps_sock, &args, sizeof(args));
+    h2o_privsep_must_read(psd->ps_sock, &ret_pid, sizeof(ret_pid));
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    h2o_privsep_must_read(psd->ps_sock, status, sizeof(int));
+    if (ecode != 0) {
+        errno = ecode;
+    }
+    return (ret_pid);
+}
+
+char *h2o_privsep_marshal_vec(char *const vec[], size_t *mlen)
+{
+    size_t totlen, slen, count, k;
+    char *const *copy;
+    char *bp, *buf;
+
+    copy = vec;
+    count = 0;
+    totlen = 0;
+    /*
+     * Iterate through array/vector to count the number of strings, but also
+     * to keep track of the size for each string.
+     */
+    while ((bp = *copy++)) {
+        totlen += strlen(bp);
+        count++;
+    }
+    totlen += count;    /* \0 delimeter for each string */
+    totlen += 1;        /* \0 terminating \0 */
+    buf = malloc(totlen);
+    if (buf == NULL) {
+        return (NULL);
+    }
+    *mlen = totlen;
+    bp = buf;
+    for (k = 0; k < count; k++) {
+        slen = strlen(vec[k]);
+        bcopy(vec[k], bp, slen);
+        bp += slen;
+        *bp++ = '\0';
+    }
+    *bp = '\0';
+    return (buf);
+}
+
+char **h2o_privsep_unmarshal_vec(char *marshalled, size_t len)
+{
+    char **ret, *bp, *ent;
+    size_t count, slen;
+    int k, j, h;
+
+    if (marshalled == NULL) {
+        return (NULL);
+    }
+    count = 0;
+    for (k = 0; k < len; k++) {
+       if (marshalled[k] == '\0') {
+            count++;
+        }
+    }
+    count--;
+    ret = calloc(count + 1, sizeof(char *));
+    if (ret == NULL) {
+        return (NULL);
+    }
+    bp = marshalled;
+    for (j = 0, k = 0; k < count; k++) {
+        slen = strlen(bp);
+        if (slen == 0) {
+            bp += 1;
+            continue;
+        }
+        ent = strdup(bp);
+        if (ent == NULL) {
+            for (h = 0; h < j; h++) {
+                ent = ret[h];
+                free(ent);
+            }
+            free(ret);
+            return (NULL);
+        }
+        ret[j++] = ent;
+        bp += slen;
+        bp++;
+    }
+    ret[j] = NULL;
+    return (ret);
+}
+
+/*
+ * Policy is unused currently but we will want to re-visit this in the future.
+ */
+pid_t h2o_privsep_exec(h2o_exec_context_t *ec, const char *command,
+  char *const argv[], char **env, int policy)
+{
+    char *marshalled_argv, cmdbuf[H2O_CMD_BUF];
+    h2o_privsep_t *psd;
+    int ecode, k, fd;
+    size_t msize;
+    uint32_t cmd;
+    pid_t pid;
+
+    marshalled_argv = h2o_privsep_marshal_vec(argv, &msize);
+    if (marshalled_argv == NULL) {
+        errno = ENOMEM;
+        return (-1);
+    }
+    snprintf(cmdbuf, H2O_CMD_BUF, "%s", command);
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    cmd = PRIV_FD_MAPPED_EXEC;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    h2o_privsep_must_write(psd->ps_sock, cmdbuf, H2O_CMD_BUF);
+    h2o_privsep_must_write(psd->ps_sock, &msize, sizeof(msize));
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    if (ecode != 0) {
+        errno = ecode;
+        return (-1);
+    }
+    h2o_privsep_must_write(psd->ps_sock, marshalled_argv, msize);
+    h2o_privsep_must_write(psd->ps_sock, &ec->maps_used, sizeof(ec->maps_used));
+    h2o_privsep_must_write(psd->ps_sock, ec->fdmaps,
+        ec->maps_used * sizeof(h2o_fd_mapping_t));
+    for (k = 0; k < ec->maps_used; k++) {
+        switch (ec->fdmaps[k].type) {
+        case H2O_FDMAP_BASIC:
+            break;
+        case H2O_FDMAP_SEND_TO_PROC:
+            h2o_privsep_send_fd(psd->ps_sock, ec->fdmaps[k].from);
+            break;
+        case H2O_FDMAP_READ_FROM_PROC:
+            fd = h2o_privsep_receive_fd(psd->ps_sock);
+            close(ec->fdmaps[k].from);
+            dup2(fd, ec->fdmaps[k].from);
+            break;
+        }
+    }
+    h2o_privsep_must_read(psd->ps_sock, &pid, sizeof(pid));
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    if (pid == -1) {
+        errno = ecode;
+    }
+    return (pid);
+}
+
+ssize_t h2o_privsep_sendmsg(int sock, struct msghdr *msg, int flags)
+{
+    h2o_privsep_sendmsg_t args;
+    struct iovec *iovp;
+    h2o_privsep_t *psd;
+    int ecode, index;
+    uint32_t cmd;
+    ssize_t cc;
+
+    /*
+     * FreeBSD doesn't allow network based sendmsg(2) operations in sandbox
+     * mode.  This is not tunable. The existing Linux seccomp policy will
+     * allow it for the sake performance. We might revisit this as some
+     * point, but if the sandbox implementation allows sendmsg(2) just use
+     * the non-privsep path to execute it.
+     */
+    if ((privsep_flags & SANDBOX_ALLOWS_SENDMSG) != 0) {
+        return (h2o_allpriv_sendmsg(sock, msg, flags));
+    }
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    cmd = PRIV_SENDMSG;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    /*
+     * NB: this is very inefficient. We need to implement a file descriptor
+     * cache in he privileged process so we aren't transmitted the fd
+     * everytime we want to send an H3 packet.
+     */
+    h2o_privsep_send_fd(psd->ps_sock, sock);
+    args.msg_namelen = msg->msg_namelen;
+    args.msg_iovlen = msg->msg_iovlen;
+    args.msg_controllen = msg->msg_controllen;
+    args.flags = flags;
+    h2o_privsep_must_write(psd->ps_sock, &args, sizeof(args));
+    for (index = 0; index < msg->msg_iovlen; index++) {
+        iovp = &msg->msg_iov[index];
+        h2o_privsep_must_write(psd->ps_sock, &iovp->iov_len, sizeof(iovp->iov_len));
+        h2o_privsep_must_write(psd->ps_sock, iovp->iov_base, iovp->iov_len);
+    }
+    h2o_privsep_must_write(psd->ps_sock, msg->msg_name, args.msg_namelen);
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    if (ecode != 0) {
+        errno = ecode;
+        return (-1);
+    }
+    h2o_privsep_must_write(psd->ps_sock, msg->msg_control, args.msg_controllen);
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    if (ecode != 0) {
+        errno = ecode;
+        return (-1);
+    }
+    h2o_privsep_must_read(psd->ps_sock, &cc, sizeof(cc));
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    return (cc);
+}
+
+int h2o_privsep_open_listener(int domain, int type, int protocol,
+  struct sockaddr_storage *addr, socklen_t addrlen, int reuseport)
+{
+    h2o_privsep_open_listener_t args;
+    h2o_privsep_t *psd;
+    int ecode, sock;
+    uint32_t cmd;
+
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    cmd = PRIV_OPEN_LISTENER;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    args.domain = domain;
+    args.type = type;
+    args.protocol = protocol;
+    bcopy(addr, &args.sas, addrlen);
+    args.addrlen = addrlen;
+    args.reuseport = reuseport;
+    h2o_privsep_must_write(psd->ps_sock, &args, sizeof(args));
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    if (ecode != 0) {
+        errno = ecode;
+        return (-1);
+    }
+    sock = h2o_privsep_receive_fd(psd->ps_sock);
+    return (sock);
+}
+
+void h2o_privsep_sandbox_hints(char *root)
+{
+
+#ifdef __linux__
+    sandbox_emit_linux_hints(root);
+#endif
+#ifdef __FreeBSD__
+    sandbox_emit_freebsd_hints(root);
+#endif
+}
+
+void h2o_privsep_bind_sandbox(int policy)
+{
+    /*
+     * SANDBOX_POLICY_BASIC is used to set a minimal sandbox policy on a
+     * process. This process will not be using privsep, in which case 
+     * skip the call to drop privs (which assumes the full privsep model
+     * is being used.
+     */
+    switch (policy) {
+    case SANDBOX_POLICY_NONE:
+        return;
+        break;
+    case SANDBOX_POLICY_NEVERBLEED:
+        break;
+    case SANDBOX_POLICY_H2OMAIN:
+        h2o_privsep_drop_privs();
+        break;
+    }
+#ifdef __linux__
+    sandbox_bind_linux(policy);
+    privsep_flags |= SANDBOX_ALLOWS_SENDMSG;
+#endif
+#ifdef __FreeBSD__
+    sandbox_bind_freebsd(policy);
+#endif
+}
+
+int h2o_privsep_may_read(int fd, void *buf, size_t n)
+{
+    ssize_t res, pos;
+    char *s;
+
+    s = buf;
+    pos = 0;
+    while (n > pos) {
+        res = read(fd, s + pos, n - pos);
+        switch (res) {
+        case -1:
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+        case 0:
+            return (1);
+        default:
+            pos += res;
+        }
+    }
+    return (0);
+}
+
+void h2o_privsep_must_read(int fd, void *buf, size_t n)
+{
+    ssize_t res, pos;
+    char *s;
+
+    pos = 0;
+    s = buf;
+    while (n > pos) {
+        res = read(fd, s + pos, n - pos);
+        switch (res) {
+        case -1:
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+            /* FALLTHROUGH */
+        case 0:
+            if ((privsep_flags & PRIVSEP_PRIVILEGED) != 0) {
+                _exit(0);
+            } else {
+                exit(0);
+            }
+        default:
+            pos += res;
+        }
+    }
+}
+
+void h2o_privsep_must_readv(int fd, const struct iovec *iov, int iovcnt)
+{
+    ssize_t cc;
+
+    while (1) {
+        cc = readv(fd, iov, iovcnt);
+        if (cc == -1 && errno == EINTR) {
+            continue;
+        }
+        if (cc == -1) {
+            warn("readv failed");
+            if ((privsep_flags & PRIVSEP_PRIVILEGED) != 0) {
+                _exit(1);
+            } else {
+                exit(1);
+            }
+        }
+        break;
+    }
+}
+
+void h2o_privsep_must_writev(int fd, const struct iovec *iov, int iovcnt)
+{
+    ssize_t cc;
+
+    while (1) {
+        cc = writev(fd, iov, iovcnt);
+        if (cc == -1 && errno == EINTR) {
+            continue;
+        }
+        if (cc == -1) {
+            warn("writev failed");
+            if ((privsep_flags & PRIVSEP_PRIVILEGED) != 0) {
+                _exit(1);
+            } else {
+                exit(1);
+            }
+        }
+        break;
+    }
+}
+
+void h2o_privsep_must_write(int fd, void *buf, size_t n)
+{
+    ssize_t res, pos;
+    char *s;
+
+    pos = 0;
+    s = buf;
+    while (n > pos) {
+        res = write(fd, s + pos, n - pos);
+        switch (res) {
+        case -1:
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+        case 0:
+            if ((privsep_flags & PRIVSEP_PRIVILEGED) != 0) {
+                _exit(0);
+            } else {
+                exit(0);
+            }
+        default:
+            pos += res;
+        }
+    }
+}
+
+void h2o_privsep_send_fd(int sock, int fd)
+{
+    struct msghdr msg;
+    union {
+        struct cmsghdr hdr;
+        char buf[CMSG_SPACE(sizeof(int))];
+    } cmsgbuf;
+    struct cmsghdr *cmsg;
+    struct iovec vec;
+    int *fdp, result;
+    ssize_t n;
+
+    result = 0;
+    memset(&msg, 0, sizeof(msg));
+    if (fd < 0) {
+        return;
+    }
+    msg.msg_control = (caddr_t)&cmsgbuf.buf;
+    msg.msg_controllen = sizeof(cmsgbuf.buf);
+    cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    fdp = (int *)CMSG_DATA(cmsg);
+    *fdp = fd;
+    vec.iov_base = &result;
+    vec.iov_len = sizeof(int);
+    msg.msg_iov = &vec;
+    msg.msg_iovlen = 1;
+    if ((n = sendmsg(sock, &msg, 0)) == -1)  {
+        fprintf(stderr, "h2o_privsep_send_fd: %s\n", strerror(errno));
+        abort();
+    }
+    if (n != sizeof(int)) {
+        fprintf(stderr, "h2o_privsep_send_fd: %s\n", strerror(errno));
+        abort();
+    }
+}
+
+int h2o_privsep_receive_fd(int sock)
+{
+    struct msghdr msg;
+    union {
+        struct cmsghdr hdr;
+        char buf[CMSG_SPACE(sizeof(int))];
+    } cmsgbuf;
+    struct cmsghdr *cmsg;
+    struct iovec vec;
+    ssize_t n;
+    int result;
+    int fd, *fdp;
+
+    memset(&msg, 0, sizeof(msg));
+    vec.iov_base = &result;
+    vec.iov_len = sizeof(int);
+    msg.msg_iov = &vec;
+    msg.msg_iovlen = 1;
+    msg.msg_control = &cmsgbuf.buf;
+    msg.msg_controllen = sizeof(cmsgbuf.buf);
+    if ((n = recvmsg(sock, &msg, 0)) == -1) {
+        fprintf(stderr, "%s: %s\n", __func__, strerror(errno));
+        abort();
+    }
+    if (n != sizeof(int)) {
+        fprintf(stderr, "%s: %s\n", __func__, strerror(errno));
+        abort();
+    }
+    if (result == 0) {
+        cmsg = CMSG_FIRSTHDR(&msg);
+        if (cmsg == NULL) {
+            abort();
+        }
+        if (cmsg->cmsg_type != SCM_RIGHTS) {
+            (void) fprintf(stderr, "%s: expected type %d got %d", __func__,
+                SCM_RIGHTS, cmsg->cmsg_type);
+            abort();
+        }
+        fdp = (int *)CMSG_DATA(cmsg);
+        fd = *fdp;
+        assert(fd != -1);
+        return (fd);
+    } else {
+        errno = result;
+        return (-1);
+    }
+}
+
+static int h2o_privsep_active(void)
+{
+
+    return (privsep_active != 0);
+}
+
+void h2o_privsep_set_neverbleed_path(const char *path)
+{
+	h2o_privsep_neverbleed_path_t args;
+	uint32_t cmd;
+	int ecode;
+
+	cmd = PRIV_SET_NEVERBLEED_PATH;
+	pthread_mutex_lock(&privsep_mutex);
+	h2o_privsep_must_write(privsep_global_sock, &cmd, sizeof(cmd));
+	snprintf(args.path, sizeof(args.path), "%s", path);
+	h2o_privsep_must_write(privsep_global_sock, &args, sizeof(args));
+	h2o_privsep_must_read(privsep_global_sock, &ecode, sizeof(ecode));
+	pthread_mutex_unlock(&privsep_mutex);
+}
+
+int h2o_privsep_get_sock(void)
+{
+    int ecode, sock;
+    uint32_t cmd;
+
+    pthread_mutex_lock(&privsep_mutex);
+    cmd = PRIV_PRIVSEP_SOCK;
+    h2o_privsep_must_write(privsep_global_sock, &cmd, sizeof(cmd));
+    h2o_privsep_must_read(privsep_global_sock, &ecode, sizeof(ecode));
+    if (ecode != 0) {
+        warnx("%s: PRIV_PRIVSEP_SOCK: %s\n", __func__, strerror(ecode));
+        errno = ecode;
+        pthread_mutex_unlock(&privsep_mutex);
+        return -1;
+    }
+    sock = h2o_privsep_receive_fd(privsep_global_sock);
+    pthread_mutex_unlock(&privsep_mutex);
+    return (sock);
+}
+
+int h2o_privsep_activate(void)
+{
+
+    if (pthread_key_create(&privsep_key, free) != 0) {
+        h2o_fatal("[privsep] failed tp initialize thread specific data: %s",
+          strerror(errno));
+    }
+    privsep_active = 1;
+    return (0);
+}
+
+h2o_privsep_t *h2o_get_tsd(void)
+{
+    h2o_privsep_t *tsd;
+
+    assert(h2o_privsep_active());
+    tsd = pthread_getspecific(privsep_key);
+    if (tsd) {
+        return (tsd);
+    }
+    tsd = calloc(1, sizeof(*tsd));
+    if (tsd == NULL) {
+        return (NULL);
+    }
+    tsd->ps_sock = h2o_privsep_get_sock();
+    if (tsd->ps_sock == -1) {
+        /*
+         * If we fail to get privsep socket, bail. Something has gone very
+         * wrong and nothing will be able to facilitate whatever privilege
+         * we are requesting.
+         */
+        abort();
+    }
+    if (pthread_setspecific(privsep_key, tsd) != 0) {
+        free(tsd);
+        close(tsd->ps_sock);
+    }
+    return (tsd);
+}
+
+int h2o_privsep_get_neverbleed_sock(void)
+{
+    h2o_privsep_t *psd;
+    int ecode, sock;
+    uint32_t cmd;
+
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    cmd = PRIV_NEVERBLEED_SOCK;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    if (ecode != 0) {
+        errno = ecode;
+        return -1;
+    }
+    sock = h2o_privsep_receive_fd(psd->ps_sock);
+    return (sock);
+}
+
+int h2o_privsep_open(const char *path, int flags, ...)
+{
+    h2o_privsep_open_t oa;
+    h2o_privsep_t *psd;
+    int cmd, fd, ecode;
+
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    snprintf(oa.path, sizeof(oa.path), "%s", path);
+    oa.flags = flags;
+    cmd = PRIV_OPEN;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    h2o_privsep_must_write(psd->ps_sock, &oa, sizeof(oa));
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    if (ecode != 0) {
+        errno = ecode;
+        return (-1);
+    }
+    fd = h2o_privsep_receive_fd(psd->ps_sock);
+    return (fd);
+}
+
+static struct addrinfo *addrinfo_copy(h2o_privsep_getaddrinfo_result_t *ent)
+{
+	struct addrinfo *cres;
+
+	cres = malloc(sizeof(*cres));
+	if (cres == NULL)
+		return (NULL);
+	cres->ai_flags = ent->ai_flags;
+	cres->ai_family = ent->ai_family;
+	cres->ai_socktype = ent->ai_socktype;
+	cres->ai_protocol = ent->ai_protocol;
+	cres->ai_addrlen = ent->ai_addrlen;
+	cres->ai_addr = malloc(cres->ai_addrlen);
+	memcpy(cres->ai_addr, &ent->sas, cres->ai_addrlen);
+	cres->ai_canonname = strdup(ent->ai_canonname);
+	if (cres->ai_canonname == NULL) {
+		free(cres);
+		return (NULL);
+	}
+	return (cres);
+}
+
+static int process_getaddr_data(h2o_privsep_getaddrinfo_result_t *vec,
+  size_t blen, struct addrinfo **res)
+{
+    h2o_privsep_getaddrinfo_result_t *ent;
+    struct addrinfo *cres, *head;
+    int nitems;
+
+    if (blen % sizeof(*ent) != 0) {
+        return (-1);
+    }
+    head = NULL;
+    nitems = blen / sizeof(*ent);
+    for (ent = &vec[0]; ent < &vec[nitems]; ent++) {
+        cres = addrinfo_copy(ent);
+        if (cres == NULL) {
+            return (-1);
+        }
+        cres->ai_next = head;
+        head = cres;
+    }
+    *res = head;
+    return (0);
+}
+
+void h2o_privsep_freeaddrinfo(struct addrinfo *ai)
+{
+
+    assert(ai != NULL);
+    free(ai->ai_addr);
+    free(ai->ai_canonname);
+    free(ai);
+}
+
+int h2o_privsep_getaddrinfo(const char *hostname, const char *servname,
+  const struct addrinfo *hints, struct addrinfo **res)
+{
+    h2o_privsep_getaddrinfo_result_t *vec;
+    h2o_privsep_getaddrinfo_t ga_args;
+    h2o_privsep_t *psd;
+    int cmd, ret;
+    size_t blen;
+ 
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    memset(&ga_args, 0, sizeof(ga_args));
+    snprintf(ga_args.hostname, sizeof(ga_args.hostname), "%s", hostname);
+    snprintf(ga_args.servname, sizeof(ga_args.servname), "%s", servname);
+    memcpy(&ga_args.hints, hints, sizeof(ga_args.hints));
+    cmd = PRIV_GETADDRINFO;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    h2o_privsep_must_write(psd->ps_sock, &ga_args, sizeof(ga_args));
+	h2o_privsep_must_read(psd->ps_sock, &ret, sizeof(cmd));
+    if (ret != 0) {
+        return (ret);
+    }
+    h2o_privsep_must_read(psd->ps_sock, &blen, sizeof(blen));
+    if (blen == -1) {
+        return (EAI_MEMORY);
+    }
+    vec = malloc(blen);
+    if (vec == NULL) {
+        return (EAI_MEMORY);
+    }
+    h2o_privsep_must_read(psd->ps_sock, vec, blen);
+    ret = process_getaddr_data(vec, blen, res);
+    free(vec);
+    if (ret == -1) {
+        return (EAI_MEMORY);
+    }
+    return (0);
+}
+
+/*
+ * This privilege is used in the critical path, so we want to squeeze whatever
+ * performance we can out of it. We are using iov's here to reduce the number
+ * of context switches required per connect operation.
+ */
+int h2o_privsep_connect_sock_noblock(struct sockaddr_storage *sas,
+  int *sock_ret, int *connect_ret)
+{
+    int s_ret, s_errno, c_ret, c_errno, *ptr, priv, sock;
+    struct iovec iov[8];
+    h2o_privsep_t *psd;
+
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    priv = PRIV_CONNECT;
+    h2o_privsep_must_write(psd->ps_sock, &priv, sizeof(int));
+    h2o_privsep_must_write(psd->ps_sock, sas, sizeof(struct sockaddr_storage));
+
+    iov[0].iov_base = &s_ret;
+    iov[0].iov_len = sizeof(s_ret);
+    iov[1].iov_base = &s_errno;
+    iov[1].iov_len = sizeof(s_errno);
+    iov[2].iov_base = &c_ret;
+    iov[2].iov_len = sizeof(c_ret);
+    iov[3].iov_base = &c_errno;
+    iov[3].iov_len = sizeof(c_errno);
+    h2o_privsep_must_readv(psd->ps_sock, iov, 4);
+    ptr = iov[0].iov_base;
+    *sock_ret = *ptr;
+    if (*sock_ret == -1)  {
+        ptr = iov[1].iov_base;
+        errno = *ptr;
+        return (-1);
+    }
+    ptr = iov[2].iov_base;
+    *connect_ret = *ptr;
+    ptr = iov[3].iov_base;
+    errno = *ptr;
+    sock = h2o_privsep_receive_fd(psd->ps_sock);
+    return (sock);
+}
+
+int h2o_privsep_drop_privs(void)
+{
+    h2o_privsep_t *psd;
+    uint32_t cmd;
+    int ecode;
+
+    psd = h2o_get_tsd();
+    assert(psd != NULL);
+    cmd = PRIV_DROP_PRIVS;
+    h2o_privsep_must_write(psd->ps_sock, &cmd, sizeof(cmd));
+    h2o_privsep_must_read(psd->ps_sock, &ecode, sizeof(ecode));
+    return (ecode);
+}

--- a/lib/common/privsep_dispatch.c
+++ b/lib/common/privsep_dispatch.c
@@ -1,0 +1,875 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/param.h>
+#include <sys/wait.h>
+#include <sys/un.h>
+
+#include <err.h>
+#include <stdio.h>
+#include <grp.h>
+#include <string.h>
+#include <errno.h>
+#include <pthread.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "h2o.h"
+#include "h2o/privsep.h"
+#include "h2o/serverutil.h"
+#include "h2o/memory.h" /* NB: for h2o_fatal */
+
+int privsep_flags;
+int privsep_global_sock;
+
+static const char *neverbleed_sock_path;
+const char *privsep_sock_path;
+
+static void privsep_handle_dotime_r(privsep_worker_t *pswd)
+{
+    char tzbuf[H2O_TZ_BUF];
+    time_t clock;
+    struct tm gmt;
+    int type, valid;
+
+    bzero(tzbuf, sizeof(tzbuf));
+    h2o_privsep_must_read(pswd->sock, &type, sizeof(type));
+    h2o_privsep_must_read(pswd->sock, &clock, sizeof(clock));
+    valid = 0;
+    switch (type) {
+    case PRIV_GMTIME:
+        gmtime_r(&clock, &gmt);
+        valid = 1;
+        break;
+    case PRIV_LOCALTIME:
+        localtime_r(&clock, &gmt);
+        valid = 1;
+        break;
+    default:
+        warnx("%s: invalid type time specified", __func__);
+        bzero(&gmt, sizeof(gmt));
+        bzero(tzbuf, sizeof(tzbuf));
+        valid = 0;
+    }
+    if (valid) {
+        snprintf(tzbuf, sizeof(tzbuf), "%s", gmt.tm_zone);
+    }
+    h2o_privsep_must_write(pswd->sock, tzbuf, sizeof(tzbuf));
+    gmt.tm_zone = NULL;
+    h2o_privsep_must_write(pswd->sock, &gmt, sizeof(gmt));
+}
+
+static void privsep_handle_waitpid(privsep_worker_t *pswd)
+{
+    h2o_privsep_watpid_t args;
+    int status, ecode;
+    pid_t pid;
+
+    h2o_privsep_must_read(pswd->sock, &args, sizeof(args));
+    while (1) {
+        status = 0;
+        pid = waitpid(args.pid, &status, args.options);
+        if (pid == -1 && errno == EINTR) {
+            continue;
+        }
+        h2o_privsep_must_write(pswd->sock, &pid, sizeof(pid));
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        h2o_privsep_must_write(pswd->sock, &status, sizeof(status));
+        return;
+    }
+}
+
+static void privsep_handle_fd_mapped_exec(privsep_worker_t *pswd)
+{
+    char *f, cmdbuf[H2O_CMD_BUF], **copy, **argv, *marshalled, **envp;
+    int error_pipe[2], ecode, ret, k, maps_used;
+    h2o_exec_context_t ec;
+    extern char **environ;
+    size_t msize;
+    ssize_t cc;
+    pid_t pid;
+
+    /*
+     * NB: add access control checks here. We will likely have a registration
+     * function for the various files, hosts and executables we want to access
+     * from within the sandbox.
+     */
+    h2o_privsep_must_read(pswd->sock, cmdbuf, H2O_CMD_BUF);
+    /*
+     * We are dealing with a potentially compromised process. Double chck the
+     * data points coming from this process which controls how much memory we
+     * are allocating et al.
+     */
+    h2o_privsep_must_read(pswd->sock, &msize, sizeof(msize));
+    if (msize > 8192) {
+        ecode = EOVERFLOW;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    marshalled = malloc(msize);
+    if (marshalled == NULL) {
+        ecode = ENOMEM;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    }
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    /*
+     * Read the marshalled version of argv array so we can convert it to an in
+     * memory array of pointers good for the exec(2) syscall.
+     *
+     * NB: we should be validating the commands/arguments that are passed long
+     * here.
+     */
+    h2o_privsep_must_read(pswd->sock, marshalled, msize);
+    argv = h2o_privsep_unmarshal_vec(marshalled, msize);
+    if (argv == NULL) {
+        pid = -1;
+        ecode = ENOMEM;
+        free(marshalled);
+        h2o_privsep_must_write(pswd->sock, &pid, sizeof(pid));
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    free(marshalled);
+    /*
+     * Read the file descriptors from the non-privileged process that the
+     * caller would like overlayed on stdin, stdout and stderr. Once we
+     * get them into this process, use dup2() to map them.
+     */
+    h2o_priv_init_exec_context(&ec);
+    h2o_privsep_must_read(pswd->sock, &maps_used, sizeof(maps_used));
+    ec.fdmaps = calloc(maps_used, sizeof(h2o_fd_mapping_t));
+    h2o_privsep_must_read(pswd->sock, ec.fdmaps,
+        maps_used * sizeof(h2o_fd_mapping_t));
+    for (k = 0; k < maps_used; k++) {
+        if (pipe(ec.fdmaps[k].pipefds) == -1) {
+            h2o_fatal("pipe failed");
+        }
+        switch (ec.fdmaps[k].type) {
+        case H2O_FDMAP_BASIC:
+            break;
+        case H2O_FDMAP_SEND_TO_PROC:
+            ec.fdmaps[k].from = h2o_privsep_receive_fd(pswd->sock);
+            close(ec.fdmaps[k].pipefds[0]);
+            close(ec.fdmaps[k].pipefds[1]);
+            break;
+        case H2O_FDMAP_READ_FROM_PROC:
+            h2o_privsep_send_fd(pswd->sock, ec.fdmaps[k].pipefds[0]);
+            break;
+        }
+    }
+    if (pipe2(error_pipe, O_CLOEXEC) == -1) {
+        pid = -1;
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &pid, sizeof(pid));
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    pid = fork();
+    if (pid == -1) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &pid, sizeof(pid));
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    if (pid == 0) {
+        /*
+         * Overlay the file descriptors per the mapping specification in the
+         * the caller. h2o_read_command() has a different mapping specification
+         * than the backtrace producer. I think we have captured all the use
+         * cases for this feature.
+         */
+        for (k = 0; k < maps_used; k++) {
+            switch (ec.fdmaps[k].type) {
+            case H2O_FDMAP_BASIC:
+                dup2(ec.fdmaps[k].from, ec.fdmaps[k].to);
+                break;
+            case H2O_FDMAP_SEND_TO_PROC:
+                close(ec.fdmaps[k].to);
+                dup2(ec.fdmaps[k].from, ec.fdmaps[k].to);
+                break;
+            case H2O_FDMAP_READ_FROM_PROC:
+                close(ec.fdmaps[k].pipefds[0]);
+                dup2(ec.fdmaps[k].pipefds[1], ec.fdmaps[k].to);
+                break;
+            }
+        }
+        envp = h2o_priv_gen_env();
+        if (envp != NULL) {
+            environ = envp;
+        }
+        (void) execvp(cmdbuf, argv);
+        ecode = errno;
+        (void) write(error_pipe[1], &ecode, sizeof(ecode));
+        _exit(EX_SOFTWARE);
+    }
+    for (k = 0; k < maps_used; k++) {
+        switch (ec.fdmaps[k].type) {
+        case H2O_FDMAP_BASIC:
+            break;
+        case H2O_FDMAP_SEND_TO_PROC:
+            close(ec.fdmaps[k].from);
+            break;
+        case H2O_FDMAP_READ_FROM_PROC:
+            close(ec.fdmaps[k].pipefds[1]);
+            /*
+             * NB: do we need to close(pipefds[0] here too since we sent it
+             * to the non-privilged process ?
+             */
+            break;
+        }
+    }
+    /*
+     * However the execution goes, we are done with the un-marshalled version
+     * of the argv array. Iterate through each element freeing them and cleanup
+     * the underlying array after that.
+     */
+    copy = argv;
+    while ((f = *copy++)) {
+        free(f);
+    }
+    free(argv);
+    close(error_pipe[1]);
+    while (1) {
+        cc = read(error_pipe[0], &ecode, sizeof(ecode));
+        if (cc == -1 && errno == EINTR) {
+            continue;
+        }
+        /*
+         * EOF on this file descriptor is what we want to see. It means that
+         * the exec(2) was successful, and the file descriptor was closed as
+         * as a result. If this is the case, break from the loop and deliver
+         * the PID to the caller.
+         */
+        if (cc == 0) {
+            break;
+        }
+        /*
+         * If we received data, it was the child process informing us that the
+         * exec(2) operation was not successful. Copy the error code and and
+         * send it to the caller. Call waitpid(2) to collect the exit status
+         * since it's invariant that the process is dead.
+         */
+        while (1) {
+            ret = waitpid(pid, NULL, 0);
+            if (ret == -1 && errno == EINTR) {
+                continue;
+            } else if (ret == -1) {
+                ecode = errno;
+            }
+            break;
+        }
+        pid = -1;
+        h2o_privsep_must_write(pswd->sock, &pid, sizeof(pid));
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &pid, sizeof(pid));
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+}
+
+static void privsep_msghdr_cleanup(struct msghdr *msg)
+{
+    struct iovec *iovp;
+    int index;
+
+    assert(msg != NULL);
+    for (index = 0; index < msg->msg_iovlen; index++) {
+        iovp = &msg->msg_iov[index];
+        free(iovp->iov_base);
+    }
+    free(msg->msg_iov);
+    free(msg->msg_name);
+    free(msg->msg_control);
+}
+
+static void privsep_handle_sendmsg(privsep_worker_t *pswd)
+{
+    h2o_privsep_sendmsg_t args;
+    int sock, ecode, index;
+    struct iovec *iovp;
+    struct msghdr msg;
+    ssize_t cc;
+
+    bzero(&msg, sizeof(msg));
+    sock = h2o_privsep_receive_fd(pswd->sock);
+    h2o_privsep_must_read(pswd->sock, &args, sizeof(args));
+    msg.msg_namelen = args.msg_namelen;
+    msg.msg_controllen = args.msg_controllen;
+    msg.msg_iovlen = args.msg_iovlen;
+    msg.msg_iov = calloc(msg.msg_iovlen, sizeof(*iovp));
+    /* NB: XXX send ecode */
+    for (index = 0; index < msg.msg_iovlen; index++) {
+        iovp = &msg.msg_iov[index];
+        h2o_privsep_must_read(pswd->sock, &iovp->iov_len, sizeof(iovp->iov_len));
+        iovp->iov_base = calloc(1, iovp->iov_len);
+        h2o_privsep_must_read(pswd->sock, iovp->iov_base, iovp->iov_len);
+    }
+    /*
+     * msg.msg_flags is not used by sendmsg(2). We can just leave it as zero.
+     */
+    msg.msg_name = calloc(1, args.msg_namelen);
+    if (msg.msg_name == NULL) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        close(sock);
+        return;
+    }
+    h2o_privsep_must_read(pswd->sock, msg.msg_name, args.msg_namelen);
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    msg.msg_control = calloc(1, args.msg_controllen);
+    if (msg.msg_name == NULL) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        close(sock);
+        return;
+    }
+    h2o_privsep_must_read(pswd->sock, msg.msg_control, args.msg_controllen);
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    cc = sendmsg(sock, &msg, args.flags);
+    h2o_privsep_must_write(pswd->sock, &cc, sizeof(cc));
+    if (cc == -1) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        close(sock);
+    }
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    privsep_msghdr_cleanup(&msg);
+    close(sock);
+}
+
+static void privsep_handle_open_listener(privsep_worker_t *pswd)
+{
+    h2o_privsep_open_listener_t args;
+    int sock, ecode;
+
+    h2o_privsep_must_read(pswd->sock, &args, sizeof(args));
+    sock = h2o_allpriv_open_listener(args.domain, args.type, args.protocol,
+      &args.sas, args.addrlen, args.reuseport);
+    if (sock == -1) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    h2o_privsep_send_fd(pswd->sock, sock);
+    close(sock);
+}
+
+static void privsep_deliver_connected_sock(privsep_worker_t *pswd)
+{
+    int s_ret, s_errno, c_ret, c_errno, sock;
+    struct sockaddr_storage saddr;
+    struct iovec iov[8];
+    socklen_t s;
+
+    sock = pswd->sock;
+    /*
+     * NB: ACL check from whatever was specified in the configuration.
+     * This could probably a generic interface used by neverbleed too.
+     */
+    h2o_privsep_must_read(sock, &saddr, sizeof(struct sockaddr_storage));
+    switch (saddr.ss_family) {
+    case PF_UNIX:
+        s = sizeof(struct sockaddr_un);
+        break;
+    case PF_INET:
+        s = sizeof(struct sockaddr_in);
+        break;
+    case PF_INET6:
+        s = sizeof(struct sockaddr_in6);
+        break;
+    default:
+        abort();
+    }
+    /*
+     * We need to write multiple error codes back .One for socket and
+     * the other for connect so we can replicate the same error
+     * conditions exactly.
+     */
+    s_ret = socket(saddr.ss_family, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (s_ret != -1) {
+        (void) fcntl(s_ret, F_SETFL, O_NONBLOCK);
+    }
+    s_errno = errno;
+    iov[0].iov_base = &s_ret;
+    iov[0].iov_len = sizeof(s_ret);
+    iov[1].iov_base = &s_errno;
+    iov[1].iov_len = sizeof(s_errno);
+    if (s_ret == -1) {
+        iov[2].iov_base = NULL;
+        iov[2].iov_len = 0;
+        iov[3].iov_base = NULL;
+        iov[3].iov_len = 0;
+        h2o_privsep_must_writev(sock, iov, 4);
+        return;
+    }
+    c_ret = connect(s_ret, (struct sockaddr *)&saddr, s);
+    c_errno = errno;
+    iov[2].iov_base = &c_ret;
+    iov[2].iov_len = sizeof(c_ret);
+    iov[3].iov_base = &c_errno;
+    iov[3].iov_len = sizeof(c_errno);
+    h2o_privsep_must_writev(sock, iov, 4);
+    h2o_privsep_send_fd(sock, s_ret);
+    close(s_ret);
+}
+
+static void privsep_handle_getaddrinfo(privsep_worker_t *pswd)
+{
+    h2o_privsep_getaddrinfo_result_t *ent, *vec;
+    size_t vec_used, vec_alloc, curlen;
+    h2o_privsep_getaddrinfo_t ga_args;
+    struct addrinfo *res, *res0;
+    int error, sock, ret;
+
+    sock = pswd->sock;
+    h2o_privsep_must_read(sock, &ga_args, sizeof(ga_args));
+    ret = getaddrinfo(ga_args.hostname, ga_args.servname, &ga_args.hints,
+      &res0);
+    if (ret != 0) {
+        warnx("[PRIVSEP]: getaddr failed: %s\n", gai_strerror(ret));
+    }
+    vec_used = 0;
+    vec_alloc = 0;
+    vec = NULL;
+    for (res = res0; res; res = res->ai_next) {
+        if (vec == NULL) {
+            vec_alloc = sizeof(*ent);
+            vec = calloc(1, vec_alloc);
+            if (vec == NULL) {
+                error = -1;
+                h2o_privsep_must_write(sock, &error, sizeof(error));
+                return;
+            }
+        } else {
+            vec_alloc = vec_alloc + sizeof(*ent);
+            vec = realloc(vec,vec_alloc);
+            if (vec == NULL) {
+                error = -1;
+                h2o_privsep_must_write(sock, &error, sizeof(error));
+                return;
+            }
+        }
+        ent = &vec[vec_used++];
+        ent->ai_flags = res->ai_flags;
+        ent->ai_family = res->ai_family;
+        ent->ai_socktype = res->ai_socktype;
+        ent->ai_protocol = res->ai_protocol;
+        ent->ai_addrlen = res->ai_addrlen;
+        memcpy(&ent->sas, res->ai_addr, res->ai_addrlen);
+        if (res->ai_canonname != NULL) {
+            snprintf(ent->ai_canonname, sizeof(ent->ai_canonname),
+              "%s", res->ai_canonname);
+        } else {
+            ent->ai_canonname[0] = '\0';
+        }
+    }
+    /* report success/failure */
+    h2o_privsep_must_write(sock, &ret, sizeof(ret));
+    if (ret != 0) {
+        return;
+    }
+    curlen = vec_used * sizeof(*ent);
+    if (curlen == 0) {
+        curlen = -1;
+        h2o_privsep_must_write(sock, &curlen, sizeof(curlen));
+        return;
+    }
+    h2o_privsep_must_write(sock, &curlen, sizeof(curlen));
+    h2o_privsep_must_write(sock, vec, curlen);
+    free(vec);
+}
+
+static void privsep_handle_set_neverbleed_path(privsep_worker_t *pswd)
+{
+	h2o_privsep_neverbleed_path_t args;
+	int ecode;
+
+	h2o_privsep_must_read(pswd->sock, &args, sizeof(args));
+	neverbleed_sock_path = strdup(args.path);
+	ecode = 0;
+	h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+}
+
+static void privsep_handle_neverbleed_sock(privsep_worker_t *pswd)
+{
+    struct sockaddr_un sun;
+    int sock, ecode, ret;
+
+    sock = socket(PF_UNIX, SOCK_STREAM, 0);
+    if (sock == -1) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    bzero(&sun, sizeof(sun));
+    sun.sun_family = PF_UNIX;
+    snprintf(sun.sun_path, sizeof(sun.sun_path), "%s", neverbleed_sock_path);
+    while (1) {
+        ret = connect(sock, (struct sockaddr *)&sun, sizeof(sun));
+        if (ret == -1 && errno == EINTR) {
+            continue;
+        } else if (ret == -1) {
+            abort();
+        }
+        break;
+    }
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    h2o_privsep_send_fd(pswd->sock, sock);
+    close(sock);
+}
+
+static void privsep_handle_privsep_sock(privsep_worker_t *pswd)
+{
+    struct sockaddr_un sun;
+    int sock, ecode, ret;
+
+    sock = socket(PF_UNIX, SOCK_STREAM, 0);
+    if (sock == -1) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    bzero(&sun, sizeof(sun));
+    sun.sun_family = PF_UNIX;
+    snprintf(sun.sun_path, sizeof(sun.sun_path), "%s", privsep_sock_path);
+    while (1) {
+        ret = connect(sock, (struct sockaddr *)&sun, sizeof(sun));
+        if (ret == -1 && errno == EINTR) {
+            continue;
+        } else if (ret == -1) {
+            close(sock);
+            ecode = errno;
+            h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+            return;
+        }
+        break;
+    }
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    h2o_privsep_send_fd(pswd->sock, sock);
+    close(sock);
+}
+
+static void privsep_handle_open(privsep_worker_t *pswd)
+{
+    h2o_privsep_open_t args;
+    int ecode, fd;
+
+    /*
+     * NB: implement path based access control check
+     */
+    h2o_privsep_must_read(pswd->sock, &args, sizeof(args));
+    fd = open(args.path, args.flags, args.mode);
+    if (fd == -1) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    ecode = 0;
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+    h2o_privsep_send_fd(pswd->sock, fd);
+    close(fd);
+}
+
+static void privsep_handle_drop_privs(privsep_worker_t *pswd)
+{
+    struct passwd pwbuf, *pw;
+    char pwstrbuf[65536]; /* should be large enough */
+    int ecode;
+
+    ecode = 0;
+    if (getpwnam_r(pswd->gcp->user, &pwbuf, pwstrbuf, sizeof(pwstrbuf), &pw) != 0) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    if (pw == NULL) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    if (setgid(pw->pw_gid) != 0) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    if (initgroups(pw->pw_name, pw->pw_gid) != 0) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    if (setuid(pw->pw_uid) != 0) {
+        ecode = errno;
+        h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+        return;
+    }
+    h2o_privsep_must_write(pswd->sock, &ecode, sizeof(ecode));
+}
+
+static void *privsep_handle_global_sock(void *arg)
+{
+    h2o_privsep_socket_worker_t *wdata;
+    privsep_worker_t psw;
+    uint32_t cmd;
+
+    /*
+     * NB: we mighjt be able top consolidate this handler now.
+     */
+    wdata = (h2o_privsep_socket_worker_t *) arg;
+    psw.sock = wdata->sock;
+    while (1) {
+        if (h2o_privsep_may_read(psw.sock, &cmd, sizeof(cmd))) {
+            break;
+        } 
+        switch (cmd) {
+        case PRIV_SET_NEVERBLEED_PATH:
+            privsep_handle_set_neverbleed_path(&psw);
+            break;
+        case PRIV_PRIVSEP_SOCK:
+            privsep_handle_privsep_sock(&psw);
+            break;
+        default:
+            h2o_fatal("invalid command over privsep socket: %d", cmd);
+            break;
+        }
+    }
+    return NULL;
+}
+
+static void *privsep_handle_requests(void *arg)
+{
+    privsep_worker_t *pswd;
+    uint32_t cmd;
+
+    pswd = (privsep_worker_t *) arg;
+    while (1) {
+        if (h2o_privsep_may_read(pswd->sock, &cmd, sizeof(cmd))) {
+            break;
+        }
+        switch (cmd) {
+        case PRIV_PRIVSEP_SOCK:
+            privsep_handle_privsep_sock(pswd);
+            break;
+        case PRIV_LOCALTIME:
+        case PRIV_GMTIME:
+            privsep_handle_dotime_r(pswd);
+            break;
+        case PRIV_WAITPID:
+            privsep_handle_waitpid(pswd);
+            break;
+        case PRIV_FD_MAPPED_EXEC:
+            privsep_handle_fd_mapped_exec(pswd);
+            break;
+        case PRIV_SENDMSG:
+            privsep_handle_sendmsg(pswd);
+            break;
+        case PRIV_OPEN_LISTENER:
+            privsep_handle_open_listener(pswd);
+            break;
+        case PRIV_DROP_PRIVS:
+            privsep_handle_drop_privs(pswd);
+            break;
+        case PRIV_CONNECT:
+            privsep_deliver_connected_sock(pswd);
+            break;
+        case PRIV_GETADDRINFO:
+            privsep_handle_getaddrinfo(pswd);
+            break;
+        case PRIV_NEVERBLEED_SOCK:
+            privsep_handle_neverbleed_sock(pswd);
+            break;
+        case PRIV_OPEN:
+            privsep_handle_open(pswd);
+            break;
+        default:
+            h2o_fatal("invalid command over privsep socket: %d", cmd);
+            break;
+        }
+    }
+    close(pswd->sock);
+    free(pswd);
+    return (NULL);
+}
+
+static void *privsep_handle_accept(void *arg)
+{
+    h2o_privsep_socket_worker_t *wdata;
+    privsep_worker_t *pswp;
+    int nsock;
+
+    wdata = (h2o_privsep_socket_worker_t *) arg;
+    while (1) {
+        nsock = accept(wdata->sock, NULL, NULL);
+        if (nsock == -1 && (errno == EINTR || errno == EAGAIN)) {
+            continue;
+        } else if (nsock == -1) {
+            h2o_fatal("[privsep] accept failed: %s", strerror(errno));
+        }
+        pswp = calloc(1, sizeof(*pswp));
+        if (pswp == NULL) {
+            h2o_fatal("[privsep] failed to allocate memory");
+        }
+        pswp->sock = nsock;
+        pswp->gcp = wdata->gcp;
+        if (pthread_create(&pswp->thr, NULL,
+          privsep_handle_requests, pswp) != 0) {
+            h2o_fatal("[privsep] pthread create worker: %s", strerror(errno));
+        }
+    }
+    return (NULL);
+}
+
+void h2o_privsep_event_loop(h2o_globalconf_t *gcp, int sock, int global_sock)
+{
+    h2o_privsep_socket_worker_t wdata[2];
+    pthread_t thr[2];
+    void *ptr;
+    int k;
+
+    wdata[0].sock = sock;
+    wdata[0].gcp = gcp;
+    if (pthread_create(&thr[0], NULL, privsep_handle_accept, &wdata[0]) != 0) {
+        h2o_fatal("[privsep] failed to launch accept thread");
+    }
+    wdata[1].sock = global_sock;
+    wdata[1].gcp = gcp;
+    if (pthread_create(&thr[1], NULL, privsep_handle_global_sock, &wdata[1]) != 0) {
+        h2o_fatal("[privsep] failed to launch accept thread");
+    }
+    for (k = 0; k < 2; k++) {
+        if (pthread_join(thr[k], &ptr) != 0) {
+            h2o_fatal("pthread join failed: %s", strerror(errno));
+        }
+    }
+}
+
+int h2o_privsep_set_global_sock(int sock)
+{
+
+    privsep_global_sock = sock;
+    return (0);
+}
+
+static int privsep_setup_socket(h2o_globalconf_t *gcp)
+{
+    char sock_path[MAXPATHLEN], sock_dir[MAXPATHLEN], *buf;
+    struct passwd *pwd, pwbuf;
+    struct sockaddr_un sun;
+    int sock, alloc;
+    struct stat sb;
+
+    if (stat("/etc/passwd", &sb) == -1) {
+        h2o_fatal("passwd database not accessible");
+    }
+    if (sb.st_size == 0) {
+        h2o_fatal("invalid passwd database");
+    }
+    alloc = 3 * sb.st_size;
+    buf = malloc(alloc);
+    if (buf == NULL) {
+        h2o_fatal("failed to allocate buffer");
+    }
+    if (getpwnam_r(gcp->user, &pwbuf, buf, alloc, &pwd) != 0) {
+        h2o_fatal("[privsep] user %s does not exist %s", gcp->user, strerror(errno));
+    }
+    if (snprintf(sock_dir, MAXPATHLEN, "/tmp/h2o_privsep.XXXXXX") < 0) {
+        h2o_fatal("snprintf failed");
+    }
+    if (mkdtemp(sock_dir) == NULL) {
+        h2o_fatal("mkdtemp failed");
+    }
+    if (chown(sock_dir, pwd->pw_uid, pwd->pw_gid) == -1) {
+        h2o_fatal("[privsep] chown failed: %s", strerror(errno));
+    }
+    free(buf);
+    sock = socket(PF_UNIX, SOCK_STREAM, 0);
+    if (sock == -1) {
+        h2o_fatal("[privsep] socket failed: %s", strerror(errno));
+    }
+    snprintf(sock_path, sizeof(sock_path), "%s/_", sock_dir);
+    bzero(&sun, sizeof(sun));
+    sun.sun_family = PF_UNIX;
+    bcopy(sock_path, sun.sun_path, strlen(sock_path));
+    (void) unlink(sock_path);
+    if (bind(sock, (struct sockaddr *)&sun, sizeof(sun)) == -1) {
+        h2o_fatal("[privsep] bind failed: %s", strerror(errno));
+    }
+    if (listen(sock, SOMAXCONN) == -1) {
+        h2o_fatal("[privsep] listen failed");
+    }
+    if (chown(sock_path, pwd->pw_uid, pwd->pw_gid) == -1) {
+        h2o_fatal("[privsep] chown failed: %s", strerror(errno));
+    }
+    privsep_sock_path = strdup(sock_path);
+    if (privsep_sock_path == NULL) {
+        h2o_fatal("failed to set privsep socket path");
+    }
+    return (sock);
+}
+
+int h2o_privsep_init(h2o_globalconf_t *gcp)
+{
+    int sock, sock_pair[2];
+    pid_t pid;
+
+    if (gcp->privsep_dir == NULL) {
+        return (0);
+    }
+    if (chdir(gcp->privsep_dir) == -1) {
+        return -1;
+    }
+    printf("[PRIVSEP] initializing outer sandbox (chroot)...");
+    fflush(stdout);
+    if (chroot(".") == -1) {
+        return -1;
+    }
+    if (socketpair(AF_LOCAL, SOCK_STREAM, PF_UNSPEC, sock_pair) == -1) {
+        h2o_fatal("socketpair failed: %s", strerror(errno));
+    }
+    sock = privsep_setup_socket(gcp);
+    privsep_flags |= PRIVSEP_NON_PRIVILEGED;
+    pid = fork();
+    if (pid == -1) {
+        h2o_fatal("fork of privileged process failed: %s", strerror(errno));
+    }
+    if (pid == 0) {
+        privsep_flags &= ~PRIVSEP_NON_PRIVILEGED;
+        privsep_flags |= PRIVSEP_PRIVILEGED;
+        close(sock_pair[0]);
+        h2o_privsep_event_loop(gcp, sock, sock_pair[1]);
+        _exit(0);
+    }
+    printf("SUCCESS\n[PRIVSEP] ambient process pid %d\n", pid);
+    h2o_privsep_set_global_sock(sock_pair[0]);
+    close(sock_pair[1]);
+    h2o_privsep_activate();
+    return (0);
+}

--- a/lib/common/privsep_sandbox_freebsd.c
+++ b/lib/common/privsep_sandbox_freebsd.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020 Christian S.J. Peron
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/capsicum.h>
+
+#include <stdio.h>
+#include <err.h>
+
+static char *nullfs_mounts[] = {
+    "bin",
+    "libexec",
+    "etc/ssl",
+    "lib",
+    "sbin",
+    "usr/lib",
+    "usr/libexec",
+    "usr/bin",
+    "usr/sbin",
+    "usr/share",
+    "usr/local",
+    "var/",
+    NULL
+};
+
+void sandbox_emit_freebsd_hints(char *root)
+{
+    char *path, **copy;
+
+    copy = nullfs_mounts;
+    /*
+     * NB: copy /etc/passwd/group
+     */
+    /*
+     * On Linux, we get away with --bind mounts to create the outer sandbox
+     */
+    while ((path = *copy++)) {
+        printf("mount -t nullfs -o ro /%s %s/%s;\n", path, root, path);
+    }
+    /*
+     * This assumes a typical FreeBSD devfs setup. rc creates default rulesets
+     * for various levels of jails. We aren't going to need PTYs so we can stop
+     * at level 3.
+     */
+    printf("mount -t devfs devfs %s/dev;\n", root);
+    printf("devfs -m %s/dev ruleset 1\n", root);
+    printf("devfs -m %s/dev rule applyset;\n", root);
+    printf("devfs -m %s/dev ruleset 2\n", root);
+    printf("devfs -m %s/dev rule applyset;\n", root);
+}
+
+void
+sandbox_bind_freebsd(int policy)
+{
+
+	if (cap_enter() == -1) {
+		err(1, "cap_enter failed");
+	}
+    printf("[PRIVSEP] sandbox type: CAPSICUM bound to process\n");
+}
+
+#endif	/* __FreeBSD__ */

--- a/lib/common/privsep_sandbox_linux.c
+++ b/lib/common/privsep_sandbox_linux.c
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) 2020 Christian Peron
+ *
+ * This largely came from the OpenSSH seccomp filter code.
+ * There are obviously changes in the syscall execution profle
+ * so the policies have been updated to reflect that.
+ *
+ * Copyright (c) 2012 Will Drewry <wad@dataspill.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifdef __linux__
+#ifdef SANDBOX_SECCOMP_FILTER_DEBUG
+# include <asm/siginfo.h>
+# define __have_siginfo_t 1
+# define __have_sigval_t 1
+# define __have_sigevent_t 1
+#endif
+
+#define SECCOMP_AUDIT_ARCH AUDIT_ARCH_X86_64
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/resource.h>
+#include <sys/prctl.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+
+#include <linux/net.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <elf.h>
+
+#include <asm/unistd.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stddef.h>  /* for offsetof */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "h2o/privsep.h"
+#include "h2o/privsep_sandbox_linux.h"
+
+#define H2O_SECCOMP_DEBUG 1
+#ifdef H2O_SECCOMP_DEBUG
+#define SECCOMP_FILTER_FAIL SECCOMP_RET_TRAP
+#else
+#define SECCOMP_FILTER_FAIL SECCOMP_RET_KILL
+#endif
+
+static char *loopback_mounts[] = {
+    "bin",
+    "etc/alternatives",
+    "etc/ssl",
+    "lib",
+    "lib64",
+    "sbin",
+    "usr/lib",
+    "usr/libexec",
+    "usr/bin",
+    "usr/sbin",
+    "usr/share",
+    "usr/local",
+    "proc",
+    /*
+     * NB: we need to re-visit this and emit commands to create a more
+     * restrictive subset of the device entries.
+     */
+    "dev",
+    NULL
+};
+
+void sandbox_emit_linux_hints(char *root)
+{
+    char *path, **copy;
+
+    copy = loopback_mounts;
+    /*
+     * NB: copy /etc/passwd/group
+     */
+    /*
+     * On Linux, we get away with --bind mounts to create the outer sandbox
+     */
+    while ((path = *copy++)) {
+	printf("[ ! -d \"%s/%s\" ] && mkdir -p \"%s/%s\";\n",
+	    root, path, root, path);
+        printf("mount -o ro --bind /%s %s/%s;\n", path, root, path);
+    }
+}
+
+static const struct sock_filter h2o_neverbleed_insns[] = {
+    /*
+     * Begin BPF filter program specification.
+     */
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
+        offsetof(struct seccomp_data, arch)),
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
+        offsetof(struct seccomp_data, nr)),
+    /*
+     * Make sure signal/fault handlers work.
+     */
+#ifdef __NR_rt_sigaction
+    SC_ALLOW(__NR_rt_sigaction),
+#endif
+#ifdef __NR_rt_sigreturn
+    SC_ALLOW(__NR_rt_sigreturn),
+#endif
+#ifdef __NR_poll
+    SC_ALLOW(__NR_poll),
+#endif
+#ifdef __NR_writev
+    SC_ALLOW(__NR_writev),
+#endif
+#ifdef __NR_readv
+    SC_ALLOW(__NR_readv),
+#endif
+
+#ifdef __NR_tgkill
+    SC_ALLOW(__NR_tgkill),
+#endif
+#ifdef __NR_set_robust_list
+    SC_ALLOW(__NR_set_robust_list),
+#endif
+#ifdef __NR_clone
+    SC_ALLOW(__NR_clone),
+#endif
+
+#ifdef __NR_accept4
+    SC_ALLOW(__NR_accept4),
+#endif
+#ifdef __NR_brk
+    SC_ALLOW(__NR_brk),
+#endif
+#ifdef __NR_clock_gettime
+    SC_ALLOW(__NR_clock_gettime),
+#endif
+#ifdef __NR_clock_gettime64
+    SC_ALLOW(__NR_clock_gettime64),
+#endif
+#ifdef __NR_close
+    SC_ALLOW(__NR_close),
+#endif
+#ifdef __NR_exit
+    SC_ALLOW(__NR_exit),
+#endif
+#ifdef __NR_exit_group
+    SC_ALLOW(__NR_exit_group),
+#endif
+#ifdef __NR_futex
+    SC_ALLOW(__NR_futex),
+#endif
+#ifdef __NR_getrandom
+    SC_ALLOW(__NR_getrandom),
+#endif
+#ifdef __NR_gettimeofday
+    SC_ALLOW(__NR_gettimeofday),
+#endif
+#ifdef __NR_getuid
+    SC_ALLOW(__NR_getuid),
+#endif
+#ifdef __NR_getuid32
+    SC_ALLOW(__NR_getuid32),
+#endif
+#ifdef __NR_madvise
+    SC_ALLOW(__NR_madvise),
+#endif
+#ifdef __NR_mmap
+    SC_ALLOW_ARG_MASK(__NR_mmap, 2, PROT_READ|PROT_WRITE|PROT_NONE),
+#endif
+#ifdef __NR_mmap2
+    SC_ALLOW_ARG_MASK(__NR_mmap2, 2, PROT_READ|PROT_WRITE|PROT_NONE),
+#endif
+#ifdef __NR_mprotect
+    SC_ALLOW_ARG_MASK(__NR_mprotect, 2, PROT_READ|PROT_WRITE|PROT_NONE),
+#endif
+#ifdef __NR_mremap
+    SC_ALLOW(__NR_mremap),
+#endif
+#ifdef __NR_munmap
+    SC_ALLOW(__NR_munmap),
+#endif
+#ifdef __NR_nanosleep
+    SC_ALLOW(__NR_nanosleep),
+#endif
+#ifdef __NR_clock_nanosleep
+    SC_ALLOW(__NR_clock_nanosleep),
+#endif
+#ifdef __NR_clock_nanosleep_time64
+    SC_ALLOW(__NR_clock_nanosleep_time64),
+#endif
+#ifdef __NR_clock_gettime64
+    SC_ALLOW(__NR_clock_gettime64),
+#endif
+#ifdef __NR_read
+    SC_ALLOW(__NR_read),
+#endif
+#ifdef __NR_rt_sigprocmask
+    SC_ALLOW(__NR_rt_sigprocmask),
+#endif
+#ifdef __NR_shutdown
+    SC_ALLOW(__NR_shutdown),
+#endif
+#ifdef __NR_time
+    SC_ALLOW(__NR_time),
+#endif
+#ifdef __NR_write
+    SC_ALLOW(__NR_write),
+#endif
+#ifdef __NR_socketcall
+    SC_ALLOW_ARG(__NR_socketcall, 0, SYS_SHUTDOWN),
+    SC_DENY(__NR_socketcall, EACCES),
+#endif
+#if defined(__x86_64__) && defined(__ILP32__) && defined(__X32_SYSCALL_BIT)
+    /*
+     * On Linux x32, the clock_gettime VDSO falls back to the
+     * x86-64 syscall under some circumstances, e.g.
+     * https://bugs.debian.org/849923
+     */
+    SC_ALLOW(__NR_clock_gettime & ~__X32_SYSCALL_BIT),
+#endif
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
+};
+
+static const struct sock_filter h2o_main_insns[] = {
+    /*
+     * Begin BPF filter program specification.
+     */
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
+        offsetof(struct seccomp_data, arch)),
+    BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
+    BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
+        offsetof(struct seccomp_data, nr)),
+
+    /*
+     * Deny open(2) and openat(2) in a non-fatal manner. Often times libraries
+     * open files behind the scenes but can tolerate EPERM or EACCES. This is
+     * an attempt to make these operations less catstrophic while enforcing
+     * sandbox boundaries.
+     */
+#ifdef __NR_open
+    SC_DENY(__NR_open, EACCES),
+#endif
+#ifdef __NR_openat
+    SC_DENY(__NR_openat, EACCES),
+#endif
+    /*
+     * Make sure signal/fault handlers work.
+     */
+#ifdef __NR_rt_sigaction
+    SC_ALLOW(__NR_rt_sigaction),
+#endif
+#ifdef __NR_rt_sigreturn
+    SC_ALLOW(__NR_rt_sigreturn),
+#endif
+    /*
+     * NB: required for mruby, but I think we could probably see about getting
+     * a file descriptor and changing it to fstat() instead.
+     */
+    SC_ALLOW(__NR_lstat),
+#ifdef __NR_ioctl
+    SC_ALLOW(__NR_ioctl),
+#endif
+#ifdef __NR_sendmmsg
+    SC_ALLOW(__NR_sendmmsg),
+#endif
+#ifdef __NR_poll
+    SC_ALLOW(__NR_poll),
+#endif
+    /*
+     * NB: stat(2) path is required by try_dynamic_request() no real way
+     * around this outside of creating a priv for it. We are in a chroot
+     * so this should probably be ok for now.
+     */
+#ifdef __NR_stat
+    SC_ALLOW(__NR_stat),
+#endif
+#ifdef __NR_fstat
+    SC_ALLOW(__NR_fstat),
+#endif
+#ifdef __NR_pread64
+    SC_ALLOW(__NR_pread64),
+#endif
+
+#ifdef __NR_getpeername
+    SC_ALLOW(__NR_getpeername),
+#endif
+#ifdef __NR_epoll_wait
+    SC_ALLOW(__NR_epoll_wait),
+#endif
+#ifdef __NR_epoll_ctl
+    SC_ALLOW(__NR_epoll_ctl),
+#endif
+#ifdef __NR_epoll_create
+    SC_ALLOW(__NR_epoll_create),
+#endif
+#ifdef __NR_eventfd2
+    SC_ALLOW(__NR_eventfd2),
+#endif
+#ifdef __NR_dup
+    SC_ALLOW(__NR_dup),
+#endif
+    /*
+     * I am not happy about allowing socket, but lets scope it down to allow
+     * the less dangerous socket domains. i.e. smack down SOCK_SEQPACKET,
+     * SOCK_RAW etc.. which requires privilge which we shouldn't have, but
+     * do it anyway.
+     */
+#ifdef __NR_socket
+    SC_ALLOW_ARG(__NR_socket, 1, SOCK_STREAM),
+    SC_ALLOW_ARG(__NR_socket, 1, SOCK_DGRAM),
+#endif
+#ifdef __NR_socketpair
+    SC_ALLOW(__NR_socketpair),
+#endif
+#ifdef __NR_epoll_create
+    SC_ALLOW(__NR_epoll_create),
+#endif
+#ifdef __NR_writev
+    SC_ALLOW(__NR_writev),
+#endif
+#ifdef __NR_readv
+    SC_ALLOW(__NR_readv),
+#endif
+
+#ifdef __NR_tgkill
+    SC_ALLOW(__NR_tgkill),
+#endif
+#ifdef __NR_set_robust_list
+    SC_ALLOW(__NR_set_robust_list),
+#endif
+#ifdef __NR_clone
+    SC_ALLOW(__NR_clone),
+#endif
+
+#ifdef __NR_accept4
+    SC_ALLOW(__NR_accept4),
+#endif
+
+#ifdef __NR_pipe
+    SC_ALLOW(__NR_pipe),
+#endif
+#ifdef __NR_getsockopt
+    SC_ALLOW(__NR_getsockopt),
+#endif
+#ifdef __NR_setsockopt
+    SC_ALLOW(__NR_setsockopt),
+#endif
+#ifdef __NR_sendmsg
+    SC_ALLOW(__NR_sendmsg),
+#endif
+#ifdef __NR_recvmsg
+    SC_ALLOW(__NR_recvmsg),
+#endif
+#ifdef __NR_sendto
+    SC_ALLOW(__NR_sendto),
+#endif
+#ifdef __NR_recvfrom
+    SC_ALLOW(__NR_recvfrom),
+#endif
+#ifdef __NR_sysinfo
+    SC_ALLOW(__NR_sysinfo),
+#endif
+#ifdef __NR_fcntl
+    SC_ALLOW(__NR_fcntl),
+#endif
+#ifdef __NR_connect
+    SC_ALLOW(__NR_connect),
+#endif
+#ifdef __NR_accept
+    SC_ALLOW(__NR_accept),
+#endif
+#ifdef __NR_getsockname
+    SC_ALLOW(__NR_getsockname),
+#endif
+
+#ifdef __NR_brk
+    SC_ALLOW(__NR_brk),
+#endif
+#ifdef __NR_clock_gettime
+    SC_ALLOW(__NR_clock_gettime),
+#endif
+#ifdef __NR_clock_gettime64
+    SC_ALLOW(__NR_clock_gettime64),
+#endif
+#ifdef __NR_close
+    SC_ALLOW(__NR_close),
+#endif
+#ifdef __NR_exit
+    SC_ALLOW(__NR_exit),
+#endif
+#ifdef __NR_exit_group
+    SC_ALLOW(__NR_exit_group),
+#endif
+#ifdef __NR_futex
+    SC_ALLOW(__NR_futex),
+#endif
+#ifdef __NR_geteuid
+    SC_ALLOW(__NR_geteuid),
+#endif
+#ifdef __NR_geteuid32
+    SC_ALLOW(__NR_geteuid32),
+#endif
+#ifdef __NR_getpgid
+    SC_ALLOW(__NR_getpgid),
+#endif
+#ifdef __NR_getpid
+    SC_ALLOW(__NR_getpid),
+#endif
+#ifdef __NR_getrandom
+    SC_ALLOW(__NR_getrandom),
+#endif
+#ifdef __NR_gettimeofday
+    SC_ALLOW(__NR_gettimeofday),
+#endif
+#ifdef __NR_getuid
+    SC_ALLOW(__NR_getuid),
+#endif
+#ifdef __NR_getuid32
+    SC_ALLOW(__NR_getuid32),
+#endif
+#ifdef __NR_madvise
+    SC_ALLOW(__NR_madvise),
+#endif
+#ifdef __NR_mmap
+    SC_ALLOW_ARG_MASK(__NR_mmap, 2, PROT_READ|PROT_WRITE|PROT_NONE),
+#endif
+#ifdef __NR_mmap2
+    SC_ALLOW_ARG_MASK(__NR_mmap2, 2, PROT_READ|PROT_WRITE|PROT_NONE),
+#endif
+#ifdef __NR_mprotect
+    SC_ALLOW_ARG_MASK(__NR_mprotect, 2, PROT_READ|PROT_WRITE|PROT_NONE),
+#endif
+#ifdef __NR_mremap
+    SC_ALLOW(__NR_mremap),
+#endif
+#ifdef __NR_munmap
+    SC_ALLOW(__NR_munmap),
+#endif
+#ifdef __NR_nanosleep
+    SC_ALLOW(__NR_nanosleep),
+#endif
+#ifdef __NR_clock_nanosleep
+    SC_ALLOW(__NR_clock_nanosleep),
+#endif
+#ifdef __NR_clock_nanosleep_time64
+    SC_ALLOW(__NR_clock_nanosleep_time64),
+#endif
+#ifdef __NR_clock_gettime64
+    SC_ALLOW(__NR_clock_gettime64),
+#endif
+#ifdef __NR_read
+    SC_ALLOW(__NR_read),
+#endif
+#ifdef __NR_rt_sigprocmask
+    SC_ALLOW(__NR_rt_sigprocmask),
+#endif
+#ifdef __NR_select
+    SC_ALLOW(__NR_select),
+#endif
+#ifdef __NR_shutdown
+    SC_ALLOW(__NR_shutdown),
+#endif
+#ifdef __NR_time
+    SC_ALLOW(__NR_time),
+#endif
+#ifdef __NR_write
+    SC_ALLOW(__NR_write),
+#endif
+#ifdef __NR_socketcall
+    SC_ALLOW_ARG(__NR_socketcall, 0, SYS_SHUTDOWN),
+    SC_DENY(__NR_socketcall, EACCES),
+#endif
+#if defined(__x86_64__) && defined(__ILP32__) && defined(__X32_SYSCALL_BIT)
+    /*
+     * On Linux x32, the clock_gettime VDSO falls back to the
+     * x86-64 syscall under some circumstances, e.g.
+     * https://bugs.debian.org/849923
+     */
+    SC_ALLOW(__NR_clock_gettime & ~__X32_SYSCALL_BIT),
+#endif
+
+    /* Default deny */
+    //BPF_STMT(BPF_RET+BPF_K, SECCOMP_RET_ERRNO | (SECCOMP_RET_DATA & EACCES)),
+    BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
+};
+
+static const struct sock_fprog h2o_main_program = {
+    .len = (sizeof(h2o_main_insns)/sizeof(h2o_main_insns[0])),
+    .filter = (struct sock_filter *)h2o_main_insns,
+};
+
+
+static const struct sock_fprog h2o_neverbleed_program = {
+    .len = (sizeof(h2o_neverbleed_insns)/sizeof(h2o_neverbleed_insns[0])),
+    .filter = (struct sock_filter *)h2o_neverbleed_insns,
+};
+
+static void
+sandbox_violation(int signum, siginfo_t *info, void *void_context)
+{
+    char msg[256];
+
+    snprintf(msg, sizeof(msg),
+        "%s: unexpected system call (arch:0x%x,syscall:%d @ %p)",
+        __func__, info->si_arch, info->si_syscall, info->si_call_addr);
+    printf("%s\n", msg);
+    fflush(stdout);
+    _exit(1);
+}
+
+static void
+sandbox_child_debugging(void)
+{
+    struct sigaction act;
+    sigset_t mask;
+
+    memset(&act, 0, sizeof(act));
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGSYS);
+    act.sa_sigaction = &sandbox_violation;
+    act.sa_flags = SA_SIGINFO;
+    if (sigaction(SIGSYS, &act, NULL) == -1) {
+        fprintf(stderr, "%s: sigaction(SIGSYS): %s\n", __func__, strerror(errno));
+        exit(1);
+    }
+    if (sigprocmask(SIG_UNBLOCK, &mask, NULL) == -1) {
+        fprintf(stderr, "%s: sigprocmask(SIGSYS): %s", __func__, strerror(errno));
+        exit(1);
+    }
+}
+
+void
+sandbox_bind_linux(int policy)
+{
+    const struct sock_fprog *fprog;
+    char *ptype;
+
+    ptype = NULL;
+    fprog = NULL;
+    sandbox_child_debugging();
+    switch (policy) {
+    case SANDBOX_POLICY_NEVERBLEED:
+        ptype = "neverbleed";
+        fprog = &h2o_neverbleed_program;
+        break;
+    case SANDBOX_POLICY_H2OMAIN:
+        ptype = "h2o_main";
+        fprog = &h2o_main_program;
+        break;
+    default:
+        abort();
+    }
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == -1) {
+        printf("%s: prctl(PR_SET_NO_NEW_PRIVS): %s", __func__, strerror(errno));
+        exit(1);
+    }
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, fprog) == -1) {
+        printf("%s: prctl(PR_SET_SECCOMP): %s", __func__, strerror(errno));
+        exit(1);
+    }
+    printf("[PRIVSEP] sandbox type: SECCOMP-BPF bound. policy: %s\n", ptype);
+}
+#endif	/* __linux__ */

--- a/lib/common/time.c
+++ b/lib/common/time.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "h2o/time_.h"
+#include "h2o/privsep.h"
 
 static char *emit_wday(char *dst, int wday)
 {
@@ -140,7 +141,7 @@ static int calc_gmt_offset(time_t t, struct tm *local)
     struct tm gmt;
     int delta;
 
-    gmtime_r(&t, &gmt);
+    h2o_priv_gmtime_r(&t, &gmt);
     delta = (local->tm_hour - gmt.tm_hour) * 60 + (local->tm_min - gmt.tm_min);
 
     if (local->tm_yday != gmt.tm_yday) {
@@ -157,7 +158,7 @@ static int calc_gmt_offset(time_t t, struct tm *local)
 void h2o_time2str_log(char *buf, time_t time)
 {
     struct tm localt;
-    localtime_r(&time, &localt);
+    h2o_priv_localtime_r(&time, &localt);
     int gmt_off = calc_gmt_offset(time, &localt);
     int gmt_sign;
 

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -24,6 +24,7 @@
 #include <sys/time.h>
 #include "h2o.h"
 #include "h2o/memcached.h"
+#include "h2o/privsep.h"
 
 void h2o_context_init_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pathconf)
 {
@@ -183,7 +184,7 @@ void h2o_context_update_timestamp_string_cache(h2o_context_t *ctx)
     if (ctx->_timestamp_cache.value != NULL)
         h2o_mem_release_shared(ctx->_timestamp_cache.value);
     ctx->_timestamp_cache.value = h2o_mem_alloc_shared(NULL, sizeof(h2o_timestamp_string_t), NULL);
-    gmtime_r(&ctx->_timestamp_cache.tv_at.tv_sec, &gmt);
+    h2o_priv_gmtime_r(&ctx->_timestamp_cache.tv_at.tv_sec, &gmt);
     h2o_time2str_rfc1123(ctx->_timestamp_cache.value->rfc1123, &gmt);
     h2o_time2str_log(ctx->_timestamp_cache.value->log, ctx->_timestamp_cache.tv_at.tv_sec);
 }

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -33,6 +33,7 @@
 #include "h2o/http3_common.h"
 #include "h2o/http3_internal.h"
 #include "h2o/multithread.h"
+#include "h2o/privsep.h"
 #include "h2o.h"
 #include "../probes_.h"
 
@@ -178,7 +179,7 @@ int h2o_http3_send_datagrams(h2o_http3_ctx_t *ctx, quicly_address_t *dest, quicl
     for (size_t i = 0; i < num_datagrams; ++i) {
         mess.msg_iov = datagrams + i;
         mess.msg_iovlen = 1;
-        while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
+        while ((ret = (int)h2o_priv_sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
             ;
         if (ret == -1)
             goto SendmsgError;

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,7 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
+#include <err.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <inttypes.h>
@@ -66,6 +67,7 @@
 #include "neverbleed.h"
 #include "h2o.h"
 #include "h2o/configurator.h"
+#include "h2o/privsep.h"
 #include "h2o/http1.h"
 #include "h2o/http2.h"
 #include "h2o/http3_server.h"
@@ -170,6 +172,7 @@ struct st_h2o_quic_forward_node_t {
 
 static struct {
     h2o_globalconf_t globalconf;
+    int emit_sandbox_hint;
     run_mode_t run_mode;
     struct {
         int *fds;
@@ -446,7 +449,6 @@ static int get_ocsp_response(const char *cert_fn, const char *cmd, h2o_buffer_t 
             goto Exit;
         }
     }
-
     if (!(WIFEXITED(child_status) && WEXITSTATUS(child_status) == 0))
         h2o_buffer_dispose(resp);
     if (!WIFEXITED(child_status)) {
@@ -1136,32 +1138,11 @@ static int open_listener(int domain, int type, int protocol, struct sockaddr *ad
 {
     int fd;
 
-    if ((fd = socket(domain, type, protocol)) == -1)
+    fd = h2o_priv_open_listener(domain, type, protocol,
+      (struct sockaddr_storage *)addr, addrlen, reuseport);
+    if (fd == -1) {
         goto Error;
-    set_cloexec(fd);
-    /* if the socket is TCP, set SO_REUSEADDR flag to avoid TIME_WAIT after shutdown */
-    if (type == SOCK_STREAM) {
-        int flag = 1;
-        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag)) != 0)
-            goto Error;
     }
-#ifdef IPV6_V6ONLY
-    /* set IPv6only */
-    if (domain == AF_INET6) {
-        int flag = 1;
-        if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &flag, sizeof(flag)) != 0)
-            goto Error;
-    }
-#endif
-    if (reuseport) {
-#if H2O_HTTP3_USE_REUSEPORT
-        int flag = 1;
-        if (setsockopt(fd, SOL_SOCKET, H2O_SO_REUSEPORT, &flag, sizeof(flag)) != 0)
-            fprintf(stderr, "[warning] setsockopt(SO_REUSEPORT) failed:%s\n", strerror(errno));
-#endif
-    }
-    if (bind(fd, addr, addrlen) != 0)
-        goto Error;
 
     /* TCP-specific actions */
     if (protocol == IPPROTO_TCP) {
@@ -1172,9 +1153,6 @@ static int open_listener(int domain, int type, int protocol, struct sockaddr *ad
                 goto Error;
         }
 #endif
-        /* listen */
-        if (listen(fd, H2O_SOMAXCONN) != 0)
-            goto Error;
         /* set TCP_FASTOPEN; when tfo_queues is zero TFO is always disabled */
         if (conf.tfo_queues > 0) {
 #ifdef TCP_FASTOPEN
@@ -1185,8 +1163,12 @@ static int open_listener(int domain, int type, int protocol, struct sockaddr *ad
 #else
             tfo_queues = conf.tfo_queues;
 #endif
-            if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (const void *)&tfo_queues, sizeof(tfo_queues)) != 0)
-                fprintf(stderr, "[warning] failed to set TCP_FASTOPEN:%s\n", strerror(errno));
+            if (setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (const void *)&tfo_queues, sizeof(tfo_queues)) != 0) {
+                fprintf(stderr, "[warning] failed to set TCP_FASTOPEN: %s\n", strerror(errno));
+#ifdef __FreeBSD__
+                fprintf(stderr, "[warning] TCP_FASTOPEN on FreeBSD requires net.inet.tcp.fastopen.server_enable=1\n");
+#endif
+            }
 #else
             assert(!"conf.tfo_queues not zero on platform without TCP_FASTOPEN");
 #endif
@@ -1196,8 +1178,9 @@ static int open_listener(int domain, int type, int protocol, struct sockaddr *ad
     return fd;
 
 Error:
-    if (fd != -1)
+    if (fd != -1) {
         close(fd);
+    }
     return -1;
 }
 
@@ -1949,6 +1932,8 @@ static void on_sigterm(int signo)
 
 static int popen_crash_handler(void)
 {
+    h2o_exec_context_t ec;
+
     char *cmd_fullpath = h2o_configurator_get_cmd_path(conf.crash_handler), *argv[] = {cmd_fullpath, NULL};
     int pipefds[2];
 
@@ -1962,15 +1947,21 @@ static int popen_crash_handler(void)
         return -1;
     }
     /* spawn the logger */
-    int mapped_fds[] = {pipefds[0], 0, /* output of the pipe is connected to STDIN of the spawned process */
-                        2, 1,          /* STDOUT of the spawned process in connected to STDERR of h2o */
-                        -1};
-    if (h2o_spawnp(cmd_fullpath, argv, mapped_fds, 0) == -1) {
+    h2o_priv_init_exec_context(&ec);
+    h2o_priv_bind_fd(&ec, pipefds[0], STDIN_FILENO, H2O_FDMAP_SEND_TO_PROC);
+    /*
+     * Standard map for STDERR/STDOUT. They share the same controlling TTY
+     * and nothing will be explicitly "reading" from the file descriptor.
+     */
+    h2o_priv_bind_fd(&ec, STDERR_FILENO, STDOUT_FILENO, H2O_FDMAP_BASIC);
+    if (h2o_priv_exec(&ec, cmd_fullpath, argv, SANDBOX_POLICY_NONE) == - 1) {
         /* silently ignore error */
+        h2o_priv_cleanup_exec_context(&ec);
         close(pipefds[0]);
         close(pipefds[1]);
         return -1;
     }
+    h2o_priv_cleanup_exec_context(&ec);
     /* do the rest, and return the fd */
     close(pipefds[0]);
     return pipefds[1];
@@ -2419,7 +2410,7 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     struct listener_ctx_t *listeners = alloca(sizeof(*listeners) * conf.num_listeners);
     size_t i;
 
-    h2o_context_init(&conf.threads[thread_index].ctx, h2o_evloop_create(), &conf.globalconf);
+    //h2o_context_init(&conf.threads[thread_index].ctx, h2o_evloop_create(), &conf.globalconf);
     h2o_multithread_register_receiver(conf.threads[thread_index].ctx.queue, &conf.threads[thread_index].server_notifications,
                                       on_server_notification);
     h2o_multithread_register_receiver(conf.threads[thread_index].ctx.queue, &conf.threads[thread_index].memcached,
@@ -2793,6 +2784,16 @@ jemalloc_err:
 #undef BUFSIZE
 }
 
+static void setup_configurators_post_privsep(void)
+{
+    h2o_configurator_t *c = h2o_configurator_create(&conf.globalconf, sizeof(*c));
+
+    c->enter = on_config_listen_enter;
+    c->exit = on_config_listen_exit;
+    h2o_configurator_define_command(c, "listen", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST, on_config_listen);
+    h2o_fastcgi_register_configurator(&conf.globalconf);
+}
+
 static void setup_configurators(void)
 {
     h2o_config_init(&conf.globalconf);
@@ -2802,10 +2803,10 @@ static void setup_configurators(void)
         conf.globalconf.user = "nobody";
 
     {
-        h2o_configurator_t *c = h2o_configurator_create(&conf.globalconf, sizeof(*c));
-        c->enter = on_config_listen_enter;
-        c->exit = on_config_listen_exit;
-        h2o_configurator_define_command(c, "listen", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST, on_config_listen);
+        // h2o_configurator_t *c = h2o_configurator_create(&conf.globalconf, sizeof(*c));
+        // c->enter = on_config_listen_enter;
+        // c->exit = on_config_listen_exit;
+        // h2o_configurator_define_command(c, "listen", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST, on_config_listen);
     }
 
     {
@@ -2846,7 +2847,6 @@ static void setup_configurators(void)
     h2o_compress_register_configurator(&conf.globalconf);
     h2o_expires_register_configurator(&conf.globalconf);
     h2o_errordoc_register_configurator(&conf.globalconf);
-    h2o_fastcgi_register_configurator(&conf.globalconf);
     h2o_file_register_configurator(&conf.globalconf);
     h2o_throttle_resp_register_configurator(&conf.globalconf);
     h2o_headers_register_configurator(&conf.globalconf);
@@ -2890,11 +2890,24 @@ int main(int argc, char **argv)
 
     { /* parse options */
         int ch;
-        static struct option longopts[] = {{"conf", required_argument, NULL, 'c'}, {"mode", required_argument, NULL, 'm'},
-                                           {"test", no_argument, NULL, 't'},       {"version", no_argument, NULL, 'v'},
-                                           {"help", no_argument, NULL, 'h'},       {NULL}};
-        while ((ch = getopt_long(argc, argv, "c:m:tvh", longopts, NULL)) != -1) {
+        static struct option longopts[] = {
+            {"conf", required_argument, NULL, 'c'},
+            {"mode", required_argument, NULL, 'm'},
+            {"test", no_argument, NULL, 't'},
+            {"version", no_argument, NULL, 'v'},
+            {"help", no_argument, NULL, 'h'},
+            {"chroot-directory", required_argument, NULL, 'R'},
+            {"emit-sandbox-hint", no_argument, NULL, 'E'},
+            {NULL}
+        };
+        while ((ch = getopt_long(argc, argv, "c:Em:tvhR:", longopts, NULL)) != -1) {
             switch (ch) {
+            case 'E':
+                conf.emit_sandbox_hint = 1;
+                break;
+            case 'R':
+                conf.globalconf.privsep_dir = optarg;
+                break;
             case 'c':
                 opt_config_file = optarg;
                 break;
@@ -2959,6 +2972,8 @@ int main(int argc, char **argv)
                        "                               connections. Users may send SIGHUP to the master\n"
                        "                               process to reconfigure or upgrade the server.\n"
                        "                     - test:   tests the configuration and exits\n"
+                       "  -R, --chroot-directory\n"
+                       "                     Directory to chroot to for privsep mode\n"
                        "  -t, --test         synonym of `--mode=test`\n"
                        "  -v, --version      prints the version number\n"
                        "  -h, --help         print this help\n"
@@ -2980,6 +2995,22 @@ int main(int argc, char **argv)
         argc -= optind;
         argv += optind;
     }
+
+    if (conf.emit_sandbox_hint) {
+        if (!conf.globalconf.privsep_dir) {
+            fprintf(stderr, "privsep directory must be specified for -E\n");
+            return EX_OSERR;
+        }
+        h2o_priv_sandbox_hints(conf.globalconf.privsep_dir);
+        return 0;
+    }
+
+    if (h2o_priv_init(&conf.globalconf)) {
+        fprintf(stderr, "FAILED\n[PRIVSEP] failed to initialize sandbox: %s\n",
+            strerror(errno));
+        return EX_OSERR;
+    }
+    setup_configurators_post_privsep();
 
     /* setup conf.server_starter */
     if ((conf.server_starter.num_fds = h2o_server_starter_get_fds(&conf.server_starter.fds)) == SIZE_MAX)
@@ -3176,9 +3207,14 @@ int main(int argc, char **argv)
         error_log_fd = -1;
     }
 
-    /* start the threads */
+
     conf.threads = alloca(sizeof(conf.threads[0]) * conf.thread_map.size);
     size_t i;
+    for (i = 0; i < conf.thread_map.size; i++) {
+        h2o_context_init(&conf.threads[i].ctx, h2o_evloop_create(), &conf.globalconf);
+    }
+    h2o_priv_bind_sandbox(SANDBOX_POLICY_H2OMAIN);
+    /* start the threads */
     for (i = 1; i != conf.thread_map.size; ++i) {
         pthread_t tid;
         h2o_multithread_create_thread(&tid, NULL, run_loop, (void *)i);


### PR DESCRIPTION
This PR adds the code to facilitate additional sandboxing support for the H2O main, FastCGI
and neverbleed process. While the current H2O security model provides higher levels
of security assurance than many other Internet facing services, there are additional
risk scenarios that we want to mitigate in the event that specific threats materialize.

**Note**: There is some additional code (specifically more granular restrictions on
the privileges that are granted) that needs to come in yet. For that reason I am adding
the do not merge tag, but I think that this work is far enough along that it would benefit
from wider review from the community.

There are many core features implemented within H2O leveraging third party library
dependencies. Some of this code is assessed to carry higher levels of risk. This conclusion
was reached based on both the relative complexity of the linked code base(s) and
their historical vulnerability track records. The following areas or components of H2O were identified as higher risk:

* HTTP version 1.1/2/3 protocol encode/decode: C based parsing and processing of Internet sourced, user defined data. These areas are historically associated with memory corruption vulnerabilities
* FastCGI services: Execution of [generally] interpreted code which is processing Internet sourced, user defined data. These interfaces have a history of being abused and leveraged for things like shell injection and web implants.
* Embedded ruby (mruby) interpreter execution: Similar to the FastCGI services, this feature embeds a ruby interpreter which runs in the context of the request dispatching threads (h2o user)
* Compression (e.g.: zlib) services used by HTTP content encoding, and TLS with a history of memory corruption vulnerabilities
* OpenSSL used to implement the cryptographic services underlying TLS 1.1, 1.2 and many of the core cryptographic functions in the PicoTLS stack. History of containing memory corruption vulnerabilities leading to RCE, memory exposure (containing sensitive keying data) and denial of service vulnerabilities.

One common thread for all of the risk factors listed above is that if an attacker is able to exploit a vulnerability in one of these components, they have access to the full privileges granted to the respective system process.

### Outer sandbox assumptions

This design assumes the presence of an outer sandbox. This can be thought of as the execution environment in which H2O operates in. This should be isolated, at the very least from the file system namespace of the host environment.

A `chroot` environment should be considered a mediocre implementation of an outer sandbox, as this will not limit access to process, network and device namespaces.

Following is a list of the suggested security properties for the outer sandbox:

* No access to the global process [PID] namespace. This can be accomplished via the unshare(2) syscall, or jail(2) on FreeBSD
* Access to minimal device nodes (`/dev/…`) entries which can be accomplished through mount namespaces and file system bindings, or devfs rules on FreeBSD. Giving non-privileged processes access to device entries can have unintended consequences from allowing adversaries to insert writable, and executable mappings into a process or manipulating underlying block devices containing file system data.
* Network namespace restriction: The H2O process would only be able to access networks that it's serving requests for. Out of band or management networks should be restricted. In the event of compromise this will help prevent lateral movement within a network in the event of compromise, it can also reduce the severity of server side request forgery (SSRF) vulnerabilities

**Note**: Most if not all of these requirements can be met through containerized or jailed operation of the H2O process.

To facilitate privsep operation, a new process security model has been defined.

### Privilege separation process model

Each H2O domain is implemented as one or more processes. These domains are defined and described in the table below:| Domain | Description | Sandbox |
|--------|-------------|---------|
| Outer Sandbox | Overarching H2O compartment. This has been implemented via chroot(2) as a base level of protection. However this can be implemented in the form of a Docker container, or FreeBSD jail. These mechanisms can provide further restrictions to the global namespaces of the host environment | N/A |
| Ambient Authority | Forked from H2O early in the bootstrapping process. This process executes within the outer sandbox, and has access to everything within the outer sandbox. This process facilitates and mediates all access for resources within the outer sandbox| Outer
| H2O main | This is a non-privileged domain which executes the main event loop. This process terminates all TLS connections, negotiates HTTP protocol version via ALPN and is responsible for dispatching all user requests. This domain is considered higher risk due to the various protocol processing and handling of untrusted, user defined data. There is no access to global namespaces or dangerous system calls. Required to go through the Ambient authority for all privileged operations | Syscall
| Never Bleed | Existing Ambient process which contains TLS keying materials. This process handles requests to load keys, encrypt, decrypt and sign data. Compromised H2O main domains have limited access to TLS secrets. i.e.: they are limited to the exploitation of cache side channels and speculative execution vulnerabilities | Syscall
| FastCGI | Will load code to execute in the context of the FCGI handler. This process is connected to H2O main via inter-process communication mechanisms (IPC) and will currently be restricted to file system namespaces relative to a directory within the outer sandbox. | Syscall

### Code organization

The following table defines the key source files for the privsep implementation. The libh2o library was chosen as the location of the privsep code as many of the privsep candidates were used by the H2O http server as well as the HTTP client which ships as part of this repository. Therefore these filenames are relative to lib/common in the root of the repository for the project:| Filename | Description |

|----------|-------------|
| priv_wrapper.c | Abstraction interface used by the H2O code. These are the drop in replacements for the otherwise dangerous syscalls/operations. This could be thought of as the entry point for the privsep work.
| privsep.c | This file contains the sandboxed variants of the dangerous interfaces. This code will run in the context of the sandbox, accessing the ambient process when it needs access to the outer sandboxes namespace(s).
| allpriv.c | Contains the non-privsep mode variants of the interfaces. This should match the behavior of the pre-privsep code base. This code does not run in a sandbox.
| privsep_dispatch.c | Code for the ambient authority process. This code is responsible for brokering access between the sandbox and the outer sandbox namespaces.
| privsep_sandbox_linux.c | Linux specific implementation for SECCOMP-BPF and fault handling.
| privsep_sandbox_freebsd.c | FreeBSD specific implementation for Capsicum
| deps/fcgi/fcgi.c| Sandbox loader for FastCGI applications (e.g.: php-cgi)

