### PR TITLE
validate temp-buffer-path in startup

### DIFF
--- a/include/h2o/file.h
+++ b/include/h2o/file.h
@@ -28,7 +28,7 @@ h2o_iovec_t h2o_file_read(const char *fn);
 
 /**
  * creates a temporary file using the fn_template param.
- * This is a wrapper to mkstemp(3), but there's no way to access the actual filename.
+ * This is a wrapper to mkstemp(3), but the file is unlinked before returning from the function. Therefore, the name of the file is not provided to the caller.
  * @return fd. -1 on failure and set errno as mkstemp(3) does.
  */
 int h2o_file_mktemp(const char *fn_template);

--- a/include/h2o/file.h
+++ b/include/h2o/file.h
@@ -26,4 +26,11 @@
 
 h2o_iovec_t h2o_file_read(const char *fn);
 
+/**
+ * creates a temporary file using the fn_template param.
+ * This is a wrapper to mkstemp(3), but there's no way to access the actual filename.
+ * @return fd. -1 on failure and set errno as mkstemp(3) does.
+ */
+int h2o_file_mktemp(const char *fn_template);
+
 #endif

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -246,7 +246,6 @@ static void h2o_mem_addref_shared(void *p);
  * The chunk gets freed when the ref-count reaches zero.
  */
 static int h2o_mem_release_shared(void *p);
-
 /**
  * initialize the buffer using given prototype.
  */

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -248,13 +248,6 @@ static void h2o_mem_addref_shared(void *p);
 static int h2o_mem_release_shared(void *p);
 
 /**
- * creates a temporary file using to the fn_template param.
- * This is a wrapper to mkstemp(3), but there's no way to access the actual filename.
- * @return fd. -1 on failure and set errno.
- */
-int h2o_make_temp_file(const char *fn_template);
-
-/**
  * initialize the buffer using given prototype.
  */
 static void h2o_buffer_init(h2o_buffer_t **buffer, h2o_buffer_prototype_t *prototype);

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -246,6 +246,14 @@ static void h2o_mem_addref_shared(void *p);
  * The chunk gets freed when the ref-count reaches zero.
  */
 static int h2o_mem_release_shared(void *p);
+
+/**
+ * creates a temporary file using to the fn_template param.
+ * This is a wrapper to mkstemp(3), but there's no way to access the actual filename.
+ * @return fd. -1 on failure and set errno.
+ */
+int h2o_make_temp_file(const char *fn_template);
+
 /**
  * initialize the buffer using given prototype.
  */

--- a/lib/common/file.c
+++ b/lib/common/file.c
@@ -66,3 +66,15 @@ Error:
     free(ret.base);
     return (h2o_iovec_t){NULL};
 }
+
+int h2o_file_mktemp(const char *fn_template)
+{
+    int fd;
+    char *tmpfn = alloca(strlen(fn_template) + 1);
+    strcpy(tmpfn, fn_template);
+    if ((fd = mkstemp(tmpfn)) == -1) {
+        return -1;
+    }
+    unlink(tmpfn);
+    return fd;
+}

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -31,6 +31,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include "h2o/memory.h"
+#include "h2o/file.h"
 
 #if defined(__linux__)
 #if defined(__ANDROID__) && (__ANDROID_API__ < 21)
@@ -243,18 +244,6 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
     return reserved;
 }
 
-int h2o_make_temp_file(const char *fn_template)
-{
-    int fd;
-    char *tmpfn = alloca(strlen(fn_template) + 1);
-    strcpy(tmpfn, fn_template);
-    if ((fd = mkstemp(tmpfn)) == -1) {
-        return -1;
-    }
-    unlink(tmpfn);
-    return fd;
-}
-
 h2o_iovec_t h2o_buffer_try_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
 {
     h2o_buffer_t *inbuf = *_inbuf;
@@ -291,7 +280,7 @@ h2o_iovec_t h2o_buffer_try_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
                 int fd;
                 h2o_buffer_t *newp;
                 if (inbuf->_fd == -1) {
-                    if ((fd = h2o_make_temp_file(inbuf->_prototype->mmap_settings->fn_template)) == -1) {
+                    if ((fd = h2o_file_mktemp(inbuf->_prototype->mmap_settings->fn_template)) == -1) {
                         h2o_perror("failed to create temporary file");
                         goto MapError;
                     }

--- a/src/main.c
+++ b/src/main.c
@@ -31,7 +31,6 @@
 #include <getopt.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <libgen.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -3030,12 +3029,12 @@ int main(int argc, char **argv)
     }
 
     {
-        const char *dir = dirname(h2o_socket_buffer_mmap_settings.fn_template);
-        struct stat st;
-        if (!(stat(dir, &st) == 0 && S_ISDIR(st.st_mode) && access(dir, W_OK) == 0)) {
-            fprintf(stderr, "temp-buffer-path: '%s' is not a writable directory\n", dir);
+        int fd = h2o_make_temp_file(h2o_socket_buffer_mmap_settings.fn_template);
+        if (fd == -1) {
+            fprintf(stderr, "temp-buffer-path: failed to create temporary file from the mkstemp(3) template '%s': %s\n", h2o_socket_buffer_mmap_settings.fn_template, strerror(errno));
             return EX_CONFIG;
         }
+        close(fd);
     }
 
     /* calculate defaults (note: open file cached is purged once every loop) */

--- a/src/main.c
+++ b/src/main.c
@@ -70,6 +70,7 @@
 #include "h2o/http2.h"
 #include "h2o/http3_server.h"
 #include "h2o/serverutil.h"
+#include "h2o/file.h"
 #if H2O_USE_MRUBY
 #include "h2o/mruby_.h"
 #endif
@@ -3029,9 +3030,10 @@ int main(int argc, char **argv)
     }
 
     {
-        int fd = h2o_make_temp_file(h2o_socket_buffer_mmap_settings.fn_template);
+        int fd = h2o_file_mktemp(h2o_socket_buffer_mmap_settings.fn_template);
         if (fd == -1) {
-            fprintf(stderr, "temp-buffer-path: failed to create temporary file from the mkstemp(3) template '%s': %s\n", h2o_socket_buffer_mmap_settings.fn_template, strerror(errno));
+            fprintf(stderr, "temp-buffer-path: failed to create temporary file from the mkstemp(3) template '%s': %s\n",
+                    h2o_socket_buffer_mmap_settings.fn_template, strerror(errno));
             return EX_CONFIG;
         }
         close(fd);

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@
 #include <getopt.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <libgen.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -3027,6 +3028,16 @@ int main(int argc, char **argv)
         dispose_resolve_tag_arg(&resolve_tag_arg);
         yoml_free(yoml, NULL);
     }
+
+    {
+        const char *dir = dirname(h2o_socket_buffer_mmap_settings.fn_template);
+        struct stat st;
+        if (!(stat(dir, &st) == 0 && S_ISDIR(st.st_mode) && access(dir, W_OK) == 0)) {
+            fprintf(stderr, "temp-buffer-path: '%s' is not a writable directory\n", dir);
+            return EX_CONFIG;
+        }
+    }
+
     /* calculate defaults (note: open file cached is purged once every loop) */
     conf.globalconf.filecache.capacity = conf.globalconf.http2.max_concurrent_requests_per_connection * 2;
     if (conf.quic.num_threads == 0) {


### PR DESCRIPTION
[temp-buffer-path](https://h2o.examp1e.net/configure/base_directives.html#temp-buffer-path) must be a writable directory, but if not, h2o runs and will report errors when it is used in `h2o_buffer_try_reserve()`. I think it's better to validate if the spec of `temp-buffer-path` is correct.