### PR TITLE
[http3] peer might send QPACK decoder instructions before the QPACK encoder is instantiated

### DIFF
--- a/include/h2o/qpack.h
+++ b/include/h2o/qpack.h
@@ -56,6 +56,10 @@ int h2o_qpack_parse_response(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, i
 
 h2o_qpack_encoder_t *h2o_qpack_create_encoder(uint32_t header_table_size, uint16_t max_blocked);
 void h2o_qpack_destroy_encoder(h2o_qpack_encoder_t *qpack);
+/**
+ * Handles packets sent to the QPACK encoder (i.e., the bytes carried by the "decoder" stream)
+ * @param qpack can be NULL
+ */
 int h2o_qpack_encoder_handle_input(h2o_qpack_encoder_t *qpack, const uint8_t **src, const uint8_t *src_end, const char **err_desc);
 /**
  * flattens a QPACK request.


### PR DESCRIPTION
H2O does not instantiate the QPACK encoder until it receives the SETTINGS frame, that contains the maximum QPACK table size that is accepted by the peer.

Note that the peer is required to send a QPACK decoder instruction when it resets the request stream, and that can arrive before the SETTINGS frame.