### PR TITLE
add GitHub Actions problem matchers for Test::More

### DIFF
--- a/.github/problem-matcher-test-more.json
+++ b/.github/problem-matcher-test-more.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "problem-matcher-test-more",
+      "pattern": [
+        {
+          "regexp": "^\\s*#\\s+(Failed test.*)$",
+          "message": 1
+        },
+        {
+          "regexp": "^\\s*#\\s+at (\\S+) line (\\d+)\\.",
+          "file": 1,
+          "line": 2
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Setup Problem Matchers
+      run: |
+        echo "::add-matcher::.github/problem-matcher-test-more.json"
+
     - name: Run with Docker
       shell: 'script -q -e -c "bash {0}"'
       env:


### PR DESCRIPTION
Problem Matchers generates comments (or annotations) matched in a particular pattern in build logs. See the following logs:

demo with failing tests: https://github.com/gfx/h2o/pull/8/files

Yeah, it has two problems:

* Comments have no links to the corresponding build page or log page
* Too many duplicate messages since each build generates a separate comment

However, I think it's better than nothing. 

(I've made feedback about them, though)


---

doc: https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md

FWIW the doc describes multiline matching, but it's too verbose -- it makes one comment per line, so if we used it, # of lines x # of build types of comments would be generated. 


