### PR TITLE
[t/50mruby-error-log.t] set `num-threads` to 1 to avoid race bet. messages emitted from different threads

### DIFF
--- a/t/50mruby-error-log.t
+++ b/t/50mruby-error-log.t
@@ -57,6 +57,7 @@ subtest 'middleware' => sub {
         my ($port, $tls_port) = empty_ports(2, { host => "0.0.0.0" });
         my $empty_port = empty_port();
         my $server = spawn_h2o_raw(<<"EOT", [$port, $tls_port]);
+num-threads: 1
 hosts:
   "127.0.0.1:$port":
     paths: &paths


### PR DESCRIPTION
The test assumes that once the server port becomes open, the only message being emitted to the log is that from the request handler.

However, messages like `h2o server (pid:19023) is ready to serve requests with 2 threads` are also emitted, and depending on the number of worker threads running, that message might appear _after_ the error message from the request handler.

As an example, see https://github.com/h2o/h2o/pull/2520/checks?check_run_id=2020292112.

This PR addresses that race by setting `num-threads` to 1.
