### PR TITLE
[t/50reverse-proxy-early-response.t] don't kill upstream server before it receives a request

### DIFF
--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -136,7 +136,7 @@ EOS
             my $upstream = create_upstream($upstream_port, $up_is_h2, +{ wait_body => 2, drain_body => 1 });
             my $server = spawn_h2o(h2o_conf($upstream_port, $up_is_h2));
             local $SIG{ALRM} = sub { $upstream->{kill}->() };
-            Time::HiRes::alarm(0.5);
+            Time::HiRes::alarm(1);
             if ($down_is_h2) {
                 my $output = run_with_h2get_simple($server, <<"EOS");
                     req = { ":method" => "POST", ":authority" => authority, ":scheme" => "https", ":path" => "/",
@@ -167,7 +167,7 @@ EOS
             my $upstream = create_upstream($upstream_port, $up_is_h2, +{ drain_body => 1 });
             my $server = spawn_h2o(h2o_conf($upstream_port, $up_is_h2));
             local $SIG{ALRM} = sub { $upstream->{kill}->() };
-            Time::HiRes::alarm(0.5);
+            Time::HiRes::alarm(1);
             if ($down_is_h2) {
                 my $output = run_with_h2get_simple($server, <<"EOS");
                     req = { ":method" => "POST", ":authority" => authority, ":scheme" => "https", ":path" => "/",


### PR DESCRIPTION
Below is the log of a failed run on GitHub Actions.

If we look carefully, we notice the following:
* `spawn_h2o` returned some time around 06:33:10.329.
* H2O started accepting new connections at 06:33:10.826.
* H2O succeeded in connecting to the upstream server, but the socket was closed before receiving anything at 06:33:10.829.

The plausible explanation of this behavior is that the upstream server was killed too early, before accepting the connection from H2O or handling the requests. At the moment, we kill the upstream server 0.5 seconds after `spawn_h2o` returns.

This PR increases the timeout from 0.5 seconds to 1 second.

```
2020-12-24T06:33:10.2218559Z         # Subtest: body send error after sending headers[0m
2020-12-24T06:33:10.3292582Z spawning /home/ci/build/h2o... done
2020-12-24T06:33:10.8180180Z [INFO] raised RLIMIT_NOFILE to 1048576
2020-12-24T06:33:10.8268879Z h2o server (pid:31400) is ready to serve requests with 2 threads
2020-12-24T06:33:10.8293660Z [lib/core/proxy.c] in request:/:socket closed by peer
2020-12-24T06:33:10.8407686Z         not ok 1[0m
2020-12-24T06:33:10.8413706Z         
2020-12-24T06:33:10.8415838Z         #   Failed test at t/50reverse-proxy-early-response.t line 195.
2020-12-24T06:33:10.8417200Z         #                   'HTTP/1.1 502 Gateway Error
2020-12-24T06:33:10.8417754Z 
2020-12-24T06:33:10.8418551Z         # Connection: keep-alive
2020-12-24T06:33:10.8419110Z 
2020-12-24T06:33:10.8419897Z         # Content-Length: 21
2020-12-24T06:33:10.8420420Z 
2020-12-24T06:33:10.8421273Z         # Server: h2o/2.3.0-DEV@e32ae1e
2020-12-24T06:33:10.8421819Z 
2020-12-24T06:33:10.8422687Z         # content-type: text/plain; charset=utf-8
2020-12-24T06:33:10.8423303Z 
2020-12-24T06:33:10.8423805Z         # 
2020-12-24T06:33:10.8424480Z 
2020-12-24T06:33:10.8425102Z         # socket closed by peer'
2020-12-24T06:33:10.8425773Z         #     doesn't match '(?^si:HTTP/1.1 200 )'
2020-12-24T06:33:10.8659376Z fetch-ocsp-response (using OpenSSL 1.0.2g  1 Mar 2016)
2020-12-24T06:33:10.8694854Z failed to extract ocsp URI from examples/h2o/server.crt
2020-12-24T06:33:10.8758537Z [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2020-12-24T06:33:11.8422060Z         ok 2[0m
2020-12-24T06:33:11.8423238Z killing /home/ci/build/h2o... received SIGTERM, gracefully shutting down
2020-12-24T06:33:11.9430980Z killed (got 0)
2020-12-24T06:33:11.9432491Z         1..2[0m
2020-12-24T06:33:11.9445502Z         # Looks like you failed 1 test of 2.
2020-12-24T06:33:11.9467642Z     not ok 5 - body send error after sending headers[0m
2020-12-24T06:33:11.9468610Z     
2020-12-24T06:33:11.9469986Z     #   Failed test 'body send error after sending headers'
2020-12-24T06:33:11.9471805Z     #   at t/50reverse-proxy-early-response.t line 200.
2020-12-24T06:33:11.9473185Z     1..5[0m
2020-12-24T06:33:11.9482146Z     # Looks like you failed 1 test of 5.
2020-12-24T06:33:11.9483207Z [31mnot ok 2 - (1) h2 up x h1 down[0m
```