### PR TITLE
limit POST concurrency

### DIFF
--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -970,6 +970,14 @@ void quicly_stream_sync_recvbuf(quicly_stream_t *stream, size_t shift_amount);
 /**
  *
  */
+static uint32_t quicly_stream_get_receive_window(quicly_stream_t *stream);
+/**
+ *
+ */
+static void quicly_stream_set_receive_window(quicly_stream_t *stream, uint32_t window);
+/**
+ *
+ */
 static int quicly_stream_is_client_initiated(quicly_stream_id_t stream_id);
 /**
  *
@@ -1153,6 +1161,16 @@ inline void **quicly_get_data(quicly_conn_t *conn)
 inline int quicly_stop_requested(quicly_stream_t *stream)
 {
     return stream->_send_aux.stop_sending.sender_state != QUICLY_SENDER_STATE_NONE;
+}
+
+inline uint32_t quicly_stream_get_receive_window(quicly_stream_t *stream)
+{
+    return stream->_recv_aux.window;
+}
+
+inline void quicly_stream_set_receive_window(quicly_stream_t *stream, uint32_t window)
+{
+    stream->_recv_aux.window = window;
 }
 
 inline int quicly_stream_is_client_initiated(quicly_stream_id_t stream_id)

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -1026,6 +1026,7 @@
 		E908A2AF2320AE4D0039BCEE /* Dockerfile.ubuntu1904 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Dockerfile.ubuntu1904; sourceTree = "<group>"; };
 		E90A95F21E30795100483D6C /* headers_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = headers_util.c; sourceTree = "<group>"; };
 		E90A95F41E30797D00483D6C /* headers_util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = headers_util.c; sourceTree = "<group>"; };
+		E90BB43B24F38937006507EA /* 40http3-concurrency.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http3-concurrency.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E90C514D230BB28800D6AD8E /* 90dtrace.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = 90dtrace.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E918FC392136583F00CCB252 /* proptest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = proptest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E918FC3B213658BE00CCB252 /* prop.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = prop.c; sourceTree = "<group>"; };
@@ -1072,8 +1073,8 @@
 		E9316EEE2441C08100C9C127 /* certificate_compression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = certificate_compression.h; sourceTree = "<group>"; };
 		E93C7F95226EBEC9007BF39A /* frame.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = frame.c; sourceTree = "<group>"; };
 		E93C7F9922701806007BF39A /* frame.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = frame.c; sourceTree = "<group>"; };
-		E9414F8E24ED1CD700273C59 /* 40http3-shutdown.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40http3-shutdown.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9414F8D24EBFBDA00273C59 /* 40http3-reconnect.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http3-reconnect.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9414F8E24ED1CD700273C59 /* 40http3-shutdown.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "40http3-shutdown.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9414F8F24ED1D5300273C59 /* 80reverse-proxy-truncated-chunked.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "80reverse-proxy-truncated-chunked.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9414F9024ED1D7400273C59 /* 50proxy-forward-close-connection.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50proxy-forward-close-connection.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9414F9124ED1D7400273C59 /* 50reverse-proxy-header-filtering.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50reverse-proxy-header-filtering.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -2087,6 +2088,7 @@
 				E9F677CA1FF47BD0006476D3 /* 40http2-h2spec.t */,
 				E9BCE6921FF344D4003CEA11 /* 40http2-request-window-size.t */,
 				E98041C22230C45E008B9745 /* 40http3.t */,
