### PR TITLE
ci: login DockerHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
 
     - name: Run with Docker
       shell: 'script -q -e -c "bash -xe {0}"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-      if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
+      continue-on-error: true
 
     - name: Run with Docker
       shell: 'script -q -e -c "bash -xe {0}"'


### PR DESCRIPTION
This PR tries to login DockerHub in order to mitigate a limitation-exceeded problem of docker-pull, which we have occasionally run into.

Authenticated users have doubled quota for docker pull, as https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/ describes:

> We detailed the following pull rate limits to Docker subscription plans that will take effect November 1, 2020:
> 
> Free plan – anonymous users: 100 pulls per 6 hours 
> Free plan – authenticated users: 200 pulls per 6 hours

---

I don't touch Travis CI settings until the limitation-exceeded problem arises again. 

The credentials are defined in this repository. See `Settings` -> `Secrets` if you have an admin permission.
