### PR TITLE
Run CI when pushed, like we do for Travis

### DIFF
--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -1,10 +1,6 @@
 name: CI/default
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci-dtrace.yml
+++ b/.github/workflows/ci-dtrace.yml
@@ -1,10 +1,6 @@
 name: CI/dtrace
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci-fuzz.yml
+++ b/.github/workflows/ci-fuzz.yml
@@ -1,10 +1,6 @@
 name: CI/fuzz
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci-openssl_1_1_0.yml
+++ b/.github/workflows/ci-openssl_1_1_0.yml
@@ -1,10 +1,6 @@
 name: CI/OpenSSL 1.1.0
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci-openssl_1_1_1.yml
+++ b/.github/workflows/ci-openssl_1_1_1.yml
@@ -1,10 +1,6 @@
 name: CI/OpenSSL 1.1.1
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
There are cases where maintainers want to run CI without creating a branch (e.g., testing CI issues). We have been using Travis CI that way, and there's no reason to change the work pattern for GitHub Actions.