### PR TITLE
Update support for delayed ack extension

### DIFF
--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -223,7 +223,8 @@ typedef struct st_quicly_transport_parameters_t {
      */
     uint16_t max_ack_delay;
     /**
-     * quicly ignores the value set for quicly_context_t::transport_parameters. Set to UINT64_MAX when not specified by remote peer.
+     * Delayed-ack extension. UINT64_MAX indicates that the extension is disabled or that the peer does not support it. Any local
+     * value other than UINT64_MAX indicates that the use of the extension should be negotiated.
      */
     uint64_t min_ack_delay_usec;
     /**
@@ -390,6 +391,9 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t sent;                                                                                                             \
     } num_bytes;                                                                                                                   \
+    /**                                                                                                                            \
+     * Total number of each frame being sent / received.                                                                           \
+     */                                                                                                                            \
     struct {                                                                                                                       \
         uint64_t padding, ping, ack, reset_stream, stop_sending, crypto, new_token, stream, max_data, max_stream_data,             \
             max_streams_bidi, max_streams_uni, data_blocked, stream_data_blocked, streams_blocked, new_connection_id,              \
@@ -397,9 +401,9 @@ struct st_quicly_conn_streamgroup_state_t {
             ack_frequency;                                                                                                         \
     } num_frames_sent, num_frames_received;                                                                                        \
     /**                                                                                                                            \
-     * Total number of PTOs during the connections.                                                                                \
+     * Total number of PTOs observed during the connection.                                                                        \
      */                                                                                                                            \
-    uint32_t num_ptos
+    uint64_t num_ptos
 
 typedef struct st_quicly_stats_t {
     /**
@@ -832,9 +836,9 @@ uint64_t quicly_get_next_expected_packet_number(quicly_conn_t *conn);
 int quicly_is_blocked(quicly_conn_t *conn);
 /**
  * Returns if stream data can be sent.
- * When the connection is blocked by the connection-level flow control (see `quicly_is_flow_capped`), `at_stream_level` should be
- * set to false to see if any retransmissions are to be done. Otherwise, `at_steram_level` should be set to true to test the stream-
- * level flow control.
+ * When the connection is blocked by the connection-level flow control (see `quicly_is_blocked`), `at_stream_level` should be set to
+ * false to see if any retransmissions are to be done. Otherwise, `at_stream_level` should be set to true to test the stream-level
+ * flow control.
  */
 int quicly_stream_can_send(quicly_stream_t *stream, int at_stream_level);
 /**
@@ -927,7 +931,7 @@ int quicly_encode_transport_parameter_list(ptls_buffer_t *buf, const quicly_tran
  */
 int quicly_decode_transport_parameter_list(quicly_transport_parameters_t *params, quicly_cid_t *original_dcid,
                                            quicly_cid_t *initial_scid, quicly_cid_t *retry_scid, void *stateless_reset_token,
-                                           const uint8_t *src, const uint8_t *end);
+                                           const uint8_t *src, const uint8_t *end, int recognize_delayed_ack);
 /**
  * Initiates a new connection.
  * @param new_cid the CID to be used for the connection. path_id is ignored.

--- a/deps/quicly/include/quicly/frame.h
+++ b/deps/quicly/include/quicly/frame.h
@@ -749,9 +749,7 @@ inline uint8_t *quicly_encode_ack_frequency_frame(uint8_t *dst, uint64_t sequenc
     dst = quicly_encodev(dst, sequence);
     dst = quicly_encodev(dst, packet_tolerance);
     dst = quicly_encodev(dst, max_ack_delay);
-#if 0 // not in -00
     *dst++ = !!ignore_order;
-#endif
     return dst;
 }
 
@@ -765,9 +763,6 @@ inline int quicly_decode_ack_frequency_frame(const uint8_t **src, const uint8_t 
         goto Error;
     if (*src == end)
         goto Error;
-#if 1 // not in -00
-    frame->ignore_order = 0;
-#else
     switch (*(*src)++) {
     case 0:
         frame->ignore_order = 0;
@@ -778,7 +773,6 @@ inline int quicly_decode_ack_frequency_frame(const uint8_t **src, const uint8_t 
     default:
         goto Error;
     }
-#endif
     return 0;
 Error:
     return QUICLY_TRANSPORT_ERROR_FRAME_ENCODING;

--- a/deps/quicly/misc/probe2trace.pl
+++ b/deps/quicly/misc/probe2trace.pl
@@ -127,7 +127,7 @@ for my $probe (@probes) {
                 for my $container (qw(num_frames_sent num_frames_received)) {
                     push @fields, map{["$container.$_" => '%llu']} qw(padding ping ack reset_stream stop_sending crypto new_token stream max_data max_stream_data max_streams_bidi max_streams_uni data_blocked stream_data_blocked streams_blocked new_connection_id retire_connection_id path_challenge path_response transport_close application_close handshake_done ack_frequency);
                 }
-            push @fields, ["num_ptos" => '%u'];
+            push @fields, ["num_ptos" => '%llu'];
             # generate @fmt, @ap
             push @fmt, map {my $n = $_->[0]; $n =~ tr/./_/; sprintf '"%s":%s', $n, $_->[1]} @fields;
             if ($arch eq 'linux') {

--- a/deps/quicly/misc/quic-interop-runner/Dockerfile
+++ b/deps/quicly/misc/quic-interop-runner/Dockerfile
@@ -18,8 +18,6 @@ RUN cd quicly &&  git pull && git submodule update --init --recursive && cmake .
 FROM martenseemann/quic-network-simulator-endpoint:latest
 
 COPY --from=builder /quicly/cli quicly/cli
-COPY server.key quicly
-COPY server.crt quicly
 
 # endpoint
 COPY run_endpoint.sh .

--- a/deps/quicly/misc/quic-interop-runner/run_endpoint.sh
+++ b/deps/quicly/misc/quic-interop-runner/run_endpoint.sh
@@ -73,6 +73,6 @@ elif [ "$ROLE" == "server" ]; then
     esac
     echo "Starting quicly server ..."
     echo "SERVER_PARAMS:" $SERVER_PARAMS "TEST_PARAMS:" $TEST_PARAMS
-    echo "/quicly/cli $SERVER_PARAMS $TEST_PARAMS -k /quicly/server.key -c /quicly/server.crt -e /logs/$TESTCASE.out 0.0.0.0 443"
-    /quicly/cli $SERVER_PARAMS $TEST_PARAMS -k /quicly/server.key -c /quicly/server.crt -x x25519 -x secp256r1 -a "hq-29" -e /logs/$TESTCASE.out 0.0.0.0 443
+    echo "/quicly/cli $SERVER_PARAMS $TEST_PARAMS -k /certs/priv.key -c /certs/cert.pem -e /logs/$TESTCASE.out 0.0.0.0 443"
+    /quicly/cli $SERVER_PARAMS $TEST_PARAMS -k /certs/priv.key -c /certs/cert.pem -x x25519 -x secp256r1 -a "hq-29" -e /logs/$TESTCASE.out 0.0.0.0 443
 fi

--- a/deps/quicly/src/cli.c
+++ b/deps/quicly/src/cli.c
@@ -755,7 +755,7 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                     if (quicly_decode_packet(&ctx, &packet, buf, rret, &off) == SIZE_MAX)
                         break;
                     if (QUICLY_PACKET_IS_LONG_HEADER(packet.octets.base[0])) {
-                        if (!quicly_is_supported_version(packet.version)) {
+                        if (packet.version != 0 && !quicly_is_supported_version(packet.version)) {
                             uint8_t payload[ctx.transport_params.max_udp_payload_size];
                             size_t payload_len = quicly_send_version_negotiation(&ctx, packet.cid.src, packet.cid.dest.encrypted,
                                                                                  quicly_supported_versions, payload);
@@ -891,7 +891,7 @@ static void load_session(void)
             src = end;
         });
         ptls_decode_open_block(src, end, 2, {
-            if ((ret = quicly_decode_transport_parameter_list(&resumed_transport_params, NULL, NULL, NULL, NULL, src, end)) != 0)
+            if ((ret = quicly_decode_transport_parameter_list(&resumed_transport_params, NULL, NULL, NULL, NULL, src, end, 0)) != 0)
                 goto Exit;
             src = end;
         });

--- a/deps/quicly/t/lossy.c
+++ b/deps/quicly/t/lossy.c
@@ -405,7 +405,7 @@ static void loss_check_stats(int64_t *time_spent, unsigned max_failures, double 
     ok(num_failures_in_loss_core <= max_failures);
     ok(time_mean >= expected_time_mean * 0.6);
     ok(time_mean <= expected_time_mean * 1.2);
-    ok(time_median >= expected_time_median * 0.8);
+    ok(time_median >= expected_time_median * 0.6);
     ok(time_median <= expected_time_median * 1.2);
     // ok(time_90th >= expected_time_90th * 0.9); 90th is fragile to errors, we track this as an guarantee
     ok(time_90th <= expected_time_90th * 1.2);
@@ -426,49 +426,49 @@ static void test_downstream(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 3, 19927, 4188, 23030);
+    loss_check_stats(time_spent, 4, 13812, 3582, 17579);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 1294.1, 710, 2988);
+    loss_check_stats(time_spent, 0, 1941, 608, 3006);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 225.6, 230, 408);
+    loss_check_stats(time_spent, 0, 228.7, 230, 408);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 134.6, 80, 298);
+    loss_check_stats(time_spent, 0, 140.2, 80, 298);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 102.8, 80, 230);
+    loss_check_stats(time_spent, 0, 99.9, 80, 230);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 88.2, 80, 80);
+    loss_check_stats(time_spent, 0, 90.8, 80, 80);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 91.3, 80, 80);
+    loss_check_stats(time_spent, 0, 91.1, 80, 80);
 }
 
 static void test_bidirectional(void)
@@ -483,7 +483,7 @@ static void test_bidirectional(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 27, 271754, 113887, 688726);
+    loss_check_stats(time_spent, 27, 266649.4, 102052, 649336);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
@@ -491,7 +491,7 @@ static void test_bidirectional(void)
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 4913.4, 1815, 7106);
+    loss_check_stats(time_spent, 1, 2283.5, 1171, 6424);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
@@ -499,7 +499,7 @@ static void test_bidirectional(void)
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 394, 264, 652);
+    loss_check_stats(time_spent, 0, 331, 284, 635);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
@@ -507,7 +507,7 @@ static void test_bidirectional(void)
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 150.1, 80, 298);
+    loss_check_stats(time_spent, 0, 151.7, 80, 298);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
@@ -515,7 +515,7 @@ static void test_bidirectional(void)
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 107.8, 80, 230);
+    loss_check_stats(time_spent, 0, 110.4, 80, 230);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
@@ -523,7 +523,7 @@ static void test_bidirectional(void)
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 90.9, 80, 170);
+    loss_check_stats(time_spent, 0, 95.6, 80, 190);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
@@ -531,7 +531,7 @@ static void test_bidirectional(void)
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 86.9, 80, 80);
+    loss_check_stats(time_spent, 0, 95.8, 80, 190);
 }
 
 void test_lossy(void)

--- a/deps/quicly/t/test.c
+++ b/deps/quicly/t/test.c
@@ -282,8 +282,8 @@ static void test_transport_parameters(void)
                                           0x07, 0x04, 0x80, 0x10, 0x00, 0x00, 0x04, 0x04, 0x81, 0x00, 0x00, 0x00,
                                           0x01, 0x04, 0x80, 0x00, 0x75, 0x30, 0x08, 0x01, 0x0a, 0x0a, 0x01, 0x0a};
     memset(&decoded, 0x55, sizeof(decoded));
-    ok(quicly_decode_transport_parameter_list(&decoded, NULL, NULL, NULL, NULL, valid_bytes, valid_bytes + sizeof(valid_bytes)) ==
-       0);
+    ok(quicly_decode_transport_parameter_list(&decoded, NULL, NULL, NULL, NULL, valid_bytes, valid_bytes + sizeof(valid_bytes),
+                                              1) == 0);
     ok(decoded.max_stream_data.bidi_local = 0x100000);
     ok(decoded.max_stream_data.bidi_remote = 0x100000);
     ok(decoded.max_stream_data.uni = 0x100000);
@@ -297,7 +297,7 @@ static void test_transport_parameters(void)
 
     static const uint8_t dup_bytes[] = {0x05, 0x04, 0x80, 0x10, 0x00, 0x00, 0x05, 0x04, 0x80, 0x10, 0x00, 0x00};
     memset(&decoded, 0x55, sizeof(decoded));
-    ok(quicly_decode_transport_parameter_list(&decoded, NULL, NULL, NULL, NULL, dup_bytes, dup_bytes + sizeof(dup_bytes)) ==
+    ok(quicly_decode_transport_parameter_list(&decoded, NULL, NULL, NULL, NULL, dup_bytes, dup_bytes + sizeof(dup_bytes), 1) ==
        QUICLY_TRANSPORT_ERROR_TRANSPORT_PARAMETER);
 }
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -422,6 +422,10 @@ struct st_h2o_globalconf_t {
          */
         uint32_t active_stream_window_size;
         /**
+         * a boolean indicating if the delayed ack extension should be used (default true)
+         */
+        uint8_t use_delayed_ack;
+        /**
          * the callbacks
          */
         h2o_protocol_callbacks_t callbacks;

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -198,6 +198,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http2.callbacks = H2O_HTTP2_CALLBACKS;
     config->http3.idle_timeout = quicly_spec_context.transport_params.max_idle_timeout;
     config->http3.active_stream_window_size = H2O_DEFAULT_HTTP3_ACTIVE_STREAM_WINDOW_SIZE;
+    config->http3.use_delayed_ack = 1;
     config->http3.callbacks = H2O_HTTP3_SERVER_CALLBACKS;
     config->send_informational_mode = H2O_SEND_INFORMATIONAL_MODE_EXCEPT_H1;
     config->mimemap = h2o_mimemap_create();

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -588,6 +588,16 @@ static int on_config_http3_input_window_size(h2o_configurator_command_t *cmd, h2
     return 0;
 }
 
+static int on_config_http3_delayed_ack(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ssize_t on;
+
+    if ((on = h2o_configurator_get_one_of(cmd, node, "OFF,ON")) == -1)
+        return -1;
+    ctx->globalconf->http3.use_delayed_ack = (uint8_t)on;
+    return 0;
+}
+
 static int assert_is_mimetype(h2o_configurator_command_t *cmd, yoml_t *node)
 {
     if (node->type != YOML_TYPE_SCALAR) {
@@ -1023,6 +1033,9 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(&c->super, "http3-input-window-size",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http3_input_window_size);
+        h2o_configurator_define_command(&c->super, "http3-delayed-ack",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http3_delayed_ack);
         h2o_configurator_define_command(&c->super, "file.mime.settypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1587,6 +1587,7 @@ void h2o_http3_server_amend_quicly_context(h2o_globalconf_t *conf, quicly_contex
     quic->transport_params.max_streams_uni = 10;
     quic->transport_params.max_stream_data.bidi_remote = H2O_HTTP3_INITIAL_REQUEST_STREAM_WINDOW_SIZE;
     quic->transport_params.max_idle_timeout = conf->http3.idle_timeout;
+    quic->transport_params.min_ack_delay_usec = conf->http3.use_delayed_ack ? 0 : UINT64_MAX;
     quic->stream_open = &on_stream_open;
     quic->stream_scheduler = &scheduler;
 }


### PR DESCRIPTION
* updates quicly to the revision that has support for delayed ack -01 (https://github.com/h2o/quicly/pull/411)
* adds a knob (`http3-delayed-ack`) for turning on / off the extension (default is ON)