### PR TITLE
retain the main thread until all the worker threads exit

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3316,11 +3316,9 @@ int main(int argc, char **argv)
 
     /* wait for all threads to exit */
     for (size_t i = 1; i != conf.thread_map.size; ++i) {
-        while (pthread_join(tids[i], NULL) != 0) {
-            if (errno != EINTR) {
-                perror("pthread_join(2) failed");
-                exit(EX_SOFTWARE);
-            }
+        if (pthread_join(tids[i], NULL) != 0) {
+            char errbuf[256];
+            h2o_fatal("pthread_join: %s", h2o_strerror_r(errno, errbuf, sizeof(errbuf)));
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -202,7 +202,6 @@ static struct {
     int tfo_queues;
     time_t launch_time;
     struct {
-        pthread_t tid;
         h2o_context_t ctx;
         h2o_multithread_receiver_t server_notifications;
         h2o_multithread_receiver_t memcached;
@@ -2531,7 +2530,6 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
                                       on_server_notification);
     h2o_multithread_register_receiver(conf.threads[thread_index].ctx.queue, &conf.threads[thread_index].memcached,
                                       h2o_memcached_receiver);
-    conf.threads[thread_index].tid = pthread_self();
 
     if (conf.thread_map.entries[thread_index] >= 0) {
 #ifdef H2O_HAS_PTHREAD_SETAFFINITY_NP

--- a/src/main.c
+++ b/src/main.c
@@ -2519,7 +2519,7 @@ static void on_server_notification(h2o_multithread_receiver_t *receiver, h2o_lin
     }
 }
 
-H2O_NORETURN static void *run_loop(void *_thread_index)
+static void *run_loop(void *_thread_index)
 {
     size_t thread_index = (size_t)_thread_index;
     struct listener_ctx_t *listeners = alloca(sizeof(*listeners) * conf.num_listeners);
@@ -2667,10 +2667,7 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     while (num_connections(0) != 0)
         h2o_evloop_run(conf.threads[thread_index].ctx.loop, INT32_MAX);
 
-    /* the process that detects num_connections becoming zero performs the last cleanup */
-    if (conf.pid_file != NULL)
-        unlink(conf.pid_file);
-    _exit(0);
+    return NULL;
 }
 
 static char **build_server_starter_argv(const char *h2o_cmd, const char *config_file)
@@ -3310,15 +3307,26 @@ int main(int argc, char **argv)
 
     /* start the threads */
     conf.threads = alloca(sizeof(conf.threads[0]) * conf.thread_map.size);
-    size_t i;
-    for (i = 1; i != conf.thread_map.size; ++i) {
-        pthread_t tid;
-        h2o_multithread_create_thread(&tid, NULL, run_loop, (void *)i);
-    }
+    pthread_t *tids = alloca(sizeof(*tids) * conf.thread_map.size);
+    for (size_t i = 1; i != conf.thread_map.size; ++i)
+        h2o_multithread_create_thread(&tids[i], NULL, run_loop, (void *)i);
 
     /* this thread becomes the first thread */
     run_loop((void *)0);
 
-    /* notreached */
+    /* wait for all threads to exit */
+    for (size_t i = 1; i != conf.thread_map.size; ++i) {
+        while (pthread_join(tids[i], NULL) != 0) {
+            if (errno != EINTR) {
+                perror("pthread_join(2) failed");
+                exit(EX_SOFTWARE);
+            }
+        }
+    }
+
+    /* remove the pid file */
+    if (conf.pid_file != NULL)
+        unlink(conf.pid_file);
+
     return 0;
 }


### PR DESCRIPTION
Worker threads refer to values on the stack of the main thread, the most notable one being `conf.threads[].ctx`.

In the current design, any thread can call `_exit`, and then threads will be destroyed in an unspecified order. If the main thread gets destroyed and then a worker thread refers to `conf.threads[].ctx`, SEGV can be raised.