### PR TITLE
[CI] allocate 3G for the workspace for non-travis env

### DIFF
--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -24,7 +24,7 @@ dtrace:
 
 _check:
 	mkdir -p build
-	sudo mount -t tmpfs tmpfs build
+	sudo mount -t tmpfs tmpfs build -o size=3G
 	sudo chown -R ci:ci build
 	sudo chmod 0755 build
 	$(MAKE) -f $(CHECK_MK) -C build _do-check CMAKE_ARGS=$(CMAKE_ARGS)


### PR DESCRIPTION
Mounting `tmpfs` uses 50% of the memory by default. It is enough for Travis because its Linux instances have [7.5G memory](https://docs.travis-ci.com/user/reference/overview/), but it's not for local VMs which tend to have less memory and to cause disk-full on a `docker build`. Adding `-o size=3G` is not a perfect solution, but likely to avoid disk-full.