### PR TITLE
[http3] add knob to configure IW

### DIFF
--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -273,6 +273,10 @@ struct st_quicly_context_t {
      */
     uint64_t max_crypto_bytes;
     /**
+     * initial CWND in terms of packet numbers
+     */
+    uint32_t initcwnd_packets;
+    /**
      * (client-only) Initial QUIC protocol version used by the client. Setting this to a greased version will enforce version
      * negotiation.
      */

--- a/deps/quicly/include/quicly/cc.h
+++ b/deps/quicly/include/quicly/cc.h
@@ -168,7 +168,7 @@ extern struct st_quicly_init_cc_t quicly_cc_cubic_init;
 /**
  * Calculates the initial congestion window size given the maximum UDP payload size.
  */
-uint32_t quicly_cc_calc_initial_cwnd(uint16_t max_udp_payload_size);
+uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size);
 
 #ifdef __cplusplus
 }

--- a/deps/quicly/lib/cc-reno.c
+++ b/deps/quicly/lib/cc-reno.c
@@ -98,13 +98,15 @@ static void reno_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd
 
 quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 
-uint32_t quicly_cc_calc_initial_cwnd(uint16_t max_udp_payload_size)
+uint32_t quicly_cc_calc_initial_cwnd(uint32_t max_packets, uint16_t max_udp_payload_size)
 {
-    static const uint32_t max_packets = 10, max_bytes = 14720;
-    uint32_t cwnd = max_packets * max_udp_payload_size;
-    if (cwnd > max_bytes)
-        cwnd = max_bytes;
-    if (cwnd < QUICLY_MIN_CWND * max_udp_payload_size)
-        cwnd = QUICLY_MIN_CWND * max_udp_payload_size;
-    return cwnd;
+    static const uint32_t mtu_max = 1472;
+
+    /* apply filters to the two arguments */
+    if (max_packets < QUICLY_MIN_CWND)
+        max_packets = QUICLY_MIN_CWND;
+    if (max_udp_payload_size > mtu_max)
+        max_udp_payload_size = mtu_max;
+
+    return max_packets * max_udp_payload_size;
 }

--- a/deps/quicly/lib/defaults.c
+++ b/deps/quicly/lib/defaults.c
@@ -26,6 +26,7 @@
 #define DEFAULT_MAX_UDP_PAYLOAD_SIZE 1472
 #define DEFAULT_MAX_PACKETS_PER_KEY 16777216
 #define DEFAULT_MAX_CRYPTO_BYTES 65536
+#define DEFAULT_INITCWND_PACKETS 10
 #define DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT 3
 
 /* profile that employs IETF specified values */
@@ -40,6 +41,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                                DEFAULT_MAX_UDP_PAYLOAD_SIZE},
                                               DEFAULT_MAX_PACKETS_PER_KEY,
                                               DEFAULT_MAX_CRYPTO_BYTES,
+                                              DEFAULT_INITCWND_PACKETS,
                                               QUICLY_PROTOCOL_VERSION_CURRENT,
                                               DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                               0, /* is_clustered */
@@ -67,6 +69,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                      DEFAULT_MAX_UDP_PAYLOAD_SIZE},
                                                     DEFAULT_MAX_PACKETS_PER_KEY,
                                                     DEFAULT_MAX_CRYPTO_BYTES,
+                                                    DEFAULT_INITCWND_PACKETS,
                                                     QUICLY_PROTOCOL_VERSION_CURRENT,
                                                     DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
                                                     0, /* is_clustered */
@@ -414,7 +417,7 @@ Exit:
             ptls_aead_free(*aead_ctx);
             *aead_ctx = NULL;
         }
-        if (*hp_ctx != NULL) {
+        if (hp_ctx != NULL && *hp_ctx != NULL) {
             ptls_cipher_free(*hp_ctx);
             *hp_ctx = NULL;
         }

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -2148,8 +2148,9 @@ int quicly_connect(quicly_conn_t **_conn, quicly_context_t *ctx, const char *ser
         }
     }
 
-    if ((conn = create_connection(ctx, ctx->initial_version, server_name, dest_addr, src_addr, NULL, new_cid, handshake_properties,
-                                  quicly_cc_calc_initial_cwnd(ctx->transport_params.max_udp_payload_size))) == NULL) {
+    if ((conn = create_connection(
+             ctx, ctx->initial_version, server_name, dest_addr, src_addr, NULL, new_cid, handshake_properties,
+             quicly_cc_calc_initial_cwnd(ctx->initcwnd_packets, ctx->transport_params.max_udp_payload_size))) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }
@@ -2906,7 +2907,8 @@ struct st_quicly_send_context_t {
         uint8_t *end;
     } payload_buf;
     /**
-     * the currently available window for sending (in bytes)
+     * Currently available window for sending (in bytes); the value becomes negative when the sender uses more space than permitted.
+     * That happens because the sender operates at packet-level rather than byte-level.
      */
     ssize_t send_window;
     /**
@@ -3078,7 +3080,8 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
     } else {
         if (s->num_datagrams >= s->max_datagrams)
             return QUICLY_ERROR_SENDBUF_FULL;
-        if (ack_eliciting && s->send_window == 0)
+        /* note: send_window (ssize_t) can become negative; see doc-comment */
+        if (ack_eliciting && s->send_window <= 0)
             return QUICLY_ERROR_SENDBUF_FULL;
         if (s->payload_buf.end - s->payload_buf.datagram < conn->egress.max_udp_payload_size)
             return QUICLY_ERROR_SENDBUF_FULL;
@@ -5485,8 +5488,9 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
     }
 
     /* create connection */
