### PR TITLE
[h2olog] define how generated_raw_tracer.cc is generated in regen.mk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -929,17 +929,10 @@ IF (WITH_H2OLOG)
         "include/h2o/version.h"
     )
 
-    SET(H2OLOG_GEN_DEPS
-        "h2o-probes.d"
-        "deps/quicly/quicly-probes.d"
-        "deps/quicly/include/quicly.h"
-    )
-
     ADD_CUSTOM_COMMAND(
         OUTPUT  "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/generated_raw_tracer.cc"
         COMMAND make -f misc/regen.mk src/h2olog/generated_raw_tracer.cc
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDS ${H2OLOG_GEN_DEPS} "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/misc/gen_raw_tracer.py"
     )
     LIST(APPEND H2OLOG_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/generated_raw_tracer.cc")
     LINK_DIRECTORIES("${LIBBCC_LIBRARY_DIRS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -937,7 +937,7 @@ IF (WITH_H2OLOG)
 
     ADD_CUSTOM_COMMAND(
         OUTPUT  "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/generated_raw_tracer.cc"
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/misc/gen_raw_tracer.py" "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/generated_raw_tracer.cc"
+        COMMAND make -f misc/regen.mk src/h2olog/generated_raw_tracer.cc
         DEPENDS ${H2OLOG_GEN_DEPS} "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/misc/gen_raw_tracer.py"
     )
     LIST(APPEND H2OLOG_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/generated_raw_tracer.cc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -938,6 +938,7 @@ IF (WITH_H2OLOG)
     ADD_CUSTOM_COMMAND(
         OUTPUT  "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/generated_raw_tracer.cc"
         COMMAND make -f misc/regen.mk src/h2olog/generated_raw_tracer.cc
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         DEPENDS ${H2OLOG_GEN_DEPS} "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/misc/gen_raw_tracer.py"
     )
     LIST(APPEND H2OLOG_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/generated_raw_tracer.cc")

--- a/misc/regen.mk
+++ b/misc/regen.mk
@@ -27,7 +27,6 @@ lib/handler/file/templates.c.h: misc/picotemplate-conf.pl lib/handler/file/_temp
 	misc/picotemplate/picotemplate.pl --conf misc/picotemplate-conf.pl lib/handler/file/_templates.c.h || exit 1
 	clang-format -i $@
 
-
 src/h2olog/generated_raw_tracer.cc: src/h2olog/misc/gen_raw_tracer.py h2o-probes.d deps/quicly/quicly-probes.d deps/quicly/include/quicly.h
 	src/h2olog/misc/gen_raw_tracer.py . $@
 

--- a/misc/regen.mk
+++ b/misc/regen.mk
@@ -5,7 +5,7 @@ exec $${H2O_PERL:-perl} -x $$0 "$$@"
 endef
 export FATPACK_SHEBANG
 
-all: tokens lib/handler/mruby/embedded.c.h lib/http2/hpack_huffman_table.h lib/handler/file/templates.c.h clang-format-all share/h2o/start_server share/h2o/fastcgi-cgi share/h2o/ca-bundle.crt
+all: tokens lib/handler/mruby/embedded.c.h lib/http2/hpack_huffman_table.h lib/handler/file/templates.c.h clang-format-all share/h2o/start_server share/h2o/fastcgi-cgi share/h2o/ca-bundle.crt src/h2olog/generated_raw_tracer.cc
 
 tokens:
 	misc/tokens.pl
@@ -26,6 +26,9 @@ lib/http2/hpack_huffman_table.h: misc/mkhufftbl.py
 lib/handler/file/templates.c.h: misc/picotemplate-conf.pl lib/handler/file/_templates.c.h
 	misc/picotemplate/picotemplate.pl --conf misc/picotemplate-conf.pl lib/handler/file/_templates.c.h || exit 1
 	clang-format -i $@
+
+src/h2olog/generated_raw_tracer.cc: FORCE
+	src/h2olog/misc/gen_raw_tracer.py . $@
 
 clang-format-all:
 	misc/clang-format-all.sh

--- a/misc/regen.mk
+++ b/misc/regen.mk
@@ -27,7 +27,8 @@ lib/handler/file/templates.c.h: misc/picotemplate-conf.pl lib/handler/file/_temp
 	misc/picotemplate/picotemplate.pl --conf misc/picotemplate-conf.pl lib/handler/file/_templates.c.h || exit 1
 	clang-format -i $@
 
-src/h2olog/generated_raw_tracer.cc: FORCE
+
+src/h2olog/generated_raw_tracer.cc: src/h2olog/misc/gen_raw_tracer.py h2o-probes.d deps/quicly/quicly-probes.d deps/quicly/include/quicly.h
 	src/h2olog/misc/gen_raw_tracer.py . $@
 
 clang-format-all:


### PR DESCRIPTION
To follow the code generation manner in h2o.

* [x] checked if it works on macOS
* [x] checked if it works on Ubuntu