### PR TITLE
[http3] transmit FIN when upstream closes after all the response body have been acked by the client

### DIFF
--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -363,9 +363,12 @@ static int handle_input_data_payload(struct st_h2o_http3client_req_t *req, const
 int handle_input_expect_data_frame(struct st_h2o_http3client_req_t *req, const uint8_t **src, const uint8_t *src_end, int err,
                                    const char **err_desc)
 {
-    if (*src == src_end && err == H2O_HTTP3_ERROR_EOS) {
-        /* if the input is EOS, delegate the task to the payload processing function */
-        assert(req->bytes_left_in_data_frame == 0);
+    assert(req->bytes_left_in_data_frame == 0);
+    if (*src == src_end) {
+        /* return early if no input, no state change */
+        if (err == 0)
+            return 0;
+        /* either EOS or an unexpected close; delegate the task to the payload processing function */
     } else {
         /* otherwise, read the frame */
         h2o_http3_read_frame_t frame;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1171,10 +1171,8 @@ static void do_send(h2o_ostream_t *_ostr, h2o_req_t *_req, h2o_sendvec_t *bufs, 
     case H2O_SEND_STATE_ERROR:
         /* TODO consider how to forward error, pending resolution of https://github.com/quicwg/base-drafts/issues/3300 */
         quicly_sendstate_shutdown(&stream->quic->sendstate, stream->sendbuf.final_size);
-        if (stream->sendbuf.vecs.size == 0) {
+        if (stream->sendbuf.vecs.size == 0)
             set_state(stream, H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT);
-            return;
-        }
         break;
     }
 

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -154,6 +154,8 @@ builder {
             my $writer = $responder->([ 200, [ 'content-type' => 'text/plain' ] ]);
             sleep 1;
             $writer->write('x');
+            sleep 1
+                if $env->{QUERY_STRING} =~ /delay-fin/;
             $writer->close;
         };
     };


### PR DESCRIPTION
Status quo fails to transmit FIN when all the bytes being sent to the client has been acked then upstream closes the connection. This PR, specifically 4df864d, addresses this bug.

Additionally, this PR fixes the http3 client reporting an abnormal close of a stream (including the behavior explained above) as "malformed frame."