### PR TITLE
[http3] fix startup failure when OS does not provide support for IP_DONTFRAG

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1510,7 +1510,7 @@ int h2o_socket_set_df_bit(int fd, int domain)
     do {                                                                                                                           \
         int optvar = _optvar;                                                                                                      \
         if (setsockopt(fd, ip, optname, &optvar, sizeof(optvar)) != 0) {                                                           \
-            perror("setsockopt(" H2O_TO_STR(optname) ")");                                                                         \
+            perror("failed to set the DF bit through setsockopt(" H2O_TO_STR(ip) ", " H2O_TO_STR(optname) ")");                    \
             return 0;                                                                                                              \
         }                                                                                                                          \
         return 1;                                                                                                                  \

--- a/src/main.c
+++ b/src/main.c
@@ -1215,12 +1215,11 @@ static int open_listener(int domain, int type, int protocol, struct sockaddr *ad
         if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) != 0)
             goto Error;
     } break;
-    case SOCK_DGRAM: {
+    case SOCK_DGRAM:
         /* UDP: set SO_REUSEPORT and DF bit */
         socket_reuseport(fd);
-        if (!h2o_socket_set_df_bit(fd, domain))
-            goto Error;
-    } break;
+        h2o_socket_set_df_bit(fd, domain);
+        break;
     default:
         h2o_fatal("unexpected socket type %d", type);
         break;


### PR DESCRIPTION
macOS SDK for 10.16 added support for IP_DONTFRAG, but macOS 10.15 does not provide runtime support for the socket option.

Hence, failure to set that socket option should not be consider a fatal issue.