### PR TITLE
Fix occasional test failures in t/50reverse-proxy*.t

### DIFF
--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -56,7 +56,7 @@ my $upstream = $unix_socket_file ? "[unix:$unix_socket_file]" : "127.0.0.1:@{[em
 
 my $guard = do {
     local $ENV{FORCE_CHUNKED} = $starlet_force_chunked;
-    my @args = (qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $unix_socket_file || $upstream);
+    my @args = (qw(plackup -s Starlet --max-workers=20 --keepalive-timeout 100 --access-log /dev/null --listen), $unix_socket_file || $upstream);
     if ($starlet_keepalive) {
         push @args, "--max-keepalive-reqs=100";
     }


### PR DESCRIPTION
... by increasing connection concurrency of Starlet.

The cause was a combination of the following factors:
* By default, Starlet accepts at most concurrent 10 connections.
* H2O creates a connection pool for each `proxy.reverse.url` directive, and another connection pool for "reproxy"-ing.
* One of the test case issues 10 concurrent requests using nghttp, then a different test case fetches an object through "reproxy"-ing.

When persistent connection to the backend server is turned on, 10 connections might be opened when handling concurrent requests from nghttp. If that happens, the reproxy test fails as Starlet would not accept a new connection.