### PR TITLE
avoiding a memcpy in find_hostconf

### DIFF
--- a/include/h2o/string_.h
+++ b/include/h2o/string_.h
@@ -70,6 +70,10 @@ static int h2o_tolower(int ch);
  */
 static void h2o_strtolower(char *s, size_t len);
 /**
+ * copies and converts the string to lower-case
+ */
+static void h2o_strcopytolower(char *d, const char *s, size_t len);
+/**
  * tr/a-z/A-Z/
  */
 static int h2o_toupper(int ch);
@@ -183,8 +187,13 @@ inline int h2o_tolower(int ch)
 
 inline void h2o_strtolower(char *s, size_t len)
 {
-    for (; len != 0; ++s, --len)
-        *s = h2o_tolower(*s);
+    h2o_strcopytolower(s, s, len);
+}
+
+inline void h2o_strcopytolower(char *d, const char *s, size_t len)
+{
+    for (; len != 0; ++d, ++s, --len)
+        *d = h2o_tolower(*s);
 }
 
 inline int h2o_toupper(int ch)

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -71,12 +71,6 @@ static struct st_deferred_request_action_t *create_deferred_action(h2o_req_t *re
     return action;
 }
 
-static void strtolower_cpy(char *d, const char *s, size_t len)
-{
-    for (; len != 0; ++d, ++s, --len)
-        *d = h2o_tolower(*s);
-}
-
 static h2o_hostconf_t *find_hostconf(h2o_hostconf_t **hostconfs, h2o_iovec_t authority, uint16_t default_port,
                                      h2o_iovec_t *wildcard_match)
 {
@@ -96,7 +90,7 @@ static h2o_hostconf_t *find_hostconf(h2o_hostconf_t **hostconfs, h2o_iovec_t aut
 
     /* convert supplied hostname to lower-case */
     hostname_lc = alloca(hostname.len);
-    strtolower_cpy(hostname_lc, hostname.base, hostname.len);
+    h2o_strcopytolower(hostname_lc, hostname.base, hostname.len);
 
     do {
         h2o_hostconf_t *hostconf = *hostconfs;

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -71,6 +71,12 @@ static struct st_deferred_request_action_t *create_deferred_action(h2o_req_t *re
     return action;
 }
 
+static void strtolower_cpy(char *d, const char *s, size_t len)
+{
+    for (; len != 0; ++d, ++s, --len)
+        *d = h2o_tolower(*s);
+}
+
 static h2o_hostconf_t *find_hostconf(h2o_hostconf_t **hostconfs, h2o_iovec_t authority, uint16_t default_port,
                                      h2o_iovec_t *wildcard_match)
 {
@@ -90,8 +96,7 @@ static h2o_hostconf_t *find_hostconf(h2o_hostconf_t **hostconfs, h2o_iovec_t aut
 
     /* convert supplied hostname to lower-case */
     hostname_lc = alloca(hostname.len);
-    memcpy(hostname_lc, hostname.base, hostname.len);
-    h2o_strtolower(hostname_lc, hostname.len);
+    strtolower_cpy(hostname_lc, hostname.base, hostname.len);
 
     do {
         h2o_hostconf_t *hostconf = *hostconfs;


### PR DESCRIPTION
A bit pedantic I know, but avoids a `memcpy` per request.

`strtolower_cpy` could go into `string_.h` (prob as something like `h2o_strtolower_cpy`) but thought those are very specific.

thank you.
