### PR TITLE
Transparent Reverse Proxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/headers.c
     lib/handler/mimemap.c
     lib/handler/proxy.c
+    lib/handler/proxy/tproxy.c
     lib/handler/redirect.c
     lib/handler/reproxy.c
     lib/handler/throttle_resp.c

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -98,6 +98,8 @@ extern "C" {
 #define H2O_DEFAULT_PROXY_SSL_SESSION_CACHE_CAPACITY 4096
 #define H2O_DEFAULT_PROXY_SSL_SESSION_CACHE_DURATION 86400000 /* 24 hours */
 #define H2O_DEFAULT_PROXY_HTTP2_MAX_CONCURRENT_STREAMS 100
+#define H2O_DEFAULT_PROXY_CONNPOOL_DURATION_IN_SECS 1
+#define H2O_DEFAULT_PROXY_CONNPOOL_DURATION (H2O_DEFAULT_PROXY_CONNPOOL_DURATION_IN_SECS * 1000)
 
 typedef struct st_h2o_conn_t h2o_conn_t;
 typedef struct st_h2o_context_t h2o_context_t;
@@ -1711,6 +1713,10 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
  * processes a request (by sending the request upstream)
  */
 void h2o__proxy_process_request(h2o_req_t *req);
+/**
+ * return source request from struct rp_generator_t
+ */
+h2o_req_t *h2o__proxy_get_srcreq(void *data);
 
 /* mime mapper */
 
@@ -2023,6 +2029,8 @@ typedef struct st_h2o_proxy_config_vars_t {
     uint64_t keepalive_timeout;
     unsigned preserve_host : 1;
     unsigned use_proxy_protocol : 1;
+    unsigned spoof_srcaddr : 1;
+    uint64_t connpool_duration;
     struct {
         int enabled;
         uint64_t timeout;
@@ -2362,4 +2370,5 @@ COMPUTE_DURATION(proxy_total_time, &req->proxy_stats.timestamps.request_begin_at
 }
 #endif
 
+#include "h2o/util.h"
 #endif

--- a/include/h2o/cache.h
+++ b/include/h2o/cache.h
@@ -59,7 +59,11 @@ enum {
     /**
      * if set, the cache triggers an early update
      */
-    H2O_CACHE_FLAG_EARLY_UPDATE = 0x2
+    H2O_CACHE_FLAG_EARLY_UPDATE = 0x2,
+    /**
+     * if set, fetch updates age
+     */
+    H2O_CACHE_FLAG_AGE_UPDATE = 0x4
 };
 
 /**

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -89,6 +89,11 @@ typedef struct st_h2o_httpclient_connection_pool_t {
         h2o_linklist_t conns;
     } http2;
 
+    /**
+     * static connection pools have zero refcnt.
+     * dynamic allocated connection pools have nonzero refcnt.
+     */
+    int refcnt;
 } h2o_httpclient_connection_pool_t;
 
 typedef struct st_h2o_httpclient_ctx_t {
@@ -259,6 +264,8 @@ extern const char h2o_httpclient_error_http2_protocol_violation[];
 extern const char h2o_httpclient_error_internal[];
 
 void h2o_httpclient_connection_pool_init(h2o_httpclient_connection_pool_t *connpool, h2o_socketpool_t *sockpool);
+h2o_httpclient_connection_pool_t *h2o_httpclient_connection_pool_create(h2o_socketpool_t *sockpool);
+void h2o_httpclient_connection_pool_dispose(h2o_httpclient_connection_pool_t *connpool);
 
 /**
  * issues a HTTP request using the connection pool. Either H1 or H2 may be used, depending on the given context.
@@ -272,8 +279,12 @@ extern const size_t h2o_httpclient__h1_size;
 
 void h2o_httpclient__h2_on_connect(h2o_httpclient_t *client, h2o_socket_t *sock, h2o_url_t *origin);
 uint32_t h2o_httpclient__h2_get_max_concurrent_streams(h2o_httpclient__h2_conn_t *conn);
+void h2o_httpclient__trigger_keepalive_timeout(h2o_httpclient__h2_conn_t *conn);
 extern const size_t h2o_httpclient__h2_size;
 
+h2o_httpclient_connection_pool_t *h2o_httpclient_connpool_create(void);
+void h2o_httpclient_connpool_dispose(h2o_httpclient_connection_pool_t *);
+    
 #ifdef quicly_h /* create http3client.h? */
 
 #include "h2o/http3_common.h"

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -219,6 +219,13 @@ void h2o_socket_dont_read(h2o_socket_t *sock, int dont_read);
  */
 h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, socklen_t addrlen, h2o_socket_cb cb);
 /**
+ * connects to peer with src ip spoofing
+ */
+h2o_socket_t *h2o_socket_connect_tproxy(h2o_loop_t *loop,
+                                        struct sockaddr *srcaddr, socklen_t srclen,
+                                        struct sockaddr *dstaddr, socklen_t dstrlen,
+                                        h2o_socket_cb cb);
+/**
  * prepares for latency-optimized write and returns the number of octets that should be written, or SIZE_MAX if failed to prepare
  */
 static size_t h2o_socket_prepare_for_latency_optimized_write(h2o_socket_t *sock,

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -303,6 +303,10 @@ size_t h2o_socket_getnumerichost(struct sockaddr *sa, socklen_t salen, char *buf
  */
 int32_t h2o_socket_getport(struct sockaddr *sa);
 /**
+ * sets the port number. returns zero on success and -1 on failure
+ */
+int h2o_socket_setport(struct sockaddr *sa, uint16_t port_hostorder);
+/**
  * performs SSL handshake on a socket
  * @param sock the socket
  * @param ssl_ctx SSL context

--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -36,7 +36,8 @@ extern "C" {
 
 typedef enum en_h2o_socketpool_target_type_t {
     H2O_SOCKETPOOL_TYPE_NAMED,
-    H2O_SOCKETPOOL_TYPE_SOCKADDR
+    H2O_SOCKETPOOL_TYPE_SOCKADDR,
+    H2O_SOCKETPOOL_TYPE_TPROXY  /* Connect to original destination IP address */
 } h2o_socketpool_target_type_t;
 
 /**
@@ -72,6 +73,10 @@ typedef struct st_h2o_socketpool_target_t {
             socklen_t len;
         } sockaddr;
     } peer;
+    /*
+     * srcaddr spoofing target
+     */
+    int spoof_srcaddr;
     /**
      * per-target lb configuration
      */
@@ -93,6 +98,13 @@ typedef struct st_h2o_socketpool_target_t {
 typedef H2O_VECTOR(h2o_socketpool_target_t *) h2o_socketpool_target_vector_t;
 
 typedef struct st_h2o_balancer_t h2o_balancer_t;
+
+typedef struct st_h2o_sockaddr_pair_t {
+    struct {
+        struct sockaddr_storage bytes;
+        socklen_t len;
+    } src, dst;
+} h2o_sockaddr_pair_t;
 
 typedef struct st_h2o_socketpool_t {
 
@@ -128,6 +140,9 @@ typedef struct st_h2o_socketpool_t {
 
     /* load balancer */
     h2o_balancer_t *balancer;
+
+    /* when used as transparent reverse proxy */
+    h2o_sockaddr_pair_t sockpair;
     /* refcnt is zero for static socketpools, nonzero for dynamically allocated ones */
     int refcnt;
 } h2o_socketpool_t;

--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -128,6 +128,8 @@ typedef struct st_h2o_socketpool_t {
 
     /* load balancer */
     h2o_balancer_t *balancer;
+    /* refcnt is zero for static socketpools, nonzero for dynamically allocated ones */
+    int refcnt;
 } h2o_socketpool_t;
 
 typedef struct st_h2o_socketpool_connect_request_t h2o_socketpool_connect_request_t;

--- a/include/h2o/tproxy.h
+++ b/include/h2o/tproxy.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 Chul-Woong Yang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef h2o__tproxy_h
+#define h2o__tproxy_h
+
+#ifdef __cplusplus
+//extern "C" {
+#endif
+
+#include "h2o.h"
+#include "h2o/cache.h"
+#include "h2o/socketpool.h"
+
+h2o_httpclient_connection_pool_t *h2o_tproxy_get_connpool(h2o_cache_t *cache, h2o_req_t *req,
+                                                          h2o_proxy_config_vars_t *config,
+                                                          h2o_socketpool_t *_sockpool);
+h2o_cache_t *h2o_tproxy_create_connpool_cache(size_t pool_duration);
+
+#ifdef __cplusplus
+//}
+#endif
+
+#endif

--- a/include/h2o/util.h
+++ b/include/h2o/util.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020 Chul-Woong Yang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef h2o__util_h
+#define h2o__util_h
+#ifdef __cplusplus
+//extern "C" {
+#endif
+#include <arpa/inet.h>
+
+static inline void h2o_addr_to_str(struct sockaddr *srcaddr, char *buf, int buflen)
+{
+    uint16_t port = 0;
+    char name[64];
+
+    switch (srcaddr->sa_family) {
+    case AF_UNIX: {
+        struct sockaddr_un *sun = (struct sockaddr_un *) srcaddr;
+        snprintf(buf, buflen, "unix:%s", sun->sun_path);
+        return;
+    }
+    case AF_INET: {
+        struct sockaddr_in *sin = (struct sockaddr_in *) srcaddr;
+        inet_ntop(AF_INET, &sin->sin_addr.s_addr, name, INET_ADDRSTRLEN);
+        port = sin->sin_port;
+        snprintf(buf, buflen, "%s:%d", name, ntohs(port));
+        return;
+    }
+    default: {
+        struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) srcaddr;
+        inet_ntop(AF_INET6, &sin6->sin6_addr, name, INET6_ADDRSTRLEN);    /* len = 46 */
+        port = sin6->sin6_port;
+        break;
+    }
+    }
+    snprintf(buf, buflen, "[%s]:%d", name, ntohs(port));
+}
+
+/* used for development session */
+#define h2o_pinfo(fmt, args...) do {                             \
+        fprintf(stderr, "%-18.18s| " fmt, __func__, ##args); \
+        fprintf(stderr, "\n");                               \
+    } while (0)
+
+#ifdef __cplusplus
+//}
+#endif
+#endif

--- a/lib/common/cache.c
+++ b/lib/common/cache.c
@@ -179,6 +179,11 @@ h2o_cache_ref_t *h2o_cache_fetch(h2o_cache_t *cache, uint64_t now, h2o_iovec_t k
         ref->_requested_early_update = 1;
         goto NotFound;
     }
+    if (cache->flags & H2O_CACHE_FLAG_AGE_UPDATE) {
+        ref->at = now;
+        h2o_linklist_unlink(&ref->_age_link);
+        h2o_linklist_insert(&cache->age, &ref->_age_link);
+    }
     /* move the entry to the top of LRU */
     h2o_linklist_unlink(&ref->_lru_link);
     h2o_linklist_insert(&cache->lru, &ref->_lru_link);

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -884,6 +884,16 @@ static void on_keepalive_timeout(h2o_timer_t *entry)
     close_connection(conn);
 }
 
+void h2o_httpclient__trigger_keepalive_timeout(h2o_httpclient__h2_conn_t *_conn)
+{
+    struct st_h2o_http2client_conn_t *conn = (void *) _conn;
+    if (h2o_timer_is_linked(&conn->keepalive_timeout))
+        h2o_timer_unlink(&conn->keepalive_timeout);
+    else
+        assert(!"keepalive_timeout must be linked");
+    h2o_timer_link(conn->super.ctx->loop, 0, &conn->keepalive_timeout);
+}
+
 static int parse_input(struct st_h2o_http2client_conn_t *conn)
 {
     /* handle the input */

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -914,9 +914,23 @@ int32_t h2o_socket_getport(struct sockaddr *sa)
 {
     switch (sa->sa_family) {
     case AF_INET:
-        return htons(((struct sockaddr_in *)sa)->sin_port);
+        return ntohs(((struct sockaddr_in *)sa)->sin_port);
     case AF_INET6:
-        return htons(((struct sockaddr_in6 *)sa)->sin6_port);
+        return ntohs(((struct sockaddr_in6 *)sa)->sin6_port);
+    default:
+        return -1;
+    }
+}
+
+int h2o_socket_setport(struct sockaddr *sa, uint16_t port)
+{
+    switch (sa->sa_family) {
+    case AF_INET:
+        ((struct sockaddr_in *)sa)->sin_port = htons(port);
+        return 0;
+    case AF_INET6:
+        ((struct sockaddr_in6 *)sa)->sin6_port = htons(port);
+        return 0;
     default:
         return -1;
     }

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -472,15 +472,17 @@ h2o_socket_t *h2o_socket_connect_tproxy(h2o_loop_t *loop,
 #ifdef IP_TRANSPARENT
     if (srclen) {       /* tproxy */
         int flag = 1;
-        if (setsockopt(fd, SOL_IP, IP_TRANSPARENT, &flag, sizeof(flag)) != 0)
+        if (setsockopt(fd, SOL_IP, IP_TRANSPARENT, &flag, sizeof(flag)) != 0) {
             goto Error;
-        if (bind(fd, srcaddr, srclen))
+        }
+        if (bind(fd, srcaddr, srclen)) {
             goto Error;
+        }
     }
 #endif
-    
-    if (!(connect(fd, dstaddr, dstlen) == 0 || errno == EINPROGRESS))
+    if (!(connect(fd, dstaddr, dstlen) == 0 || errno == EINPROGRESS)) {
         goto Error;
+    }
 
     sock = create_socket_set_nodelay(loop, fd, H2O_SOCKET_FLAG_IS_CONNECTING);
     h2o_socket_notify_write(&sock->super, cb);

--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -34,6 +34,7 @@
 #include "h2o/socket.h"
 #include "h2o/balancer.h"
 
+#include "h2o.h"
 /**
  * timeout will be set to this value when calculated less than this value
  */
@@ -69,6 +70,9 @@ struct on_close_data_t {
 };
 
 static void start_connect(h2o_socketpool_connect_request_t *req, struct sockaddr *addr, socklen_t addrlen);
+static void start_connect_tproxy(h2o_socketpool_connect_request_t *req,
+                                 struct sockaddr *srcaddr, socklen_t srclen,
+                                 struct sockaddr *dstaddr, socklen_t dstlen);
 static void on_getaddr(h2o_hostinfo_getaddr_req_t *getaddr_req, const char *errstr, struct addrinfo *res, void *_req);
 
 static void destroy_detached(struct pool_entry_t *entry)
@@ -150,6 +154,12 @@ static void common_init(h2o_socketpool_t *pool, h2o_socketpool_target_t **target
 h2o_socketpool_target_type_t detect_target_type(h2o_url_t *url, struct sockaddr_storage *sa, socklen_t *salen)
 {
     memset(sa, 0, sizeof(*sa));
+#define TPROXY_TARGET "tproxy"
+    if (url->host.len == sizeof(TPROXY_TARGET) - 1 &&
+        strncasecmp(url->host.base, TPROXY_TARGET, sizeof(TPROXY_TARGET) - 1) == 0) {
+        return H2O_SOCKETPOOL_TYPE_TPROXY;
+    }
+#undef TPROXY_TARGET
     const char *to_sun_err = h2o_url_host_to_sun(url->host, (struct sockaddr_un *)sa);
     if (to_sun_err == h2o_url_host_to_sun_err_is_not_unix_socket) {
         sa->ss_family = AF_INET;
@@ -184,6 +194,7 @@ h2o_socketpool_target_t *h2o_socketpool_create_target(h2o_url_t *origin, h2o_soc
     }
 
     switch (target->type) {
+    case H2O_SOCKETPOOL_TYPE_TPROXY:
     case H2O_SOCKETPOOL_TYPE_NAMED:
         target->peer.named_serv.base = h2o_mem_alloc(sizeof(H2O_UINT16_LONGEST_STR));
         target->peer.named_serv.len = sprintf(target->peer.named_serv.base, "%u", (unsigned)h2o_url_get_port(&target->url));
@@ -202,6 +213,7 @@ h2o_socketpool_target_t *h2o_socketpool_create_target(h2o_url_t *origin, h2o_soc
     }
 
     h2o_linklist_init_anchor(&target->_shared.sockets);
+    target->spoof_srcaddr = 0;
     return target;
 }
 
@@ -225,7 +237,12 @@ void h2o_socketpool_init_global(h2o_socketpool_t *pool, size_t capacity)
 
 void h2o_socketpool_destroy_target(h2o_socketpool_target_t *target)
 {
+    if (target->spoof_srcaddr) {   /* spoofing target was copied shallow */
+        free(target);
+        return;
+    }
     switch (target->type) {
+    case H2O_SOCKETPOOL_TYPE_TPROXY:
     case H2O_SOCKETPOOL_TYPE_NAMED:
         free(target->peer.named_serv.base);
         break;
@@ -340,17 +357,31 @@ static void try_connect(h2o_socketpool_connect_request_t *req)
     target = req->pool->targets.entries[req->selected_target];
     __sync_add_and_fetch(&req->pool->targets.entries[req->selected_target]->_shared.leased_count, 1);
 
+    struct sockaddr *src = NULL, *dst = NULL;
+    socklen_t src_len = 0, dst_len = 0;
     switch (target->type) {
     case H2O_SOCKETPOOL_TYPE_NAMED:
         /* resolve the name, and connect */
         req->getaddr_req = h2o_hostinfo_getaddr(req->getaddr_receiver, target->url.host, target->peer.named_serv, AF_UNSPEC,
                                                 SOCK_STREAM, IPPROTO_TCP, AI_ADDRCONFIG | AI_NUMERICSERV, on_getaddr, req);
+        return;
+    case H2O_SOCKETPOOL_TYPE_TPROXY:
+        dst = (void *)&req->pool->sockpair.dst.bytes;
+        dst_len = req->pool->sockpair.dst.len;
+        if (target->url._port != 65535)
+            h2o_socket_setport(dst, target->url._port);
         break;
     case H2O_SOCKETPOOL_TYPE_SOCKADDR:
         /* connect (using sockaddr_in) */
-        start_connect(req, (void *)&target->peer.sockaddr.bytes, target->peer.sockaddr.len);
+        dst = (void *)&target->peer.sockaddr.bytes;
+        dst_len = target->peer.sockaddr.len;
         break;
     }
+    if (target->spoof_srcaddr) { /* connect with client source ip address bounded */
+        src = (void *)&req->pool->sockpair.src.bytes;
+        src_len = req->pool->sockpair.src.len;
+    }
+    start_connect_tproxy(req, src, src_len, dst, dst_len);
 }
 
 static void on_handshake_complete(h2o_socket_t *sock, const char *err)
@@ -388,7 +419,13 @@ static void on_connect(h2o_socket_t *sock, const char *err)
         h2o_url_t *target_url = &req->pool->targets.entries[req->selected_target]->url;
         if (target_url->scheme->is_ssl) {
             assert(req->pool->_ssl_ctx != NULL && "h2o_socketpool_set_ssl_ctx must be called for a pool that contains SSL target");
-            h2o_socket_ssl_handshake(sock, req->pool->_ssl_ctx, target_url->host.base, req->alpn_protos, on_handshake_complete);
+            if  (req->pool->targets.entries[req->selected_target]->type == H2O_SOCKETPOOL_TYPE_TPROXY) {
+                h2o_httpclient_t *client = req->data;
+                h2o_req_t *src_req = h2o__proxy_get_srcreq(client->data);
+                char *host = h2o_strdup(&src_req->pool, src_req->input.authority.base, src_req->input.authority.len).base;
+                h2o_socket_ssl_handshake(sock, req->pool->_ssl_ctx, host, req->alpn_protos, on_handshake_complete);
+            } else
+                h2o_socket_ssl_handshake(sock, req->pool->_ssl_ctx, target_url->host.base, req->alpn_protos, on_handshake_complete);
             return;
         }
     }
@@ -405,11 +442,13 @@ static void on_close(void *data)
     __sync_sub_and_fetch(&pool->_shared.count, 1);
 }
 
-static void start_connect(h2o_socketpool_connect_request_t *req, struct sockaddr *addr, socklen_t addrlen)
+static void start_connect_tproxy(h2o_socketpool_connect_request_t *req,
+                                 struct sockaddr *src, socklen_t srclen,
+                                 struct sockaddr *dst, socklen_t dstlen)
 {
     struct on_close_data_t *close_data;
 
-    req->sock = h2o_socket_connect(req->loop, addr, addrlen, on_connect);
+    req->sock = h2o_socket_connect_tproxy(req->loop, src, srclen, dst, dstlen, on_connect);
     if (req->sock == NULL) {
         __sync_sub_and_fetch(&req->pool->targets.entries[req->selected_target]->_shared.leased_count, 1);
         if (req->remaining_try_count > 0) {
@@ -426,6 +465,10 @@ static void start_connect(h2o_socketpool_connect_request_t *req, struct sockaddr
     req->sock->data = req;
     req->sock->on_close.cb = on_close;
     req->sock->on_close.data = close_data;
+}
+static void start_connect(h2o_socketpool_connect_request_t *req, struct sockaddr *addr, socklen_t addrlen)
+{
+    start_connect_tproxy(req, NULL, 0, addr, addrlen);
 }
 
 static void on_getaddr(h2o_hostinfo_getaddr_req_t *getaddr_req, const char *errstr, struct addrinfo *res, void *_req)
@@ -446,8 +489,15 @@ static void on_getaddr(h2o_hostinfo_getaddr_req_t *getaddr_req, const char *errs
         return;
     }
 
+    h2o_socketpool_target_t *target = req->pool->targets.entries[req->selected_target];
+    struct sockaddr *src = NULL;
+    socklen_t src_len = 0;
+    if (target->spoof_srcaddr) { /* connect with client source ip address bounded */
+        src = (void *)&req->pool->sockpair.src.bytes;
+        src_len = req->pool->sockpair.src.len;
+    }
     struct addrinfo *selected = h2o_hostinfo_select_one(res);
-    start_connect(req, selected->ai_addr, selected->ai_addrlen);
+    start_connect_tproxy(req, src, src_len, selected->ai_addr, selected->ai_addrlen);
 }
 
 static size_t lookup_target(h2o_socketpool_t *pool, h2o_url_t *url)

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -781,3 +781,9 @@ void h2o__proxy_process_request(h2o_req_t *req)
      */
     h2o_httpclient_connect(&self->client, &req->pool, self, client_ctx, connpool, target, on_connect);
 }
+
+h2o_req_t *h2o__proxy_get_srcreq(void *data) 
+{
+    struct rp_generator_t *self = data;
+    return self->src_req;
+}

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -25,6 +25,7 @@
 #include <sys/uio.h>
 #include "h2o.h"
 #include "h2o/socket.h"
+#include "h2o/tproxy.h"
 
 #ifndef IOV_MAX
 #define IOV_MAX UIO_MAXIOV
@@ -326,6 +327,9 @@ void h2o_dispose_request(h2o_req_t *req)
     if (req->error_logs != NULL)
         h2o_buffer_dispose(&req->error_logs);
 
+    if (req->overrides && req->overrides->connpool)
+        h2o_httpclient_connection_pool_dispose(req->overrides->connpool);
+    
     h2o_mem_clear_pool(&req->pool);
 }
 

--- a/lib/handler/proxy/tproxy.c
+++ b/lib/handler/proxy/tproxy.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2020 Chul-Woong Yang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "khash.h"
+#include "h2o.h"
+#include "h2o/tproxy.h"
+
+/*
+ * The main purpose of tproxy module is to keep per-client connpool & sockpool.
+ *
+ * Connpool holds links to h1 sockpool and links to h2 sock lists.
+ * Connpool is per-thread structure (h2o decision), while sockpool is not. (sockpool is shared)
+ *
+ * New req lookups connpool. create if not exist.
+ * Connpool lookups sockpool. create if not exist.
+ * h2o_cache keeps connpool and sockpool and free idle pools for regular interval.
+ * sockpool must not be freed when connpool is exist
+ */
+
+typedef uint32_t /* eq. khint_t */ h2o_connpool_hashcode_t;
+static h2o_cache_t *sockpool_cache = NULL;
+
+typedef struct st_h2o_connpool_key_t
+{
+    uint8_t saddr[16];
+    uint8_t daddr[16];
+    uint16_t dport;
+} h2o_connpool_key_t;
+
+static int make_connpool_key(h2o_req_t *req, h2o_connpool_key_t *key)
+{
+    h2o_sockaddr_pair_t sp;
+    if (!req->conn)
+        return -1;
+    sp.src.len = req->conn->callbacks->get_sockname(req->conn, (void *)&sp.src.bytes);
+    sp.dst.len = req->conn->callbacks->get_sockname(req->conn, (void *)&sp.dst.bytes);
+
+    if (sp.src.bytes.ss_family == AF_INET6) {
+        memcpy(key->saddr, (void *)&((struct sockaddr_in6 *) &sp.src.bytes)->sin6_addr, 16);
+        memcpy(key->daddr, (void *)&((struct sockaddr_in6 *) &sp.dst.bytes)->sin6_addr, 16);
+        key->dport = ((struct sockaddr_in6 *) &sp.dst.bytes)->sin6_port;
+    } else {
+        *key = (h2o_connpool_key_t) {};
+        memcpy(key->saddr+12, (void *)&((struct sockaddr_in *) &sp.src.bytes)->sin_addr, 4);
+        memcpy(key->daddr+12, (void *)&((struct sockaddr_in *) &sp.dst.bytes)->sin_addr, 4);
+        key->dport = ((struct sockaddr_in *) &sp.dst.bytes)->sin_port;
+    }
+    return 0;
+}
+
+/*
+ * create per-client sockpool and shallow copy socketpool_target from base_sockpool
+ */
+static h2o_socketpool_t *create_per_client_sockpool(h2o_socketpool_t *base_sockpool,
+                                                    h2o_conn_t *conn,
+                                                    size_t capacity, uint64_t keepalive_ms)
+{
+    assert(base_sockpool->targets.size == 1);
+    h2o_socketpool_target_t *target;
+    target = h2o_mem_alloc(sizeof(*target));
+    *target = *(base_sockpool->targets.entries[0]);
+    target->spoof_srcaddr = 1;
+    target->_shared.leased_count = 0;
+    target->conf.weight_m1 = 0;
+    h2o_linklist_init_anchor(&target->_shared.sockets);
+
+    h2o_socketpool_t *s = h2o_mem_alloc(sizeof(*s));
+    memset(s, 0, sizeof(*s));
+    /* init socket pool */
+    h2o_socketpool_init_specific(s, capacity, &target, 1, NULL);
+    h2o_socketpool_set_timeout(s, keepalive_ms);
+    h2o_socketpool_set_ssl_ctx(s, base_sockpool->_ssl_ctx);
+    s->sockpair.src.len = conn->callbacks->get_peername(conn, (void *)&s->sockpair.src.bytes);
+    s->sockpair.dst.len = conn->callbacks->get_sockname(conn, (void *)&s->sockpair.dst.bytes);
+    h2o_socket_setport((struct sockaddr *)&s->sockpair.src.bytes, 0);
+    s->refcnt = 1;
+    return s;
+}
+
+h2o_httpclient_connection_pool_t *h2o_tproxy_get_connpool(h2o_cache_t *cache, h2o_req_t *req,
+                                                          h2o_proxy_config_vars_t *config,
+                                                          h2o_socketpool_t *base_sockpool)
+{
+    h2o_connpool_key_t key;
+    if (make_connpool_key(req, &key) < 0)
+        return NULL;
+
+    h2o_iovec_t cache_key = {.base = (char *) &key, .len = sizeof(key) };
+    h2o_cache_hashcode_t hash = h2o_cache_calchash(cache_key.base, cache_key.len);
+    h2o_cache_ref_t *cp_ref = h2o_cache_fetch(cache, h2o_now(req->conn->ctx->loop),
+                                                cache_key, hash);
+    h2o_httpclient_connection_pool_t *connpool;
+    if (cp_ref != NULL) {
+        connpool = (void *) cp_ref->value.base;
+        connpool->refcnt++;
+        h2o_cache_release(cache, cp_ref);
+        return connpool;
+    }
+
+    h2o_cache_ref_t *sp_ref = h2o_cache_fetch(sockpool_cache, h2o_now(req->conn->ctx->loop),
+                                              cache_key, hash);
+    h2o_socketpool_t *sockpool;
+    int new_sockpool = 0;
+    if (sp_ref != NULL) {
+        sockpool = (void *) sp_ref->value.base;
+        __sync_add_and_fetch(&sockpool->refcnt, 1);
+        h2o_cache_release(cache, sp_ref);
+    } else {
+        new_sockpool = 1;
+        sockpool = create_per_client_sockpool(base_sockpool, req->conn, SIZE_MAX, config->keepalive_timeout);
+        sockpool->refcnt ++;
+        /* when race happens, previous sockpool gets out from cache and released when corresponding
+           connpool puts the sockpool */
+        /* But socketpool_detach() aborts at that case! */
+        h2o_cache_set(sockpool_cache, h2o_now(req->conn->ctx->loop),
+                      cache_key, hash,
+                      h2o_iovec_init(sockpool, 1));
+        /* use the loop of first context for handling socketpool timeouts */
+        //sockpool->ctx = req->conn->ctx;
+        h2o_socketpool_register_loop(sockpool, req->conn->ctx->loop);
+    }
+
+    connpool = h2o_httpclient_connection_pool_create(sockpool);
+    connpool->refcnt++;
+    h2o_cache_set(cache, h2o_now(req->conn->ctx->loop),
+                  cache_key, hash,
+                  h2o_iovec_init(connpool, 1));
+
+    return connpool;
+}
+
+static void destroy_connpool_entry(h2o_iovec_t value)
+{
+    h2o_httpclient_connection_pool_t *connpool = (void *) value.base;
+    h2o_httpclient_connection_pool_dispose(connpool);
+}
+
+static void destroy_sockpool_entry(h2o_iovec_t value)
+{
+    h2o_socketpool_t *sockpool = (void *) value.base;
+    h2o_socketpool_dispose(sockpool);
+}
+
+h2o_cache_t *h2o_tproxy_create_connpool_cache(size_t pool_duration)
+{
+    if (!sockpool_cache) {
+        sockpool_cache = h2o_cache_create(H2O_CACHE_FLAG_MULTITHREADED | H2O_CACHE_FLAG_AGE_UPDATE,
+                                          SIZE_MAX,                 /* unlimited size cache*/
+                                          pool_duration,           /* duration check */
+                                          destroy_sockpool_entry);
+    }
+    h2o_cache_t *ret = h2o_cache_create(H2O_CACHE_FLAG_AGE_UPDATE,
+                                        SIZE_MAX /* unlimited size cache*/,
+                                        pool_duration /* duration check */,
+                                        destroy_connpool_entry);
+    return ret;
+}


### PR DESCRIPTION
Hi, I send several patches for Transparent Reverse Proxy implementation of issue https://github.com/h2o/h2o/issues/2416

Following three patches are simple APIs:
* add h2o_socket_setport()
* h2o_cache_t: H2O_CACHE_FLAG_AGE_UPDATE …
* h2o_socket_connect_tproxy(.. srcaddr, srclen, dstaddr, dstlen ..) …

I use simple stdout h2o_pinfo() macro during development session:
* h2o/util.h …

This patch adds configuration and enables IP_TRANSPARENT on listen socket
* tproxy: listen.transparent configuration …

These two patches are main contribution.
First patch lets us allocate connection pool and socket pool. We maintain connection pool and socketpool per 5-tuples.
Second patch uses the former patch to implement src-address spoofed upstream session. The patch also
provides TPROXY socket pool target, which has`proxy.reverse.url="http[s]://tproxy/` configuration:
* connection pool and socket pool can be allocated …
* tproxy: Transparent Reverse Proxy …

For test, I separate client namespace and h2o namespace and setup routing rule and iptables rule to feed the packet to h2o.
Web browser repeatedly send web request and the request was served from h2o transparently to both ends.
I wonder whether I can make automatic testing for this.

Best regards,
Chul-Woong 