### PR TITLE
ci: do not use docker caches on building CI images

### DIFF
--- a/misc/docker-ci/build
+++ b/misc/docker-ci/build
@@ -15,6 +15,6 @@ SCRIPT_DIR=$(realpath $(dirname $0))
 cd "$SCRIPT_DIR/docker-root"
 
 for variant  in $@ ; do
-    docker build --tag "${IMAGE_NAME}:${variant}" -f "${SCRIPT_DIR}/Dockerfile.${variant}" .
+    docker build --no-cache --tag "${IMAGE_NAME}:${variant}" -f "${SCRIPT_DIR}/Dockerfile.${variant}" .
     docker push "${IMAGE_NAME}:${variant}"
 done


### PR DESCRIPTION
`docker build` uses caches by default, which may result in build failures.