### PR TITLE
[h2olog] Fix parameter position in example usage

### DIFF
--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -52,7 +52,7 @@ Optional arguments:
     -w Path to write the output (default: stdout)
 
 Examples:
-    h2olog -p -H $(pgrep -o h2o)
+    h2olog -p $(pgrep -o h2o) -H
     h2olog -p $(pgrep -o h2o) -t quicly:accept -t quicly:free
     h2olog -p $(pgrep -o h2o) -t h2o:send_response_header -t h2o:h3s_accept -t h2o:h3s_destroy -s alt-svc
 )",


### PR DESCRIPTION
`-p` should appear right in front of a process ID.