### PR TITLE
[http3client] fix incorrect use of `h2o_buffer_reserve`

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -266,7 +266,7 @@ h2o_iovec_t h2o_buffer_reserve(h2o_buffer_t **inbuf, size_t min_guarantee);
 /**
  * allocates a buffer.
  * @param inbuf - pointer to a pointer pointing to the structure (set *inbuf to NULL to allocate a new buffer)
- * @param min_guarantee minimum number of bytes to reserve
+ * @param min_guarantee minimum number of additional bytes to reserve
  * @return buffer to which the next data should be stored
  * @note When called against a new buffer, the function returns a buffer twice the size of requested guarantee.  The function uses
  * exponential backoff for already-allocated buffers.

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -547,7 +547,7 @@ static void on_receive(quicly_stream_t *qs, size_t off, const void *input, size_
         /* slow path; copy data to partial_frame */
         size_t size_required = off + len;
         if (req->recvbuf.stream->size < size_required) {
-            H2O_HTTP3_CHECK_SUCCESS(h2o_buffer_reserve(&req->recvbuf.stream, size_required).base != NULL);
+            h2o_buffer_reserve(&req->recvbuf.stream, size_required - req->recvbuf.stream->size);
             req->recvbuf.stream->size = size_required;
         }
         memcpy(req->recvbuf.stream->bytes + off, input, len);


### PR DESCRIPTION
The second argument of `h2o_buffer_reserve` accepts the amount of additional space that has to be reserved. However, http3client has been over-allocating memory, by passing the entire size of the buffer.

This PR address the issue as well as adding clarification to the doc-comment of `h2o_buffer_reserve`.

In addition, it removes the unnecessary assertion around the use of `h2o_buffer_reserve`. It is unnecessary because `h2o_buffer_reserve` is guaranteed to succeed (or abort).