### PR TITLE
fix deprecated warnings by s/TLSv1_client_method/SSLv23_client_method/

### DIFF
--- a/examples/libh2o/socket-client.c
+++ b/examples/libh2o/socket-client.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
         SSL_load_error_strings();
         SSL_library_init();
         OpenSSL_add_all_algorithms();
-        ssl_ctx = SSL_CTX_new(TLSv1_client_method());
+        ssl_ctx = SSL_CTX_new(SSLv23_client_method());
         SSL_CTX_load_verify_locations(ssl_ctx, H2O_TO_STR(H2O_ROOT) "/share/h2o/ca-bundle.crt", NULL);
         SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
     }

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -193,7 +193,7 @@ static void start_request(h2o_httpclient_ctx_t *ctx)
         sprintf(crt_fullpath, "%s%s", root, CA_PATH);
 #undef CA_PATH
 
-        SSL_CTX *ssl_ctx = SSL_CTX_new(TLSv1_client_method());
+        SSL_CTX *ssl_ctx = SSL_CTX_new(SSLv23_client_method());
         SSL_CTX_load_verify_locations(ssl_ctx, crt_fullpath, NULL);
         if (ssl_verify_none) {
             SSL_CTX_set_verify(ssl_ctx, SSL_VERIFY_NONE, NULL);


### PR DESCRIPTION
`TLSv1_client_method` has been deprecated in OpenSSL 1.1.0. `TLS_client_method` is not available in older OpenSSL, but `SSLv23_client_method` is portable and not deprecated, which is `#define SSLv23_client_method    TLS_client_method` as of OpenSSL 1.1.1i.