### PR TITLE
fix the compatibility of annotate-backtrace-symbols with the latest gcc

### DIFF
--- a/share/h2o/annotate-backtrace-symbols
+++ b/share/h2o/annotate-backtrace-symbols
@@ -7,12 +7,17 @@ use warnings;
 
 my $ppid = getppid;
 
+# backtrace_symbols_fd(3) in Linux glibc shows different outputs for each compiler:
+#   clang: `./prog[0x1234]` where `0x1234` is the position addr
+#   gcc: `./prog(+0x1234)[0x55c98ec6a23b]` where `0x1234` is the position addr
+
 while (my $line = <STDIN>) {
     chomp $line;
-    if ($line =~ m{^([^\(\[]+)(.*?)\[(0x[0-9A-Fa-f]+)\]}) {
-        my ($exe, $info, $addr) = ($1, $2, $3);
+    if ($line =~ m{^([^\(\[]+)(?:\(\+(0x[0-9A-Fa-f]+)\))?[^\[]*\[(0x[0-9A-Fa-f]+)\]}) {
+        my $exe = $1;
+        my $addr = $2 // $3;
         my $resolved = addr2line($exe, $addr);
-        $line = "$exe${info}[$addr] $resolved"
+        $line .= " $resolved"
             if $resolved;
     }
     print "[$ppid] $line\n";


### PR DESCRIPTION
As commented, `backtrace_symbols_fd(3)` shows different output in clang 10 and gcc 9 on Ubuntu 20.04 , especially if `-rdynamic` is not specified. 

This PR is checked with `backtrace(3)`'s sample program: https://man7.org/linux/man-pages/man3/backtrace.3.html

