### PR TITLE
Document and export http1-request-io-timeout

### DIFF
--- a/doc/configure/http1_directives.html
+++ b/doc/configure/http1_directives.html
@@ -67,6 +67,9 @@ This document describes the configuration directives for controlling the HTTP/1 
 <li><a href="configure/http1_directives.html#http1-request-timeout">
 <code>http1-request-timeout</code>
 </a></li>
+<li><a href="configure/http1_directives.html#http1-request-io-timeout">
+<code>http1-request-io-timeout</code>
+</a></li>
 <li><a href="configure/http1_directives.html#http1-upgrade-to-http2">
 <code>http1-upgrade-to-http2</code>
 </a></li>
@@ -89,6 +92,23 @@ Timeout for incoming requests in seconds.
 <dd>global</dd>
 <dt>Default:</dt>
 <dd><code><pre>http1-request-timeout: 10</pre></code>
+</dl>
+<div id="http1-request-io-timeout" class="directive-head">
+<h3><a href="configure/http1_directives.html#http1-request-io-timeout"><code>"http1-request-io-timeout"</code></a></h3>
+</div>
+
+<dl class="directive-desc">
+<dt>Description:</dt>
+<dd>
+<p>
+Timeout for incoming request I/O in seconds.
+</p>
+
+</dd>
+<dt><a href="configure/syntax_and_structure.html#config_levels">Level</a>:</dt>
+<dd>global</dd>
+<dt>Default:</dt>
+<dd><code><pre>http1-request-io-timeout: 5</pre></code>
 </dl>
 <div id="http1-upgrade-to-http2" class="directive-head">
 <h3><a href="configure/http1_directives.html#http1-upgrade-to-http2"><code>"http1-upgrade-to-http2"</code></a></h3>

--- a/examples/h2o_mruby/h2o.conf
+++ b/examples/h2o_mruby/h2o.conf
@@ -17,6 +17,11 @@ hosts:
       /:
         file.dir: examples/doc_root
         mruby.handler-file: examples/h2o_mruby/hello.rb
+      /status:
+        - mruby.handler: |
+            require 'prometheus.rb'
+            H2O::Prometheus.new(H2O.next)
+        - status: ON
     access-log: /dev/stdout
   "alternate.127.0.0.1.xip.io:8081":
     listen:

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -88,6 +88,8 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        " \"status-errors.500\": %" PRIu64 ",\n"
                        " \"status-errors.502\": %" PRIu64 ",\n"
                        " \"status-errors.503\": %" PRIu64 ",\n"
+                       " \"http1-errors.request-timeout\": %" PRIu64 ",\n"
+                       " \"http1-errors.request-io-timeout\": %" PRIu64 ",\n"
                        " \"http2-errors.protocol\": %" PRIu64 ", \n"
                        " \"http2-errors.internal\": %" PRIu64 ", \n"
                        " \"http2-errors.flow-control\": %" PRIu64 ", \n"
@@ -105,11 +107,11 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        " \"ssl.errors\": %" PRIu64 ", \n"
                        " \"memory.mmap_errors\": %zu\n",
                        H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
-                       H1_AGG_ERR(500), H1_AGG_ERR(502), H1_AGG_ERR(503), H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL),
-                       H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT), H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE),
-                       H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL), H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT),
-                       H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY), esc->h2_read_closed, esc->h2_write_closed,
-                       esc->ssl_errors, h2o_mmap_errors);
+                       H1_AGG_ERR(500), H1_AGG_ERR(502), H1_AGG_ERR(503), esc->h1_request_timeout, esc->h1_request_io_timeout,
+                       H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL), H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT),
+                       H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE), H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL),
+                       H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT), H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY),
+                       esc->h2_read_closed, esc->h2_write_closed, esc->ssl_errors, h2o_mmap_errors);
     pthread_mutex_destroy(&esc->mutex);
     free(esc);
     return ret;

--- a/srcdoc/configure/http1_directives.mt
+++ b/srcdoc/configure/http1_directives.mt
@@ -16,6 +16,13 @@ $ctx->{directive}->(
 )->(sub {});
 
 $ctx->{directive}->(
+    name    => "http1-request-io-timeout",
+    levels  => [ qw(global) ],
+    default => 'http1-request-io-timeout: 5',
+    desc    => q{Timeout for incoming request I/O in seconds.},
+)->(sub {});
+
+$ctx->{directive}->(
     name    => "http1-upgrade-to-http2",
     levels  => [ qw(global) ],
     default => 'http1-upgrade-to-http2: ON',


### PR DESCRIPTION
Hello! This PR accomplishes three things:

1. Export the `http1-request-timeout` and `http1-request-io-timeout` counters
2. Document `http1-request-io-timeout` (generated file is also checked in)
3. Enable the Prometheus handler in the example mruby h2o.conf (for dev convenience)

JSON output:

```
$ curl -s localhost:8080/status/json | grep http1-errors
 "http1-errors.request-timeout": 1234,
 "http1-errors.request-io-timeout": 1234,
```

Prometheus output via mruby:

```
$ curl -s localhost:8080/status | grep http1_errors_request
# HELP h2o_http1_errors_request_timeout http1-errors.request-timeout
# TYPE h2o_http1_errors_request_timeout counter
h2o_http1_errors_request_timeout{version="2.3.0-DEV@5ed940034"} 1234
# HELP h2o_http1_errors_request_io_timeout http1-errors.request-io-timeout
# TYPE h2o_http1_errors_request_io_timeout counter
h2o_http1_errors_request_io_timeout{version="2.3.0-DEV@5ed940034"} 1234
```
