### PR TITLE
[http3] knob for changing the amplification limit

### DIFF
--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -257,6 +257,10 @@ struct st_quicly_context_t {
      */
     uint64_t max_crypto_bytes;
     /**
+     * (server-only) amplification limit before the peer address is validated
+     */
+    uint16_t pre_validation_amplification_limit;
+    /**
      * client-only
      */
     unsigned enforce_version_negotiation : 1;

--- a/deps/quicly/lib/defaults.c
+++ b/deps/quicly/lib/defaults.c
@@ -26,6 +26,7 @@
 #define DEFAULT_MAX_UDP_PAYLOAD_SIZE 1472
 #define DEFAULT_MAX_PACKETS_PER_KEY 16777216
 #define DEFAULT_MAX_CRYPTO_BYTES 65536
+#define DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT 3
 
 /* profile that employs IETF specified values */
 const quicly_context_t quicly_spec_context = {NULL,                                                 /* tls */
@@ -39,6 +40,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                                DEFAULT_MAX_UDP_PAYLOAD_SIZE},
                                               DEFAULT_MAX_PACKETS_PER_KEY,
                                               DEFAULT_MAX_CRYPTO_BYTES,
+                                              DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                               0, /* enforce_version_negotiation */
                                               0, /* is_clustered */
                                               0, /* enlarge_client_hello */
@@ -64,6 +66,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                      DEFAULT_MAX_UDP_PAYLOAD_SIZE},
                                                     DEFAULT_MAX_PACKETS_PER_KEY,
                                                     DEFAULT_MAX_CRYPTO_BYTES,
