### PR TITLE
http3: check the pointer before dereferencing

### DIFF
--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -321,6 +321,8 @@ static void control_stream_handle_input(h2o_http3_conn_t *conn, struct st_h2o_ht
 static void discard_handle_input(h2o_http3_conn_t *conn, struct st_h2o_http3_ingress_unistream_t *stream, const uint8_t **src,
                                  const uint8_t *src_end, int is_eos)
 {
+    if (src == NULL)
+        return;
     *src = src_end;
 }
 


### PR DESCRIPTION
This PR adds an early return to `discard_handle_input()` if the `src` pointer is NULL. This happens on a rare occasion when handling a RESET.