### PR TITLE
`proxy.ssl.*` should emit empty string when plaintext protocol is used

### DIFF
--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -478,15 +478,15 @@ Fail:
     return pos;
 }
 
-#define APPEND_SAFE_STRING_WITH_LEN(pos, s, len)                                                                                   \
+#define RESERVE_APPEND_SAFE_STRING_WITH_LEN(pos, s, len)                                                                           \
     do {                                                                                                                           \
         if (s == NULL)                                                                                                             \
             goto EmitNull;                                                                                                         \
         RESERVE(len);                                                                                                              \
         pos = append_safe_string(pos, s, len);                                                                                     \
     } while (0)
-#define APPEND_SAFE_STRING(pos, s) APPEND_SAFE_STRING_WITH_LEN(pos, s, strlen(s))
-#define APPEND_DURATION(pos, name)                                                                                                 \
+#define RESERVE_APPEND_SAFE_STRING(pos, s) RESERVE_APPEND_SAFE_STRING_WITH_LEN(pos, s, strlen(s))
+#define RESERVE_APPEND_DURATION(pos, name)                                                                                         \
     do {                                                                                                                           \
         int64_t delta_usec;                                                                                                        \
         if (!h2o_time_compute_##name(req, &delta_usec))                                                                            \
@@ -763,31 +763,31 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             break;
 
         case ELEMENT_TYPE_CONNECT_TIME:
-            APPEND_DURATION(pos, connect_time);
+            RESERVE_APPEND_DURATION(pos, connect_time);
             break;
 
         case ELEMENT_TYPE_REQUEST_HEADER_TIME:
-            APPEND_DURATION(pos, header_time);
+            RESERVE_APPEND_DURATION(pos, header_time);
             break;
 
         case ELEMENT_TYPE_REQUEST_BODY_TIME:
-            APPEND_DURATION(pos, body_time);
+            RESERVE_APPEND_DURATION(pos, body_time);
             break;
 
         case ELEMENT_TYPE_REQUEST_TOTAL_TIME:
-            APPEND_DURATION(pos, request_total_time);
+            RESERVE_APPEND_DURATION(pos, request_total_time);
             break;
 
         case ELEMENT_TYPE_PROCESS_TIME:
-            APPEND_DURATION(pos, process_time);
+            RESERVE_APPEND_DURATION(pos, process_time);
             break;
 
         case ELEMENT_TYPE_RESPONSE_TIME:
-            APPEND_DURATION(pos, response_time);
+            RESERVE_APPEND_DURATION(pos, response_time);
             break;
 
         case ELEMENT_TYPE_TOTAL_TIME:
-            APPEND_DURATION(pos, total_time);
+            RESERVE_APPEND_DURATION(pos, total_time);
             break;
 
         case ELEMENT_TYPE_ERROR:
@@ -796,27 +796,27 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             break;
 
         case ELEMENT_TYPE_PROXY_IDLE_TIME:
-            APPEND_DURATION(pos, proxy_idle_time);
+            RESERVE_APPEND_DURATION(pos, proxy_idle_time);
             break;
 
         case ELEMENT_TYPE_PROXY_CONNECT_TIME:
-            APPEND_DURATION(pos, proxy_connect_time);
+            RESERVE_APPEND_DURATION(pos, proxy_connect_time);
             break;
 
         case ELEMENT_TYPE_PROXY_REQUEST_TIME:
-            APPEND_DURATION(pos, proxy_request_time);
+            RESERVE_APPEND_DURATION(pos, proxy_request_time);
             break;
 
         case ELEMENT_TYPE_PROXY_PROCESS_TIME:
-            APPEND_DURATION(pos, proxy_process_time);
+            RESERVE_APPEND_DURATION(pos, proxy_process_time);
             break;
 
         case ELEMENT_TYPE_PROXY_RESPONSE_TIME:
-            APPEND_DURATION(pos, proxy_response_time);
+            RESERVE_APPEND_DURATION(pos, proxy_response_time);
             break;
 
         case ELEMENT_TYPE_PROXY_TOTAL_TIME:
-            APPEND_DURATION(pos, proxy_total_time);
+            RESERVE_APPEND_DURATION(pos, proxy_total_time);
             break;
 
         case ELEMENT_TYPE_PROXY_REQUEST_BYTES:
@@ -859,17 +859,17 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             pos += sprintf(pos, "%" PRIu16, (uint16_t)req->proxy_stats.ssl.cipher_bits);
             break;
         case ELEMENT_TYPE_PROXY_SSL_PROTOCOL_VERSION:
-            APPEND_SAFE_STRING(pos, req->proxy_stats.ssl.protocol_version);
+            RESERVE_APPEND_SAFE_STRING(pos, req->proxy_stats.ssl.protocol_version);
             break;
         case ELEMENT_TYPE_PROXY_SSL_CIPHER:
-            APPEND_SAFE_STRING(pos, req->proxy_stats.ssl.cipher);
+            RESERVE_APPEND_SAFE_STRING(pos, req->proxy_stats.ssl.cipher);
             break;
         case ELEMENT_TYPE_PROTOCOL_SPECIFIC: {
             h2o_iovec_t (*cb)(h2o_req_t *) = req->conn->callbacks->log_.callbacks[element->data.protocol_specific_callback_index];
             if (cb == NULL)
                 goto EmitNull;
             h2o_iovec_t s = cb(req);
-            APPEND_SAFE_STRING_WITH_LEN(pos, s.base, s.len);
+            RESERVE_APPEND_SAFE_STRING_WITH_LEN(pos, s.base, s.len);
         } break;
 
         case ELEMENT_TYPE_LOGNAME:      /* %l */


### PR DESCRIPTION
`proxy.ssl.*` are counterpart of `ssl.*`, that log the TLS properties of connections going to the backend server. The semantics of the former is assumed to mimic that of the latter.

This PR address the differences between the two. Additionally it renames the macros to improve readability; the requirement for each case label is that a RESERVE and (if necessary) an append is being done.