### PR TITLE
qlog-adapter.py: add -l to list USDT probes used in the script

### DIFF
--- a/deps/quicly/misc/qlog-adapter.py
+++ b/deps/quicly/misc/qlog-adapter.py
@@ -22,6 +22,7 @@
 
 import sys
 import json
+import getopt
 
 PACKET_LABELS = ["initial", "0rtt", "handshake", "1rtt"]
 
@@ -328,7 +329,10 @@ FRAME_EVENT_HANDLERS = {
 def usage():
     print(r"""
 Usage:
-    python qlog-adapter.py inTrace.jsonl
+    qlog-adapter.py inTrace.jsonl
+
+    -l Prints list of USDT probes to be used and exit
+    -h Prints this help and exit
 """.strip())
 
 def load_quicly_events(infile):
@@ -338,12 +342,29 @@ def load_quicly_events(infile):
             events.append(json.loads(line))
     return events
 
+def list_events():
+    for name in [
+        *sorted(QLOG_EVENT_HANDLERS.keys()),
+        *sorted(FRAME_EVENT_HANDLERS.keys()),
+    ]:
+        print(name)
+
 def main():
-    if len(sys.argv) != 2:
+    opts, args = getopt.getopt(sys.argv[1:], "hl")
+
+    for opt, arg in opts:
+        if opt == "-h":
+            usage()
+            sys.exit(0)
+        if opt == "-l":
+            list_events()
+            sys.exit(0)
+
+    if len(args) != 1:
         usage()
         sys.exit(1)
 
-    (_, infile) = sys.argv
+    (infile,) = args
     source_events = load_quicly_events(infile)
     print(json.dumps({
         "qlog_format": "NDJSON",


### PR DESCRIPTION
I'd like to have a way to list probe names used in qlog-adapter.py to build h2olog args gathering only QLog stuff, like this:

```
deps/quicly/misc/qlog-adapter.py -l | perl -E 'say join "", map { chomp; s/-/_/;  qq{-t "*:$_" \\\n} } <STDIN>;'
```

Output:

```
-t "*:packet_lost" \
-t "*:packet_received" \
-t "*:packet_sent" \
-t "*:ack_send" \
-t "*:data_blocked-receive" \
-t "*:data_blocked-send" \
-t "*:handshake_done-receive" \
-t "*:handshake_done-send" \
-t "*:max_data-receive" \
-t "*:max_data-send" \
-t "*:max_stream-data-receive" \
-t "*:max_stream-data-send" \
-t "*:max_streams-send" \
-t "*:new_connection-id-receive" \
-t "*:new_connection-id-send" \
-t "*:new_token-receive" \
-t "*:new_token-send" \
-t "*:ping_receive" \
-t "*:retire_connection-id-receive" \
-t "*:retire_connection-id-send" \
-t "*:stream_data-blocked-receive" \
-t "*:stream_data-blocked-send" \
-t "*:stream_on-receive-reset" \
-t "*:stream_on-send-stop" \
-t "*:stream_receive" \
-t "*:stream_send" \
-t "*:streams_blocked-receive" \
-t "*:streams_blocked-send" \
-t "*:transport_close-receive" \
-t "*:transport_close-send" \
```