### PR TITLE
accesslog: upstream TLS info format strings for reverse proxy (reissue of PR#2398)

### DIFF
--- a/doc/configure/access_log_directives.html
+++ b/doc/configure/access_log_directives.html
@@ -205,14 +205,6 @@ As an example, it is possible to log timestamps in millisecond resolution using 
 <tr><td><code>ssl.server-name</code><td>hostname provided in Server Name Indication (SNI) extension, if any
 </table>
 <table>
-<caption>Upstream Proxy Connection</caption>
-<tr><th>Name<th>Description
-<tr><td><code>proxy.ssl.protocol-version</code><td>SSL protocol version obtained from <a href="https://www.openssl.org/docs/manmaster/ssl/SSL_get_version.html"><code>SSL_get_version</code></a>
-<tr><td><code>proxy.ssl.session-reused</code><td><code>1</code> if the <a href="configure/base_directives.html#ssl-session-resumption">SSL session was reused</a>, or <code>0</code> if not<sup><a href="#note_1" id="#cite_1" title="A single SSL connection may transfer more than one HTTP request.">1</sup></a></sup>
-<tr><td><code>proxy.ssl.cipher</code><td>name of the <a href="https://tools.ietf.org/html/rfc5246#appendix-A.5">cipher suite</a> being used, obtained from <a href="https://www.openssl.org/docs/manmaster/ssl/SSL_CIPHER_get_name.html">SSL_CIPHER_get_name</a>
-<tr><td><code>proxy.ssl.cipher-bits</code><td>strength of the cipher suite in bits
-</table>
-<table>
 <caption>HTTP/2 (since v2.0)</caption>
 <tr><th>Name<th>Description
 <tr><td><code>http2.stream-id</code><td>stream ID

--- a/doc/configure/access_log_directives.html
+++ b/doc/configure/access_log_directives.html
@@ -205,6 +205,14 @@ As an example, it is possible to log timestamps in millisecond resolution using 
 <tr><td><code>ssl.server-name</code><td>hostname provided in Server Name Indication (SNI) extension, if any
 </table>
 <table>
+<caption>Upstream Proxy Connection</caption>
+<tr><th>Name<th>Description
+<tr><td><code>proxy.ssl.protocol-version</code><td>SSL protocol version obtained from <a href="https://www.openssl.org/docs/manmaster/ssl/SSL_get_version.html"><code>SSL_get_version</code></a>
+<tr><td><code>proxy.ssl.session-reused</code><td><code>1</code> if the <a href="configure/base_directives.html#ssl-session-resumption">SSL session was reused</a>, or <code>0</code> if not<sup><a href="#note_1" id="#cite_1" title="A single SSL connection may transfer more than one HTTP request.">1</sup></a></sup>
+<tr><td><code>proxy.ssl.cipher</code><td>name of the <a href="https://tools.ietf.org/html/rfc5246#appendix-A.5">cipher suite</a> being used, obtained from <a href="https://www.openssl.org/docs/manmaster/ssl/SSL_CIPHER_get_name.html">SSL_CIPHER_get_name</a>
+<tr><td><code>proxy.ssl.cipher-bits</code><td>strength of the cipher suite in bits
+</table>
+<table>
 <caption>HTTP/2 (since v2.0)</caption>
 <tr><th>Name<th>Description
 <tr><td><code>http2.stream-id</code><td>stream ID

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1107,6 +1107,13 @@ struct st_h2o_req_t {
             uint64_t body;
         } bytes_read;
         h2o_httpclient_timings_t timestamps;
+        struct {
+            const char *protocol_version;
+            const char *cipher;
+            int session_reused;
+            int cipher_bits;
+            /* server name and session id are omitted since they are not static data */
+        } ssl;
     } proxy_stats;
     /**
      * the response

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -855,7 +855,7 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             if (req->proxy_stats.ssl.cipher_bits == 0)
                 goto EmitNull;
             RESERVE(sizeof(H2O_INT16_LONGEST_STR));
-            pos += sprintf(pos, "%" PRIu16, req->proxy_stats.ssl.cipher_bits);
+            pos += sprintf(pos, "%" PRIu16, (uint16_t) req->proxy_stats.ssl.cipher_bits);
             break;
         case ELEMENT_TYPE_PROXY_SSL_PROTOCOL_VERSION:
             APPEND_SAFE_STRING(pos, req->proxy_stats.ssl.protocol_version);

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -77,6 +77,10 @@ enum {
     ELEMENT_TYPE_PROXY_RESPONSE_BYTES,          /* %{proxy.response-bytes}x */
     ELEMENT_TYPE_PROXY_RESPONSE_BYTES_HEADER,   /* %{proxy.response-bytes-header}x */
     ELEMENT_TYPE_PROXY_RESPONSE_BYTES_BODY,     /* %{proxy.response-bytes-body}x */
