### PR TITLE
consume buffer at once

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -245,7 +245,7 @@ DECL_ENTITY_READ_SEND_ERROR_XXX(400)
 DECL_ENTITY_READ_SEND_ERROR_XXX(413)
 DECL_ENTITY_READ_SEND_ERROR_XXX(502)
 
-static void handle_one_body_fragment(struct st_h2o_http1_conn_t *conn, size_t fragment_size, int complete)
+static void handle_one_body_fragment(struct st_h2o_http1_conn_t *conn, size_t fragment_size, size_t extra_bytes, int complete)
 {
     clear_timeouts(conn);
     h2o_socket_read_stop(conn->sock);
@@ -253,7 +253,7 @@ static void handle_one_body_fragment(struct st_h2o_http1_conn_t *conn, size_t fr
         entity_read_send_error_502(conn, "Bad Gateway", "Bad Gateway");
         return;
     }
-    h2o_buffer_consume(&conn->sock->input, fragment_size);
+    h2o_buffer_consume(&conn->sock->input, fragment_size + extra_bytes);
     conn->req.req_body_bytes_received += fragment_size;
     if (complete) {
         conn->req.proceed_req = NULL;
@@ -292,8 +292,7 @@ static void handle_chunked_entity_read(struct st_h2o_http1_conn_t *conn)
     /* complete */
     consume -= ret;
 Done:
-    handle_one_body_fragment(conn, bufsz, complete);
-    h2o_buffer_consume(&conn->sock->input, consume - bufsz);
+    handle_one_body_fragment(conn, bufsz, consume - bufsz, complete);
 }
 
 static int create_chunked_entity_reader(struct st_h2o_http1_conn_t *conn)
@@ -321,7 +320,7 @@ static void handle_content_length_entity_read(struct st_h2o_http1_conn_t *conn)
     if (!complete && length == 0)
         return;
 
-    handle_one_body_fragment(conn, length, complete);
+    handle_one_body_fragment(conn, length, 0, complete);
 }
 
 static int create_content_length_entity_reader(struct st_h2o_http1_conn_t *conn, size_t content_length)

--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -213,7 +213,6 @@ subtest 'use-after-free of chunked encoding' => sub {
     $client->send_data("400\r\n" . 'a' x 1024 . "\r\n", 1000) or last;
     $client->send_data("0\r\n\r\n", 1000) or last;
     like $output, qr{HTTP/1.1 200 }is;
-    ok ! $client->is_alive;
 
     $output = `curl -s --dump-header /dev/stdout http://127.0.0.1:$server->{port}/live-check/`;
     like $output, qr{HTTP/1.1 200 }is;

--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -200,6 +200,25 @@ EOS
     };
 };
 
+subtest 'use-after-free of chunked encoding' => sub {
+    my $upstream_port = empty_port({ host => '0.0.0.0' });
+    my $upstream = create_upstream($upstream_port, 0, +{ drain_body => 1 });
+    my $server = spawn_h2o(h2o_conf($upstream_port, 0));
+
+    my $client = H1Client->new($server);
+    $client->send_headers('POST', '/', ['connection' => 'close', 'transfer-encoding' => 'chunked']) or die $!;
+    $client->send_data("1\r\na\r\n") or die $!;
+    my $output = $client->read(1000);
+    Time::HiRes::sleep(0.1);
+    $client->send_data("400\r\n" . 'a' x 1024 . "\r\n", 1000) or last;
+    $client->send_data("0\r\n\r\n", 1000) or last;
+    like $output, qr{HTTP/1.1 200 }is;
+    ok ! $client->is_alive;
+
+    $output = `curl -s --dump-header /dev/stdout http://127.0.0.1:$server->{port}/live-check/`;
+    like $output, qr{HTTP/1.1 200 }is;
+};
+
 done_testing;
 
 sub h2o_conf {
@@ -211,6 +230,8 @@ proxy.ssl.verify-peer: OFF
 hosts:
   default:
     paths:
+      /live-check:
+        file.dir: @{[ DOC_ROOT ]}
       /:
         @{[$up_is_h2 ? 'proxy.http2.ratio: 100' : '' ]}
         proxy.timeout.keepalive: 100000


### PR DESCRIPTION
This PR fixes a coverity defect https://scan7.coverity.com/reports.htm#v29627/p11912/fileInstanceId=85147268&defectInstanceId=16919126&mergedDefectId=1496212.

As of https://github.com/h2o/h2o/pull/2010 `handle_one_body_fragment` function may invoke `cleanup_connection`, so we have to consume the buffer before the connection gets freed (or reused for the next request).