### PR TITLE
[http3] fix mishandling of early response

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -1272,6 +1272,7 @@
 		E9CD042A1F8F1D8A00524877 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		E9D4978E25E49FCA00F4A80D /* 40http1-pipeline.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http1-pipeline.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9D497C625E4DE1E00F4A80D /* 80chunked.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 80chunked.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		E9D498B725EE684500F4A80D /* 50reverse-proxy-h3-early-response.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50reverse-proxy-h3-early-response.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9DF012724E4CDEE0002EEC7 /* cc-cubic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cc-cubic.c"; sourceTree = "<group>"; };
 		E9E50472214A5B8A004DC170 /* http3client.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = http3client.c; sourceTree = "<group>"; };
 		E9E50475214B3D28004DC170 /* http3_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = http3_common.h; sourceTree = "<group>"; };
@@ -2184,6 +2185,7 @@
 				108102151C3DB05100C024CD /* 50reverse-proxy-disconnected-keepalive.t */,
 				E9F677CD1FF62216006476D3 /* 50reverse-proxy-drop-headers.t */,
 				E9414F9624ED1D7500273C59 /* 50reverse-proxy-early-response.t */,
+				E9D498B725EE684500F4A80D /* 50reverse-proxy-h3-early-response.t */,
 				E9414F9124ED1D7400273C59 /* 50reverse-proxy-header-filtering.t */,
 				E9414F9324ED1D7500273C59 /* 50reverse-proxy-http2.t */,
 				10DA969A1CCEF2C200679165 /* 50reverse-proxy-https.t */,

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1232,8 +1232,6 @@ static void do_send(h2o_ostream_t *_ostr, h2o_req_t *_req, h2o_sendvec_t *bufs, 
     stream->proceed_requested = 0;
 
     if (stream->state == H2O_HTTP3_SERVER_STREAM_STATE_SEND_HEADERS) {
-        if (!quicly_recvstate_transfer_complete(&stream->quic->recvstate) && !quicly_stop_requested(stream->quic))
-            quicly_request_stop(stream->quic, H2O_HTTP3_ERROR_EARLY_RESPONSE);
         write_response(stream);
         h2o_probe_log_response(&stream->req, stream->quic->stream_id, NULL);
         set_state(stream, H2O_HTTP3_SERVER_STREAM_STATE_SEND_BODY);

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -374,7 +374,7 @@ static void check_run_blocked(struct st_h2o_http3_server_conn_t *conn)
         request_run_delayed(conn);
 }
 
-static void dispose_request(struct st_h2o_http3_server_stream_t *stream)
+static void pre_dispose_request(struct st_h2o_http3_server_stream_t *stream)
 {
     size_t i;
 
@@ -407,9 +407,6 @@ static void dispose_request(struct st_h2o_http3_server_stream_t *stream)
             h2o_timer_unlink(&stream->tunnel->up.delayed_write);
         free(stream->tunnel);
     }
-
-    /* dispose the request */
-    h2o_dispose_request(&stream->req);
 }
 
 static void set_state(struct st_h2o_http3_server_stream_t *stream, enum h2o_http3_server_stream_state state)