+    ELEMENT_TYPE_PROXY_SSL_PROTOCOL_VERSION,    /* ${proxy.ssl.protocol-version}x */
+    ELEMENT_TYPE_PROXY_SSL_SESSION_REUSED,      /* ${proxy.ssl.session-reused}x */
+    ELEMENT_TYPE_PROXY_SSL_CIPHER,              /* ${proxy.ssl.cipher}x */
+    ELEMENT_TYPE_PROXY_SSL_CIPHER_BITS,         /* ${proxy.ssl.cipher_bits}x */
     NUM_ELEMENT_TYPES
 };
 
@@ -272,6 +276,10 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_TYPE("proxy.response-bytes", ELEMENT_TYPE_PROXY_RESPONSE_BYTES);
                     MAP_EXT_TO_TYPE("proxy.response-bytes-header", ELEMENT_TYPE_PROXY_RESPONSE_BYTES_HEADER);
                     MAP_EXT_TO_TYPE("proxy.response-bytes-body", ELEMENT_TYPE_PROXY_RESPONSE_BYTES_BODY);
+                    MAP_EXT_TO_TYPE("proxy.ssl.protocol-version", ELEMENT_TYPE_PROXY_SSL_PROTOCOL_VERSION);
+                    MAP_EXT_TO_TYPE("proxy.ssl.session-reused", ELEMENT_TYPE_PROXY_SSL_SESSION_REUSED);
+                    MAP_EXT_TO_TYPE("proxy.ssl.cipher", ELEMENT_TYPE_PROXY_SSL_CIPHER);
+                    MAP_EXT_TO_TYPE("proxy.ssl.cipher-bits", ELEMENT_TYPE_PROXY_SSL_CIPHER_BITS);
                     MAP_EXT_TO_PROTO("http1.request-index", http1.request_index);
                     MAP_EXT_TO_PROTO("http2.stream-id", http2.stream_id);
                     MAP_EXT_TO_PROTO("http2.priority.received", http2.priority_received);
@@ -469,6 +477,14 @@ Fail:
     return pos;
 }
 
+#define APPEND_SAFE_STRING_WITH_LEN(pos, s, len)        \
+    do {                                                \
+        if (s == NULL)                                  \
+            goto EmitNull;                              \
+        RESERVE(len);                                   \
+        pos = append_safe_string(pos, s, len);          \
+    } while (0)
+#define APPEND_SAFE_STRING(pos, s) APPEND_SAFE_STRING_WITH_LEN(pos, s, strlen(s))
 #define APPEND_DURATION(pos, name)                                                                                                 \
     do {                                                                                                                           \
         int64_t delta_usec;                                                                                                        \
@@ -487,7 +503,7 @@ Fail:
             }                                                                                                                      \
             pos += 6;                                                                                                              \
         }                                                                                                                          \
-    } while (0);
+    } while (0)
 
 static char *expand_line_buf(char *line, size_t *cur_size, size_t required, int should_realloc)
 {
@@ -831,18 +847,28 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
             pos += sprintf(pos, "%" PRIu64, req->proxy_stats.bytes_read.body);
             break;
-
+        case ELEMENT_TYPE_PROXY_SSL_SESSION_REUSED:
+            RESERVE(1);
+            *pos++ = (req->proxy_stats.ssl.session_reused) ? '1' : '0';
+            break;
+        case ELEMENT_TYPE_PROXY_SSL_CIPHER_BITS:
+            if (req->proxy_stats.ssl.cipher_bits == 0)
+                goto EmitNull;
+            RESERVE(sizeof(H2O_INT16_LONGEST_STR));
+            pos += sprintf(pos, "%" PRIu16, req->proxy_stats.ssl.cipher_bits);
+            break;
+        case ELEMENT_TYPE_PROXY_SSL_PROTOCOL_VERSION:
+            APPEND_SAFE_STRING(pos, req->proxy_stats.ssl.protocol_version);
+            break;
+        case ELEMENT_TYPE_PROXY_SSL_CIPHER:
+            APPEND_SAFE_STRING(pos, req->proxy_stats.ssl.cipher);
+            break;
         case ELEMENT_TYPE_PROTOCOL_SPECIFIC: {
             h2o_iovec_t (*cb)(h2o_req_t *) = req->conn->callbacks->log_.callbacks[element->data.protocol_specific_callback_index];
-            if (cb != NULL) {
-                h2o_iovec_t s = cb(req);
-                if (s.base == NULL)
-                    goto EmitNull;
-                RESERVE(s.len);
-                pos = append_safe_string(pos, s.base, s.len);
-            } else {
+            if (cb == NULL)
                 goto EmitNull;
-            }
+            h2o_iovec_t s = cb(req);
+            APPEND_SAFE_STRING_WITH_LEN(pos, s.base, s.len);
         } break;
 
         case ELEMENT_TYPE_LOGNAME:      /* %l */

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -398,6 +398,14 @@ static void copy_stats(struct rp_generator_t *self)
     self->src_req->proxy_stats.bytes_read.body = self->client->bytes_read.body;
 }
 
