### PR TITLE
fix occasional CI failure in t/50status.t

### DIFF
--- a/t/50status.t
+++ b/t/50status.t
@@ -38,6 +38,7 @@ hosts:
         status: ON
 EOT
 
+    sleep 1; # wait for the spawn checker to disconnect
     my $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/s/json?show=main,events' 2>&1 > /dev/null`;
     my $jresp = decode_json("$resp");
     is $jresp->{'connections'}, 1, "One connection";
@@ -55,6 +56,8 @@ hosts:
       /s:
         status: ON
 EOT
+
+    sleep 1; # wait for the spawn checker to disconnect
     my $resp;
     $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/beeb98fcf148317be5fe5d763c658bc9ea9c087a' 2>&1 > /dev/null`;
     $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/s/json?show=events' 2>&1 > /dev/null`;
@@ -76,6 +79,7 @@ hosts:
         status: ON
 EOT
 
+    sleep 1; # wait for the spawn checker to disconnect
     my $resp = `curl --silent -o /dev/stderr http://127.0.0.1:$server->{port}/s/json?noreqs 2>&1 > /dev/null`;
     my $jresp = decode_json("$resp");
     my @nr_requests = @{ $jresp->{'requests'} };


### PR DESCRIPTION
In an attempt to not return until the server is up, `spawn_h2o` function actually tries to establish a connection against the server process being spawned. Once that succeeds, `spawn_h2o` closes that connection and returns.

The side-effect of that is that if the test script then immediately issues a request to the server, h2o might process that request before noticing that the aforementioned connection has been closed.

That leads to unexpected results that we see in the num-connections test in t/50status.t.

The obvious solution to this problem is to insert a wait right after returning from `spawn_h2o`. We have had that wait in some of the cases, but not all.

This PR add such wait to the locations that have been missed.