### PR TITLE
HTTP/3 graceful shutdown

### DIFF
--- a/h2o-probes.d
+++ b/h2o-probes.d
@@ -68,7 +68,7 @@ provider h2o {
     probe h3s_stream_set_state(uint64_t conn_id, uint64_t req_id, unsigned state);
 
     /**
-     * HTTP/3 event, indicating that a H3 frame has been received. `base` is available available except when frame_type is DATA.
+     * HTTP/3 event, indicating that a H3 frame has been received. `base` is available except when frame_type is DATA.
      */
     probe h3_frame_receive(uint64_t frame_type, const void *base, size_t len);
     /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -637,6 +637,17 @@ struct st_h2o_context_t {
 
     struct {
         /**
+         * link-list of h2o_http3_server_conn_t
+         */
+        h2o_linklist_t _conns;
+        /**
+         * timeout entry used for graceful shutdown
+         */
+        h2o_timer_t _graceful_shutdown_timeout;
+    } http3;
+
+    struct {
+        /**
          * the default client context for proxy
          */
         h2o_httpclient_ctx_t client_ctx;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -408,6 +408,10 @@ struct st_h2o_globalconf_t {
     } http2;
 
     struct {
+        /**
+         * graceful shutdown timeout (in milliseconds)
+         */
+        uint64_t graceful_shutdown_timeout;
         h2o_protocol_callbacks_t callbacks;
     } http3;
 

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -102,12 +102,17 @@ typedef struct st_h2o_http3_priority_update_frame_t {
     h2o_absprio_t priority;
 } h2o_http3_priority_update_frame_t;
 
+typedef struct st_h2o_http3_goaway_frame_t {
+    uint64_t stream_or_push_id;
+} h2o_http3_goaway_frame_t;
+
 #define H2O_HTTP3_PRIORITY_UPDATE_FRAME_CAPACITY (1 /* len */ + 1 /* frame type */ + 8 + sizeof("u=1,i=?0") - 1)
 uint8_t *h2o_http3_encode_priority_update_frame(uint8_t *dst, const h2o_http3_priority_update_frame_t *frame);
 int h2o_http3_decode_priority_update_frame(h2o_http3_priority_update_frame_t *frame, const uint8_t *payload, size_t len,
                                            const char **err_desc);
 size_t h2o_http3_goaway_frame_capacity(quicly_stream_id_t stream_or_push_id);
 uint8_t *h2o_http3_encode_goaway_frame(uint8_t *buff, quicly_stream_id_t stream_or_push_id);
+int h2o_http3_decode_goaway_frame(h2o_http3_goaway_frame_t *frame, const uint8_t *payload, size_t len, const char **err_desc);
 
 typedef h2o_quic_conn_t *(*h2o_quic_accept_cb)(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,
                                                quicly_decoded_packet_t *packet);

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -106,6 +106,8 @@ typedef struct st_h2o_http3_priority_update_frame_t {
 uint8_t *h2o_http3_encode_priority_update_frame(uint8_t *dst, const h2o_http3_priority_update_frame_t *frame);
 int h2o_http3_decode_priority_update_frame(h2o_http3_priority_update_frame_t *frame, const uint8_t *payload, size_t len,
                                            const char **err_desc);
+size_t h2o_http3_goaway_frame_capacity(quicly_stream_id_t stream_or_push_id);
+uint8_t *h2o_http3_encode_goaway_frame(uint8_t *buff, quicly_stream_id_t stream_or_push_id);
 
 typedef h2o_quic_conn_t *(*h2o_quic_accept_cb)(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,
                                                quicly_decoded_packet_t *packet);

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -408,6 +408,10 @@ void h2o_http3_send_qpack_stream_cancel(h2o_http3_conn_t *conn, quicly_stream_id
  */
 void h2o_http3_send_qpack_header_ack(h2o_http3_conn_t *conn, const void *bytes, size_t len);
 /**
+ * Enqueue GOAWAY frame for sending
+ */
+void h2o_http3_send_goaway_frame(h2o_http3_conn_t *conn, uint64_t stream_or_push_id);
+/**
  *
  */
 static int h2o_http3_has_received_settings(h2o_http3_conn_t *conn);

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -200,6 +200,16 @@ typedef struct st_h2o_quic_conn_callbacks_t {
     void (*destroy_connection)(h2o_quic_conn_t *conn);
 } h2o_quic_conn_callbacks_t;
 
+/**
+ * states of an HTTP/3 connection (not stream)
+ * mainly to see if a new request can be accepted
+ */
+typedef enum enum_h2o_http3_conn_state_t {
+    H2O_HTTP3_CONN_STATE_OPEN,        /* accepting new connections */
+    H2O_HTTP3_CONN_STATE_HALF_CLOSED, /* no more accepting new streams */
+    H2O_HTTP3_CONN_STATE_IS_CLOSING   /* nothing should be sent */
+} h2o_http3_conn_state_t;
+
 struct st_h2o_quic_conn_t {
     /**
      * context
@@ -233,6 +243,10 @@ struct st_h2o_http3_conn_t {
      *
      */
     h2o_quic_conn_t super;
+    /**
+     * connection state
+     */
+    h2o_http3_conn_state_t state;
     /**
      * QPACK states
      */

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -242,6 +242,13 @@ static void handle_control_stream_frame(h2o_http3_conn_t *_conn, uint8_t type, c
             err = H2O_HTTP3_ERROR_FRAME_UNEXPECTED;
             err_desc = "unexpected SETTINGS frame";
             goto Fail;
+        case H2O_HTTP3_FRAME_TYPE_GOAWAY: {
+            h2o_http3_goaway_frame_t frame;
+            if ((err = h2o_http3_decode_goaway_frame(&frame, payload, len, &err_desc)) != 0)
+                goto Fail;
+            /* FIXME: stop issuing new requests */
+            break;
+        }
         default:
             break;
         }

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -239,7 +239,7 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
 {
     h2o_iovec_t reserved = h2o_buffer_try_reserve(_inbuf, min_guarantee);
     if (reserved.base == NULL) {
-        h2o_fatal("failed to reserve buffer; capacity: %zu, min_gurantee: %zu", (*_inbuf)->capacity, min_guarantee);
+        h2o_fatal("failed to reserve buffer; capacity: %zu, min_guarantee: %zu", (*_inbuf)->capacity, min_guarantee);
     }
     return reserved;
 }

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -564,6 +564,11 @@ static int on_config_http2_casper(h2o_configurator_command_t *cmd, h2o_configura
     return 0;
 }
 
+static int on_config_http3_graceful_shutdown_timeout(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    return config_timeout(cmd, node, &ctx->globalconf->http3.graceful_shutdown_timeout);
+}
+
 static int assert_is_mimetype(h2o_configurator_command_t *cmd, yoml_t *node)
 {
     if (node->type != YOML_TYPE_SCALAR) {
@@ -990,6 +995,9 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
                                         on_config_http2_allow_cross_origin_push);
         h2o_configurator_define_command(&c->super, "http2-casper", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST,
                                         on_config_http2_casper);
+        h2o_configurator_define_command(&c->super, "http3-graceful-shutdown-timeout",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http3_graceful_shutdown_timeout);
         h2o_configurator_define_command(&c->super, "file.mime.settypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -95,6 +95,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
 
     h2o_linklist_init_anchor(&ctx->http1._conns);
     h2o_linklist_init_anchor(&ctx->http2._conns);
+    h2o_linklist_init_anchor(&ctx->http3._conns);
     ctx->proxy.client_ctx.loop = loop;
     ctx->proxy.client_ctx.io_timeout = ctx->globalconf->proxy.io_timeout;
     ctx->proxy.client_ctx.connect_timeout = ctx->globalconf->proxy.connect_timeout;

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -176,6 +176,8 @@ void h2o_context_request_shutdown(h2o_context_t *ctx)
         ctx->globalconf->http1.callbacks.request_shutdown(ctx);
     if (ctx->globalconf->http2.callbacks.request_shutdown != NULL)
         ctx->globalconf->http2.callbacks.request_shutdown(ctx);
+    if (ctx->globalconf->http3.callbacks.request_shutdown != NULL)
+        ctx->globalconf->http3.callbacks.request_shutdown(ctx);
 }
 
 void h2o_context_update_timestamp_string_cache(h2o_context_t *ctx)

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -109,7 +109,6 @@ static void graceful_shutdown_resend_goaway(h2o_timer_t *entry)
     /* After waiting a second, we still had active connections. If configured, wait one
      * final timeout before closing the connections */
     if (do_close_stragglers && ctx->globalconf->http2.graceful_shutdown_timeout) {
-        h2o_timer_unlink(&ctx->http2._graceful_shutdown_timeout);
         ctx->http2._graceful_shutdown_timeout.cb = graceful_shutdown_close_stragglers;
         h2o_timer_link(ctx->loop, ctx->globalconf->http2.graceful_shutdown_timeout, &ctx->http2._graceful_shutdown_timeout);
     }

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -108,7 +108,7 @@ static void graceful_shutdown_resend_goaway(h2o_timer_t *entry)
 
     /* After waiting a second, we still had active connections. If configured, wait one
      * final timeout before closing the connections */
-    if (do_close_stragglers && ctx->globalconf->http2.graceful_shutdown_timeout) {
+    if (do_close_stragglers && ctx->globalconf->http2.graceful_shutdown_timeout > 0) {
         ctx->http2._graceful_shutdown_timeout.cb = graceful_shutdown_close_stragglers;
         h2o_timer_link(ctx->loop, ctx->globalconf->http2.graceful_shutdown_timeout, &ctx->http2._graceful_shutdown_timeout);
     }

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -1024,6 +1024,7 @@ int h2o_http3_setup(h2o_http3_conn_t *conn, quicly_conn_t *quic)
     int ret;
 
     h2o_quic_setup(&conn->super, quic);
+    conn->state = H2O_HTTP3_CONN_STATE_OPEN;
 
     /* setup h3 objects, only when the connection state has been created */
     if (quicly_get_state(quic) > QUICLY_STATE_CONNECTED)

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -1168,3 +1168,12 @@ void h2o_http3_send_qpack_header_ack(h2o_http3_conn_t *conn, const void *bytes, 
     h2o_buffer_append(&stream->sendbuf, bytes, len);
     H2O_HTTP3_CHECK_SUCCESS(quicly_stream_sync_sendbuf(stream->quic, 1));
 }
+
+void h2o_http3_send_goaway_frame(h2o_http3_conn_t *conn, uint64_t stream_or_push_id)
+{
+    size_t cap = h2o_http3_goaway_frame_capacity(stream_or_push_id);
+    h2o_iovec_t alloced = h2o_buffer_reserve(&conn->_control_streams.egress.control->sendbuf, cap);
+    h2o_http3_encode_goaway_frame((uint8_t *)alloced.base, stream_or_push_id);
+    conn->_control_streams.egress.control->sendbuf->size += cap;
+    quicly_stream_sync_sendbuf(conn->_control_streams.egress.control->quic, 1);
+}

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -856,7 +856,7 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
                 goto Validation_Success;                                                                                           \
             break;                                                                                                                 \
         default:                                                                                                                   \
-            h2o_fatal("enxpected stream type");                                                                                    \
+            h2o_fatal("unexpected stream type");                                                                                   \
             break;                                                                                                                 \
         }                                                                                                                          \
         break

--- a/lib/http3/frame.c
+++ b/lib/http3/frame.c
@@ -59,3 +59,19 @@ int h2o_http3_decode_priority_update_frame(h2o_http3_priority_update_frame_t *fr
 
     return 0;
 }
+
+size_t h2o_http3_goaway_frame_capacity(quicly_stream_id_t stream_or_push_id)
+{
+    return 1   /* type */
+           + 1 /* length field. length should be less than 64, so 1 byte should be enough to represent it */
+           + quicly_encodev_capacity(stream_or_push_id);
+}
+
+uint8_t *h2o_http3_encode_goaway_frame(uint8_t *dst, quicly_stream_id_t stream_or_push_id)
+{
+    *dst++ = H2O_HTTP3_FRAME_TYPE_GOAWAY;                /* type */
+    *dst++ = quicly_encodev_capacity(stream_or_push_id); /* payload length */
+    dst = quicly_encodev(dst, stream_or_push_id);
+
+    return dst;
+}

--- a/lib/http3/frame.c
+++ b/lib/http3/frame.c
@@ -80,12 +80,13 @@ int h2o_http3_decode_goaway_frame(h2o_http3_goaway_frame_t *frame, const uint8_t
 {
     const uint8_t *src = payload, *end = src + len;
 
-    /* quicly_decodev below will reject len == 0 case */
-    if (len > PTLS_ENCODE_QUICINT_CAPACITY)
-        goto Fail;
-
     if ((frame->stream_or_push_id = quicly_decodev(&src, end)) == UINT64_MAX)
         goto Fail;
+
+    if (src != end) {
+        /* there was an extra byte(s) after a valid QUIC variable-length integer */
+        goto Fail;
+    }
 
     return 0;
 

--- a/lib/http3/frame.c
+++ b/lib/http3/frame.c
@@ -75,3 +75,21 @@ uint8_t *h2o_http3_encode_goaway_frame(uint8_t *dst, quicly_stream_id_t stream_o
 
     return dst;
 }
+
+int h2o_http3_decode_goaway_frame(h2o_http3_goaway_frame_t *frame, const uint8_t *payload, size_t len, const char **err_desc)
+{
+    const uint8_t *src = payload, *end = src + len;
+
+    /* quicly_decodev below will reject len == 0 case */
+    if (len > PTLS_ENCODE_QUICINT_CAPACITY)
+        goto Fail;
+
+    if ((frame->stream_or_push_id = quicly_decodev(&src, end)) == UINT64_MAX)
+        goto Fail;
+
+    return 0;
+
+Fail:
+    *err_desc = "Invalid GOAWAY frame";
+    return H2O_HTTP3_ERROR_FRAME;
+}

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1541,7 +1541,6 @@ static void graceful_shutdown_resend_goaway(h2o_timer_t *entry)
     /* After waiting a second, we still had active connections. If configured, wait one
      * final timeout before closing the connections */
     if (do_close_stragglers && ctx->globalconf->http3.graceful_shutdown_timeout) {
-        h2o_timer_unlink(&ctx->http3._graceful_shutdown_timeout);
         ctx->http3._graceful_shutdown_timeout.cb = graceful_shutdown_close_stragglers;
         h2o_timer_link(ctx->loop, ctx->globalconf->http3.graceful_shutdown_timeout, &ctx->http3._graceful_shutdown_timeout);
     }

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1505,8 +1505,71 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
     return &conn->h3;
 }
 
+static void graceful_shutdown_close_stragglers(h2o_timer_t *entry)
+{
+    h2o_context_t *ctx = H2O_STRUCT_FROM_MEMBER(h2o_context_t, http3._graceful_shutdown_timeout, entry);
+    h2o_linklist_t *node, *next;
+
+    /* We've sent two GOAWAY frames, close the remaining connections */
+    for (node = ctx->http3._conns.next; node != &ctx->http3._conns; node = node->next) {
+        struct st_h2o_http3_server_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_conn_t, _conns, node);
+        next = node->next;
+        h2o_quic_close_connection(&conn->h3.super, 0, "shutting down");
+    }
+}
+
+static void graceful_shutdown_resend_goaway(h2o_timer_t *entry)
+{
+    h2o_context_t *ctx = H2O_STRUCT_FROM_MEMBER(h2o_context_t, http3._graceful_shutdown_timeout, entry);
+    h2o_linklist_t *node;
+    int do_close_stragglers = 0;
+
+    /* HTTP/3 draft section 5.2.8 --
+     * "After allowing time for any in-flight requests or pushes to arrive, the endpoint can send another GOAWAY frame
+     * indicating which requests or pushes it might accept before the end of the connection.
+     * This ensures that a connection can be cleanly shut down without losing requests. */
+    for (node = ctx->http3._conns.next; node != &ctx->http3._conns; node = node->next) {
+        struct st_h2o_http3_server_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_conn_t, _conns, node);
+        if (conn->h3.state < H2O_HTTP3_CONN_STATE_HALF_CLOSED && quicly_get_state(conn->h3.super.quic) == QUICLY_STATE_CONNECTED) {
+            quicly_stream_id_t max_stream_id = quicly_get_remote_next_stream_id(conn->h3.super.quic, 0 /* == bidi */) - 4;
+            h2o_http3_send_goaway_frame(&conn->h3, max_stream_id);
+            conn->h3.state = H2O_HTTP3_CONN_STATE_HALF_CLOSED;
+            do_close_stragglers = 1;
+        }
+    }
+
+    /* After waiting a second, we still had active connections. If configured, wait one
+     * final timeout before closing the connections */
+    if (do_close_stragglers && ctx->globalconf->http3.graceful_shutdown_timeout) {
+        h2o_timer_unlink(&ctx->http3._graceful_shutdown_timeout);
+        ctx->http3._graceful_shutdown_timeout.cb = graceful_shutdown_close_stragglers;
+        h2o_timer_link(ctx->loop, ctx->globalconf->http3.graceful_shutdown_timeout, &ctx->http3._graceful_shutdown_timeout);
+    }
+}
+
 static void initiate_graceful_shutdown(h2o_context_t *ctx)
 {
+    h2o_linklist_t *node;
+
+    /* only doit once */
+    if (ctx->http3._graceful_shutdown_timeout.cb != NULL)
+        return;
+    ctx->http3._graceful_shutdown_timeout.cb = graceful_shutdown_resend_goaway;
+
+    for (node = ctx->http3._conns.next; node != &ctx->http3._conns; node = node->next) {
+        struct st_h2o_http3_server_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_conn_t, _conns, node);
+        /* There is a moment where the control stream is already closed while st_h2o_http3_server_conn_t is not.
+         * Check QUIC connection state to skip sending GOAWAY in such a case. */
+        if (conn->h3.state < H2O_HTTP3_CONN_STATE_HALF_CLOSED && quicly_get_state(conn->h3.super.quic) == QUICLY_STATE_CONNECTED) {
+            /* advertise the maximum stream ID to indicate that we will no longer accept new requests.
+             * HTTP/3 draft section 5.2.8 --
+             * "An endpoint that is attempting to gracefully shut down a connection can send a GOAWAY frame with a value set to the
+             * maximum possible value (2^62-4 for servers, 2^62-1 for clients). This ensures that the peer stops creating new
+             * requests or pushes." */
+            h2o_http3_send_goaway_frame(&conn->h3, (UINT64_C(1) << 62) - 4);
+        }
+    }
+    h2o_timer_link(ctx->loop, 1000, &ctx->http3._graceful_shutdown_timeout);
 }
 
 static int foreach_request(h2o_context_t *ctx, int (*cb)(h2o_req_t *req, void *cbdata), void *cbdata)

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1540,7 +1540,7 @@ static void graceful_shutdown_resend_goaway(h2o_timer_t *entry)
 
     /* After waiting a second, we still had active connections. If configured, wait one
      * final timeout before closing the connections */
-    if (do_close_stragglers && ctx->globalconf->http3.graceful_shutdown_timeout) {
+    if (do_close_stragglers && ctx->globalconf->http3.graceful_shutdown_timeout > 0) {
         ctx->http3._graceful_shutdown_timeout.cb = graceful_shutdown_close_stragglers;
         h2o_timer_link(ctx->loop, ctx->globalconf->http3.graceful_shutdown_timeout, &ctx->http3._graceful_shutdown_timeout);
     }

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1511,7 +1511,7 @@ static void graceful_shutdown_close_stragglers(h2o_timer_t *entry)
     h2o_linklist_t *node, *next;
 
     /* We've sent two GOAWAY frames, close the remaining connections */
-    for (node = ctx->http3._conns.next; node != &ctx->http3._conns; node = node->next) {
+    for (node = ctx->http3._conns.next; node != &ctx->http3._conns; node = next) {
         struct st_h2o_http3_server_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_conn_t, _conns, node);
         next = node->next;
         h2o_quic_close_connection(&conn->h3.super, 0, "shutting down");

--- a/t/90http3-graceful-shutdown.t
+++ b/t/90http3-graceful-shutdown.t
@@ -59,8 +59,6 @@ die "fork failed:$!"
 	unless defined $client_pid;
 
 if ($client_pid == 0) {
-	close STDERR;
-	open STDERR, ">", "/dev/null";
 	my @args = ("$client_prog", qw(-3 -t 5 -d 1000 -b 10 -c 2 -i 1000), "https://127.0.0.1:$quic_port/echo");
 	exec @args;
 	die "should not reach here!";

--- a/t/90http3-graceful-shutdown.t
+++ b/t/90http3-graceful-shutdown.t
@@ -85,7 +85,7 @@ EOT
 	} else {
 		exec(
 			qw(unbuffer dtrace -p), $client_pid, "-n", <<'EOT',
-:h2o::h3_frame_receive {
+:h2o-httpclient::h3_frame_receive {
 	if (arg0 == 7) {
 		printf("\nXXXXH3 GOAWAY frame received: len=%d\n", arg2);
 	}

--- a/t/90http3-graceful-shutdown.t
+++ b/t/90http3-graceful-shutdown.t
@@ -97,8 +97,7 @@ EOT
 }
 
 # wait until bpftrace and the trace log becomes ready
-my $read_trace;
-$read_trace = get_tracer($tracer_pid, "$tempdir/trace.out");
+my $read_trace = get_tracer($tracer_pid, "$tempdir/trace.out");
 if ($^O eq 'linux') {
     while ($read_trace->() eq '') {
         sleep 1;

--- a/t/90http3-graceful-shutdown.t
+++ b/t/90http3-graceful-shutdown.t
@@ -1,0 +1,131 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use File::Temp qw(tempdir);
+use Net::EmptyPort qw(empty_port wait_port);
+use POSIX ":sys_wait_h";
+use Test::More;
+use t::Util;
+
+# test scenario:
+# 0. set up a probe for client to emit message on GOAWAY reception
+# 1. send SIGTERM to server to generate GOAWAY
+# 2. upon receiving GOAWAY, tracer will emit message
+# 3. make sure an expected string (from the GOAWAY probe) appears in the tracer log
+
+check_dtrace_availability();
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+
+plan skip_all => 'mruby support is off'
+	unless server_features()->{mruby};
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+my $client_prog = bindir() . "/h2o-httpclient";
+plan skip_all => "$client_prog not found"
+    unless -e $client_prog;
+
+my $quic_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
+
+# spawn a simple HTTP/3 echo server, excerpted from 40http3.t
+my $server = spawn_h2o(<< "EOT");
+listen:
+  type: quic
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+http3-graceful-shutdown-timeout: 1
+hosts:
+  default:
+    paths:
+      /echo:
+        mruby.handler: |
+          Proc.new do |env|
+            [200, {}, env["rack.input"]]
+          end
+EOT
+
+wait_port({port => $quic_port, proto => 'udp'});
+
+# launch httpclient
+my $client_pid = fork;
+die "fork failed:$!"
+	unless defined $client_pid;
+
+if ($client_pid == 0) {
+	close STDERR;
+	open STDERR, ">", "/dev/null";
+	my @args = ("$client_prog", qw(-3 -t 5 -d 1000 -b 10 -c 2 -i 1000), "https://127.0.0.1:$quic_port/echo");
+	exec @args;
+	die "should not reach here!";
+}
+
+# spawn bpftrace/dtrace to probe GOAWAY frame reception
+my $tracer_pid = fork;
+die "fork(2) failed:$!"
+	unless defined $tracer_pid;
+if ($tracer_pid == 0) {
+	# child process, spawn bpftrace
+	close STDOUT;
+	open STDOUT, ">", "$tempdir/trace.out"
+		or die "failed to create temporary file:$tempdir/trace.out:$!";
+	if ($^O eq 'linux') {
+		# because there is no easy way to inspect the payload, we inspect the length of the payload instead
+		# as a minimal validation
+		exec qw(bpftrace -v -B none -p), $client_pid, "-e", <<'EOT';
+usdt::h2o:h3_frame_receive { if (arg0 == 7) { printf("H3 GOAWAY frame received: len=%d\n", arg2); } }
+EOT
+		die "failed to spawn bpftrace:$!";
+	} else {
+		exec(
+			qw(unbuffer dtrace -p), $client_pid, "-n", <<'EOT',
+:h2o::h3_frame_receive {
+	if (arg0 == 7) {
+		printf("\nXXXXH3 GOAWAY frame received: len=%d\n", arg2);
+	}
+}
+EOT
+		);
+		die "failed to spawn dtrace:$!";
+	}
+}
+
+# wait until bpftrace and the trace log becomes ready
+my $read_trace;
+$read_trace = get_tracer($tracer_pid, "$tempdir/trace.out");
+if ($^O eq 'linux') {
+    while ($read_trace->() eq '') {
+        sleep 1;
+    }
+}
+sleep 2;
+
+# shutdown server, which will send SIGTERM to the server and it will then send GOAWAY to the client
+undef $server;
+
+sleep 3;
+
+my $trace;
+do {
+	sleep 1;
+} while (($trace = $read_trace->()) eq '');
+
+like $trace, qr{H3 GOAWAY frame received: len=8}s; # first GOAWAY frame, stream_id=2^62-1
+like $trace, qr{H3 GOAWAY frame received: len=1}s; # second GOAWAY frame, stream_id=last stream ID that the client sent
+# note: once the client implements correct handling of GOAWAY, it will exit at the first GOAWAY,
+# so it will never see the second one.
+
+# `http3-graceful-shutdown-timeout` > 0 lets the server forcefully close connections at the end,
+# which then lets the client exit. Here we just claim a defunct process (otherwise the tracer would stuck).
+while (waitpid($client_pid, 0) != $client_pid) {}
+
+# wait for the tracer to exit
+while (waitpid($tracer_pid, 0) != $tracer_pid) {}
+
+done_testing;


### PR DESCRIPTION
This is an initial attempt to implement HTTP/3 graceful shutdown (#2394).

# What is supported in this PR

* send `GOAWAY` frame upon graceful shutdown request (i.e. `SIGTERM`)
    * resend GOAWAY after 1 second from the initial GOAWAY
* `http3-graceful-shutdown-timeout` configuration support, as in HTTP/2
* minimal GOAWAY frame validation (check frame length, etc.) on client side when receiving GOAWAY frame
* simple test case that ensures a client actually receives GOAWAY when a server is shutting down

# What is NOT supported in this PR

* Server side: rejecting further requests after sending GOAWAY
* Client side: closing connection after receiving GOAWAY (and thus suppressing further requests)

# Discussion

The GOAWAY frame encoder (`frame.c: h2o_http3_encode_goaway_frame`) now follows the same way as  `h2o_http3_encode_priority_update_frame`. There are a few alternatives we can take.

* Pass `h2o_buffer_t *` to the encoder function instead of `uint8_t *` (as in `h2o_http2_encode_goaway_frame`). This will encapsulate the buffer management (allocation) inside the encoder function, which makes the caller-side code simpler.
* Use `h2o_http3_encode_frame` macro -- I haven't fully figured out if this is actually a viable option though.

Let me know if you have a preference on one way over others.

# Known issue

* The test case fails in my local macOS environment (Mojave). It appears that `dtrace -p ${client_pid}` is attached to the server process for some reason, thus emitting incorrect strings. Will see if it also happens in CI.
