### PR TITLE
[h2olog] dump unknown types by their addresses

### DIFF
--- a/src/h2olog/json.cc
+++ b/src/h2olog/json.cc
@@ -149,3 +149,10 @@ void json_write_pair_c(FILE *out, const char *name, size_t name_len, const h2olo
 
     fputc('"', out);
 }
+
+void json_write_pair_c(FILE *out, const char *name, size_t name_len, const void *value)
+{
+    fputc(',', out);
+    json_write_name_value(out, name, name_len);
+    fprintf(out, "0x%" PRIx64, (uint64_t)value);
+}

--- a/src/h2olog/json.h
+++ b/src/h2olog/json.h
@@ -16,5 +16,6 @@ void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const 
 void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const std::int32_t value);
 void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const std::uint32_t value);
 void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const h2olog_address_t &value);
+void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const void *value);
 
 #endif


### PR DESCRIPTION
This is useful for tracking objects that can be identified by their addresses (e.g., events that happen with same `h2o_socket_t *`).