### PR TITLE
Fix fallocate error message.

### DIFF
--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -292,6 +292,9 @@ h2o_iovec_t h2o_buffer_try_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
                 int fallocate_ret;
 #if USE_POSIX_FALLOCATE
                 fallocate_ret = posix_fallocate(fd, 0, new_allocsize);
+                if (fallocate_ret != 0) {
+                    errno = fallocate_ret;
+                }
 #else
                 fallocate_ret = ftruncate(fd, new_allocsize);
 #endif


### PR DESCRIPTION
According to the documentation of `posix_fallocate`

> RETURN VALUE
>       posix_fallocate() returns zero on success, or an error number on failure.  Note that errno is not set.

Since errno is not set by `posix_fallocate`, potentially confusing error
messages can be printed as `h2o_perror` (called below) expects errno
to be set appropriately.

This change fixes this, so that h2o will print correct error messages if
`posix_fallocate` fails.