### PR TITLE
h2olog: drop the root privilege once BPF is set up

### DIFF
--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -43,6 +43,7 @@ Usage: h2olog -p PID
 Other options:
     -h Print this help and exit
     -d Print debugging information (-dd shows more)
+    -r Run without dropping root privilege
     -w Path to write the output (default: stdout)
 )",
            H2O_VERSION);
@@ -234,7 +235,7 @@ int main(int argc, char **argv)
     std::vector<std::string> response_header_filters;
     int c;
     pid_t h2o_pid = -1;
-    while ((c = getopt(argc, argv, "hdp:t:s:w:")) != -1) {
+    while ((c = getopt(argc, argv, "hdrp:t:s:w:")) != -1) {
         switch (c) {
         case 'p':
             h2o_pid = atoi(optarg);

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -133,7 +133,12 @@ static void drop_root_privilege(void)
             fprintf(stderr, "Error: failed to read the SUDO_GID env variable\n");
             exit(EXIT_FAILURE);
         }
-        gid_t gid = atoi(sudo_gid);
+        errno = 0;
+        gid_t gid = (gid_t)strtol(sudo_gid, NULL, 10);
+        if (errno != 0) {
+            fprintf(stderr, "Error: overflow while parsing SUDO_GID\n");
+            exit(EXIT_FAILURE);
+        }
         if (gid != 0 && setgid(gid) != 0) {
             fprintf(stderr, "Error: failed to drop the root group\n");
             exit(EXIT_FAILURE);
@@ -145,8 +150,13 @@ static void drop_root_privilege(void)
             fprintf(stderr, "Error: failed to read the SUDO_UID env variable\n");
             exit(EXIT_FAILURE);
         }
-        uid_t uid = atoi(sudo_uid);
-        if (uid > 0 && setuid(uid) != 0) {
+        errno = 0;
+        uid_t uid = (uid_t)strtol(sudo_uid, NULL, 10);
+        if (errno != 0) {
+            fprintf(stderr, "Error: overflow while parsing SUDO_UID\n");
+            exit(EXIT_FAILURE);
+        }
+        if (uid != 0 && setuid(uid) != 0) {
             fprintf(stderr, "Error: failed to drop the root user\n");
             exit(EXIT_FAILURE);
         }

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -138,7 +138,7 @@ static void drop_root_privilege(void)
             errno = 0;
             gid_t gid = (gid_t)strtol(sudo_gid, NULL, 10);
             if (errno != 0) {
-                fprintf(stderr, "Error: overflow while parsing SUDO_GID\n");
+                fprintf(stderr, "Error: failed to parse SUDO_GID\n");
                 exit(EXIT_FAILURE);
             }
             if (gid != 0 && setgid(gid) != 0) {
@@ -154,7 +154,7 @@ static void drop_root_privilege(void)
         errno = 0;
         uid_t uid = (uid_t)strtol(sudo_uid, NULL, 10);
         if (errno != 0) {
-            fprintf(stderr, "Error: overflow while parsing SUDO_UID\n");
+            fprintf(stderr, "Error: failed to parse SUDO_UID\n");
             exit(EXIT_FAILURE);
         }
         if (uid != 0 && setuid(uid) != 0) {

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -141,7 +141,7 @@ static void drop_root_privilege(void)
             exit(EXIT_FAILURE);
         }
         if (setgid(gid) != 0) {
-            perror("Error: setgid(2) failed\n");
+            perror("Error: setgid(2) failed");
             exit(EXIT_FAILURE);
         }
         const char *sudo_uid = getenv("SUDO_UID");

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -131,7 +131,7 @@ static void drop_root_privilege(void)
     if (getuid() == 0) {
         const char *sudo_gid = getenv("SUDO_GID");
         if (sudo_gid == NULL) {
-            fprintf(stderr, "Error: failed to read the SUDO_GID env variable\n");
+            fprintf(stderr, "Error: the SUDO_GID environment variable is not set\n");
             exit(EXIT_FAILURE);
         }
         errno = 0;
@@ -146,7 +146,7 @@ static void drop_root_privilege(void)
         }
         const char *sudo_uid = getenv("SUDO_UID");
         if (sudo_uid == NULL) {
-            fprintf(stderr, "Error: failed to read the SUDO_UID env variable\n");
+            fprintf(stderr, "Error: the SUDO_UID environment variable is not set\n");
             exit(EXIT_FAILURE);
         }
         errno = 0;

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -228,6 +228,7 @@ int main(int argc, char **argv)
     }
 
     int debug = 0;
+    int drop_root = 1;
     FILE *outfp = stdout;
     std::vector<std::string> event_type_filters;
     std::vector<std::string> response_header_filters;
@@ -252,6 +253,9 @@ int main(int argc, char **argv)
             break;
         case 'd':
             debug++;
+            break;
+        case 'r':
+            drop_root = 0;
             break;
         case 'h':
             usage();
@@ -329,8 +333,10 @@ int main(int argc, char **argv)
     if (debug) {
         show_process(h2o_pid);
     }
+    if (drop_root) {
+        drop_root_privilege();
+    }
 
-    drop_root_privilege();
     ebpf::BPFPerfBuffer *perf_buffer = bpf->get_perf_buffer("events");
     if (perf_buffer) {
         time_t t0 = time(NULL);

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -141,7 +141,7 @@ static void drop_root_privilege(void)
             exit(EXIT_FAILURE);
         }
         if (setgid(gid) != 0) {
-            fprintf(stderr, "Error: failed to drop the root group\n");
+            perror("Error: setgid(2) failed\n");
             exit(EXIT_FAILURE);
         }
         const char *sudo_uid = getenv("SUDO_UID");
@@ -156,7 +156,7 @@ static void drop_root_privilege(void)
             exit(EXIT_FAILURE);
         }
         if (setuid(uid) != 0) {
-            fprintf(stderr, "Error: failed to drop the root user\n");
+            perror("Error: setuid(2) failed\n");
             exit(EXIT_FAILURE);
         }
     }

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
     }
 
     int debug = 0;
