### PR TITLE
[http1client] don't invoke `proceed_req` synchronously

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -1271,6 +1271,7 @@
 		E9CD04291F8F1D7F00524877 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		E9CD042A1F8F1D8A00524877 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		E9D4978E25E49FCA00F4A80D /* 40http1-pipeline.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http1-pipeline.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9D497C625E4DE1E00F4A80D /* 80chunked.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 80chunked.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9DF012724E4CDEE0002EEC7 /* cc-cubic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cc-cubic.c"; sourceTree = "<group>"; };
 		E9E50472214A5B8A004DC170 /* http3client.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = http3client.c; sourceTree = "<group>"; };
 		E9E50475214B3D28004DC170 /* http3_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = http3_common.h; sourceTree = "<group>"; };
@@ -2218,6 +2219,7 @@
 				E9AFBF1C212A9814000F5DB8 /* 50unexpected-upstream-body.t */,
 				E9AFBF27212A985D000F5DB8 /* 50zero-sized-streaming-body.t */,
 				E9F677D32004CCCA006476D3 /* 50zero-sized-timeout.t */,
+				E9D497C625E4DE1E00F4A80D /* 80chunked.t */,
 				109EEFE11D77B350001F11D1 /* 80dup-host-headers.t */,
 				E9BC76C51EE4AB6C00EB7A09 /* 80graceful-shutdown.t */,
 				E9AFBF2C212A985E000F5DB8 /* 80http2-idle-timeout-for-zero-window.t */,

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -574,12 +574,6 @@ static int do_write_req(h2o_httpclient_t *_client, h2o_iovec_t chunk, int is_end
 
     swap_buffers(&client->_body_buf, &client->_body_buf_in_flight);
 
-    if (client->_body_buf_in_flight->size == 0) {
-        /* return immediately if the chunk is empty */
-        on_req_body_done(client->sock, NULL);
-        return 0;
-    }
-
     h2o_timer_unlink(&client->super._timeout);
 
     h2o_iovec_t iov = h2o_iovec_init(client->_body_buf_in_flight->bytes, client->_body_buf_in_flight->size);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -622,7 +622,6 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
     size_t i;
     uint64_t prev_bytes_written = sock->bytes_written;
 
-    assert(bufcnt > 0);
     for (i = 0; i != bufcnt; ++i) {
         sock->bytes_written += bufs[i].len;
 #if H2O_SOCKET_DUMP_WRITE

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -532,6 +532,7 @@ static void proceed_request(h2o_req_t *req, size_t written, h2o_send_state_t sen
         return;
     }
 
+    assert(send_state == H2O_SEND_STATE_IN_PROGRESS);
     set_req_timeout(conn, conn->super.ctx->globalconf->http1.req_timeout, reqread_on_timeout);
     set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, req_io_on_timeout);
     h2o_socket_read_start(conn->sock, reqread_on_read);

--- a/t/80chunked.t
+++ b/t/80chunked.t
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+use IO::Socket::INET;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use Time::HiRes qw(sleep);
+use t::Util;
+
+subtest "reverse-proxy" => sub {
+    # spawn upstream psgi
+    plan skip_all => 'Starlet not found'
+        unless system 'perl -MStarlet /dev/null > /dev/null 2>&1' == 0;
+    my $upstream_port = empty_port();
+    my $upstream = spawn_server(
+        argv     => [qw(plackup -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port", "t/assets/upstream.psgi"],
+        is_ready => sub {
+            check_port($upstream_port);
+        },
+    );
+    # spawn h2o
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+    # connect, send, fetch response
+    my $resp = send_and_receive($server->{port});
+    like $resp, qr{^HTTP/1\.1 404 Not Found\r\n.*HTTP/1\.1 404 Not Found\r\n}s;
+};
+
+done_testing;
+
+sub send_and_receive {
+    my $server_port = shift;
+    my $sock = IO::Socket::INET->new(
+        PeerAddr => "127.0.0.1:$server_port",
+        Proto    => "tcp",
+    ) or die "connection failed:$!";
+    my $msg = <<"EOT";
+POST / HTTP/1.1\r
+Transfer-Encoding: chunked\r
+\r
+5\r
+abcde\r
+EOT
+    syswrite($sock, $msg) == length($msg)
+        or die "failed to send data:$!";
+    sleep 1;
+    $msg = <<"EOT";
+0\r
+\r
+GET / HTTP/1.0\r
+\r
+EOT
+    syswrite($sock, $msg) == length($msg)
+        or die "failed to send data:$!";
+    my $resp = '';
+    while (sysread($sock, $resp, 65536, length($resp)) != 0) {}
+    $resp;
+}

--- a/t/80chunked.t
+++ b/t/80chunked.t
@@ -9,7 +9,7 @@ use t::Util;
 subtest "reverse-proxy" => sub {
     # spawn upstream psgi
     plan skip_all => 'Starlet not found'
-        unless system 'perl -MStarlet /dev/null > /dev/null 2>&1' == 0;
+        unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
     my $upstream_port = empty_port();
     my $upstream = spawn_server(
         argv     => [qw(plackup -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port", "t/assets/upstream.psgi"],


### PR DESCRIPTION
When the request body is being closed without any additional data, and if the request body has been streamed, protocol handlers call `write_req.cb` with zero-length data. In response, http1client invokes `proceed_req` synchronously when a zero-byte chunk is being provided as part of request body streaming.

However, such behavior is unexpected on the caller side. To give an example, `proceed_request` of http1.c starts reading from the socket even after all the request body has been read. This is rather nasty, though the condition eventually gets fixed as the calls return.

This PR makes sure that `proceed_req` is called asynchronously.