+static void retain_ssl_info(h2o_req_t *req, h2o_socket_t *sock)
+{
+    req->proxy_stats.ssl.protocol_version = h2o_socket_get_ssl_protocol_version(sock);
+    req->proxy_stats.ssl.session_reused = h2o_socket_get_ssl_session_reused(sock);
+    req->proxy_stats.ssl.cipher = h2o_socket_get_ssl_cipher(sock);
+    req->proxy_stats.ssl.cipher_bits = h2o_socket_get_ssl_cipher_bits(sock);
+}
+
 static int on_body(h2o_httpclient_t *client, const char *errstr)
 {
     struct rp_generator_t *self = client->data;
@@ -700,6 +708,8 @@ static h2o_httpclient_head_cb on_connect(h2o_httpclient_t *client, const char *e
         }
     }
     self->client->informational_cb = on_1xx;
+    
+    retain_ssl_info(req, client->get_socket(client));
     return on_head;
 }
 

--- a/srcdoc/configure/access_log_directives.mt
+++ b/srcdoc/configure/access_log_directives.mt
@@ -136,6 +136,14 @@ As an example, it is possible to log timestamps in millisecond resolution using 
 <tr><td><code>ssl.server-name</code><td>hostname provided in Server Name Indication (SNI) extension, if any
 </table>
 <table>
+<caption>Upstream Proxy Connection (since v2.3)</caption>
+<tr><th>Name<th>Description
+<tr><td><code>proxy.ssl.protocol-version</code><td>SSL protocol version obtained from <a href="https://www.openssl.og/docs/manmaster/ssl/SSL_get_version.html"><code>SSL_get_version</code></a>
+<tr><td><code>proxy.ssl.session-reused</code><td><code>1</code> if the <a href="configure/base_directives.html#ssl-session-resumption">SSL session was reused</a>, or <code>0</code> if not
+<tr><td><code>proxy.ssl.cipher</code><td>name of the <a href="https://tools.ietf.org/html/rfc5246#appendix-A.5">cipher suite</a> being used, obtained from <a href="https://www.openssl.org/docs/manmaster/ssl/SSL_CIPHER_get_name.html">SSL_CIPHER_get_name</a>
+<tr><td><code>proxy.ssl.cipher-bits</code><td>strength of the cipher suite in bits
+</table>
+<table>
 <caption>HTTP/2 (since v2.0)</caption>
 <tr><th>Name<th>Description
 <tr><td><code>http2.stream-id</code><td>stream ID


### PR DESCRIPTION
Since it's convienient to provide information of both end for many occasion,
this patch provides following %{proxy.ssl.*}x format strings for server-side (upstream) TLS session:
  proxy.ssl.protocol-version
  proxy.ssl.cipher
  proxy.ssl.cipher-bits
  proxy.ssl.session-reused

Two dynamic data, server name and session id, are omitted to minimize memory use with use cases
which does not use this feature. By the way, server name at both ends must be same.

To do that, `h2o_req_t` remembers upstream SSL information at `on_connect()` and use it at logging.

proxy.ssl.* logging primitves are categorized as MAP_EXT_TO_TYPE.

This patch worked most PR comments of https://github.com/h2o/h2o/pull/2398.

--
I think that it is better not to leave cluttered commit history, so
I re-issue the PR#2398 here, to compact commit history.

Thank you.