### PR TITLE
[test issue] avoid race condition bet. 0-RTT test and session ticket encryption key generation

### DIFF
--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -84,7 +84,7 @@ subtest "http/2" => sub {
 
 sub run_tests {
     my $do_test = shift;
-# spawn server
+    # spawn server
     my $server = spawn_h2o(<< "EOT");
 http2-idle-timeout: 1
 num-threads: 1
@@ -109,6 +109,8 @@ hosts:
 EOT2
 ]}
 EOT
+    # give some time to h2o to setup the session ticket encryption key
+    sleep 1;
     # run tests
     subtest "proxy" => sub {
         for my $sleep (0, 1) {


### PR DESCRIPTION
When the standalone server is spawned, [an independent thread is created for updating the session ticket encryption keys](https://github.com/h2o/h2o/blob/5de9a86/src/ssl.c#L1112). Until the thread fetches the necessary keys (or generates one by itself), the encryption key is not available.

When a client connects to the server before the encryption keys become available, [a dummy key is used for generating the session ticket](https://github.com/h2o/h2o/blob/5de9a86/src/ssl.c#L274-L280). When a client uses such session ticket, resumption will fail, and 0-RTT data would de rejected.

t/40tls13-early-data.t is our end-to-end test that makes sure that 0-RTT works as expected, and therefore depends on the availability of a valid session ticket encryption key on the server-side. However, at the moment, the test connects to the server as soon as it knows that the server is up (via `Test::TCP::empty_port`). This leads to a race, that causes the test to fail occasionally.

FWIW, this race condition was confirmed by adding printfs to the source file of H2O, that are activated only when running t/40tls13-early-data.t; see https://gist.github.com/kazuho/b4467a04a73ef2013868e15593d8a646. A raw log of one of the failed CI attempts can be found at https://gist.github.com/kazuho/8bcb6677efd31bba61a20d6b78eadbe6; you can see the encryption keys are generated after the first session ticket is being sent to the client.

This PR addresses the problem by adding a `sleep` to the test script.