### PR TITLE
ci: add job-level `timeout-minutes: 60`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
             task: dtrace
             container: h2oserver/h2o-ci:ubuntu2004
 
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
       with:
@@ -53,6 +54,7 @@ jobs:
     # see above
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
+    timeout-minutes: 60
     steps:
     - name: Build Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master


### PR DESCRIPTION
As discussed in #2532, adding timeouts for CI jobs.

ref. https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes