### PR TITLE
connections listener, TCP_DEFER_ACCEPT's FreeBSD equivalent.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1255,6 +1255,14 @@ static int open_listener(int domain, int type, int protocol, struct sockaddr *ad
         /* listen */
         if (listen(fd, H2O_SOMAXCONN) != 0)
             goto Error;
+#ifdef SO_ACCEPTFILTER
+        { /* set SO_ACCEPTFILTER */
+            struct accept_filter_arg arg = {0};
+            strcpy(arg.af_name, "httpready");
+            if (setsockopt(fd, SOL_SOCKET, SO_ACCEPTFILTER, &arg, sizeof(arg)) != 0)
+                fprintf(stderr, "[warning] failed to set SO_ACCEPTFILTER:%s\n", strerror(errno));
+        }
+#endif
         /* set TCP_FASTOPEN; when tfo_queues is zero TFO is always disabled */
         if (conf.tfo_queues > 0) {
 #ifdef TCP_FASTOPEN


### PR DESCRIPTION
SO_ACCEPTFILTER relies on the accf_http kernel module here, which is loaded only explicitly, thus we treat it only as a warning.
Other key difference, the connection needs to be listened firsthand.