### PR TITLE
call setsockopt(TCP_NODELAY) when the address family is unknown

### DIFF
--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -406,9 +406,7 @@ static struct st_h2o_evloop_socket_t *create_socket(h2o_evloop_t *loop, int fd, 
  */
 static void set_nodelay_if_likely_tcp(int fd, struct sockaddr *sa)
 {
-    if (sa == NULL)
-        return;
-    if (!(sa->sa_family == AF_INET || sa->sa_family == AF_INET6))
+    if (sa != NULL && !(sa->sa_family == AF_INET || sa->sa_family == AF_INET6))
         return;
 
     int on = 1;

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -442,7 +442,7 @@ h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *_listener)
     if ((fd = accept4(listener->fd, (struct sockaddr *)peeraddr, peeraddrlen, SOCK_NONBLOCK | SOCK_CLOEXEC)) == -1)
         return NULL;
 #if !defined(NDEBUG)
-    { /* assert once that TCP_NODELAY flag is inherited */
+    { /* assert once that TCP_NODELAY flag is inherited (TODO move this check into a unit test) */
         static __thread int done = 0;
         if (!done) {
             done = 1;


### PR DESCRIPTION
Fix performance regression that went in with #2502. We fail to set TCP_NODELAY on linux. Also enables the test that we have had in the code path.