### PR TITLE
add `%{ssl.negotiated-protocol}x` for logging selected protocol

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -847,6 +847,7 @@ typedef struct st_h2o_conn_callbacks_t {
                 h2o_iovec_t (*cipher_bits)(h2o_req_t *req);
                 h2o_iovec_t (*session_id)(h2o_req_t *req);
                 h2o_iovec_t (*server_name)(h2o_req_t *req);
+                h2o_iovec_t (*negotiated_protocol)(h2o_req_t *req);
             } ssl;
             struct {
                 h2o_iovec_t (*request_index)(h2o_req_t *req);

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -287,6 +287,7 @@ static h2o_iovec_t h2o_socket_log_ssl_cipher(h2o_socket_t *sock, h2o_mem_pool_t 
 h2o_iovec_t h2o_socket_log_ssl_cipher_bits(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 h2o_iovec_t h2o_socket_log_ssl_session_id(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 static h2o_iovec_t h2o_socket_log_ssl_server_name(h2o_socket_t *sock, h2o_mem_pool_t *pool);
+static h2o_iovec_t h2o_socket_log_ssl_negotiated_protocol(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 int h2o_socket_ssl_new_session_cb(SSL *s, SSL_SESSION *sess);
 
 /**
@@ -439,6 +440,12 @@ inline h2o_iovec_t h2o_socket_log_ssl_server_name(h2o_socket_t *sock, h2o_mem_po
     (void)pool;
     const char *s = h2o_socket_get_ssl_server_name(sock);
     return s != NULL ? h2o_iovec_init(s, strlen(s)) : h2o_iovec_init(NULL, 0);
+}
+
+inline h2o_iovec_t h2o_socket_log_ssl_negotiated_protocol(h2o_socket_t *sock, h2o_mem_pool_t *pool)
+{
+    (void)pool;
+    return h2o_socket_ssl_get_selected_protocol(sock);
 }
 
 inline int h2o_sliding_counter_is_running(h2o_sliding_counter_t *counter)

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -289,6 +289,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_PROTO("ssl.cipher-bits", ssl.cipher_bits);
                     MAP_EXT_TO_PROTO("ssl.session-id", ssl.session_id);
                     MAP_EXT_TO_PROTO("ssl.server-name", ssl.server_name);
+                    MAP_EXT_TO_PROTO("ssl.negotiated-protocol", ssl.negotiated_protocol);
                     { /* not found */
                         h2o_iovec_t name = strdup_lowercased(pt, quote_end - pt);
                         NEW_ELEMENT(ELEMENT_TYPE_EXTENDED_VAR);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -1127,6 +1127,7 @@ DEFINE_TLS_LOGGER(cipher)
 DEFINE_TLS_LOGGER(cipher_bits)
 DEFINE_TLS_LOGGER(session_id)
 DEFINE_TLS_LOGGER(server_name)
+DEFINE_TLS_LOGGER(negotiated_protocol)
 
 #undef DEFINE_TLS_LOGGER
 
@@ -1165,6 +1166,7 @@ static const h2o_conn_callbacks_t h1_callbacks = {
                 .cipher_bits = log_cipher_bits,
                 .session_id = log_session_id,
                 .server_name = log_server_name,
+                .negotiated_protocol = log_negotiated_protocol,
             },
         .http1 =
             {

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1452,13 +1452,13 @@ static int skip_tracing(h2o_conn_t *_conn)
         h2o_http2_conn_t *conn = (void *)req->conn;                                                                                \
         return h2o_socket_log_ssl_##name(conn->sock, &req->pool);                                                                  \
     }
-
 DEFINE_TLS_LOGGER(protocol_version)
 DEFINE_TLS_LOGGER(session_reused)
 DEFINE_TLS_LOGGER(cipher)
 DEFINE_TLS_LOGGER(cipher_bits)
 DEFINE_TLS_LOGGER(session_id)
 DEFINE_TLS_LOGGER(server_name)
+DEFINE_TLS_LOGGER(negotiated_protocol)
 #undef DEFINE_TLS_LOGGER
 
 static h2o_iovec_t log_stream_id(h2o_req_t *req)
@@ -1556,6 +1556,7 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
                     .cipher_bits = log_cipher_bits,
                     .session_id = log_session_id,
                     .server_name = log_server_name,
+                    .negotiated_protocol = log_negotiated_protocol,
                 },
             .http2 =
                 {

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -373,6 +373,14 @@ static h2o_iovec_t log_server_name(h2o_req_t *req)
     return server_name != NULL ? h2o_iovec_init(server_name, strlen(server_name)) : h2o_iovec_init(NULL, 0);
 }
 
+static h2o_iovec_t log_negotiated_protocol(h2o_req_t *req)
+{
+    struct st_h2o_http3_server_conn_t *conn = (struct st_h2o_http3_server_conn_t *)req->conn;
+    ptls_t *tls = quicly_get_tls(conn->h3.quic);
+    const char *proto = ptls_get_negotiated_protocol(tls);
+    return proto != NULL ? h2o_iovec_init(proto, strlen(proto)) : h2o_iovec_init(NULL, 0);
+}
+
 static h2o_iovec_t log_stream_id(h2o_req_t *_req)
 {
     struct st_h2o_http3_server_stream_t *stream = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_stream_t, req, _req);
@@ -1440,6 +1448,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
                     .cipher_bits = log_cipher_bits,
                     .session_id = log_session_id,
                     .server_name = log_server_name,
+                    .negotiated_protocol = log_negotiated_protocol,
                 },
             .http3 =
                 {


### PR DESCRIPTION
This feature is useful for checking which draft version of HTTP/3 was being used.