### PR TITLE
[t/40max-connections.t] fix TOCTOU that leads to accepting more connections than configured

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2417,10 +2417,13 @@ static h2o_quic_conn_t *on_http3_accept(h2o_quic_ctx_t *_ctx, quicly_address_t *
                                         quicly_decoded_packet_t *packet)
 {
     /* adjust number of connections, or drop the incoming packet when handling too many connections */
-    if (num_connections(1) >= conf.max_connections)
+    if (num_connections(1) >= conf.max_connections) {
+        num_connections(-1);
         return NULL;
+    }
     if (num_quic_connections(1) >= conf.max_quic_connections) {
         num_connections(-1);
+        num_quic_connections(-1);
         return NULL;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -2349,7 +2349,7 @@ static void on_accept(h2o_socket_t *listener, const char *err)
 
     do {
         h2o_socket_t *sock;
-        if (num_connections(1) > conf.max_connections) {
+        if (num_connections(1) >= conf.max_connections) {
             /* The accepting socket is disactivated before entering the next in `run_loop`.
              * Note: it is possible that the server would accept at most `max_connections + num_threads` connections, since the
              * server does not check if the number of connections has exceeded _after_ epoll notifies of a new connection _but_
@@ -2417,9 +2417,9 @@ static h2o_quic_conn_t *on_http3_accept(h2o_quic_ctx_t *_ctx, quicly_address_t *
                                         quicly_decoded_packet_t *packet)
 {
     /* adjust number of connections, or drop the incoming packet when handling too many connections */
-    if (num_connections(1) > conf.max_connections)
+    if (num_connections(1) >= conf.max_connections)
         return NULL;
-    if (num_quic_connections(1) > conf.max_quic_connections) {
+    if (num_quic_connections(1) >= conf.max_quic_connections) {
         num_connections(-1);
         return NULL;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -2349,18 +2349,18 @@ static void on_accept(h2o_socket_t *listener, const char *err)
 
     do {
         h2o_socket_t *sock;
-        if (num_connections(0) >= conf.max_connections) {
+        if (num_connections(1) > conf.max_connections) {
             /* The accepting socket is disactivated before entering the next in `run_loop`.
              * Note: it is possible that the server would accept at most `max_connections + num_threads` connections, since the
              * server does not check if the number of connections has exceeded _after_ epoll notifies of a new connection _but_
              * _before_ calling `accept`.  In other words t/40max-connections.t may fail.
              */
+            num_connections(-1);
             break;
         }
         if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
             break;
         }
-        num_connections(1);
         num_sessions(1);
 
         sock->on_close.cb = on_socketclose;
@@ -2416,15 +2416,19 @@ static int validate_token(h2o_http3_server_ctx_t *ctx, struct sockaddr *remote, 
 static h2o_quic_conn_t *on_http3_accept(h2o_quic_ctx_t *_ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,
                                         quicly_decoded_packet_t *packet)
 {
+    /* adjust number of connections, or drop the incoming packet when handling too many connections */
+    if (num_connections(1) > conf.max_connections)
+        return NULL;
+    if (num_quic_connections(1) > conf.max_quic_connections) {
+        num_connections(-1);
+        return NULL;
+    }
+
     h2o_http3_server_ctx_t *ctx = (void *)_ctx;
     struct init_ebpf_key_info_t ebpf_keyinfo = {&destaddr->sa, &srcaddr->sa};
     h2o_ebpf_map_value_t ebpf_value = h2o_socket_ebpf_lookup(ctx->super.loop, init_ebpf_key_info, &ebpf_keyinfo);
     quicly_address_token_plaintext_t *token = NULL, token_buf;
-    h2o_http3_conn_t *conn;
-
-    /* just drop when handling too many connections */
-    if (num_connections(0) >= conf.max_connections || num_quic_connections(0) >= conf.max_quic_connections)
-        return NULL;
+    h2o_http3_conn_t *conn = NULL;
 
     /* handle retry, setting `token` to a non-NULL pointer if contains a valid token */
     if (packet->token.len != 0) {
@@ -2440,7 +2444,7 @@ static h2o_quic_conn_t *on_http3_accept(h2o_quic_ctx_t *_ctx, quicly_address_t *
             assert(payload_size != SIZE_MAX);
             struct iovec vec = {.iov_base = payload, .iov_len = payload_size};
             h2o_quic_send_datagrams(&ctx->super, srcaddr, destaddr, &vec, 1);
-            return NULL;
+            goto Exit;
         }
     }
 
@@ -2483,17 +2487,22 @@ static h2o_quic_conn_t *on_http3_accept(h2o_quic_ctx_t *_ctx, quicly_address_t *
             assert(payload_size != SIZE_MAX);
             struct iovec vec = {.iov_base = payload, .iov_len = payload_size};
             h2o_quic_send_datagrams(&ctx->super, srcaddr, destaddr, &vec, 1);
-            return NULL;
+            goto Exit;
         }
     }
 
     /* accept the connection */
     conn = h2o_http3_server_accept(ctx, destaddr, srcaddr, packet, token, ebpf_value.skip_tracing, &conf.quic.conn_callbacks);
     if (conn == NULL || &conn->super == H2O_QUIC_ACCEPT_CONN_DECRYPTION_FAILED)
-        return &conn->super;
-    num_connections(1);
-    num_quic_connections(1);
+        goto Exit;
     num_sessions(1);
+
+Exit:
+    if (conn == NULL) {
+        /* revert the changes to the connection counts */
+        num_connections(-1);
+        num_quic_connections(-1);
+    }
     return &conn->super;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -2359,6 +2359,7 @@ static void on_accept(h2o_socket_t *listener, const char *err)
             break;
         }
         if ((sock = h2o_evloop_socket_accept(listener)) == NULL) {
+            num_connections(-1);
             break;
         }
         num_sessions(1);


### PR DESCRIPTION
At the moment, the logic tests the current value of the counter to see if it is below the limit, accepts the connections, then increments the counter. This design has TOCTOU issue as multiple threads might be running concurrently.

This PR addresses the issue by changing the logic from test-then-increment to increment-then-test-and-decrement-if-necessary.

While this issue might sound like theoretical, I think that it is why t/40max-connections.t fails occasionally, as shown in the log below. When H2O is being spawned, all worker threads are notified to start receiving new connections at the same moment. This TOCTOU issue will be observed if the time difference between when the threads receive that notification is smaller than the time required to accept a new connection.

```
2020-12-29T00:39:01.5684367Z t/40max-connections.t ................................ 
2020-12-29T00:39:01.5685249Z     # Subtest: single-threaded[0m
2020-12-29T00:39:01.6725209Z spawning /home/ci/build/h2o... done
2020-12-29T00:39:02.1736944Z [INFO] raised RLIMIT_NOFILE to 1048576
2020-12-29T00:39:02.1750071Z h2o server (pid:15593) is ready to serve requests with 1 threads
2020-12-29T00:39:02.2208814Z fetch-ocsp-response (using OpenSSL 1.0.2g  1 Mar 2016)
2020-12-29T00:39:02.2242053Z failed to extract ocsp URI from examples/h2o/server.crt
2020-12-29T00:39:02.2314183Z [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2020-12-29T00:39:02.6735701Z     ok 1 - succeeding conn is not handled[0m
2020-12-29T00:39:03.1746621Z     ok 2 - succeeding conn should have been handled[0m
2020-12-29T00:39:03.1759549Z     ok 3 - response is valid[0m
2020-12-29T00:39:03.1760383Z killing /home/ci/build/h2o... received SIGTERM, gracefully shutting down
2020-12-29T00:39:03.2746790Z killed (got 0)
2020-12-29T00:39:03.2775304Z     1..3[0m
2020-12-29T00:39:03.2776525Z ok 1 - single-threaded[0m
2020-12-29T00:39:03.2777418Z     # Subtest: multi-threaded[0m
2020-12-29T00:39:03.3810464Z spawning /home/ci/build/h2o... done
2020-12-29T00:39:03.9039371Z [INFO] raised RLIMIT_NOFILE to 1048576
2020-12-29T00:39:03.9142794Z h2o server (pid:15604) is ready to serve requests with 4 threads
2020-12-29T00:39:03.9536117Z fetch-ocsp-response (using OpenSSL 1.0.2g  1 Mar 2016)
2020-12-29T00:39:03.9577521Z failed to extract ocsp URI from examples/h2o/server.crt
2020-12-29T00:39:03.9639736Z [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2020-12-29T00:39:04.3819571Z     not ok 1 - succeeding conn is not handled[0m
2020-12-29T00:39:04.3820288Z     
2020-12-29T00:39:04.3821085Z     #   Failed test 'succeeding conn is not handled'
2020-12-29T00:39:04.3822024Z     #   at t/40max-connections.t line 59.
2020-12-29T00:39:04.8826256Z     ok 2 - succeeding conn should have been handled[0m
2020-12-29T00:39:04.8827076Z     ok 3 - response is valid[0m
2020-12-29T00:39:04.8827766Z killing /home/ci/build/h2o... received SIGTERM, gracefully shutting down
2020-12-29T00:39:04.9859868Z killed (got 0)
2020-12-29T00:39:04.9860912Z     1..3[0m
2020-12-29T00:39:04.9863372Z [31mnot ok 2 - multi-threaded[0m
2020-12-29T00:39:04.9863962Z 1..2[0m
2020-12-29T00:39:04.9864397Z     # Looks like you failed 1 test of 3.
2020-12-29T00:39:04.9864716Z 
2020-12-29T00:39:04.9865306Z #   Failed test 'multi-threaded'
2020-12-29T00:39:04.9866109Z #   at t/40max-connections.t line 16.
2020-12-29T00:39:04.9871475Z # Looks like you failed 1 test of 2.
2020-12-29T00:39:04.9876389Z [31mDubious, test returned 1 (wstat 256, 0x100)[0m
2020-12-29T00:39:04.9877097Z [31mFailed 1/2 subtests [0m
```