### PR TITLE
h2olog: make -t to accept a glob pattern like "quicly:*"

### DIFF
--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -230,7 +230,7 @@ static size_t add_matched_usdts(std::vector<h2o_tracer::usdt> &selected_usdts, c
                                 const char *pattern)
 {
     size_t added = 0;
-    for (auto usdt : available_usdts) {
+    for (const auto& usdt : available_usdts) {
         if (fnmatch(pattern, usdt.fully_qualified_name().c_str(), 0) == 0) {
             selected_usdts.push_back(usdt);
             added++;

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -48,7 +48,7 @@ Optional arguments:
     -l Print the list of available tracepoints and exit
     -s RESPONSE_HEADER_NAME A response header name to show, e.g. "content-type"
     -t TRACEPOINT A tracepoint, or fully-qualified probe name, to show,
-                  accepting a glob pattern, e.g. "quicly:accept", "h2o:*"
+                  including a glob pattern, e.g. "quicly:accept", "h2o:*"
     -r Run without dropping root privilege
     -w Path to write the output (default: stdout)
 

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -45,7 +45,7 @@ Usage: h2olog -p PID
 Optional arguments:
     -d Print debugging information (-dd shows more)
     -h Print this help and exit
-    -l Print the list of selected tracepoints and exit
+    -l Print the list of available tracepoints and exit
     -s RESPONSE_HEADER_NAME A response header name to show, e.g. "content-type"
     -t TRACEPOINT A tracepoint, or fully-qualified probe name, to show,
                   accepting a glob pattern, e.g. "quicly:accept", "h2o:*"
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
             debug++;
             break;
         case 'l':
-            for (const auto &usdt : selected_usdts.empty() ? available_usdts : selected_usdts) {
+            for (const auto &usdt : available_usdts) {
                 printf("%s\n", usdt.fully_qualified_name().c_str());
             }
             exit(EXIT_SUCCESS);

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -230,7 +230,7 @@ static size_t add_matched_usdts(std::vector<h2o_tracer::usdt> &selected_usdts, c
                                 const char *pattern)
 {
     size_t added = 0;
-    for (const auto& usdt : available_usdts) {
+    for (const auto &usdt : available_usdts) {
         if (fnmatch(pattern, usdt.fully_qualified_name().c_str(), 0) == 0) {
             selected_usdts.push_back(usdt);
             added++;


### PR DESCRIPTION
As discussed at https://github.com/h2o/h2o/pull/2492#issuecomment-730737191.

This PR has slightly changed the semantics of `-l` in order to test what`-t` actually select, like:

```
h2olog quic -t 'quicly:*' -l
```

The behavior of `-l` does not change without `-t`.
