### PR TITLE
docs: fix simple typo, explicitely -> explicitly

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -513,10 +513,10 @@ struct st_h2o_globalconf_t {
 
 enum {
     H2O_COMPRESS_HINT_AUTO = 0,    /* default: let h2o negociate compression based on the configuration */
-    H2O_COMPRESS_HINT_DISABLE,     /* compression was explicitely disabled for this request */
-    H2O_COMPRESS_HINT_ENABLE,      /* compression was explicitely enabled for this request */
-    H2O_COMPRESS_HINT_ENABLE_GZIP, /* compression was explicitely enabled for this request, asking for gzip */
-    H2O_COMPRESS_HINT_ENABLE_BR,   /* compression was explicitely enabled for this request, asking for br */
+    H2O_COMPRESS_HINT_DISABLE,     /* compression was explicitly disabled for this request */
+    H2O_COMPRESS_HINT_ENABLE,      /* compression was explicitly enabled for this request */
+    H2O_COMPRESS_HINT_ENABLE_GZIP, /* compression was explicitly enabled for this request, asking for gzip */
+    H2O_COMPRESS_HINT_ENABLE_BR,   /* compression was explicitly enabled for this request, asking for br */
 };
 
 /**
@@ -1212,7 +1212,7 @@ struct st_h2o_req_t {
     unsigned send_server_timing;
 
     /**
-     * Whether the producer of the response has explicitely disabled or
+     * Whether the producer of the response has explicitly disabled or
      * enabled compression. One of H2O_COMPRESS_HINT_*
      */
     char compress_hint;

--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -70,10 +70,10 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
 
     switch (req->compress_hint) {
     case H2O_COMPRESS_HINT_DISABLE:
-        /* compression was explicitely disabled, skip */
+        /* compression was explicitly disabled, skip */
         goto Next;
     case H2O_COMPRESS_HINT_ENABLE:
-        /* compression was explicitely enabled */
+        /* compression was explicitly enabled */
         break;
     case H2O_COMPRESS_HINT_ENABLE_BR:
         compressible_types_mask = H2O_COMPRESSIBLE_BROTLI;


### PR DESCRIPTION
There is a small typo in include/h2o.h, lib/handler/compress.c.

Should read `explicitly` rather than `explicitely`.

