### PR TITLE
[http3] split H3 and QUIC layer

### DIFF
--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -309,34 +309,34 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
 /**
  * initializes the context
  */
-void h2o_http3_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
-                            h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update);
+void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
+                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update);
 /**
  *
  */
-void h2o_http3_dispose_context(h2o_quic_ctx_t *ctx);
+void h2o_quic_dispose_context(h2o_quic_ctx_t *ctx);
 /**
  *
  */
-void h2o_http3_set_context_identifier(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, uint32_t thread_id, uint64_t node_id,
-                                      uint8_t ttl, h2o_quic_forward_packets_cb forward_cb,
-                                      h2o_quic_preprocess_packet_cb preprocess_cb);
+void h2o_quic_set_context_identifier(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, uint32_t thread_id, uint64_t node_id,
+                                     uint8_t ttl, h2o_quic_forward_packets_cb forward_cb,
+                                     h2o_quic_preprocess_packet_cb preprocess_cb);
 /**
  *
  */
-void h2o_http3_read_socket(h2o_quic_ctx_t *ctx, h2o_socket_t *sock);
+void h2o_quic_read_socket(h2o_quic_ctx_t *ctx, h2o_socket_t *sock);
 /**
  *
  */
-void h2o_http3_close_connection(h2o_http3_conn_t *conn, int err, const char *reason_phrase);
+void h2o_quic_close_connection(h2o_quic_conn_t *conn, int err, const char *reason_phrase);
 /**
  *
  */
-void h2o_http3_close_all_connections(h2o_quic_ctx_t *ctx);
+void h2o_quic_close_all_connections(h2o_quic_ctx_t *ctx);
 /**
  *
  */
-size_t h2o_http3_num_connections(h2o_quic_ctx_t *ctx);
+size_t h2o_quic_num_connections(h2o_quic_ctx_t *ctx);
 /**
  *
  */

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -295,7 +295,7 @@ extern const ptls_iovec_t h2o_http3_alpn[2];
 /**
  * sends datagrams
  */
-int h2o_http3_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams,
+int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams,
                              size_t num_datagrams);
 /**
  * creates a unidirectional stream object

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -296,7 +296,7 @@ extern const ptls_iovec_t h2o_http3_alpn[2];
  * sends datagrams
  */
 int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams,
