### PR TITLE
[GitHub Actions] address failures in t/50proxy-max-buffer-size.t

### DIFF
--- a/t/50proxy-max-buffer-size.t
+++ b/t/50proxy-max-buffer-size.t
@@ -121,7 +121,7 @@ EOT
 diag $duration;
 diag $resp;
         if ($max_on) {
-            cmp_ok($duration - $resp, '<=', 2, "Writing to H2O was as fast as the curl download");
+            cmp_ok($duration - $resp, '<=', 2.2, "Writing to H2O was as fast as the curl download");
         } else {
             cmp_ok($duration - $resp, '>', 3, "Writing to H2O was much faster than the curl download");
         }


### PR DESCRIPTION
The timing requirement seems to be a bit too severe for GitHub Actions.

The three failed attempts reported values of: 2.0137, 2.0535, 2.0143. Therefore, changing 2 to 2.2 hoping that it would be sufficient.