### PR TITLE
bugfix: proxy.http2.max_concurrent_streams had no effects

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1996,7 +1996,7 @@ typedef struct st_h2o_proxy_config_vars_t {
     h2o_headers_command_t *headers_cmds;
     size_t max_buffer_size;
     struct {
-        uint32_t max_concurrent_strams;
+        uint32_t max_concurrent_streams;
         int ratio;
     } http2;
 } h2o_proxy_config_vars_t;

--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -425,7 +425,7 @@ static int on_config_max_buffer_size(h2o_configurator_command_t *cmd, h2o_config
 static int on_config_http2_max_concurrent_streams(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%u", &self->vars->conf.http2.max_concurrent_strams);
+    return h2o_configurator_scanf(cmd, node, "%u", &self->vars->conf.http2.max_concurrent_streams);
 }
 
 static int on_config_http2_ratio(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
@@ -491,7 +491,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
         ctx->globalconf->proxy.first_byte_timeout = self->vars->conf.first_byte_timeout;
         ctx->globalconf->proxy.keepalive_timeout = self->vars->conf.keepalive_timeout;
         ctx->globalconf->proxy.max_buffer_size = self->vars->conf.max_buffer_size;
-        ctx->globalconf->proxy.http2.max_concurrent_streams = self->vars->conf.http2.max_concurrent_strams;
+        ctx->globalconf->proxy.http2.max_concurrent_streams = self->vars->conf.http2.max_concurrent_streams;
         ctx->globalconf->proxy.http2.ratio = self->vars->conf.http2.ratio;
         h2o_socketpool_set_ssl_ctx(&ctx->globalconf->proxy.global_socketpool, self->vars->ssl_ctx);
         h2o_socketpool_set_timeout(&ctx->globalconf->proxy.global_socketpool, self->vars->conf.keepalive_timeout);
@@ -523,7 +523,7 @@ void h2o_proxy_register_configurator(h2o_globalconf_t *conf)
     c->vars->conf.websocket.enabled = 0; /* have websocket proxying disabled by default; until it becomes non-experimental */
     c->vars->conf.websocket.timeout = H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT;
     c->vars->conf.max_buffer_size = SIZE_MAX;
-    c->vars->conf.http2.max_concurrent_strams = H2O_DEFAULT_PROXY_HTTP2_MAX_CONCURRENT_STREAMS;
+    c->vars->conf.http2.max_concurrent_streams = H2O_DEFAULT_PROXY_HTTP2_MAX_CONCURRENT_STREAMS;
     c->vars->conf.http2.ratio = -1;
     c->vars->conf.keepalive_timeout = h2o_socketpool_get_timeout(&conf->proxy.global_socketpool);
 

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -94,6 +94,7 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
 
     client_ctx->max_buffer_size = self->config.max_buffer_size;
     client_ctx->http2.ratio = self->config.http2.ratio;
+    client_ctx->http2.max_concurrent_streams = self->config.http2.max_concurrent_streams;
     client_ctx->http2.counter = -1;
 
     handler_ctx->client_ctx = client_ctx;


### PR DESCRIPTION
Since setting to `client_ctx->http2.max_concurrent_streams` were missing,
`proxy.http2.max_concurrent_streams` had no effects and
the default value `100` did not take effects, so
http2.connection was created for each proxy request to servers.

Please see `lib/handler/proxy.c`.

Best regards,
Chul-Woong