-                             size_t num_datagrams);
+                            size_t num_datagrams);
 /**
  * creates a unidirectional stream object
  */

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -346,6 +346,10 @@ void h2o_quic_init_conn(h2o_quic_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_qu
  */
 void h2o_quic_dispose_conn(h2o_quic_conn_t *conn);
 /**
+ *
+ */
+void h2o_quic_setup(h2o_quic_conn_t *conn, quicly_conn_t *quic);
+/**
  * initializes a http3 connection
  */
 void h2o_http3_init_conn(h2o_http3_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_http3_conn_callbacks_t *callbacks);

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -78,11 +78,12 @@
 #define H2O_HTTP3_ERROR_TRANSPORT -2
 #define H2O_HTTP3_ERROR_USER1 -256
 
-typedef struct st_h2o_http3_ctx_t h2o_http3_ctx_t;
+typedef struct st_h2o_quic_ctx_t h2o_quic_ctx_t;
+typedef struct st_h2o_quic_conn_t h2o_quic_conn_t;
 typedef struct st_h2o_http3_conn_t h2o_http3_conn_t;
 struct st_h2o_http3_ingress_unistream_t;
 struct st_h2o_http3_egress_unistream_t;
-struct kh_h2o_http3_idmap_s;
+struct kh_h2o_quic_idmap_s;
 struct kh_h2o_http3_unauthmap_s;
 
 typedef enum en_h2o_http3_priority_element_type_t {
@@ -106,9 +107,9 @@ uint8_t *h2o_http3_encode_priority_update_frame(uint8_t *dst, const h2o_http3_pr
 int h2o_http3_decode_priority_update_frame(h2o_http3_priority_update_frame_t *frame, const uint8_t *payload, size_t len,
                                            const char **err_desc);
 
-typedef h2o_http3_conn_t *(*h2o_http3_accept_cb)(h2o_http3_ctx_t *ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,
-                                                 quicly_decoded_packet_t *packet);
-typedef void (*h2o_http3_notify_connection_update_cb)(h2o_http3_ctx_t *ctx, h2o_http3_conn_t *conn);
+typedef h2o_quic_conn_t *(*h2o_quic_accept_cb)(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,
+                                               quicly_decoded_packet_t *packet);
+typedef void (*h2o_quic_notify_connection_update_cb)(h2o_quic_ctx_t *ctx, h2o_quic_conn_t *conn);
 /**
  * Forwards a packet to given node/thread.
  * When `node_id` is NULL, the forwarded packet is an Initial or a 0-RTT packet.  Application should forward the packet to given
@@ -119,16 +120,16 @@ typedef void (*h2o_http3_notify_connection_update_cb)(h2o_http3_ctx_t *ctx, h2o_
  * the packet is a stateless reset.
  * @return true if packet was forwarded (or was forwardable), otherwise false
  */
-typedef int (*h2o_http3_forward_packets_cb)(h2o_http3_ctx_t *ctx, const uint64_t *node_id, uint32_t thread_id,
-                                            quicly_address_t *destaddr, quicly_address_t *srcaddr, uint8_t ttl,
-                                            quicly_decoded_packet_t *packets, size_t num_packets);
+typedef int (*h2o_quic_forward_packets_cb)(h2o_quic_ctx_t *ctx, const uint64_t *node_id, uint32_t thread_id,
+                                           quicly_address_t *destaddr, quicly_address_t *srcaddr, uint8_t ttl,
+                                           quicly_decoded_packet_t *packets, size_t num_packets);
 /**
  * preprocess a received datagram (e.g., rewrite the sockaddr). Returns if the packet was modified.
  */
-typedef int (*h2o_http3_preprocess_packet_cb)(h2o_http3_ctx_t *ctx, struct msghdr *msghdr, quicly_address_t *destaddr,
-                                              quicly_address_t *srcaddr, uint8_t *ttl);
+typedef int (*h2o_quic_preprocess_packet_cb)(h2o_quic_ctx_t *ctx, struct msghdr *msghdr, quicly_address_t *destaddr,
+                                             quicly_address_t *srcaddr, uint8_t *ttl);
 
-struct st_h2o_http3_ctx_t {
+struct st_h2o_quic_ctx_t {
     /**
      * the event loop
      */
@@ -153,15 +154,15 @@ struct st_h2o_http3_ctx_t {
     /**
      * hashmap of connections by quicly_cid_plaintext_t::master_id.
      */
-    struct kh_h2o_http3_idmap_s *conns_by_id;
+    struct kh_h2o_quic_idmap_s *conns_by_id;
     /**
      * hashmap of connections being accepted. Keyed by 4-tuple. Exists to handle packets that do not use the server-generated CIDs.
      */
-    struct kh_h2o_http3_acceptmap_s *conns_accepting;
+    struct kh_h2o_quic_acceptmap_s *conns_accepting;
     /**
      * callback to receive connection status changes (optional)
      */
-    h2o_http3_notify_connection_update_cb notify_conn_update;
+    h2o_quic_notify_connection_update_cb notify_conn_update;
     /**
      * linklist of clients (see st_h2o_http3client_conn_t::clients_link)
      */
@@ -169,7 +170,7 @@ struct st_h2o_http3_ctx_t {
     /**
      * callback to accept new connections (optional)
      */
-    h2o_http3_accept_cb acceptor;
+    h2o_quic_accept_cb acceptor;
     /**
      * 0 to disable load distribution of accepting connections by h2o (i.e. relies on the kernel's disbirution based on 4-tuple)
      */
@@ -177,7 +178,7 @@ struct st_h2o_http3_ctx_t {
     /**
      * callback to forward packets (optional)
      */
-    h2o_http3_forward_packets_cb forward_packets;
+    h2o_quic_forward_packets_cb forward_packets;
     /**
      * TTL of a QUIC datagram. Used to prevent infinite forwarding of QUIC packets between nodes / threads.
      */
@@ -185,19 +186,18 @@ struct st_h2o_http3_ctx_t {
     /**
      * preprocessor that rewrites a forwarded datagram (optional)
      */
-    h2o_http3_preprocess_packet_cb preprocess_packet;
+    h2o_quic_preprocess_packet_cb preprocess_packet;
 };
 
-typedef struct st_h2o_http3_conn_callbacks_t {
-    void (*destroy_connection)(h2o_http3_conn_t *conn);
-    void (*handle_control_stream_frame)(h2o_http3_conn_t *conn, uint8_t type, const uint8_t *payload, size_t len);
-} h2o_http3_conn_callbacks_t;
+typedef struct st_h2o_quic_conn_callbacks_t {
+    void (*destroy_connection)(h2o_quic_conn_t *conn);
+} h2o_quic_conn_callbacks_t;
 
-struct st_h2o_http3_conn_t {
+struct st_h2o_quic_conn_t {
     /**
      * context
      */
-    h2o_http3_ctx_t *ctx;
+    h2o_quic_ctx_t *ctx;
     /**
      * underlying QUIC connection
      */
@@ -205,7 +205,27 @@ struct st_h2o_http3_conn_t {
     /**
      * callbacks
      */
-    const h2o_http3_conn_callbacks_t *callbacks;
+    const h2o_quic_conn_callbacks_t *callbacks;
+    /**
+     * the "transport" timer. Applications must have separate timer.
+     */
+    h2o_timer_t _timeout;
+    /**
+     *
+     */
+    uint64_t _accept_hashkey;
+};
+
+typedef struct st_h2o_http3_conn_callbacks_t {
+    h2o_quic_conn_callbacks_t super;
+    void (*handle_control_stream_frame)(h2o_http3_conn_t *conn, uint8_t type, const uint8_t *payload, size_t len);
+} h2o_http3_conn_callbacks_t;
+
+struct st_h2o_http3_conn_t {
+    /**
+     *
+     */
+    h2o_quic_conn_t super;
     /**
      * QPACK states
      */
@@ -219,10 +239,6 @@ struct st_h2o_http3_conn_t {
     struct {
         uint64_t max_header_list_size;
     } peer_settings;
-    /**
-     * the "transport" timer. Applications must have separate timer.
-     */
-    h2o_timer_t _timeout;
     struct {
         struct {
             struct st_h2o_http3_ingress_unistream_t *control;
@@ -235,10 +251,6 @@ struct st_h2o_http3_conn_t {
             struct st_h2o_http3_egress_unistream_t *qpack_decoder;
         } egress;
     } _control_streams;
-    /**
-     *
-     */
-    uint64_t _accept_hashkey;
 };
 
 #define h2o_http3_encode_frame(_pool_, _buf_, _type, _block)                                                                       \
@@ -283,7 +295,7 @@ extern const ptls_iovec_t h2o_http3_alpn[2];
 /**
  * sends datagrams
  */
-int h2o_http3_send_datagrams(h2o_http3_ctx_t *ctx, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams,
+int h2o_http3_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams,
                              size_t num_datagrams);
 /**
  * creates a unidirectional stream object
@@ -297,22 +309,22 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
 /**
  * initializes the context
  */
-void h2o_http3_init_context(h2o_http3_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
-                            h2o_http3_accept_cb acceptor, h2o_http3_notify_connection_update_cb notify_conn_update);
+void h2o_http3_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
+                            h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update);
 /**
  *
  */
-void h2o_http3_dispose_context(h2o_http3_ctx_t *ctx);
+void h2o_http3_dispose_context(h2o_quic_ctx_t *ctx);
 /**
  *
  */
-void h2o_http3_set_context_identifier(h2o_http3_ctx_t *ctx, uint32_t accept_thread_divisor, uint32_t thread_id, uint64_t node_id,
-                                      uint8_t ttl, h2o_http3_forward_packets_cb forward_cb,
-                                      h2o_http3_preprocess_packet_cb preprocess_cb);
+void h2o_http3_set_context_identifier(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, uint32_t thread_id, uint64_t node_id,
+                                      uint8_t ttl, h2o_quic_forward_packets_cb forward_cb,
+                                      h2o_quic_preprocess_packet_cb preprocess_cb);
 /**
  *
  */
-void h2o_http3_read_socket(h2o_http3_ctx_t *ctx, h2o_socket_t *sock);
+void h2o_http3_read_socket(h2o_quic_ctx_t *ctx, h2o_socket_t *sock);
 /**
  *
  */
@@ -320,15 +332,23 @@ void h2o_http3_close_connection(h2o_http3_conn_t *conn, int err, const char *rea
 /**
  *
  */
-void h2o_http3_close_all_connections(h2o_http3_ctx_t *ctx);
+void h2o_http3_close_all_connections(h2o_quic_ctx_t *ctx);
 /**
  *
  */
-size_t h2o_http3_num_connections(h2o_http3_ctx_t *ctx);
+size_t h2o_http3_num_connections(h2o_quic_ctx_t *ctx);
+/**
+ *
+ */
+void h2o_quic_init_conn(h2o_quic_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_quic_conn_callbacks_t *callbacks);
+/**
+ *
+ */
+void h2o_quic_dispose_conn(h2o_quic_conn_t *conn);
 /**
  * initializes a http3 connection
  */
-void h2o_http3_init_conn(h2o_http3_conn_t *conn, h2o_http3_ctx_t *ctx, const h2o_http3_conn_callbacks_t *callbacks);
+void h2o_http3_init_conn(h2o_http3_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_http3_conn_callbacks_t *callbacks);
 /**
  *
  */
@@ -340,7 +360,7 @@ int h2o_http3_setup(h2o_http3_conn_t *conn, quicly_conn_t *quic);
 /**
  * sends packets immediately by calling quicly_send, sendmsg (returns 1 if success, 0 if the connection was destroyed)
  */
-int h2o_http3_send(h2o_http3_conn_t *conn);
+int h2o_quic_send(h2o_quic_conn_t *conn);
 /**
  * updates receive buffer
  */
@@ -349,7 +369,7 @@ void h2o_http3_update_recvbuf(h2o_buffer_t **buf, size_t off, const void *src, s
  * Schedules the transport timer. Application must call this function when it writes data to the connection (TODO better way to
  * handle this?). The function is automatically called when packets are sent or received.
  */
-void h2o_http3_schedule_timer(h2o_http3_conn_t *conn);
+void h2o_quic_schedule_timer(h2o_quic_conn_t *conn);
 /**
  *
  */

--- a/include/h2o/http3_internal.h
+++ b/include/h2o/http3_internal.h
@@ -26,8 +26,8 @@
 #include "quicly.h"
 #include "h2o/memory.h"
 
-KHASH_MAP_INIT_INT(h2o_http3_idmap, h2o_http3_conn_t *);
-KHASH_MAP_INIT_INT64(h2o_http3_acceptmap, h2o_http3_conn_t *);
+KHASH_MAP_INIT_INT(h2o_quic_idmap, h2o_quic_conn_t *);
+KHASH_MAP_INIT_INT64(h2o_quic_acceptmap, h2o_quic_conn_t *);
 
 struct st_h2o_http3_egress_unistream_t {
     /**

--- a/include/h2o/http3_server.h
+++ b/include/h2o/http3_server.h
@@ -28,7 +28,7 @@
 #include "h2o.h"
 
 typedef struct st_h2o_http3_server_ctx_t {
-    h2o_http3_ctx_t super;
+    h2o_quic_ctx_t super;
     h2o_accept_ctx_t *accept_ctx;
     unsigned send_retry : 1;
 } h2o_http3_server_ctx_t;

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -113,7 +113,7 @@ typedef struct st_h2o_httpclient_ctx_t {
     /**
      * 1-to-(0|1) relationship; NULL when h3 is not used
      */
-    struct st_h2o_http3_ctx_t *http3;
+    struct st_h2o_quic_ctx_t *http3;
 
 } h2o_httpclient_ctx_t;
 
@@ -268,7 +268,7 @@ extern const size_t h2o_httpclient__h2_size;
 
 void h2o_httpclient_connect_h3(h2o_httpclient_t **_client, h2o_mem_pool_t *pool, void *data, h2o_httpclient_ctx_t *ctx,
                                h2o_url_t *target, h2o_httpclient_connect_cb cb);
-void h2o_httpclient_http3_notify_connection_update(h2o_http3_ctx_t *ctx, h2o_http3_conn_t *conn);
+void h2o_httpclient_http3_notify_connection_update(h2o_quic_ctx_t *ctx, h2o_quic_conn_t *conn);
 extern quicly_stream_open_t h2o_httpclient_http3_on_stream_open;
 
 #endif

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -249,7 +249,7 @@ static void handle_control_stream_frame(h2o_http3_conn_t *_conn, uint8_t type, c
 
     return;
 Fail:
-    h2o_http3_close_connection(&conn->super, err, err_desc);
+    h2o_quic_close_connection(&conn->super.super, err, err_desc);
 }
 
 struct st_h2o_http3client_conn_t *create_connection(h2o_httpclient_ctx_t *ctx, h2o_url_t *origin)

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -102,7 +102,7 @@ void on_track_sendmsg_timer(h2o_timer_t *timeout)
  * Sends a packet, returns if the connection is still maintainable (false is returned when not being able to send a packet from the
  * designated source address).
  */
-int h2o_http3_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams,
+int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams,
                              size_t num_datagrams)
 {
     int ret;
@@ -534,7 +534,7 @@ static void process_packets(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, qui
                                                                   packets[0].cid.dest.encrypted, payload);
             assert(payload_size != SIZE_MAX);
             struct iovec vec = {.iov_base = payload, .iov_len = payload_size};
-            h2o_http3_send_datagrams(ctx, srcaddr, destaddr, &vec, 1);
+            h2o_quic_send_datagrams(ctx, srcaddr, destaddr, &vec, 1);
             return;
         } else if (packets[0].cid.src.len > QUICLY_MAX_CID_LEN_V1) {
             return;
@@ -557,7 +557,7 @@ static void process_packets(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, qui
                                                                   packets[0].cid.dest.encrypted.base, payload);
                 assert(payload_size != SIZE_MAX);
                 struct iovec vec = {.iov_base = payload, .iov_len = payload_size};
-                h2o_http3_send_datagrams(ctx, srcaddr, destaddr, &vec, 1);
+                h2o_quic_send_datagrams(ctx, srcaddr, destaddr, &vec, 1);
             }
             return;
         }
@@ -1069,7 +1069,7 @@ int h2o_quic_send(h2o_quic_conn_t *conn)
         int ret = quicly_send(conn->quic, &dest, &src, datagrams, &num_datagrams, datagram_buf, sizeof(datagram_buf));
         switch (ret) {
         case 0:
-            if (num_datagrams != 0 && !h2o_http3_send_datagrams(conn->ctx, &dest, &src, datagrams, num_datagrams)) {
+            if (num_datagrams != 0 && !h2o_quic_send_datagrams(conn->ctx, &dest, &src, datagrams, num_datagrams)) {
                 /* FIXME close the connection immediately */
                 break;
             }

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -103,7 +103,7 @@ void on_track_sendmsg_timer(h2o_timer_t *timeout)
  * designated source address).
  */
 int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams,
-                             size_t num_datagrams)
+                            size_t num_datagrams)
 {
     int ret;
     struct msghdr mess;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -593,7 +593,7 @@ static void handle_buffered_input(struct st_h2o_http3_server_stream_t *stream)
                     err = H2O_HTTP3_ERROR_GENERAL_PROTOCOL;
                     err_desc = "incomplete frame";
                 }
-                h2o_http3_close_connection(&conn->h3, err, err_desc);
+                h2o_quic_close_connection(&conn->h3.super, err, err_desc);
                 return;
             }
             if (quicly_stop_requested(stream->quic)) {
@@ -1088,7 +1088,7 @@ static void handle_control_stream_frame(h2o_http3_conn_t *_conn, uint8_t type, c
 
     return;
 Fail:
-    h2o_http3_close_connection(&conn->h3, err, err_desc);
+    h2o_quic_close_connection(&conn->h3.super, err, err_desc);
 }
 
 static int stream_open_cb(quicly_stream_open_t *self, quicly_stream_t *qs)

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -69,7 +69,7 @@ static const ptls_key_exchange_algorithm_t *h3_key_exchanges[] = {
 static struct {
     ptls_context_t tls;
     quicly_context_t quic;
-    h2o_http3_ctx_t h3;
+    h2o_quic_ctx_t h3;
 } h3ctx = {{ptls_openssl_random_bytes,
             &ptls_get_time,
             h3_key_exchanges,

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -480,8 +480,8 @@ int main(int argc, char **argv)
             fprintf(stderr, "HTTP/3 is currently not supported by the libuv backend.\n");
             exit(EXIT_FAILURE);
 #else
-            h2o_http3_init_context(&h3ctx.h3, ctx.loop, create_quic_socket(ctx.loop), &h3ctx.quic, NULL,
-                                   h2o_httpclient_http3_notify_connection_update);
+            h2o_quic_init_context(&h3ctx.h3, ctx.loop, create_quic_socket(ctx.loop), &h3ctx.quic, NULL,
+                                  h2o_httpclient_http3_notify_connection_update);
             ctx.http3 = &h3ctx.h3;
 #endif
             break;
@@ -536,8 +536,8 @@ int main(int argc, char **argv)
     }
 
     if (ctx.http3 != NULL) {
-        h2o_http3_close_all_connections(ctx.http3);
-        while (h2o_http3_num_connections(ctx.http3) != 0) {
+        h2o_quic_close_all_connections(ctx.http3);
+        while (h2o_quic_num_connections(ctx.http3) != 0) {
 #if H2O_USE_LIBUV
             uv_run(ctx.loop, UV_RUN_ONCE);
 #else

--- a/src/main.c
+++ b/src/main.c
@@ -2346,7 +2346,7 @@ static h2o_quic_conn_t *on_http3_accept(h2o_quic_ctx_t *_ctx, quicly_address_t *
                                                                   &destaddr->sa, packet->cid.dest.encrypted, err_desc, payload);
             assert(payload_size != SIZE_MAX);
             struct iovec vec = {.iov_base = payload, .iov_len = payload_size};
-            h2o_http3_send_datagrams(&ctx->super, srcaddr, destaddr, &vec, 1);
+            h2o_quic_send_datagrams(&ctx->super, srcaddr, destaddr, &vec, 1);
             return NULL;
         }
     }
@@ -2389,7 +2389,7 @@ static h2o_quic_conn_t *on_http3_accept(h2o_quic_ctx_t *_ctx, quicly_address_t *
                                   ptls_iovec_init(&token_prefix, 1), ptls_iovec_init(NULL, 0), retry_integrity_aead, payload);
             assert(payload_size != SIZE_MAX);
             struct iovec vec = {.iov_base = payload, .iov_len = payload_size};
-            h2o_http3_send_datagrams(&ctx->super, srcaddr, destaddr, &vec, 1);
+            h2o_quic_send_datagrams(&ctx->super, srcaddr, destaddr, &vec, 1);
             return NULL;
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -2237,7 +2237,7 @@ static int rewrite_forwarded_quic_datagram(h2o_quic_ctx_t *h3ctx, struct msghdr 
 static void forwarded_quic_socket_on_read(h2o_socket_t *sock, const char *err)
 {
     struct listener_ctx_t *ctx = sock->data;
-    h2o_http3_read_socket(&ctx->http3.ctx.super, sock);
+    h2o_quic_read_socket(&ctx->http3.ctx.super, sock);
 }
 
 static void on_socketclose(void *data)
@@ -2509,10 +2509,10 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
         listeners[i].sock->data = listeners + i;
         /* setup quic context and the unix socket to receive forwarded packets */
         if (thread_index < conf.quic.num_threads && listener_config->quic.ctx != NULL) {
-            h2o_http3_init_context(&listeners[i].http3.ctx.super, conf.threads[thread_index].ctx.loop, listeners[i].sock,
-                                   listener_config->quic.ctx, on_http3_accept, NULL);
-            h2o_http3_set_context_identifier(&listeners[i].http3.ctx.super, 0, (uint32_t)thread_index, conf.quic.node_id, 4,
-                                             forward_quic_packets, rewrite_forwarded_quic_datagram);
+            h2o_quic_init_context(&listeners[i].http3.ctx.super, conf.threads[thread_index].ctx.loop, listeners[i].sock,
+                                  listener_config->quic.ctx, on_http3_accept, NULL);
+            h2o_quic_set_context_identifier(&listeners[i].http3.ctx.super, 0, (uint32_t)thread_index, conf.quic.node_id, 4,
+                                            forward_quic_packets, rewrite_forwarded_quic_datagram);
             listeners[i].http3.ctx.accept_ctx = &listeners[i].accept_ctx;
             listeners[i].http3.ctx.send_retry = listener_config->quic.send_retry;
             int fds[2];


### PR DESCRIPTION
* split `h2o_http3_ctx_t` into `h2o_quic_ctx_t` and `h2o_http3_ctx_t`, where the latter is defined as a sub-class of the former.
* rename functions / structures unspecific to H3 from `h2o_http3_*` to `h2o_quic_*`