### PR TITLE
suppress ubsan warning

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2618,6 +2618,7 @@ Exit:
         /* revert the changes to the connection counts */
         num_connections(-1);
         num_quic_connections(-1);
+        return NULL;
     }
     return &conn->super;
 }


### PR DESCRIPTION
it can touches `&conn->super` in the following line even if `conn == NULL`, which causes UBSAN warnings like 

```
runtime error: member access within null pointer of type 'h2o_http3_conn_t' (aka 'struct st_h2o_http3_conn_t')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/main.c:3256:19 in
```