### PR TITLE
turn QPACK table capacity (encoding side) into a configurable parameter

### DIFF
--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -50,10 +50,6 @@
 #define H2O_HTTP3_SETTINGS_MAX_HEADER_LIST_SIZE 6
 #define H2O_HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS 7
 
-#define H2O_HTTP3_DEFAULT_DECODER_HEADER_TABLE_SIZE 4096
-#define H2O_HTTP3_DEFAULT_ENCODER_HEADER_TABLE_SIZE 0
-#define H2O_HTTP3_MAX_HEADER_TABLE_SIZE ((1 << 30) + 1)
-
 #define H2O_HTTP3_ERROR_NONE QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0x100)
 #define H2O_HTTP3_ERROR_GENERAL_PROTOCOL QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0x101)
 #define H2O_HTTP3_ERROR_INTERNAL QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0x102)
@@ -241,6 +237,13 @@ struct st_h2o_quic_conn_t {
     uint64_t _accept_hashkey;
 };
 
+typedef struct st_h2o_http3_qpack_context_t {
+    /**
+     * Our preferred size of the encoder header table. The value actually used is MIN(this_value, peer_settings.header_table_size).
+     */
+    uint32_t encoder_table_size;
+} h2o_http3_qpack_context_t;
+
 typedef struct st_h2o_http3_conn_callbacks_t {
     h2o_quic_conn_callbacks_t super;
     void (*handle_control_stream_frame)(h2o_http3_conn_t *conn, uint8_t type, const uint8_t *payload, size_t len);
@@ -259,6 +262,7 @@ struct st_h2o_http3_conn_t {
      * QPACK states
      */
     struct {
+        const h2o_http3_qpack_context_t *ctx;
         h2o_qpack_encoder_t *enc;
         h2o_qpack_decoder_t *dec;
     } qpack;
@@ -381,7 +385,8 @@ void h2o_quic_setup(h2o_quic_conn_t *conn, quicly_conn_t *quic);
 /**
  * initializes a http3 connection
  */
-void h2o_http3_init_conn(h2o_http3_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_http3_conn_callbacks_t *callbacks);
+void h2o_http3_init_conn(h2o_http3_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_http3_conn_callbacks_t *callbacks,
+                         const h2o_http3_qpack_context_t *qpack_ctx);
 /**
  *
  */

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -46,8 +46,8 @@
 #define H2O_HTTP3_STREAM_TYPE_QPACK_DECODER 3
 #define H2O_HTTP3_STREAM_TYPE_REQUEST 0x4000000000000000 /* internal type */
 
-#define H2O_HTTP3_SETTINGS_HEADER_TABLE_SIZE 1
-#define H2O_HTTP3_SETTINGS_MAX_HEADER_LIST_SIZE 6
+#define H2O_HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY 1
+#define H2O_HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE 6
 #define H2O_HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS 7
 
 #define H2O_HTTP3_ERROR_NONE QUICLY_ERROR_FROM_APPLICATION_ERROR_CODE(0x100)
@@ -271,7 +271,7 @@ struct st_h2o_http3_conn_t {
      *
      */
     struct {
-        uint64_t max_header_list_size;
+        uint64_t max_field_section_size;
     } peer_settings;
     struct {
         struct {

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -239,9 +239,10 @@ struct st_h2o_quic_conn_t {
 
 typedef struct st_h2o_http3_qpack_context_t {
     /**
-     * Our preferred size of the encoder header table. The value actually used is MIN(this_value, peer_settings.header_table_size).
+     * Our preferred table capacity for the encoder. The value actually used is MIN(this_value,
+     * peer_settings.encoder_table_capacity).
      */
-    uint32_t encoder_table_size;
+    uint32_t encoder_table_capacity;
 } h2o_http3_qpack_context_t;
 
 typedef struct st_h2o_http3_conn_callbacks_t {

--- a/include/h2o/http3_server.h
+++ b/include/h2o/http3_server.h
@@ -31,6 +31,7 @@ typedef struct st_h2o_http3_server_ctx_t {
     h2o_quic_ctx_t super;
     h2o_accept_ctx_t *accept_ctx;
     unsigned send_retry : 1;
+    h2o_http3_qpack_context_t qpack;
 } h2o_http3_server_ctx_t;
 
 extern const h2o_protocol_callbacks_t H2O_HTTP3_SERVER_CALLBACKS;

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -272,9 +272,10 @@ Fail:
 struct st_h2o_http3client_conn_t *create_connection(h2o_httpclient_ctx_t *ctx, h2o_url_t *origin)
 {
     static const h2o_http3_conn_callbacks_t callbacks = {{(void *)destroy_connection}, handle_control_stream_frame};
+    static const h2o_http3_qpack_context_t qpack_ctx = {0 /* TODO */};
     struct st_h2o_http3client_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
-    h2o_http3_init_conn(&conn->super, ctx->http3.ctx, &callbacks);
+    h2o_http3_init_conn(&conn->super, ctx->http3.ctx, &callbacks, &qpack_ctx);
     memset((char *)conn + sizeof(conn->super), 0, sizeof(*conn) - sizeof(conn->super));
     conn->ctx = ctx;
     conn->server.origin_url = (h2o_url_t){origin->scheme, h2o_strdup(NULL, origin->authority.base, origin->authority.len),

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -1132,6 +1132,7 @@ int h2o_http3_handle_settings_frame(h2o_http3_conn_t *conn, const uint8_t *paylo
 {
     const uint8_t *src = payload, *src_end = src + length;
     uint32_t header_table_size = 0;
+    uint64_t blocked_streams = 0;
 
     assert(!h2o_http3_has_received_settings(conn));
 
@@ -1150,13 +1151,15 @@ int h2o_http3_handle_settings_frame(h2o_http3_conn_t *conn, const uint8_t *paylo
             header_table_size =
                 value < conn->qpack.ctx->encoder_table_capacity ? (uint32_t)value : conn->qpack.ctx->encoder_table_capacity;
             break;
-        /* TODO add */
+        case H2O_HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS:
+            blocked_streams = value;
+            break;
         default:
             break;
         }
     }
 
-    conn->qpack.enc = h2o_qpack_create_encoder(header_table_size, 100 /* FIXME */);
+    conn->qpack.enc = h2o_qpack_create_encoder(header_table_size, blocked_streams);
     return 0;
 Malformed:
     *err_desc = "malformed SETTINGS frame";

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -1147,7 +1147,8 @@ int h2o_http3_handle_settings_frame(h2o_http3_conn_t *conn, const uint8_t *paylo
             conn->peer_settings.max_header_list_size = (uint64_t)value;
             break;
         case H2O_HTTP3_SETTINGS_HEADER_TABLE_SIZE:
-            header_table_size = value < conn->qpack.ctx->encoder_table_size ? (uint32_t)value : conn->qpack.ctx->encoder_table_size;
+            header_table_size =
+                value < conn->qpack.ctx->encoder_table_capacity ? (uint32_t)value : conn->qpack.ctx->encoder_table_capacity;
             break;
         /* TODO add */
         default:

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -1143,10 +1143,10 @@ int h2o_http3_handle_settings_frame(h2o_http3_conn_t *conn, const uint8_t *paylo
         if ((value = quicly_decodev(&src, src_end)) == UINT64_MAX)
             goto Malformed;
         switch (id) {
-        case H2O_HTTP3_SETTINGS_MAX_HEADER_LIST_SIZE:
-            conn->peer_settings.max_header_list_size = (uint64_t)value;
+        case H2O_HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE:
+            conn->peer_settings.max_field_section_size = value;
             break;
-        case H2O_HTTP3_SETTINGS_HEADER_TABLE_SIZE:
+        case H2O_HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY:
             header_table_size =
                 value < conn->qpack.ctx->encoder_table_capacity ? (uint32_t)value : conn->qpack.ctx->encoder_table_capacity;
             break;

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -812,9 +812,6 @@ int h2o_qpack_parse_response(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, i
 
 h2o_qpack_encoder_t *h2o_qpack_create_encoder(uint32_t header_table_size, uint16_t max_blocked)
 {
-    if (header_table_size > H2O_HTTP3_MAX_HEADER_TABLE_SIZE)
-        header_table_size = H2O_HTTP3_MAX_HEADER_TABLE_SIZE;
-
     h2o_qpack_encoder_t *qpack = h2o_mem_alloc(sizeof(*qpack));
     header_table_init(&qpack->table, header_table_size);
     qpack->largest_known_received = 0;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1541,7 +1541,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
     /* setup the structure */
     struct st_h2o_http3_server_conn_t *conn = (void *)h2o_create_connection(
         sizeof(*conn), ctx->accept_ctx->ctx, ctx->accept_ctx->hosts, h2o_gettimeofday(ctx->accept_ctx->ctx->loop), &conn_callbacks);
-    h2o_http3_init_conn(&conn->h3, &ctx->super, h3_callbacks);
+    h2o_http3_init_conn(&conn->h3, &ctx->super, h3_callbacks, &ctx->qpack);
     conn->handshake_properties = (ptls_handshake_properties_t){{{{NULL}}}};
     h2o_linklist_init_anchor(&conn->delayed_streams.recv_body_blocked);
     h2o_linklist_init_anchor(&conn->delayed_streams.req_streaming);

--- a/src/main.c
+++ b/src/main.c
@@ -1070,7 +1070,7 @@ static struct listener_config_t *add_listener(int fd, struct sockaddr *addr, soc
     }
     memset(&listener->ssl, 0, sizeof(listener->ssl));
     memset(&listener->quic, 0, sizeof(listener->quic));
-    listener->quic.qpack = (h2o_http3_qpack_context_t){.encoder_table_size = 4096 /* our default */};
+    listener->quic.qpack = (h2o_http3_qpack_context_t){.encoder_table_capacity = 4096 /* our default */};
     listener->proxy_protocol = proxy_protocol;
     listener->tcp_congestion_controller = h2o_iovec_init(NULL, 0);
 
@@ -1543,10 +1543,10 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
                 listener = add_listener(fd, ai->ai_addr, ai->ai_addrlen, ctx->hostconf == NULL, 0);
                 listener->quic.ctx = quic;
                 if (quic_node != NULL) {
-                    yoml_t **retry_node, **sndbuf, **rcvbuf, **amp_limit, **qpack_encoder_table_size;
-                    if (h2o_configurator_parse_mapping(cmd, *quic_node, NULL,
-                                                       "retry:s,sndbuf:s,rcvbuf:s,amp-limit:s,qpack-encoder-table-size:s",
-                                                       &retry_node, &sndbuf, &rcvbuf, &amp_limit, &qpack_encoder_table_size) != 0)
+                    yoml_t **retry_node, **sndbuf, **rcvbuf, **amp_limit, **qpack_encoder_table_capacity;
+                    if (h2o_configurator_parse_mapping(
+                            cmd, *quic_node, NULL, "retry:s,sndbuf:s,rcvbuf:s,amp-limit:s,qpack-encoder-table-capacity:s",
+                            &retry_node, &sndbuf, &rcvbuf, &amp_limit, &qpack_encoder_table_capacity) != 0)
                         return -1;
                     if (retry_node != NULL) {
                         ssize_t on = h2o_configurator_get_one_of(cmd, *retry_node, "OFF,ON");
@@ -1573,9 +1573,9 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
                                                    &listener->quic.ctx->pre_validation_amplification_limit) != 0)
                             return -1;
                     }
-                    if (qpack_encoder_table_size != NULL) {
-                        if (h2o_configurator_scanf(cmd, *qpack_encoder_table_size, "%" SCNu32,
-                                                   &listener->quic.qpack.encoder_table_size) != 0)
+                    if (qpack_encoder_table_capacity != NULL) {
+                        if (h2o_configurator_scanf(cmd, *qpack_encoder_table_capacity, "%" SCNu32,
+                                                   &listener->quic.qpack.encoder_table_capacity) != 0)
                             return -1;
                     }
                 }

--- a/src/main.c
+++ b/src/main.c
@@ -135,6 +135,10 @@ struct listener_config_t {
          * whether to send retry
          */
         unsigned send_retry : 1;
+        /**
+         * QPACK settings
+         */
+        h2o_http3_qpack_context_t qpack;
     } quic;
     int proxy_protocol;
     h2o_iovec_t tcp_congestion_controller; /* default CC for this address */
@@ -1066,6 +1070,7 @@ static struct listener_config_t *add_listener(int fd, struct sockaddr *addr, soc
     }
     memset(&listener->ssl, 0, sizeof(listener->ssl));
     memset(&listener->quic, 0, sizeof(listener->quic));
+    listener->quic.qpack = (h2o_http3_qpack_context_t){.encoder_table_size = 4096 /* our default */};
     listener->proxy_protocol = proxy_protocol;
     listener->tcp_congestion_controller = h2o_iovec_init(NULL, 0);
 
@@ -1538,9 +1543,10 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
                 listener = add_listener(fd, ai->ai_addr, ai->ai_addrlen, ctx->hostconf == NULL, 0);
                 listener->quic.ctx = quic;
                 if (quic_node != NULL) {
-                    yoml_t **retry_node, **sndbuf, **rcvbuf, **amp_limit;
-                    if (h2o_configurator_parse_mapping(cmd, *quic_node, NULL, "retry:s,sndbuf:s,rcvbuf:s,amp-limit:s", &retry_node,
-                                                       &sndbuf, &rcvbuf, &amp_limit) != 0)
+                    yoml_t **retry_node, **sndbuf, **rcvbuf, **amp_limit, **qpack_encoder_table_size;
+                    if (h2o_configurator_parse_mapping(cmd, *quic_node, NULL,
+                                                       "retry:s,sndbuf:s,rcvbuf:s,amp-limit:s,qpack-encoder-table-size:s",
+                                                       &retry_node, &sndbuf, &rcvbuf, &amp_limit, &qpack_encoder_table_size) != 0)
                         return -1;
                     if (retry_node != NULL) {
                         ssize_t on = h2o_configurator_get_one_of(cmd, *retry_node, "OFF,ON");
@@ -1565,6 +1571,11 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
                     if (amp_limit != NULL) {
                         if (h2o_configurator_scanf(cmd, *amp_limit, "%" SCNu16,
                                                    &listener->quic.ctx->pre_validation_amplification_limit) != 0)
+                            return -1;
+                    }
+                    if (qpack_encoder_table_size != NULL) {
+                        if (h2o_configurator_scanf(cmd, *qpack_encoder_table_size, "%" SCNu32,
+                                                   &listener->quic.qpack.encoder_table_size) != 0)
                             return -1;
                     }
                 }
@@ -2606,6 +2617,7 @@ static void *run_loop(void *_thread_index)
                                             forward_quic_packets, rewrite_forwarded_quic_datagram);
             listeners[i].http3.ctx.accept_ctx = &listeners[i].accept_ctx;
             listeners[i].http3.ctx.send_retry = listener_config->quic.send_retry;
+            listeners[i].http3.ctx.qpack = listener_config->quic.qpack;
             int fds[2];
             /* TODO switch to using named socket in temporary directory to forward packets between server generations */
             if (socketpair(AF_UNIX, SOCK_DGRAM, 0, fds) != 0) {


### PR DESCRIPTION
Following #2467, this PR does the following:
* QPACK table capacity of the encoder is now configurable using the `qpack-encoder-table-capacity` parameter of the `listen.quic` attribute. The default value is 4096.
  * Reducing the table capacity of the encoder to zero will help when _clients_ have issues with decoding the _response_ header fields that h2o sends.
* Renames the SETTINGS values following the changes to the spec.
* Adds code to respect `SETTINGS.QPACK_BLOCKED_STREAMS` advertised by the peer. Until now, we have used a hard-coded value of 100.