### PR TITLE
fix a possible failure in t/50reverse-proxy-early-response.t

### DIFF
--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -428,7 +428,7 @@ sub is_alive {
     my ($self) = @_;
     return undef unless $self->{sock};
     my $buf;
-    #local $! = 0;
+    local $! = 0;
     my $ret = $self->{sock}->recv($buf, 1, MSG_PEEK);
     return (
         (defined($ret) && length($buf) > 0)

--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -5,7 +5,7 @@ BEGIN { $ENV{HTTP2_DEBUG} = 'debug' }
 use Net::EmptyPort qw(check_port empty_port);
 use Scope::Guard;
 use Test::More;
-use Time::HiRes;
+use Time::HiRes qw(sleep);
 use IO::Socket::INET;
 use Protocol::HTTP2::Constants qw(:frame_types :errors :settings :flags :states :limits :endpoints);
 use t::Util;
@@ -70,11 +70,12 @@ EOS
                 my $client = H1Client->new($server);
                 $client->send_headers('POST', '/', ['transfer-encoding' => 'chunked']) or die $!;
                 $client->send_data("1\r\na\r\n") or die $!;
+                sleep 0.01;
                 my $output = $client->read(1000);
-                Time::HiRes::sleep(0.1);
+                sleep 0.01;
                 for (1..10) {
                     $client->send_data("400\r\n" . 'a' x 1024 . "\r\n", 1000) or last;
-                    Time::HiRes::sleep(0.01);
+                    sleep 0.01;
                 }
                 like $output, qr{HTTP/1.1 200 }is;
                 sleep 1;
@@ -421,12 +422,18 @@ sub read {
     $buf;
 }
 
+# This code is originated from socketpool.c
+# Find for the comment "test if the connection is still alive".
 sub is_alive {
     my ($self) = @_;
     return undef unless $self->{sock};
     my $buf;
+    #local $! = 0;
     my $ret = $self->{sock}->recv($buf, 1, MSG_PEEK);
-    return $ret || ($! == EAGAIN || $! == EWOULDBLOCK);
+    return (
+        (defined($ret) && length($buf) > 0)
+        || ($! == EAGAIN || $! == EWOULDBLOCK)
+    );
 }
 
 sub close {

--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -429,10 +429,11 @@ sub is_alive {
     return undef unless $self->{sock};
     my $buf;
     my $ret = $self->{sock}->recv($buf, 1, MSG_PEEK);
-    return (
-        (defined($ret) && length($buf) > 0)
-        || ($! == EAGAIN || $! == EWOULDBLOCK)
-    );
+    if (defined $ret) {
+        return length($buf) > 0;
+    } else {
+        return $! == EAGAIN || $! == EWOULDBLOCK;
+    }
 }
 
 sub close {

--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -428,7 +428,6 @@ sub is_alive {
     my ($self) = @_;
     return undef unless $self->{sock};
     my $buf;
-    local $! = 0;
     my $ret = $self->{sock}->recv($buf, 1, MSG_PEEK);
     return (
         (defined($ret) && length($buf) > 0)


### PR DESCRIPTION
There are two problems in the test:

* `is_alive`'s implementation where `recv()` returns always falsey.
* timing issues in `Subtest: (1) h2 up x h1 down`

Thanks to @kazuho and @i110 for debugging sessions.