+                                                    DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                                     0, /* enforce_version_negotiation */
                                                     0, /* is_clustered */
                                                     0, /* enlarge_client_hello */

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -2584,10 +2584,10 @@ static inline uint64_t calc_amplification_limit_allowance(quicly_conn_t *conn)
 {
     if (conn->super.remote.address_validation.validated)
         return UINT64_MAX;
-    uint64_t budget3x = conn->super.stats.num_bytes.received * 3;
-    if (budget3x <= conn->super.stats.num_bytes.sent)
+    uint64_t budget = conn->super.stats.num_bytes.received * conn->super.ctx->pre_validation_amplification_limit;
+    if (budget <= conn->super.stats.num_bytes.sent)
         return 0;
-    return budget3x - conn->super.stats.num_bytes.sent;
+    return budget - conn->super.stats.num_bytes.sent;
 }
 
 /* Helper function to compute send window based on:


### PR DESCRIPTION
Based on https://github.com/h2o/quicly/pull/377, adds `quic/amp-limit` property to the `listen` directive. The property accepts the amplification limit, the default being 3.

Below is the trace collected using h2olog when `quic/amp-limit` is set to 1.

```
{"type":"accept","seq":1,"conn":0,"time":1595728500650,"dcid":"d8d7e4120c6bfe89"}
{"type":"crypto-decrypt","seq":2,"conn":0,"time":1595728500650,"pn":1,"decrypted-len":1315}
{"type":"quictrace-recv","seq":3,"conn":0,"time":1595728500650,"pn":1}
{"type":"stream-receive","seq":4,"conn":0,"time":1595728500650,"stream-id":-1,"off":0,"len":512}
{"type":"stream-on-receive","seq":5,"conn":0,"time":1595728500650,"stream-id":-1,"off":0,"src":"010001fc03031fe63b4307c0b63d76db4461880ef34b011711d94df4e653cfa0ea163f4c8e90000006130113021303010001cd0000001a00180000153132372e","len":512}
{"type":"crypto-update-secret","seq":6,"conn":0,"time":1595728500650,"is-enc":1,"epoch":0,"label":"QUIC_SERVER_HANDSHAKE_TRAFFIC_SECRET"}
{"type":"crypto-update-secret","seq":7,"conn":0,"time":1595728500650,"is-enc":0,"epoch":0,"label":"QUIC_CLIENT_HANDSHAKE_TRAFFIC_SECRET"}
{"type":"crypto-update-secret","seq":8,"conn":0,"time":1595728500650,"is-enc":1,"epoch":0,"label":"QUIC_SERVER_TRAFFIC_SECRET_0"}
{"type":"crypto-handshake","seq":9,"conn":0,"time":1595728500650,"ret":0}
{"type":"stream-on-open","seq":10,"conn":0,"time":0,"stream-id":3}
{"type":"stream-on-open","seq":11,"conn":0,"time":0,"stream-id":7}
{"type":"stream-on-open","seq":12,"conn":0,"time":0,"stream-id":11}
{"type":"h3s-accept","seq":13,"conn-id":1,"conn":0,"time":1595728500655}
{"type":"send","seq":14,"conn":0,"time":1595728500655,"state":1,"dcid":""}
{"type":"packet-prepare","seq":15,"conn":0,"time":1595728500655,"first-octet":192,"dcid":""}
{"type":"ack-send","seq":16,"conn":0,"time":1595728500655,"largest-acked":1,"ack-delay":4}
{"type":"stream-on-send-emit","seq":17,"conn":0,"time":1595728500655,"stream-id":-1,"off":0,"capacity":1298}
{"type":"stream-send","seq":18,"conn":0,"time":1595728500655,"stream-id":-1,"off":0,"len":90,"is-fin":0}
{"type":"quictrace-send-stream","seq":19,"conn":0,"time":1595728500655,"stream-id":-1,"off":0,"len":90,"fin":0}
{"type":"packet-commit","seq":20,"conn":0,"time":1595728500655,"pn":0,"len":144,"ack-only":0}
{"type":"quictrace-sent","seq":21,"conn":0,"time":1595728500655,"pn":0,"len":144,"packet-type":0}
{"type":"packet-prepare","seq":22,"conn":0,"time":1595728500655,"first-octet":224,"dcid":""}
{"type":"stream-on-send-emit","seq":23,"conn":0,"time":1595728500655,"stream-id":-3,"off":0,"capacity":1160}
{"type":"stream-send","seq":24,"conn":0,"time":1595728500655,"stream-id":-3,"off":0,"len":1158,"is-fin":0}
{"type":"quictrace-send-stream","seq":25,"conn":0,"time":1595728500655,"stream-id":-3,"off":0,"len":1158,"fin":0}
{"type":"packet-commit","seq":26,"conn":0,"time":1595728500655,"pn":1,"len":1206,"ack-only":0}
{"type":"quictrace-sent","seq":27,"conn":0,"time":1595728500655,"pn":1,"len":1206,"packet-type":2}
{"type":"receive","seq":28,"conn":0,"time":1595728500656,"dcid":"53aebbd94db9e5a2ab2fe15bd486378466","first-octet":205,"bytes-len":1350}
{"type":"crypto-decrypt","seq":29,"conn":0,"time":1595728500656,"pn":2,"decrypted-len":1306}
{"type":"quictrace-recv","seq":30,"conn":0,"time":1595728500656,"pn":2}
{"type":"quictrace-recv-ack","seq":31,"conn":0,"time":1595728500656,"ack-block-begin":0,"ack-block-end":0}
{"type":"packet-acked","seq":32,"conn":0,"time":1595728500656,"pn":0,"is-late-ack":0}
{"type":"stream-acked","seq":33,"conn":0,"time":1595728500656,"stream-id":-1,"off":0,"len":90}
{"type":"stream-on-send-shift","seq":34,"conn":0,"time":1595728500656,"stream-id":-1,"delta":90}
{"type":"quictrace-recv-ack-delay","seq":35,"conn":0,"time":1595728500656,"ack-delay":145}
{"type":"quictrace-cc-ack","seq":36,"conn":0,"time":1595728500656,"min-rtt":1,"smoothed-rtt":1,"variance-rtt":0,"latest-rtt":1,"cwnd":14864,"inflight":1206}
{"type":"cc-ack-received","seq":37,"conn":0,"time":1595728500656,"largest-acked":0,"bytes-acked":144,"cwnd":14864,"inflight":1206}
{"type":"send","seq":38,"conn":0,"time":1595728500656,"state":1,"dcid":""}
{"type":"packet-prepare","seq":39,"conn":0,"time":1595728500656,"first-octet":224,"dcid":""}
{"type":"stream-on-send-emit","seq":40,"conn":0,"time":1595728500656,"stream-id":-3,"off":1158,"capacity":1303}
{"type":"stream-send","seq":41,"conn":0,"time":1595728500656,"stream-id":-3,"off":1158,"len":1301,"is-fin":0}
{"type":"quictrace-send-stream","seq":42,"conn":0,"time":1595728500656,"stream-id":-3,"off":1158,"len":1301,"fin":0}
{"type":"packet-commit","seq":43,"conn":0,"time":1595728500656,"pn":2,"len":1350,"ack-only":0}
{"type":"quictrace-sent","seq":44,"conn":0,"time":1595728500656,"pn":2,"len":1350,"packet-type":2}
{"type":"receive","seq":45,"conn":0,"time":1595728500657,"dcid":"53aebbd94db9e5a2ab2fe15bd486378466","first-octet":233,"bytes-len":50}
{"type":"crypto-decrypt","seq":46,"conn":0,"time":1595728500657,"pn":3,"decrypted-len":7}
{"type":"quictrace-recv","seq":47,"conn":0,"time":1595728500657,"pn":3}
{"type":"stream-on-destroy","seq":48,"conn":0,"time":1595728500657,"stream-id":-1,"err":0}
{"type":"quictrace-recv-ack","seq":49,"conn":0,"time":1595728500657,"ack-block-begin":1,"ack-block-end":1}
{"type":"packet-acked","seq":50,"conn":0,"time":1595728500657,"pn":1,"is-late-ack":0}
{"type":"stream-acked","seq":51,"conn":0,"time":1595728500657,"stream-id":-3,"off":0,"len":1158}
{"type":"stream-on-send-shift","seq":52,"conn":0,"time":1595728500657,"stream-id":-3,"delta":1158}
{"type":"quictrace-recv-ack-delay","seq":53,"conn":0,"time":1595728500657,"ack-delay":179}
{"type":"quictrace-cc-ack","seq":54,"conn":0,"time":1595728500657,"min-rtt":1,"smoothed-rtt":1,"variance-rtt":0,"latest-rtt":2,"cwnd":16070,"inflight":1350}
{"type":"cc-ack-received","seq":55,"conn":0,"time":1595728500657,"largest-acked":1,"bytes-acked":1206,"cwnd":16070,"inflight":1350}
{"type":"send","seq":56,"conn":0,"time":1595728500657,"state":1,"dcid":""}
{"type":"packet-prepare","seq":57,"conn":0,"time":1595728500657,"first-octet":224,"dcid":""}
{"type":"stream-on-send-emit","seq":58,"conn":0,"time":1595728500657,"stream-id":-3,"off":1301,"capacity":1303}
{"type":"stream-send","seq":59,"conn":0,"time":1595728500657,"stream-id":-3,"off":2459,"len":543,"is-fin":0}
{"type":"quictrace-send-stream","seq":60,"conn":0,"time":1595728500657,"stream-id":-3,"off":2459,"len":543,"fin":0}
{"type":"packet-commit","seq":61,"conn":0,"time":1595728500657,"pn":3,"len":592,"ack-only":0}
{"type":"quictrace-sent","seq":62,"conn":0,"time":1595728500657,"pn":3,"len":592,"packet-type":2}
{"type":"packet-prepare","seq":63,"conn":0,"time":1595728500657,"first-octet":64,"dcid":""}
{"type":"stream-on-send-emit","seq":64,"conn":0,"time":1595728500657,"stream-id":-4,"off":0,"capacity":737}
{"type":"stream-send","seq":65,"conn":0,"time":1595728500657,"stream-id":-4,"off":0,"len":201,"is-fin":0}
{"type":"quictrace-send-stream","seq":66,"conn":0,"time":1595728500657,"stream-id":-4,"off":0,"len":201,"fin":0}
{"type":"new-token-send","seq":67,"conn":0,"time":1595728500657,"token":"5301b3bed950994684f8b28cddc2df73a19bf9eb3f0e48af67de983889716c6f11041b7022611df7e88383aab20eb5","token-len":47,"generation":1}
{"type":"new-connection-id-send","seq":68,"conn":0,"time":1595728500657,"sequence":1,"retire-prior-to":0,"cid":"533c9ae99de02c549f3afeeb1dae99c1a8","stateless-reset-token":"339f5f43f0fd15ad78b3f101f24f04a5"}
{"type":"stream-on-send-emit","seq":69,"conn":0,"time":1595728500657,"stream-id":3,"off":0,"capacity":446}
{"type":"stream-send","seq":70,"conn":0,"time":1595728500657,"stream-id":3,"off":0,"len":3,"is-fin":0}
{"type":"quictrace-send-stream","seq":71,"conn":0,"time":1595728500657,"stream-id":3,"off":0,"len":3,"fin":0}
{"type":"stream-on-send-emit","seq":72,"conn":0,"time":1595728500657,"stream-id":7,"off":0,"capacity":440}
{"type":"stream-send","seq":73,"conn":0,"time":1595728500657,"stream-id":7,"off":0,"len":1,"is-fin":0}
{"type":"quictrace-send-stream","seq":74,"conn":0,"time":1595728500657,"stream-id":7,"off":0,"len":1,"fin":0}
{"type":"stream-on-send-emit","seq":75,"conn":0,"time":1595728500657,"stream-id":11,"off":0,"capacity":436}
{"type":"stream-send","seq":76,"conn":0,"time":1595728500657,"stream-id":11,"off":0,"len":1,"is-fin":0}
{"type":"quictrace-send-stream","seq":77,"conn":0,"time":1595728500657,"stream-id":11,"off":0,"len":1,"fin":0}
{"type":"packet-commit","seq":78,"conn":0,"time":1595728500657,"pn":4,"len":324,"ack-only":0}
{"type":"quictrace-sent","seq":79,"conn":0,"time":1595728500657,"pn":4,"len":324,"packet-type":3}
{"type":"receive","seq":80,"conn":0,"time":1595728500658,"dcid":"53aebbd94db9e5a2ab2fe15bd486378466","first-octet":236,"bytes-len":50}
{"type":"crypto-decrypt","seq":81,"conn":0,"time":1595728500658,"pn":4,"decrypted-len":7}
{"type":"quictrace-recv","seq":82,"conn":0,"time":1595728500658,"pn":4}
{"type":"quictrace-recv-ack","seq":83,"conn":0,"time":1595728500658,"ack-block-begin":1,"ack-block-end":3}
{"type":"packet-acked","seq":84,"conn":0,"time":1595728500658,"pn":2,"is-late-ack":0}
{"type":"stream-acked","seq":85,"conn":0,"time":1595728500658,"stream-id":-3,"off":1158,"len":1301}
{"type":"packet-acked","seq":86,"conn":0,"time":1595728500658,"pn":3,"is-late-ack":0}
{"type":"stream-acked","seq":87,"conn":0,"time":1595728500658,"stream-id":-3,"off":2459,"len":543}
{"type":"stream-on-send-shift","seq":88,"conn":0,"time":1595728500658,"stream-id":-3,"delta":1844}
{"type":"quictrace-recv-ack-delay","seq":89,"conn":0,"time":1595728500658,"ack-delay":129}
{"type":"quictrace-cc-ack","seq":90,"conn":0,"time":1595728500658,"min-rtt":1,"smoothed-rtt":1,"variance-rtt":0,"latest-rtt":1,"cwnd":18012,"inflight":324}
{"type":"cc-ack-received","seq":91,"conn":0,"time":1595728500658,"largest-acked":3,"bytes-acked":1942,"cwnd":18012,"inflight":324}
{"type":"receive","seq":92,"conn":0,"time":1595728500666,"dcid":"53aebbd94db9e5a2ab2fe15bd486378466","first-octet":224,"bytes-len":82}
{"type":"crypto-decrypt","seq":93,"conn":0,"time":1595728500666,"pn":5,"decrypted-len":39}
{"type":"quictrace-recv","seq":94,"conn":0,"time":1595728500666,"pn":5}
{"type":"stream-receive","seq":95,"conn":0,"time":1595728500666,"stream-id":-3,"off":0,"len":36}
{"type":"stream-on-receive","seq":96,"conn":0,"time":1595728500666,"stream-id":-3,"off":0,"src":"14000020831ff65ce179734bfbb406c92fbf423b53829058d81b0779b905696ecdc8b817","len":36}
{"type":"crypto-update-secret","seq":97,"conn":0,"time":1595728500666,"is-enc":0,"epoch":0,"label":"QUIC_CLIENT_TRAFFIC_SECRET_0"}
{"type":"crypto-handshake","seq":98,"conn":0,"time":1595728500666,"ret":0}
{"type":"stream-on-destroy","seq":99,"conn":0,"time":1595728500666,"stream-id":-3,"err":0}
{"type":"receive","seq":100,"conn":0,"time":1595728500666,"dcid":"53aebbd94db9e5a2ab2fe15bd486378466","first-octet":75,"bytes-len":83}
{"type":"crypto-decrypt","seq":101,"conn":0,"time":1595728500666,"pn":6,"decrypted-len":48}
{"type":"quictrace-recv","seq":102,"conn":0,"time":1595728500666,"pn":6}
{"type":"quictrace-recv-stream","seq":103,"conn":0,"time":1595728500666,"stream-id":2,"off":0,"len":46,"fin":0}
{"type":"stream-on-open","seq":104,"conn":0,"time":1595728500666,"stream-id":2}
{"type":"stream-receive","seq":105,"conn":0,"time":1595728500666,"stream-id":2,"off":0,"len":46}
{"type":"stream-on-receive","seq":106,"conn":0,"time":1595728500666,"stream-id":2,"off":0,"src":"00041d01800100000680040000074064c000000a0c2506afc00000004af38863c0000007cb6c403b02d0610d0100","len":46}
{"type":"send","seq":107,"conn":0,"time":1595728500666,"state":1,"dcid":""}
{"type":"packet-prepare","seq":108,"conn":0,"time":1595728500666,"first-octet":64,"dcid":""}
{"type":"ack-send","seq":109,"conn":0,"time":1595728500666,"largest-acked":6,"ack-delay":0}
{"type":"handshake-done-send","seq":110,"conn":0,"time":1595728500666}
{"type":"packet-commit","seq":111,"conn":0,"time":1595728500666,"pn":5,"len":25,"ack-only":0}
{"type":"quictrace-sent","seq":112,"conn":0,"time":1595728500666,"pn":5,"len":25,"packet-type":3}
{"type":"receive","seq":113,"conn":0,"time":1595728500667,"dcid":"53aebbd94db9e5a2ab2fe15bd486378466","first-octet":95,"bytes-len":404}
{"type":"crypto-decrypt","seq":114,"conn":0,"time":1595728500667,"pn":7,"decrypted-len":369}
{"type":"quictrace-recv","seq":115,"conn":0,"time":1595728500667,"pn":7}
{"type":"quictrace-recv-ack","seq":116,"conn":0,"time":1595728500667,"ack-block-begin":4,"ack-block-end":4}
{"type":"packet-acked","seq":117,"conn":0,"time":1595728500667,"pn":4,"is-late-ack":0}
{"type":"stream-acked","seq":118,"conn":0,"time":1595728500667,"stream-id":-4,"off":0,"len":201}
{"type":"new-token-acked","seq":119,"conn":0,"time":1595728500667,"generation":1}
{"type":"stream-acked","seq":120,"conn":0,"time":1595728500667,"stream-id":3,"off":0,"len":3}
{"type":"stream-on-send-shift","seq":121,"conn":0,"time":1595728500667,"stream-id":-4,"delta":201}
{"type":"stream-acked","seq":122,"conn":0,"time":1595728500667,"stream-id":7,"off":0,"len":1}
{"type":"stream-on-send-shift","seq":123,"conn":0,"time":1595728500667,"stream-id":3,"delta":3}
{"type":"stream-acked","seq":124,"conn":0,"time":1595728500667,"stream-id":11,"off":0,"len":1}
{"type":"stream-on-send-shift","seq":125,"conn":0,"time":1595728500667,"stream-id":7,"delta":1}
{"type":"crypto-send-key-update-confirmed","seq":126,"conn":0,"time":1595728500667,"next-pn":16777222}
{"type":"stream-on-send-shift","seq":127,"conn":0,"time":1595728500667,"stream-id":11,"delta":1}
{"type":"quictrace-recv-ack-delay","seq":128,"conn":0,"time":1595728500667,"ack-delay":1155}
{"type":"quictrace-cc-ack","seq":129,"conn":0,"time":1595728500667,"min-rtt":1,"smoothed-rtt":2,"variance-rtt":2,"latest-rtt":10,"cwnd":18336,"inflight":25}
```