-    int drop_root = 1;
+    int preserve_root = 0;
     FILE *outfp = stdout;
     std::vector<std::string> event_type_filters;
     std::vector<std::string> response_header_filters;
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
             debug++;
             break;
         case 'r':
-            drop_root = 0;
+            preserve_root = 1;
             break;
         case 'h':
             usage();
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
     if (debug) {
         show_process(h2o_pid);
     }
-    if (drop_root) {
+    if (!preserve_root) {
         drop_root_privilege();
     }
 

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -129,22 +129,20 @@ static void show_process(pid_t pid)
 static void drop_root_privilege(void)
 {
     if (getuid() == 0) {
-        if (getgid() == 0) {
-            const char *sudo_gid = getenv("SUDO_GID");
-            if (sudo_gid == NULL) {
-                fprintf(stderr, "Error: failed to read the SUDO_GID env variable\n");
-                exit(EXIT_FAILURE);
-            }
-            errno = 0;
-            gid_t gid = (gid_t)strtol(sudo_gid, NULL, 10);
-            if (errno != 0) {
-                fprintf(stderr, "Error: failed to parse SUDO_GID\n");
-                exit(EXIT_FAILURE);
-            }
-            if (gid != 0 && setgid(gid) != 0) {
-                fprintf(stderr, "Error: failed to drop the root group\n");
-                exit(EXIT_FAILURE);
-            }
+        const char *sudo_gid = getenv("SUDO_GID");
+        if (sudo_gid == NULL) {
+            fprintf(stderr, "Error: failed to read the SUDO_GID env variable\n");
+            exit(EXIT_FAILURE);
+        }
+        errno = 0;
+        gid_t gid = (gid_t)strtol(sudo_gid, NULL, 10);
+        if (errno != 0) {
+            fprintf(stderr, "Error: failed to parse SUDO_GID\n");
+            exit(EXIT_FAILURE);
+        }
+        if (setgid(gid) != 0) {
+            fprintf(stderr, "Error: failed to drop the root group\n");
+            exit(EXIT_FAILURE);
         }
         const char *sudo_uid = getenv("SUDO_UID");
         if (sudo_uid == NULL) {
@@ -157,7 +155,7 @@ static void drop_root_privilege(void)
             fprintf(stderr, "Error: failed to parse SUDO_UID\n");
             exit(EXIT_FAILURE);
         }
-        if (uid != 0 && setuid(uid) != 0) {
+        if (setuid(uid) != 0) {
             fprintf(stderr, "Error: failed to drop the root user\n");
             exit(EXIT_FAILURE);
         }

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -156,7 +156,7 @@ static void drop_root_privilege(void)
             exit(EXIT_FAILURE);
         }
         if (setuid(uid) != 0) {
-            perror("Error: setuid(2) failed\n");
+            perror("Error: setuid(2) failed");
             exit(EXIT_FAILURE);
         }
     }

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -127,24 +127,24 @@ static void show_process(pid_t pid)
 
 static void drop_root_privilege(void)
 {
-    if (getgid() == 0) {
-        const char *sudo_gid = getenv("SUDO_GID");
-        if (sudo_gid == NULL) {
-            fprintf(stderr, "Error: failed to read the SUDO_GID env variable\n");
-            exit(EXIT_FAILURE);
-        }
-        errno = 0;
-        gid_t gid = (gid_t)strtol(sudo_gid, NULL, 10);
-        if (errno != 0) {
-            fprintf(stderr, "Error: overflow while parsing SUDO_GID\n");
-            exit(EXIT_FAILURE);
-        }
-        if (gid != 0 && setgid(gid) != 0) {
-            fprintf(stderr, "Error: failed to drop the root group\n");
-            exit(EXIT_FAILURE);
-        }
-    }
     if (getuid() == 0) {
+        if (getgid() == 0) {
+            const char *sudo_gid = getenv("SUDO_GID");
+            if (sudo_gid == NULL) {
+                fprintf(stderr, "Error: failed to read the SUDO_GID env variable\n");
+                exit(EXIT_FAILURE);
+            }
+            errno = 0;
+            gid_t gid = (gid_t)strtol(sudo_gid, NULL, 10);
+            if (errno != 0) {
+                fprintf(stderr, "Error: overflow while parsing SUDO_GID\n");
+                exit(EXIT_FAILURE);
+            }
+            if (gid != 0 && setgid(gid) != 0) {
+                fprintf(stderr, "Error: failed to drop the root group\n");
+                exit(EXIT_FAILURE);
+            }
+        }
         const char *sudo_uid = getenv("SUDO_UID");
         if (sudo_uid == NULL) {
             fprintf(stderr, "Error: failed to read the SUDO_UID env variable\n");


### PR DESCRIPTION
Technically `h2olog` only needs root privilege to:

1. Attach the BPF tracepoints
2. Open the BPF ring buffer

Therefore drop the root privilege as soon as the two operations are complete. Error handling may seem unforgiving but it follows a consistent pattern in `h2olog`.