### PR TITLE
ci: install python3-pyparsing in the ubuntu2004 image to improve dtrace(1)'s behavior

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -32,6 +32,7 @@ RUN apt-get install --yes \
 	pkgconf \
 	python3 \
 	python3-distutils \
+	python3-pyparsing \
 	redis-server \
 	ruby-dev \
 	sudo \


### PR DESCRIPTION
python3-pyparsing is an optional dependency for dtrace(1),
and its pyparsing parser can parse C-style comments in arbitrary tokens (in other words, the default parser cannot parse them).

This is needed in https://github.com/h2o/h2o/pull/2604/files#diff-9702354615a82a6210f8e54015c3d8df39d653917433da83c8c9086b8b8741a2L79

## Refs

* The source code of dtrace written in Python: https://sourceware.org/git/?p=systemtap.git;a=blob;f=dtrace.in;h=aa5f544a8954c3183e281fdcb9e15702669eef16;hb=refs/heads/master
