### PR TITLE
Update absolute priority -> H2 weight conversion formula

### DIFF
--- a/include/h2o/absprio.h
+++ b/include/h2o/absprio.h
@@ -48,7 +48,10 @@ inline uint16_t h2o_absprio_urgency_to_chromium_weight(uint8_t urgency)
 {
     uint16_t weight;
     assert(urgency < H2O_ABSPRIO_NUM_URGENCY_LEVELS);
-    weight = (H2O_ABSPRIO_NUM_URGENCY_LEVELS - urgency) * 32;
+    /* formula excerpted from:
+     * https://quiche.googlesource.com/quiche/+/8cbe7bfa5c6efa7a42652e36fabf8d21879894be/spdy/core/spdy_protocol.cc#50 */
+    const float ksteps = 255.9f / (float)(H2O_ABSPRIO_NUM_URGENCY_LEVELS - 1);
+    weight = (uint16_t)(ksteps * ((H2O_ABSPRIO_NUM_URGENCY_LEVELS - 1) - urgency)) + 1;
     return weight;
 }
 

--- a/t/00unit/lib/common/absprio.c
+++ b/t/00unit/lib/common/absprio.c
@@ -66,7 +66,20 @@ static void test_parser(void)
     ok(p.incremental == 1);
 }
 
+void test_urgency_to_weight(void)
+{
+    ok(h2o_absprio_urgency_to_chromium_weight(0) == 256);
+    ok(h2o_absprio_urgency_to_chromium_weight(1) == 220);
+    ok(h2o_absprio_urgency_to_chromium_weight(2) == 183);
+    ok(h2o_absprio_urgency_to_chromium_weight(3) == 147);
+    ok(h2o_absprio_urgency_to_chromium_weight(4) == 110);
+    ok(h2o_absprio_urgency_to_chromium_weight(5) == 74);
+    ok(h2o_absprio_urgency_to_chromium_weight(6) == 34);
+    ok(h2o_absprio_urgency_to_chromium_weight(7) == 1);
+}
+
 void test_lib__common__absprio_c(void)
 {
     subtest("parser", test_parser);
+    subtest("urgency_to_weight", test_urgency_to_weight);
 }

--- a/t/00unit/lib/common/absprio.c
+++ b/t/00unit/lib/common/absprio.c
@@ -74,7 +74,7 @@ void test_urgency_to_weight(void)
     ok(h2o_absprio_urgency_to_chromium_weight(3) == 147);
     ok(h2o_absprio_urgency_to_chromium_weight(4) == 110);
     ok(h2o_absprio_urgency_to_chromium_weight(5) == 74);
-    ok(h2o_absprio_urgency_to_chromium_weight(6) == 34);
+    ok(h2o_absprio_urgency_to_chromium_weight(6) == 37);
     ok(h2o_absprio_urgency_to_chromium_weight(7) == 1);
 }
 


### PR DESCRIPTION
This commit adopts quiche's priority to weight conversion formula for better interoperability with Chromium.

This is a follow up PR to #2431.