### PR TITLE
reverse proxy using H3 fixes

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -2047,10 +2047,7 @@ typedef struct st_h2o_proxy_config_vars_t {
     struct {
         uint32_t max_concurrent_strams;
     } http2;
-    struct {
-        int8_t http2;
-        int8_t http3;
-    } protocol_ratio;
+    h2o_httpclient_protocol_ratio_t protocol_ratio;
 } h2o_proxy_config_vars_t;
 
 /**

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -97,6 +97,21 @@ typedef struct st_h2o_httpclient_connection_pool_t {
 
 } h2o_httpclient_connection_pool_t;
 
+typedef struct st_h2o_httpclient_protocol_ratio_t {
+    /**
+     * If non-negative, indicates the percentage of requests for which use of HTTP/2 will be attempted. If set to negative, all
+     * connections are established with ALPN offering both H1 and H2, then the load is balanced between the different protocol
+     * versions. This behavior helps balance the load among a mixture of servers behind a load balancer, some supporting both H1 and
+     * H2 and some supporting only H1.
+     */
+    int8_t http2;
+    /**
+     * Indicates the percentage of requests for which HTTP/3 should be used. Unlike HTTP/2, this value cannot be negative, because
+     * unlike ALPN over TLS over TCP, the choice of the protocol is up to the client.
+     */
+    int8_t http3;
+} h2o_httpclient_protocol_ratio_t;
+
 typedef struct st_h2o_httpclient_ctx_t {
     h2o_loop_t *loop;
     h2o_multithread_receiver_t *getaddr_receiver;
@@ -108,20 +123,7 @@ typedef struct st_h2o_httpclient_ctx_t {
     size_t max_buffer_size;
 
     struct st_h2o_httpclient_protocol_selector_t {
-        struct {
-            /**
-             * If non-negative, indicates the percentage of requests for which use of HTTP/2 will be attempted. If set to negative,
-             * all connections are established with ALPN offering both H1 and H2, then the load is balanced between the different
-             * protocol versions. This behavior helps balance the load among a mixture of servers behind a load balancer, some
-             * supporting both H1 and H2 and some supporting only H1.
-             */
-            int8_t http2;
-            /**
-             * Indicates the percentage of requests for which HTTP/3 should be used. Unlike HTTP/2, this value cannot be negative,
-             * because unlike ALPN over TLS over TCP, the choice of the protocol is up to the client.
-             */
-            int8_t http3;
-        } ratio;
+        h2o_httpclient_protocol_ratio_t ratio;
         /**
          * Each deficit is initialized to zero, then incremented by the respective percentage, and the protocol corresponding to the
          * one with the highest value is chosen. Then, the chosen variable is decremented by 100.

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -293,8 +293,18 @@ typedef struct st_h2o_httpclient__h2_conn_t {
 struct st_h2o_httpclient__h3_conn_t {
     h2o_http3_conn_t super;
     h2o_httpclient_ctx_t *ctx;
+    /**
+     * When the socket is associated to a global pool, used to identify the origin. If not associated to a global pool, the values
+     * are zero-filled.
+     */
     struct {
+        /**
+         * the origin URL; null-termination of authority and host is guaranteed
+         */
         h2o_url_t origin_url;
+        /**
+         * port number in C string
+         */
         char named_serv[sizeof(H2O_UINT16_LONGEST_STR)];
     } server;
     ptls_handshake_properties_t handshake_properties;

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -97,8 +97,7 @@ static int handle_input_expect_data_frame(struct st_h2o_http3client_req_t *req, 
 static void start_request(struct st_h2o_http3client_req_t *req);
 static void destroy_request(struct st_h2o_http3client_req_t *req);
 
-static struct st_h2o_httpclient__h3_conn_t *find_connection(h2o_httpclient_connection_pool_t *pool, const h2o_url_scheme_t *scheme,
-                                                            h2o_iovec_t authority)
+static struct st_h2o_httpclient__h3_conn_t *find_connection(h2o_httpclient_connection_pool_t *pool, h2o_url_t *origin)
 {
     int should_check_target = h2o_socketpool_is_global(pool->socketpool);
 
@@ -108,9 +107,9 @@ static struct st_h2o_httpclient__h3_conn_t *find_connection(h2o_httpclient_conne
      */
     for (h2o_linklist_t *l = pool->http3.conns.next; l != &pool->http3.conns; l = l->next) {
         struct st_h2o_httpclient__h3_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_httpclient__h3_conn_t, link, l);
-        if (should_check_target && !(conn->server.origin_url.scheme == scheme &&
+        if (should_check_target && !(conn->server.origin_url.scheme == origin->scheme &&
                                      h2o_memis(conn->server.origin_url.authority.base, conn->server.origin_url.authority.len,
-                                               authority.base, authority.len)))
+                                               origin->authority.base, origin->authority.len)))
             continue;
         return conn;
     }
@@ -143,8 +142,8 @@ static void destroy_connection(struct st_h2o_httpclient__h3_conn_t *conn)
     if (conn->getaddr_req != NULL)
         h2o_hostinfo_getaddr_cancel(conn->getaddr_req);
     h2o_timer_unlink(&conn->timeout);
-    free(conn->server.origin_url.host.base);
     free(conn->server.origin_url.authority.base);
+    free(conn->server.origin_url.host.base);
     free(conn->handshake_properties.client.session_ticket.base);
     h2o_http3_dispose_conn(&conn->super);
     free(conn);
@@ -254,15 +253,20 @@ Fail:
 struct st_h2o_httpclient__h3_conn_t *create_connection(h2o_httpclient_ctx_t *ctx, h2o_httpclient_connection_pool_t *pool,
                                                        h2o_url_t *origin)
 {
+    /* FIXME When using a non-global socket pool, let the socket pool load balance H3 connections among the list of targets being
+     * available. But until then, we use the first entry. */
+    if (!h2o_socketpool_is_global(pool->socketpool))
+        origin = &pool->socketpool->targets.entries[0]->url;
+
     static const h2o_http3_conn_callbacks_t callbacks = {{(void *)destroy_connection}, handle_control_stream_frame};
     static const h2o_http3_qpack_context_t qpack_ctx = {0 /* TODO */};
+
     struct st_h2o_httpclient__h3_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
     h2o_http3_init_conn(&conn->super, ctx->http3.ctx, &callbacks, &qpack_ctx);
     memset((char *)conn + sizeof(conn->super), 0, sizeof(*conn) - sizeof(conn->super));
     conn->ctx = ctx;
-    conn->server.origin_url = (h2o_url_t){origin->scheme, h2o_strdup(NULL, origin->authority.base, origin->authority.len),
-                                          h2o_strdup(NULL, origin->host.base, origin->host.len)};
+    h2o_url_copy(NULL, &conn->server.origin_url, origin);
     sprintf(conn->server.named_serv, "%" PRIu16, h2o_url_get_port(origin));
     conn->handshake_properties.client.negotiated_protocols.list = h2o_http3_alpn;
     conn->handshake_properties.client.negotiated_protocols.count = sizeof(h2o_http3_alpn) / sizeof(h2o_http3_alpn[0]);
@@ -713,7 +717,7 @@ void h2o_httpclient__connect_h3(h2o_httpclient_t **_client, h2o_mem_pool_t *pool
     struct st_h2o_httpclient__h3_conn_t *conn;
     struct st_h2o_http3client_req_t *req;
 
-    if ((conn = find_connection(connpool, target->scheme, target->authority)) == NULL)
+    if ((conn = find_connection(connpool, target)) == NULL)
         conn = create_connection(ctx, connpool, target);
 
     req = h2o_mem_alloc(sizeof(*req));

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -741,6 +741,9 @@ void h2o_httpclient__connect_h3(h2o_httpclient_t **_client, h2o_mem_pool_t *pool
     h2o_buffer_init(&req->recvbuf.body, &h2o_socket_buffer_prototype);
     h2o_buffer_init(&req->recvbuf.stream, &h2o_socket_buffer_prototype);
 
+    if (_client != NULL)
+        *_client = &req->super;
+
     if (h2o_http3_has_received_settings(&conn->super)) {
         start_request(req);
         h2o_quic_schedule_timer(&conn->super.super);

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -725,6 +725,7 @@ static struct rp_generator_t *proxy_send_prepare(h2o_req_t *req)
     self->super.proceed = do_proceed;
     self->super.stop = do_stop;
     self->src_req = req;
+    self->client = NULL; /* when connection establish timeouts, self->client remains unset by `h2o_httpclient_connect` */
     if (client_ctx->websocket_timeout != NULL && h2o_lcstris(req->upgrade.base, req->upgrade.len, H2O_STRLIT("websocket"))) {
         self->is_websocket_handshake = 1;
     } else {

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -69,7 +69,7 @@ static h2o_http3client_ctx_t *create_http3_context(h2o_loop_t *loop)
 
     h2o_http3client_ctx_t *h3ctx = h2o_mem_alloc(sizeof(*h3ctx));
 
-    /* tls */
+    /* tls (FIXME provide knobs to configure, incl. certificate validation) */
     h3ctx->tls = (ptls_context_t){
         .random_bytes = ptls_openssl_random_bytes,
         .get_time = &ptls_get_time,
@@ -103,7 +103,7 @@ static h2o_http3client_ctx_t *create_http3_context(h2o_loop_t *loop)
     h2o_socket_t *sock = h2o_evloop_socket_create(loop, sockfd, H2O_SOCKET_FLAG_DONT_READ);
     h2o_quic_init_context(&h3ctx->h3, loop, sock, &h3ctx->quic, NULL, h2o_httpclient_http3_notify_connection_update);
 
-    h3ctx->load_session = NULL;
+    h3ctx->load_session = NULL; /* TODO reuse session? */
 
     return h3ctx;
 #endif

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -20,6 +20,8 @@
  * IN THE SOFTWARE.
  */
 #include <sys/un.h>
+#include "picotls.h"
+#include "picotls/openssl.h"
 #include "h2o.h"
 #include "h2o/socketpool.h"
 #include "h2o/balancer.h"
@@ -56,6 +58,62 @@ static int on_req(h2o_handler_t *_self, h2o_req_t *req)
     h2o_reprocess_request(req, req->method, req->scheme, req->authority, path, overrides, 0);
 
     return 0;
+}
+
+static h2o_http3client_ctx_t *create_http3_context(h2o_loop_t *loop)
+{
+#if H2O_USE_LIBUV
+    fprintf(stderr, "no HTTP/3 support for libuv\n");
+    abort();
+#else
+
+    h2o_http3client_ctx_t *h3ctx = h2o_mem_alloc(sizeof(*h3ctx));
+
+    /* tls */
+    h3ctx->tls = (ptls_context_t){
+        .random_bytes = ptls_openssl_random_bytes,
+        .get_time = &ptls_get_time,
+        .key_exchanges = ptls_openssl_key_exchanges,
+        .cipher_suites = ptls_openssl_cipher_suites,
+    };
+    quicly_amend_ptls_context(&h3ctx->tls);
+
+    /* quic */
+    h3ctx->quic = quicly_spec_context;
+    h3ctx->quic.tls = &h3ctx->tls;
+    h3ctx->quic.transport_params.max_streams_uni = 10;
+    uint8_t cid_key[PTLS_SHA256_DIGEST_SIZE];
+    ptls_openssl_random_bytes(cid_key, sizeof(cid_key));
+    h3ctx->quic.cid_encryptor = quicly_new_default_cid_encryptor(&ptls_openssl_bfecb, &ptls_openssl_aes128ecb, &ptls_openssl_sha256,
+                                                                 ptls_iovec_init(cid_key, sizeof(cid_key)));
+    ptls_clear_memory(cid_key, sizeof(cid_key));
+    h3ctx->quic.stream_open = &h2o_httpclient_http3_on_stream_open;
+
+    /* http3 */
+    int sockfd;
+    if ((sockfd = socket(PF_INET, SOCK_DGRAM, 0)) < 0) {
+        perror("failed to open UDP socket");
+        abort();
+    }
+    struct sockaddr_in sin = {};
+    if (bind(sockfd, (struct sockaddr *)&sin, sizeof(sin)) != 0) {
+        perror("failed to bind default address to UDP socket");
+        abort();
+    }
+    h2o_socket_t *sock = h2o_evloop_socket_create(loop, sockfd, H2O_SOCKET_FLAG_DONT_READ);
+    h2o_quic_init_context(&h3ctx->h3, loop, sock, &h3ctx->quic, NULL, h2o_httpclient_http3_notify_connection_update);
+
+    h3ctx->load_session = NULL;
+
+    return h3ctx;
+#endif
+}
+
+static void destroy_http3_context(h2o_http3client_ctx_t *h3ctx)
+{
+    h2o_quic_dispose_context(&h3ctx->h3);
+    quicly_free_default_cid_encryptor(h3ctx->quic.cid_encryptor);
+    free(h3ctx);
 }
 
 static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
@@ -96,6 +154,12 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
     client_ctx->max_buffer_size = self->config.max_buffer_size;
     client_ctx->protocol_selector = (struct st_h2o_httpclient_protocol_selector_t){.ratio = self->config.protocol_ratio};
 
+    client_ctx->http2.latency_optimization =
+        ctx->globalconf->http2.latency_optimization; /* TODO provide config knob, or disable? */
+    client_ctx->http2.max_concurrent_streams = self->config.http2.max_concurrent_strams;
+
+    client_ctx->http3 = client_ctx->protocol_selector.ratio.http3 != 0 ? create_http3_context(ctx->loop) : NULL;
+
     handler_ctx->client_ctx = client_ctx;
 }
 
@@ -104,8 +168,11 @@ static void on_context_dispose(h2o_handler_t *_self, h2o_context_t *ctx)
     struct rp_handler_t *self = (void *)_self;
     struct rp_handler_context_t *handler_ctx = h2o_context_get_handler_context(ctx, &self->super);
 
-    if (handler_ctx->client_ctx != NULL)
+    if (handler_ctx->client_ctx != NULL) {
+        if (handler_ctx->client_ctx->http3 != NULL)
+            destroy_http3_context(handler_ctx->client_ctx->http3);
         free(handler_ctx->client_ctx);
+    }
 
     h2o_socketpool_unregister_loop(self->sockpool, ctx->loop);
 }

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -94,8 +94,7 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
     }
 
     client_ctx->max_buffer_size = self->config.max_buffer_size;
-    client_ctx->protocol_selector =
-        (struct st_h2o_httpclient_protocol_selector_t){.ratio = {.http2 = self->config.protocol_ratio.http2}};
+    client_ctx->protocol_selector = (struct st_h2o_httpclient_protocol_selector_t){.ratio = self->config.protocol_ratio};
 
     handler_ctx->client_ctx = client_ctx;
 }

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -70,16 +70,14 @@ static const ptls_key_exchange_algorithm_t *h3_key_exchanges[] = {
     &ptls_openssl_x25519,
 #endif
     &ptls_openssl_secp256r1, NULL};
-static struct {
-    ptls_context_t tls;
-    quicly_context_t quic;
-    h2o_quic_ctx_t h3;
-} h3ctx = {{.random_bytes = ptls_openssl_random_bytes,
+static h2o_http3client_ctx_t h3ctx = {
+    .tls = {.random_bytes = ptls_openssl_random_bytes,
             .get_time = &ptls_get_time,
             .key_exchanges = h3_key_exchanges,
             .cipher_suites = ptls_openssl_cipher_suites,
             .save_ticket = &save_http3_ticket,
-            .omit_end_of_early_data = 1}};
+    },
+};
 
 static h2o_httpclient_head_cb on_connect(h2o_httpclient_t *client, const char *errstr, h2o_iovec_t *method, h2o_url_t *url,
                                          const h2o_header_t **headers, size_t *num_headers, h2o_iovec_t *body,
@@ -419,7 +417,7 @@ int main(int argc, char **argv)
         .first_byte_timeout = IO_TIMEOUT,
         .keepalive_timeout = IO_TIMEOUT,
         .max_buffer_size = H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE * 2,
-        .http3 = {.load_session = load_http3_session},
+        .http3 = &h3ctx,
     };
     int opt;
 
@@ -440,7 +438,7 @@ int main(int argc, char **argv)
         ptls_clear_memory(random_key, sizeof(random_key));
     }
     h3ctx.quic.stream_open = &h2o_httpclient_http3_on_stream_open;
-    ctx.http3.ctx = &h3ctx.h3;
+    h3ctx.load_session = load_http3_session;
 
 #if H2O_USE_LIBUV
     ctx.loop = uv_loop_new();
@@ -620,9 +618,9 @@ int main(int argc, char **argv)
 #endif
     }
 
-    if (ctx.http3.ctx != NULL) {
-        h2o_quic_close_all_connections(ctx.http3.ctx);
-        while (h2o_quic_num_connections(ctx.http3.ctx) != 0) {
+    if (ctx.http3 != NULL) {
+        h2o_quic_close_all_connections(&ctx.http3->h3);
+        while (h2o_quic_num_connections(&ctx.http3->h3) != 0) {
 #if H2O_USE_LIBUV
             uv_run(ctx.loop, UV_RUN_ONCE);
 #else


### PR DESCRIPTION
#2524 streamlined the httpclient API so that the reverse proxy handler could use HTTP/3 to the backend. But we do not have tests, nor was it ever used. Therefore, unsurprisingly, it did not work.

This PR makes it work at least, even if there aren't tests (yet).

Some things that are still missing:
* No tests yet.
* HTTP/3 client implementation does not validate the certificate chain or SNI.
* H3 reverse proxy does not use the load balancing mechanisms provided by the socket pool.

This PR also addresses bugs in the reverse proxy H2 initialization code. Up until now, it failed to initialize `client_ctx->http2.latency_optimization` and `client_ctx->http2.max_concurrent_streams`.