### PR TITLE
workaround to avoid t/40tls13-early-data.t timing issue (h2o/h2o#2509)

### DIFF
--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -66,7 +66,9 @@ subtest "http/2" => sub {
             "\x00\x00@{[chr length $hpack]}\x01\x05\x00\x00\x00\x01$hpack", # HEADERS
         );
 
-        while (waitpid($pid, 0) != $pid) {}
+        while (waitpid($pid, 0) != $pid) {
+            sleep 0.01;
+        }
 
         open my $fh, "<", "$tempdir/resp.txt"
             or die "failed to open file:$tempdir/resp.txt:$!";

--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -66,24 +66,11 @@ subtest "http/2" => sub {
             "\x00\x00@{[chr length $hpack]}\x01\x05\x00\x00\x00\x01$hpack", # HEADERS
         );
         # do not wait for idle-timeout
-
-        # FIXME: there's a pattern to take 5s to get ready to read the response,
-        #        so if `sleep 1` pattern fails, retry after 5s.
-        # See https://github.com/h2o/h2o/issues/2509 for details.
-        for my $delay(1, 5) {
-            sleep $delay;
-            open $fh, "<", "$tempdir/resp.txt"
-                or die "failed to open file:$tempdir/resp.txt:$!";
-            my $resp = do { local $/; <$fh> };
-            if (length $resp) {
-                return $resp;
-            }
-
-            diag "resp.txt is empty, retrying after 5s (`$cmd`)";
-        }
-
-        fail "failed to read the response from the command `$cmd`";
-        return undef;
+        sleep 3;
+        kill 'KILL', $pid;
+        open $fh, "<", "$tempdir/resp.txt"
+            or die "failed to open file:$tempdir/resp.txt:$!";
+        do { local $/; <$fh> };
     };
     run_tests(sub {
         my ($server, $path) = @_;

--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -65,7 +65,6 @@ subtest "http/2" => sub {
             "\x00\x00\x00\x04\x00\x00\x00\x00\x00",                         # SETTINGS
             "\x00\x00@{[chr length $hpack]}\x01\x05\x00\x00\x00\x01$hpack", # HEADERS
         );
-        close $child_in;
 
         while (waitpid($pid, 0) != $pid) {}
 

--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -48,9 +48,9 @@ subtest "http/2" => sub {
     my $fetch = sub {
         my ($server, $path) = @_;
         my $cmd = "exec @{[bindir]}/picotls/cli -I -s $tempdir/session -e 127.0.0.1 $server->{tls_port} > $tempdir/resp.txt";
-        my $pid = open my $fh, "|-", $cmd
+        my $pid = open my $child_in, "|-", $cmd
             or die "failed to invoke command:$cmd:$!";
-        autoflush $fh 1;
+        autoflush $child_in 1;
         # send request
         my $hpack_str = sub { chr(length $_[0]) . $_[0] };
         my $hpack_hdr = sub { "\x10" . $hpack_str->($_[0]) . $hpack_str->($_[1]) };
@@ -60,15 +60,16 @@ subtest "http/2" => sub {
             $hpack_hdr->(":authority", "127.0.0.1"),
             $hpack_hdr->(":path", $path),
         );
-        syswrite $fh, join '', (
+        syswrite $child_in, join '', (
             "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",                             # preface
             "\x00\x00\x00\x04\x00\x00\x00\x00\x00",                         # SETTINGS
             "\x00\x00@{[chr length $hpack]}\x01\x05\x00\x00\x00\x01$hpack", # HEADERS
         );
-        # do not wait for idle-timeout
-        sleep 3;
-        kill 'KILL', $pid;
-        open $fh, "<", "$tempdir/resp.txt"
+        close $child_in;
+
+        waitpid $pid, 0;
+
+        open my $fh, "<", "$tempdir/resp.txt"
             or die "failed to open file:$tempdir/resp.txt:$!";
         do { local $/; <$fh> };
     };
@@ -86,6 +87,7 @@ sub run_tests {
     my $do_test = shift;
 # spawn server
     my $server = spawn_h2o(<< "EOT");
+http2-idle-timeout: 1
 num-threads: 1
 hosts:
   default:

--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -66,9 +66,7 @@ subtest "http/2" => sub {
             "\x00\x00@{[chr length $hpack]}\x01\x05\x00\x00\x00\x01$hpack", # HEADERS
         );
 
-        while (waitpid($pid, 0) != $pid) {
-            sleep 0.01;
-        }
+        while (waitpid($pid, 0) != $pid) {}
 
         open my $fh, "<", "$tempdir/resp.txt"
             or die "failed to open file:$tempdir/resp.txt:$!";

--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -6,7 +6,6 @@ use Scope::Guard qw(scope_guard);
 use Test::Requires qw(Plack::Runner Starlet);
 use Test::More;
 use Time::HiRes qw(sleep);
-use IPC::Open3 qw(open3);
 use t::Util;
 
 my $tempdir = tempdir(CLEANUP => 1);
@@ -48,12 +47,10 @@ EOT
 subtest "http/2" => sub {
     my $fetch = sub {
         my ($server, $path) = @_;
-
-        my $cmd = "exec @{[bindir]}/picotls/cli -I -s $tempdir/session -e 127.0.0.1 $server->{tls_port}";
-        my $pid = open3(my $child_in, my $child_out, undef, $cmd)
+        my $cmd = "exec @{[bindir]}/picotls/cli -I -s $tempdir/session -e 127.0.0.1 $server->{tls_port} > $tempdir/resp.txt";
+        my $pid = open my $fh, "|-", $cmd
             or die "failed to invoke command:$cmd:$!";
-        $child_in->autoflush(1);
-
+        autoflush $fh 1;
         # send request
         my $hpack_str = sub { chr(length $_[0]) . $_[0] };
         my $hpack_hdr = sub { "\x10" . $hpack_str->($_[0]) . $hpack_str->($_[1]) };
@@ -63,13 +60,30 @@ subtest "http/2" => sub {
             $hpack_hdr->(":authority", "127.0.0.1"),
             $hpack_hdr->(":path", $path),
         );
-        syswrite $child_in, join '', (
+        syswrite $fh, join '', (
             "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",                             # preface
             "\x00\x00\x00\x04\x00\x00\x00\x00\x00",                         # SETTINGS
             "\x00\x00@{[chr length $hpack]}\x01\x05\x00\x00\x00\x01$hpack", # HEADERS
         );
+        # do not wait for idle-timeout
 
-        return do { local $/; <$child_out> };
+        # FIXME: there's a pattern to take 5s to get ready to read the response,
+        #        so if `sleep 1` pattern fails, retry after 5s.
+        # See https://github.com/h2o/h2o/issues/2509 for details.
+        for my $delay(1, 5) {
+            sleep $delay;
+            open $fh, "<", "$tempdir/resp.txt"
+                or die "failed to open file:$tempdir/resp.txt:$!";
+            my $resp = do { local $/; <$fh> };
+            if (length $resp) {
+                return $resp;
+            }
+
+            diag "resp.txt is empty, retrying after 5s (`$cmd`)";
+        }
+
+        fail "failed to read the response from the command `$cmd`";
+        return undef;
     };
     run_tests(sub {
         my ($server, $path) = @_;
@@ -85,7 +99,6 @@ sub run_tests {
     my $do_test = shift;
 # spawn server
     my $server = spawn_h2o(<< "EOT");
-http2-idle-timeout: 1
 num-threads: 1
 hosts:
   default:

--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -67,7 +67,7 @@ subtest "http/2" => sub {
         );
         close $child_in;
 
-        waitpid $pid, 0;
+        while (waitpid($pid, 0) != $pid) {}
 
         open my $fh, "<", "$tempdir/resp.txt"
             or die "failed to open file:$tempdir/resp.txt:$!";


### PR DESCRIPTION
This is not a fix for h2o/h2o#2509, but because it is difficult to investigate and is a blocker to #2501, I've made this workaround so far.

