### PR TITLE
[http1] respect the authority part of the absolute form

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -469,7 +469,7 @@ static const char *fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_he
             h2o_url_t url;
             if (h2o_url_parse(conn->req.input.path.base, conn->req.input.path.len, &url) == 0) {
                 conn->req.input.path = url.path;
-                host = conn->req.authority;
+                host = url.authority; /* authority part of the absolute form overrides the host header field (RFC 7230 S5.4) */
             }
         }
         /* move host header to req->authority */

--- a/t/50http1-proxy-full-uri.t
+++ b/t/50http1-proxy-full-uri.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $upstream_port = empty_port();
+
+my $guard = spawn_server(
+    argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), "127.0.0.1:$upstream_port", ASSETS_DIR . "/upstream.psgi" ],
+    is_ready =>  sub {
+        check_port($upstream_port);
+    },
+);
+
+sub doit {
+    my $preserve = shift;
+    my $hostname = shift;
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1.xip.io:$upstream_port
+        proxy.preserve-host: $preserve
+EOT
+    my $port = $server->{port};
+    if ($preserve eq "OFF") {
+        $port = $upstream_port;
+    }
+
+    my $curl = 'curl --silent -v --dump-header /dev/stderr';
+    my ($headers, $body) = run_prog("$curl "
+        . " --request-target 'http://127.0.0.1:@{[$server->{port}]}/echo-headers' "
+        . " --header 'Host: 127.0.0.1:@{[$server->{port}]}' "
+        . " http://127.0.0.1:@{[$server->{port}]}/echo-headers");
+
+    like $body, qr/^host: 127.0.0.1$hostname:$port/mi, 'host header is the expected one';
+}
+
+doit("ON", "");
+doit("OFF", ".xip.io");
+
+
+done_testing();


### PR DESCRIPTION
I think this is a bug that was introduce unintentionally as part of #1941. 