### PR TITLE
make sure the umask is 600 before calling mkstemp()

### DIFF
--- a/lib/common/file.c
+++ b/lib/common/file.c
@@ -69,10 +69,12 @@ Error:
 
 int h2o_file_mktemp(const char *fn_template)
 {
-    int fd;
     char *tmpfn = alloca(strlen(fn_template) + 1);
     strcpy(tmpfn, fn_template);
-    if ((fd = mkstemp(tmpfn)) == -1) {
+    mode_t saved = umask(0600);
+    int fd = mkstemp(tmpfn);
+    umask(saved);
+    if (fd == -1) {
         return -1;
     }
     unlink(tmpfn);


### PR DESCRIPTION
Fixes Coverity violations, as the `mkstemp(3)` manpage suggested.

>  CID 1496641:  Security best practices violations  (SECURE_TEMP)
>  Calling "mkstemp" without securely setting umask first.