### PR TITLE
[http1] fix error when handling a pipelined request following a chunked request

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -1270,6 +1270,7 @@
 		E9CD04281F8F1D7500524877 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		E9CD04291F8F1D7F00524877 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E9CD042A1F8F1D8A00524877 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		E9D4978E25E49FCA00F4A80D /* 40http1-pipeline.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http1-pipeline.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9DF012724E4CDEE0002EEC7 /* cc-cubic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cc-cubic.c"; sourceTree = "<group>"; };
 		E9E50472214A5B8A004DC170 /* http3client.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = http3client.c; sourceTree = "<group>"; };
 		E9E50475214B3D28004DC170 /* http3_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = http3_common.h; sourceTree = "<group>"; };
@@ -2101,6 +2102,7 @@
 				E9AFBF17212A9802000F5DB8 /* 40chunked.t */,
 				104CD5021CC465AF0057C62F /* 40env.t */,
 				E9414F9424ED1D7500273C59 /* 40error-log-escape.t */,
+				E9D4978E25E49FCA00F4A80D /* 40http1-pipeline.t */,
 				E9414F9924ED1D7500273C59 /* 40http1-timeouts.t */,
 				E9414F9724ED1D7500273C59 /* 40http2-h2spec-client.t */,
 				E9F677CA1FF47BD0006476D3 /* 40http2-h2spec.t */,

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -267,12 +267,11 @@ static void handle_one_body_fragment(struct st_h2o_http1_conn_t *conn, size_t fr
 static void handle_chunked_entity_read(struct st_h2o_http1_conn_t *conn)
 {
     struct st_h2o_http1_chunked_entity_reader *reader = (void *)conn->_req_entity_reader;
-    size_t bufsz, consume;
+    size_t bufsz;
     ssize_t ret;
-    int complete = 1;
 
     /* decode the incoming data */
-    if ((consume = bufsz = conn->sock->input->size) == 0)
+    if ((bufsz = conn->sock->input->size) == 0)
         return;
     ret = phr_decode_chunked(&reader->decoder, conn->sock->input->bytes, &bufsz);
     if (ret != -1 && bufsz + conn->req.req_body_bytes_received >= conn->super.ctx->globalconf->max_request_entity_size) {
@@ -282,17 +281,17 @@ static void handle_chunked_entity_read(struct st_h2o_http1_conn_t *conn)
     if (ret < 0) {
         if (ret == -2) {
             /* incomplete */
-            complete = 0;
-            goto Done;
+            handle_one_body_fragment(conn, bufsz, conn->sock->input->size - bufsz, 0);
+        } else {
+            /* error */
+            entity_read_send_error_400(conn, "Invalid Request", "broken chunked-encoding");
         }
-        /* error */
-        entity_read_send_error_400(conn, "Invalid Request", "broken chunked-encoding");
-        return;
+    } else {
+        /* complete */
+        assert(bufsz + ret <= conn->sock->input->size);
+        conn->sock->input->size = bufsz + ret;
+        handle_one_body_fragment(conn, bufsz, 0, 1);
     }
-    /* complete */
-    consume -= ret;
-Done:
-    handle_one_body_fragment(conn, bufsz, consume - bufsz, complete);
 }
 
 static int create_chunked_entity_reader(struct st_h2o_http1_conn_t *conn)

--- a/t/40http1-pipeline.t
+++ b/t/40http1-pipeline.t
@@ -1,0 +1,74 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        file.dir: @{[ DOC_ROOT ]}
+EOT
+
+subtest "2 gets" => sub {
+    my $resp = send_and_receive(<<"EOT");
+GET / HTTP/1.1\r
+Host: 127.0.0.1:$server->{port}\r
+\r
+GET / HTTP/1.1\r
+Host: 127.0.0.1:$server->{port}\r
+Connection: close\r
+\r
+EOT
+    like $resp, qr{^HTTP/1.1 200 OK\r\n.*HTTP/1.1 200 OK\r\n.*}s;
+};
+
+subtest "post(content-lenth) and get" => sub {
+    my $resp = send_and_receive(<<"EOT");
+POST / HTTP/1.1\r
+Host: 127.0.0.1:$server->{port}\r
+Content-Length: 5\r
+\r
+abc\r
+GET / HTTP/1.1\r
+Host: 127.0.0.1:$server->{port}\r
+Connection: close\r
+\r
+EOT
+    like $resp, qr{^HTTP/1.1 405 Method Not Allowed\r\n.*HTTP/1.1 200 OK\r\n.*}s;
+};
+
+subtest "post(chunked) and get" => sub {
+    my $resp = send_and_receive(<<"EOT");
+POST / HTTP/1.1\r
+Host: 127.0.0.1:$server->{port}\r
+Transfer-Encoding: chunked\r
+\r
+5\r
+abc\r
+\r
+0\r
+\r
+GET / HTTP/1.1\r
+Host: 127.0.0.1:$server->{port}\r
+Connection: close\r
+\r
+EOT
+    like $resp, qr{^HTTP/1.1 405 Method Not Allowed\r\n.*HTTP/1.1 200 OK\r\n.*}s;
+};
+
+done_testing;
+
+sub send_and_receive {
+    my $req = shift;
+    my $sock = IO::Socket::INET->new(
+        PeerAddr => "127.0.0.1:$server->{port}",
+        Proto    => "tcp",
+    ) or die "connection failed:$!";
+    syswrite($sock, $req) == length($req) or die "syswrite failed:$!";
+    my $resp = '';
+    while (sysread($sock, $resp, 65536, length($resp)) != 0) {}
+    $resp;
+}
+


### PR DESCRIPTION
When `phr_decode_chunked` concludes the processing of a chunked request body, it moves the input that followed the chunked-encoded request body to immediately after the decoded bytes. However, lib/http1.c assumes that the remaining bytes would not be moved.

That has caused h2o to process unexpected input as the next request.

This PR addresses the problem. In relation, the behavior of `phr_decode_chunked` is clarified in https://github.com/h2o/picohttpparser/pull/72.