### PR TITLE
[t/50graceful-shutdown.t] more delay until the server starts handling the connection

### DIFF
--- a/t/50graceful-shutdown.t
+++ b/t/50graceful-shutdown.t
@@ -20,7 +20,7 @@ hosts:
         - file.dir: @{[ DOC_ROOT ]}
 EOT
     unless (fork) {
-        Time::HiRes::sleep(0.5);
+        Time::HiRes::sleep(1.5);
         kill 'TERM', $server->{pid};
         exit;
     }
@@ -33,7 +33,7 @@ EOT
         ":path" => "/",
     }
     h2g.send_headers(req, 1, END_HEADERS)
-    sleep 1
+    sleep 2
     h2g.send_data(1, END_STREAM, '')
 
     loop do
@@ -67,7 +67,7 @@ hosts:
         - file.dir: @{[ DOC_ROOT ]}
 EOT
     unless (fork) {
-        Time::HiRes::sleep(0.5);
+        Time::HiRes::sleep(1.5);
         kill 'TERM', $server->{pid};
         exit;
     }
@@ -80,7 +80,7 @@ EOT
         ":path" => "/",
     }
     h2g.send_headers(req, 1, END_HEADERS)
-    sleep 2
+    sleep 3
     h2g.send_data(1, END_STREAM, '')
 
     loop do


### PR DESCRIPTION
As discussed in #2526, the 0.5-second delay to kill the server is too small when running the test on GitHub Actions.

Looking at the log below, we do not see the message that says "h2o server ... is ready to serve requests" for 
the first subtest. The server was killed before it started handling requests. No wonder the client failed to connect to the server.

For the second subtest, we see the server barely succeeding in handling the request; the time window is just 0.03 seconds between when it started handling the request and when it received SIGTERM.

This PR addresses the issue by adding 1 second to all the delays being used. Note that this is the minimum addition delay that we can introduce, as the `sleep` method of h2get only accepts integers.

```
2020-12-29T00:42:08.9913769Z t/50graceful-shutdown.t .............................. 
2020-12-29T00:42:08.9923112Z     # Subtest: case 1[0m
2020-12-29T00:42:09.0976212Z spawning /home/ci/build/h2o... done
2020-12-29T00:42:09.6011219Z [INFO] raised RLIMIT_NOFILE to 1048576
2020-12-29T00:42:09.6082235Z     not ok 1[0m
2020-12-29T00:42:09.6089192Z     1..1[0m
2020-12-29T00:42:09.6092998Z     
2020-12-29T00:42:09.6097524Z     #   Failed test at t/50graceful-shutdown.t line 52.
2020-12-29T00:42:09.6100861Z     #                   'RuntimeError: Connection failed
2020-12-29T00:42:09.6104377Z     # '
2020-12-29T00:42:09.6108417Z     #     doesn't match '(?^:received complete response)'
2020-12-29T00:42:09.6111602Z killing /home/ci/build/h2o... killed (got 0)
2020-12-29T00:42:09.6129874Z [31mnot ok 1 - case 1[0m
2020-12-29T00:42:09.6139951Z     # Subtest: case 2[0m
2020-12-29T00:42:09.6145220Z     # Looks like you failed 1 test of 1.
2020-12-29T00:42:09.6146763Z 
2020-12-29T00:42:09.6151229Z #   Failed test 'case 1'
2020-12-29T00:42:09.6154633Z #   at t/50graceful-shutdown.t line 53.
2020-12-29T00:42:09.6498727Z spawning /home/ci/build/h2o... fetch-ocsp-response (using OpenSSL 1.0.2g  1 Mar 2016)
2020-12-29T00:42:09.6548989Z failed to extract ocsp URI from examples/h2o/server.crt
2020-12-29T00:42:09.7216714Z done
2020-12-29T00:42:10.1846166Z [INFO] raised RLIMIT_NOFILE to 1048576
2020-12-29T00:42:10.1958719Z h2o server (pid:18168) is ready to serve requests with 1 threads
2020-12-29T00:42:10.2277477Z received SIGTERM, gracefully shutting down
2020-12-29T00:42:10.2330632Z fetch-ocsp-response (using OpenSSL 1.0.2g  1 Mar 2016)
2020-12-29T00:42:10.2366316Z failed to extract ocsp URI from examples/h2o/server.crt
2020-12-29T00:42:10.2435583Z [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2020-12-29T00:42:12.2023743Z     ok 1[0m
2020-12-29T00:42:12.2024319Z     1..1[0m
2020-12-29T00:42:12.2024779Z killing /home/ci/build/h2o... killed (got 0)
2020-12-29T00:42:12.2025392Z ok 2 - case 2[0m
2020-12-29T00:42:12.2025853Z 1..2[0m
2020-12-29T00:42:12.2026267Z # Looks like you failed 1 test of 2.
2020-12-29T00:42:12.2041890Z [31mDubious, test returned 1 (wstat 256, 0x100)[0m
2020-12-29T00:42:12.2047158Z [31mFailed 1/2 subtests [0m
```