@@ -428,7 +425,7 @@ static void set_state(struct st_h2o_http3_server_stream_t *stream, enum h2o_http
         assert(conn->delayed_streams.recv_body_blocked.prev == &stream->link || !"stream is not registered to the recv_body list?");
         break;
     case H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT: {
-        dispose_request(stream);
+        pre_dispose_request(stream);
         static const quicly_stream_callbacks_t close_wait_callbacks = {on_stream_destroy,
                                                                        quicly_stream_noop_on_send_shift,
                                                                        quicly_stream_noop_on_send_emit,
@@ -620,7 +617,8 @@ void on_stream_destroy(quicly_stream_t *qs, int err)
     if (h2o_linklist_is_linked(&stream->link))
         h2o_linklist_unlink(&stream->link);
     if (stream->state != H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT)
-        dispose_request(stream);
+        pre_dispose_request(stream);
+    h2o_dispose_request(&stream->req);
     free(stream);
 }
 

--- a/t/50reverse-proxy-h3-early-response.t
+++ b/t/50reverse-proxy-h3-early-response.t
@@ -1,0 +1,94 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use Net::EmptyPort qw(empty_port wait_port);
+use File::Temp qw(tempdir);
+use Test::More;
+use Time::HiRes qw(sleep);
+use t::Util;
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+my $client_prog = bindir() . "/h2o-httpclient";
+plan skip_all => "$client_prog not found"
+    unless -e $client_prog;
+plan skip_all => "nc not found"
+    unless prog_exists("nc");
+
+my $up_port = empty_port();
+my $quic_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
+
+
+my $server = spawn_h2o(<< "EOT");
+listen:
+  type: quic
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$up_port
+EOT
+
+# setup upstream server, populating it with response, but still open
+open my $up_resp, '|-', "exec nc -l 127.0.0.1 $up_port > $tempdir/up_req.txt"
+    or die "failed to launch nc:$!";
+$up_resp->autoflush(1);
+print $up_resp "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nhello";
+
+sleep 1;
+
+# open client, sending request body at 12KB/sec. The number is slightly greater than H2O_HTTP3_REQUEST_BODY_MIN_BYTES_TO_BLOCK, and
+# the expectation is that h2o would start streaming the request body
+open my $client_resp, '-|', "$client_prog -3 100 -b 120000 -c 12000 -i 1000 -m POST https://127.0.0.1:$quic_port 2>&1"
+    or die "failed to launch $client_prog:$!";
+
+# wait until the request received by upstream is 3 seconds' worth of data
+for (my $cnt = 0;; ++$cnt) {
+    if ($cnt > 40) {
+        fail "taking too long";
+        done_testing;
+        exit;
+    }
+    if (-e "$tempdir/up_req.txt") {
+        my $up_req_size = (stat "$tempdir/up_req.txt")[7];
+        last if $up_req_size > 12000 * 3;
+    }
+    sleep 0.25;
+}
+
+# kill nc
+undef $up_resp;
+
+subtest "request-received-upstream" => sub {
+    my $up_req = do {
+        open my $fh, "<", "$tempdir/up_req.txt"
+            or die "failed to open $tempdir/up_req.txt:$!";
+        local $/;
+        <$fh>;
+    };
+    my ($headers, $body) = split /\r\n\r\n/, $up_req, 2;
+    like $headers, qr{^POST / HTTP/1\.1\r\n}s;
+    like $headers, qr{^content-length: 120000($|\r\n)}m;
+    like $body, qr{^a+$}s;
+    cmp_ok length($body), '>=', 12000 * 3;
+    cmp_ok length($body), '<', 12000 * 7;
+};
+
+subtest "response" => sub {
+    my $resp = do {
+        local $/;
+        <$client_resp>;
+    };
+    my ($headers, $body) = split /\n\n/, $resp, 2;
+    like $headers, qr{^HTTP/3 200\n}s;
+    is $body, "hello";
+};
+
+done_testing;

--- a/t/50reverse-proxy-h3-early-response.t
+++ b/t/50reverse-proxy-h3-early-response.t
@@ -37,7 +37,7 @@ hosts:
 EOT
 
 # setup upstream server, populating it with response, but still open
-open my $up_resp, '|-', "exec nc -l 127.0.0.1 $up_port > $tempdir/up_req.txt"
+my $up_pid = open my $up_resp, '|-', "exec nc -l 127.0.0.1 $up_port > $tempdir/up_req.txt"
     or die "failed to launch nc:$!";
 $up_resp->autoflush(1);
 print $up_resp "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nhello";
@@ -64,6 +64,7 @@ for (my $cnt = 0;; ++$cnt) {
 }
 
 # kill nc
+kill 'KILL', $up_pid;
 undef $up_resp;
 
 subtest "request-received-upstream" => sub {


### PR DESCRIPTION
When upstream server starts sending a response while request body is inflight, that response is called an early response. Upon observing an early response, h2o should continue forwarding both the request and response until the entire response is being received from upstream. FWIW, the reason why h2o can stop forwarding the request at that moment is because the completion of a response is a sign that the remainder of the request is no longer needed by upstream; see other issues related to early response.

In #2508, we introduced a regression. H3 server has started to refuse receiving request body as soon as it receives the response headers from upstream.

This PR fixes that bug, as well as addressing a crashing bug that has been revealed due to the fixture of that bug.