### PR TITLE
[http3] refactor header field encoding process

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1426,9 +1426,15 @@ void h2o_req_bind_conf(h2o_req_t *req, h2o_hostconf_t *hostconf, h2o_pathconf_t 
  */
 static int h2o_send_state_is_in_progress(h2o_send_state_t s);
 /**
- *
+ * Initializes a send vector that refers to mutable memory region. When the `proceed` callback is invoked, it is possible for the
+ * generator to reuse (or release) that memory region.
  */
 void h2o_sendvec_init_raw(h2o_sendvec_t *vec, const void *base, size_t len);
+/**
+ * Initializes a send vector that refers to immutable memory region. It is the responsible of the generator to preserve the contents
+ * of the specified memory region until the user of the send vector finishes using the send vector.
+ */
+void h2o_sendvec_init_immutable(h2o_sendvec_t *vec, const void *base, size_t len);
 /**
  *
  */

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -287,30 +287,6 @@ struct st_h2o_http3_conn_t {
     } _control_streams;
 };
 
-#define h2o_http3_encode_frame(_pool_, _buf_, _type, _block)                                                                       \
-    do {                                                                                                                           \
-        h2o_mem_pool_t *_pool = (_pool_);                                                                                          \
-        h2o_byte_vector_t *_buf = (_buf_);                                                                                         \
-        h2o_vector_reserve(_pool, _buf, _buf->size + 9);                                                                           \
-        _buf->size += 2;                                                                                                           \
-        size_t _payload_off = _buf->size;                                                                                          \
-        _buf->entries[_payload_off - 2] = (_type);                                                                                 \
-        do {                                                                                                                       \
-            _block                                                                                                                 \
-        } while (0);                                                                                                               \
-        uint8_t _vbuf[8];                                                                                                          \
-        size_t _vlen = quicly_encodev(_vbuf, _buf->size - _payload_off) - _vbuf;                                                   \
-        if (_vlen != 1) {                                                                                                          \
-            h2o_vector_reserve(_pool, _buf, _buf->size + _vlen - 1);                                                               \
-            memmove(_buf->entries + _payload_off + _vlen - 1, _buf->entries + _payload_off, _buf->size - _payload_off);            \
-            _payload_off += _vlen - 1;                                                                                             \
-            _buf->size += _vlen - 1;                                                                                               \
-            memmove(_buf->entries + _payload_off - _vlen, _vbuf, _vlen);                                                           \
-        } else {                                                                                                                   \
-            _buf->entries[_payload_off - 1] = _vbuf[0];                                                                            \
-        }                                                                                                                          \
-    } while (0)
-
 #define H2O_HTTP3_CHECK_SUCCESS(expr)                                                                                              \
     do {                                                                                                                           \
         if (!(expr))                                                                                                               \

--- a/include/h2o/qpack.h
+++ b/include/h2o/qpack.h
@@ -43,12 +43,16 @@ int h2o_qpack_decoder_handle_input(h2o_qpack_decoder_t *qpack, int64_t **unblock
 size_t h2o_qpack_decoder_send_state_sync(h2o_qpack_decoder_t *qpack, uint8_t *outbuf);
 size_t h2o_qpack_decoder_send_stream_cancel(h2o_qpack_decoder_t *qpack, uint8_t *outbuf, int64_t stream_id);
 
+/**
+ * Parses a QPACK request. The input should be the *payload* of the HTTP/3 HEADERS frame.
+ */
 int h2o_qpack_parse_request(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, int64_t stream_id, h2o_iovec_t *method,
                             const h2o_url_scheme_t **scheme, h2o_iovec_t *authority, h2o_iovec_t *path, h2o_headers_t *headers,
                             int *pseudo_header_exists_map, size_t *content_length, h2o_cache_digests_t **digests, uint8_t *outbuf,
                             size_t *outbufsize, const uint8_t *src, size_t len, const char **err_desc);
 /**
- * outbuf should be at least H2O_HPACK_ENCODE_INT_MAX_LENGTH long
+ * Parses a QPACK response. The input should be the *payload* of the HTTP/3 HEADERS frame. `outbuf` should be at least
+ * H2O_HPACK_ENCODE_INT_MAX_LENGTH long.
  */
 int h2o_qpack_parse_response(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, int64_t stream_id, int *status,
                              h2o_headers_t *headers, uint8_t *outbuf, size_t *outbufsize, const uint8_t *src, size_t len,
@@ -62,12 +66,15 @@ void h2o_qpack_destroy_encoder(h2o_qpack_encoder_t *qpack);
  */
 int h2o_qpack_encoder_handle_input(h2o_qpack_encoder_t *qpack, const uint8_t **src, const uint8_t *src_end, const char **err_desc);
 /**
- * flattens a QPACK request.
+ * Flattens a QPACK request. The output includes the HTTP/3 frame header.
  * @param encoder_buf optional parameter pointing to buffer to store encoder stream data. Set to NULL to avoid blocking.
  */
 h2o_iovec_t h2o_qpack_flatten_request(h2o_qpack_encoder_t *qpack, h2o_mem_pool_t *pool, int64_t stream_id,
                                       h2o_byte_vector_t *encoder_buf, h2o_iovec_t method, const h2o_url_scheme_t *scheme,
                                       h2o_iovec_t authority, h2o_iovec_t path, const h2o_header_t *headers, size_t num_headers);
+/**
+ * Flattens a QPACK response. The output includes the HTTP/3 frame header.
+ */
 h2o_iovec_t h2o_qpack_flatten_response(h2o_qpack_encoder_t *qpack, h2o_mem_pool_t *pool, int64_t stream_id,
                                        h2o_byte_vector_t *encoder_buf, int status, const h2o_header_t *headers, size_t num_headers,
                                        const h2o_iovec_t *server_name, size_t content_length);

--- a/include/h2o/qpack.h
+++ b/include/h2o/qpack.h
@@ -65,11 +65,11 @@ int h2o_qpack_encoder_handle_input(h2o_qpack_encoder_t *qpack, const uint8_t **s
  * flattens a QPACK request.
  * @param encoder_buf optional parameter pointing to buffer to store encoder stream data. Set to NULL to avoid blocking.
  */
-void h2o_qpack_flatten_request(h2o_qpack_encoder_t *qpack, h2o_mem_pool_t *pool, int64_t stream_id, h2o_byte_vector_t *encoder_buf,
-                               h2o_byte_vector_t *headers_buf, h2o_iovec_t method, const h2o_url_scheme_t *scheme,
-                               h2o_iovec_t authority, h2o_iovec_t path, const h2o_header_t *headers, size_t num_headers);
-void h2o_qpack_flatten_response(h2o_qpack_encoder_t *qpack, h2o_mem_pool_t *pool, int64_t stream_id, h2o_byte_vector_t *encoder_buf,
-                                h2o_byte_vector_t *headers_buf, int status, const h2o_header_t *headers, size_t num_headers,
-                                const h2o_iovec_t *server_name, size_t content_length);
+h2o_iovec_t h2o_qpack_flatten_request(h2o_qpack_encoder_t *qpack, h2o_mem_pool_t *pool, int64_t stream_id,
+                                      h2o_byte_vector_t *encoder_buf, h2o_iovec_t method, const h2o_url_scheme_t *scheme,
+                                      h2o_iovec_t authority, h2o_iovec_t path, const h2o_header_t *headers, size_t num_headers);
+h2o_iovec_t h2o_qpack_flatten_response(h2o_qpack_encoder_t *qpack, h2o_mem_pool_t *pool, int64_t stream_id,
+                                       h2o_byte_vector_t *encoder_buf, int status, const h2o_header_t *headers, size_t num_headers,
+                                       const h2o_iovec_t *server_name, size_t content_length);
 
 #endif

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -654,12 +654,9 @@ void start_request(struct st_h2o_http3client_req_t *req)
     req->quic->data = req;
 
     /* send request (TODO optimize) */
-    h2o_byte_vector_t buf = {NULL};
-    h2o_http3_encode_frame(req->super.pool, &buf, H2O_HTTP3_FRAME_TYPE_HEADERS, {
-        h2o_qpack_flatten_request(req->conn->super.qpack.enc, req->super.pool, req->quic->stream_id, NULL, &buf, method, url.scheme,
-                                  url.authority, url.path, headers, num_headers);
-    });
-    h2o_buffer_append(&req->sendbuf, buf.entries, buf.size);
+    h2o_iovec_t headers_frame = h2o_qpack_flatten_request(req->conn->super.qpack.enc, req->super.pool, req->quic->stream_id, NULL,
+                                                          method, url.scheme, url.authority, url.path, headers, num_headers);
+    h2o_buffer_append(&req->sendbuf, headers_frame.base, headers_frame.len);
     if (body.len != 0) {
         emit_data(req, body);
         if (req->proceed_req.cb != NULL)

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -494,8 +494,21 @@ void h2o_start_response(h2o_req_t *req, h2o_generator_t *generator)
 
 void h2o_sendvec_init_raw(h2o_sendvec_t *vec, const void *base, size_t len)
 {
-    static const h2o_sendvec_callbacks_t primitive_callbacks = {h2o_sendvec_flatten_raw};
-    vec->callbacks = &primitive_callbacks;
+    static const h2o_sendvec_callbacks_t callbacks = {h2o_sendvec_flatten_raw};
+    vec->callbacks = &callbacks;
+    vec->raw = (char *)base;
+    vec->len = len;
+}
+
+static void sendvec_immutable_update_refcnt(h2o_sendvec_t *vec, h2o_req_t *req, int is_incr)
+{
+    /* noop */
+}
+
+void h2o_sendvec_init_immutable(h2o_sendvec_t *vec, const void *base, size_t len)
+{
+    static const h2o_sendvec_callbacks_t callbacks = {h2o_sendvec_flatten_raw, sendvec_immutable_update_refcnt};
+    vec->callbacks = &callbacks;
     vec->raw = (char *)base;
     vec->len = len;
 }

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1110,7 +1110,7 @@ static void write_response(struct st_h2o_http3_server_stream_t *stream)
 
     h2o_vector_reserve(&stream->req.pool, &stream->sendbuf.vecs, stream->sendbuf.vecs.size + 1);
     struct st_h2o_http3_server_sendvec_t *vec = stream->sendbuf.vecs.entries + stream->sendbuf.vecs.size++;
-    h2o_sendvec_init_raw(&vec->vec, frame.base, frame.len);
+    h2o_sendvec_init_immutable(&vec->vec, frame.base, frame.len);
     vec->entity_offset = UINT64_MAX;
     stream->sendbuf.final_size += frame.len;
 }


### PR DESCRIPTION
This PR addresses the following two complexities:
* Eliminates use of `memmove`. Existing API let's the user supply an existing buffer, to which the HEADERS frame and the QPACK payload is appended. That design requires use of `memmove`, as the size of the frame header and QPACK header depend on the QPACK payload. This PR eliminates `memmove` by changing the API to instead return a memory buffer allocated from the memory pool.
* Eliminates unnecessary duplication of send vector containing the HEADERS frame. At the moment, the send vector containing the HEADERS frame is initialized by calling `h2o_sendvec_init_raw`. The downside is that the vector gets duplicated when `on_send_emit` calls `retain_sendvecs`. This PR avoids duplication by leveraging the fact that memory used to build the HEADERS frame, which is being built using the memory pool, is not reclaimed until the stream is destroyed.

The downside is that we now have an asymmetric API where the encoder emits entire HTTP/3 frame while the decoder takes just the payload of the HTTP/3 frame as the input; but I think having concise code outweighs the downside.