-    if ((*conn = create_connection(ctx, packet->version, NULL, src_addr, dest_addr, &packet->cid.src, new_cid, handshake_properties,
-                                   quicly_cc_calc_initial_cwnd(ctx->transport_params.max_udp_payload_size))) == NULL) {
+    if ((*conn = create_connection(
+             ctx, packet->version, NULL, src_addr, dest_addr, &packet->cid.src, new_cid, handshake_properties,
+             quicly_cc_calc_initial_cwnd(ctx->initcwnd_packets, ctx->transport_params.max_udp_payload_size))) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }

--- a/deps/quicly/src/cli.c
+++ b/deps/quicly/src/cli.c
@@ -1057,6 +1057,7 @@ static void usage(const char *cmd)
            "  -U size                   maximum size of UDP datagarm payload\n"
            "  -V                        verify peer using the default certificates\n"
            "  -v                        verbose mode (-vv emits packet dumps as well)\n"
+           "  -w packets                initial congestion window (default: 10)\n"
            "  -x named-group            named group to be used (default: secp256r1)\n"
            "  -X                        max bidirectional stream count (default: 100)\n"
            "  -y cipher-suite           cipher-suite to be used (default: all)\n"
@@ -1103,7 +1104,7 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvx:X:y:h")) != -1) {
+    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:x:X:y:h")) != -1) {
         switch (ch) {
         case 'a':
             assert(negotiated_protocols.count < PTLS_ELEMENTSOF(negotiated_protocols.list));
@@ -1251,6 +1252,12 @@ int main(int argc, char **argv)
             break;
         case 'v':
             ++verbosity;
+            break;
+        case 'w':
+            if (sscanf(optarg, "%" SCNu32, &ctx.initcwnd_packets) != 1) {
+                fprintf(stderr, "invalid argument passed to `-w`\n");
+                exit(1);
+            }
             break;
         case 'x': {
             size_t i;

--- a/deps/quicly/t/lossy.c
+++ b/deps/quicly/t/lossy.c
@@ -426,14 +426,14 @@ static void test_downstream(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 4, 13812, 3582, 17579);
+    loss_check_stats(time_spent, 4, 14193, 3610, 17579);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 1941, 608, 3006);
+    loss_check_stats(time_spent, 0, 2220, 608, 2779);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
@@ -483,7 +483,7 @@ static void test_bidirectional(void)
         subtest("75%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 27, 266649.4, 102052, 649336);
+    loss_check_stats(time_spent, 20, 240012.7, 126541, 652328);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 2);
@@ -491,7 +491,7 @@ static void test_bidirectional(void)
         subtest("50%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 1, 2283.5, 1171, 6424);
+    loss_check_stats(time_spent, 0, 2286.9, 1175, 6424);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 4);
@@ -499,7 +499,7 @@ static void test_bidirectional(void)
         subtest("25%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 331, 284, 635);
+    loss_check_stats(time_spent, 0, 328.7, 237, 530);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 10);
@@ -507,7 +507,7 @@ static void test_bidirectional(void)
         subtest("10%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 151.7, 80, 298);
+    loss_check_stats(time_spent, 0, 150.1, 80, 298);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 20);
@@ -515,7 +515,7 @@ static void test_bidirectional(void)
         subtest("5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 110.4, 80, 230);
+    loss_check_stats(time_spent, 0, 103.5, 80, 192);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 40);
@@ -523,7 +523,7 @@ static void test_bidirectional(void)
         subtest("2.5%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 95.6, 80, 190);
+    loss_check_stats(time_spent, 0, 96.7, 80, 80);
 
     for (i = 0; i != 100; ++i) {
         init_cond_rand(&loss_cond_down, 1, 64);
@@ -531,7 +531,7 @@ static void test_bidirectional(void)
         subtest("1.6%", loss_core);
         time_spent[i] = quic_now - 1;
     }
-    loss_check_stats(time_spent, 0, 95.8, 80, 190);
+    loss_check_stats(time_spent, 0, 96.7, 80, 190);
 }
 
 void test_lossy(void)


### PR DESCRIPTION
This PR does the following:
* Adds `initcwnd` parameter to the `listen` directive, that specifies INITCWND by the number of packets.
* Updates quicly to latest, incorporating https://github.com/h2o/quicly/pull/428, https://github.com/h2o/quicly/pull/429. https://github.com/h2o/quicly/pull/430.

Sample configuration file:
```yaml
listen:
  port: 8443
  type: quic     # set type to QUIC
  cc: reno       # set CC to reno
  initcwnd: 2    # set IW to 2
  ssl:
    certificate-file: tmp/127.0.0.1.examp1e.net/fullchain.pem
    key-file: tmp/127.0.0.1.examp1e.net/privkey.pem
```

https://gist.github.com/kazuho/d520afd466e23edeb1a1939cb6ec49d5 shows the traces for iw2 and iw10; they look correct to me.