+				E90BB43B24F38937006507EA /* 40http3-concurrency.t */,
 				E9414F8D24EBFBDA00273C59 /* 40http3-reconnect.t */,
 				E9FC525C234B0A630076F35D /* 40http3-retry.t */,
 				E9414F8E24ED1CD700273C59 /* 40http3-shutdown.t */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -90,6 +90,7 @@ extern "C" {
 #define H2O_DEFAULT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT_IN_SECS 0 /* no timeout */
 #define H2O_DEFAULT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT (H2O_DEFAULT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_HTTP2_ACTIVE_STREAM_WINDOW_SIZE H2O_HTTP2_MAX_STREAM_WINDOW_SIZE
+#define H2O_DEFAULT_HTTP3_ACTIVE_STREAM_WINDOW_SIZE H2O_DEFAULT_HTTP2_ACTIVE_STREAM_WINDOW_SIZE
 #define H2O_DEFAULT_PROXY_IO_TIMEOUT_IN_SECS 30
 #define H2O_DEFAULT_PROXY_IO_TIMEOUT (H2O_DEFAULT_PROXY_IO_TIMEOUT_IN_SECS * 1000)
 #define H2O_DEFAULT_PROXY_WEBSOCKET_TIMEOUT_IN_SECS 300
@@ -416,6 +417,10 @@ struct st_h2o_globalconf_t {
          * graceful shutdown timeout (in milliseconds)
          */
         uint64_t graceful_shutdown_timeout;
+        /**
+         * receive window size of the unblocked request stream
+         */
+        uint32_t active_stream_window_size;
         /**
          * the callbacks
          */

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -78,6 +78,13 @@
 #define H2O_HTTP3_ERROR_TRANSPORT -2
 #define H2O_HTTP3_ERROR_USER1 -256
 
+/**
+ * maximum payload size excluding DATA frame; stream receive window MUST be at least as big as this + 16 bytes to hold the type and
+ * the length
+ */
+#define H2O_HTTP3_MAX_FRAME_PAYLOAD_SIZE 16384
+#define H2O_HTTP3_INITIAL_REQUEST_STREAM_WINDOW_SIZE (H2O_HTTP3_MAX_FRAME_PAYLOAD_SIZE * 2)
+
 typedef struct st_h2o_quic_ctx_t h2o_quic_ctx_t;
 typedef struct st_h2o_quic_conn_t h2o_quic_conn_t;
 typedef struct st_h2o_http3_conn_t h2o_http3_conn_t;

--- a/include/h2o/http3_server.h
+++ b/include/h2o/http3_server.h
@@ -43,12 +43,8 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
                                           quicly_decoded_packet_t *packet, quicly_address_token_plaintext_t *address_token,
                                           int skip_tracing, const h2o_http3_conn_callbacks_t *h3_callbacks);
 /**
- *
+ * amends the quicly context so that it could be used for the server
  */
-extern quicly_stream_open_t h2o_http3_server_on_stream_open;
-/**
- *
- */
-extern quicly_stream_scheduler_t h2o_http3_server_stream_scheduler;
+void h2o_http3_server_amend_quicly_context(h2o_globalconf_t *conf, quicly_context_t *quic);
 
 #endif

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -197,6 +197,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http2.latency_optimization.max_cwnd = 65535;
     config->http2.callbacks = H2O_HTTP2_CALLBACKS;
     config->http3.idle_timeout = quicly_spec_context.transport_params.max_idle_timeout;
+    config->http3.active_stream_window_size = H2O_DEFAULT_HTTP3_ACTIVE_STREAM_WINDOW_SIZE;
     config->http3.callbacks = H2O_HTTP3_SERVER_CALLBACKS;
     config->send_informational_mode = H2O_SEND_INFORMATIONAL_MODE_EXCEPT_H1;
     config->mimemap = h2o_mimemap_create();

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -574,6 +574,20 @@ static int on_config_http3_graceful_shutdown_timeout(h2o_configurator_command_t 
     return config_timeout(cmd, node, &ctx->globalconf->http3.graceful_shutdown_timeout);
 }
 
+static int on_config_http3_input_window_size(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    uint32_t v;
+    if (h2o_configurator_scanf(cmd, node, "%" SCNu32, &v) != 0)
+        return -1;
+    if (v < H2O_HTTP3_INITIAL_REQUEST_STREAM_WINDOW_SIZE) {
+        h2o_configurator_errprintf(cmd, node, "window size must be no less than %u",
+                                   (unsigned)H2O_HTTP3_INITIAL_REQUEST_STREAM_WINDOW_SIZE);
+        return -1;
+    }
+    ctx->globalconf->http3.active_stream_window_size = v;
+    return 0;
+}
+
 static int assert_is_mimetype(h2o_configurator_command_t *cmd, yoml_t *node)
 {
     if (node->type != YOML_TYPE_SCALAR) {
@@ -1006,6 +1020,9 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(&c->super, "http3-graceful-shutdown-timeout",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http3_graceful_shutdown_timeout);
+        h2o_configurator_define_command(&c->super, "http3-input-window-size",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http3_input_window_size);
         h2o_configurator_define_command(&c->super, "file.mime.settypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -51,11 +51,6 @@ struct st_h2o_http3_ingress_unistream_t {
                          const uint8_t *src_end, int is_eos);
 };
 
-/**
- * maximum payload size excluding DATA frame; stream receive window MUST be at least as big as this
- */
-#define MAX_FRAME_SIZE 16384
-
 const ptls_iovec_t h2o_http3_alpn[2] = {{(void *)H2O_STRLIT("h3-29")}, {(void *)H2O_STRLIT("h3-27")}};
 
 static void on_track_sendmsg_timer(h2o_timer_t *timeout);
@@ -840,7 +835,7 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
     /* read the content of the frame (unless it's a DATA frame) */
     frame->payload = NULL;
     if (frame->type != H2O_HTTP3_FRAME_TYPE_DATA) {
-        if (frame->length >= MAX_FRAME_SIZE) {
+        if (frame->length > H2O_HTTP3_MAX_FRAME_PAYLOAD_SIZE) {
             H2O_PROBE(H3_FRAME_RECEIVE, frame->type, NULL, frame->length);
             *err_desc = "H3 frame too large";
             return H2O_HTTP3_ERROR_GENERAL_PROTOCOL; /* FIXME is this the correct code? */

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -232,7 +232,7 @@ static int on_body(h2o_httpclient_t *client, const char *errstr)
 
     if (errstr == h2o_httpclient_error_is_eos) {
         --cnt_left;
-        if (cnt_left > concurrency) {
+        if (cnt_left >= concurrency) {
             /* next attempt */
             h2o_mem_clear_pool(&pool);
             ftruncate(fileno(stdout), 0); /* ignore error when stdout is a tty */

--- a/t/40http3-concurrency.t
+++ b/t/40http3-concurrency.t
@@ -22,6 +22,7 @@ my $upstream = spawn_server(
     ],
     is_ready => sub { !! -e "$tempdir/upstream.sock" },
 );
+sleep 1;
 
 my $server = spawn_h2o(<< "EOT");
 listen:

--- a/t/40http3-concurrency.t
+++ b/t/40http3-concurrency.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use Net::EmptyPort qw(empty_port wait_port);
+use Test::More;
+use t::Util;
+
+my $client_prog = bindir() . "/h2o-httpclient";
+plan skip_all => "$client_prog not found"
+    unless -e $client_prog;
+
+my $tempdir = tempdir(CLEANUP => 1);
+my $quic_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
+
+my $upstream = spawn_server(
+    argv => [
+        qw(plackup -s Starlet --max-workers 10 --access-log /dev/null --listen), "$tempdir/upstream.sock",
+        ASSETS_DIR . "/upstream.psgi",
+    ],
+    is_ready => sub { !! -e "$tempdir/upstream.sock" },
+);
+
+my $server = spawn_h2o(<< "EOT");
+listen:
+  type: quic
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://[unix:$tempdir/upstream.sock]/
+EOT
+
+# send 3 requests to /suspend-body, check that all the header fields are received before the content
+sub fetch3 {
+    my $opts = shift;
+    open my $client_fh, "-|", "$client_prog -3 -C 3 -t 3 $opts https://127.0.0.1:$quic_port/suspend-body 2>&1"
+        or die "failed to spawn $client_prog:$!";
+    local $/;
+    join "", <$client_fh>;
+}
+
+my $resp_concurrent = qr!^(?:HTTP/[0-9\.]+ 200.*?\n\n){3}x{3}$!s;
+my $resp_sequential = qr!^(?:HTTP/[0-9\.]+ 200.*?\n\nx){3}$!s;
+
+like fetch3(""), $resp_concurrent, "GETs are concurrent";
+like fetch3("-m POST -b 10000 -c 100 -i 50"), $resp_concurrent, "POST of 10KB (taking 5 seconds) is concurrent";
+like fetch3("-m POST -b 1000000 -c 10000 -i 50"), $resp_sequential, "POST of 1MB (taking 5 seconds) is not concurrent";
+
+done_testing;


### PR DESCRIPTION
To mitigate slowloris attacks, our HTTP/2 stack restricts the concurrency of requests that are "streamed" to the upstream server to one per frontend connection.

We have had the code that does the same for HTTP/3, but it has not been exercised until now.

This PR enables the logic, by reducing the initial receive window size of a request stream to 32KB, then raising it up to 16MB (the same as the HTTP/2 "streamed" request receive window) once the request is promoted to "streamed" mode.

In addition, this PR adds a test case, delays the application of the globally configured settings to `quicly_context_t` until all the directives are processed, so that the order in which the configuration directives appear in the configuration file does not affect the values being used (amends #2423).

Builds on top of https://github.com/h2o/quicly/pull/392.