### PR TITLE
Make sure all `bind()` calls are made before calling `setuid()`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3139,8 +3139,8 @@ static void create_per_thread_listeners(void)
 {
     for (size_t i = 0; i != conf.num_listeners; ++i) {
         struct listener_config_t *listener_config = conf.listeners[i];
-
-        for (size_t j = 1; j < conf.thread_map.size; j++) {
+        h2o_vector_reserve(NULL, &listener_config->fds, conf.thread_map.size);
+        while (listener_config->fds.size < conf.thread_map.size) {
             int fd = dup_listener(listener_config->fds.entries[0]);
             h2o_vector_reserve(NULL, &listener_config->fds, listener_config->fds.size + 1);
             assert(j == listener_config->fds.size);

--- a/src/main.c
+++ b/src/main.c
@@ -3142,8 +3142,6 @@ static void create_per_thread_listeners(void)
         h2o_vector_reserve(NULL, &listener_config->fds, conf.thread_map.size);
         while (listener_config->fds.size < conf.thread_map.size) {
             int fd = dup_listener(listener_config->fds.entries[0]);
-            h2o_vector_reserve(NULL, &listener_config->fds, listener_config->fds.size + 1);
-            assert(j == listener_config->fds.size);
             listener_config->fds.entries[listener_config->fds.size++] = fd;
         }
     }

--- a/t/40reuse-port.t
+++ b/t/40reuse-port.t
@@ -17,7 +17,7 @@ hosts:
       "/":
         file.dir: @{[ DOC_ROOT ]}
 EOT
-    my $out = `ss -tlnp sport $server->{port} 2>&1 | sed '1d'`;
+    my $out = `ss -tlnp | grep -w 0.0.0.0:$server->{port} 2>&1`;
     print($out);
     if ($reuseport eq 'ON') {
         my @lines = split(/\n/, $out);

--- a/t/40reuse-port.t
+++ b/t/40reuse-port.t
@@ -22,7 +22,7 @@ hosts:
         file.dir: @{[ DOC_ROOT ]}
 EOT
     print(`ss -tlnp`);
-    my $out = `ss -tlnp | grep -w 0.0.0.0:$server->{port} 2>&1`;
+    my $out = `ss -tlnp | grep -w \*:$server->{port} 2>&1`;
     print($out);
     if ($reuseport eq 'ON') {
         my @lines = split(/\n/, $out);

--- a/t/40reuse-port.t
+++ b/t/40reuse-port.t
@@ -8,9 +8,13 @@ plan skip_all => "ss not found"
 
 sub doit {
     my $reuseport = shift;
-    my $server = spawn_h2o(<< "EOT");
-num-threads: 4
+    my ($port) = empty_ports(1, { host => "0.0.0.0" });
+    my $server = spawn_h2o_raw(<< "EOT", [$port]);
 tcp-reuseport: $reuseport
+listen:
+  host: 0.0.0.0
+  port: $port
+num-threads: 4
 hosts:
   default:
     paths:

--- a/t/40reuse-port.t
+++ b/t/40reuse-port.t
@@ -17,6 +17,7 @@ hosts:
       "/":
         file.dir: @{[ DOC_ROOT ]}
 EOT
+    print(`ss -tlnp`);
     my $out = `ss -tlnp | grep -w 0.0.0.0:$server->{port} 2>&1`;
     print($out);
     if ($reuseport eq 'ON') {

--- a/t/40reuse-port.t
+++ b/t/40reuse-port.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+plan skip_all => "ss not found"
+    unless prog_exists("ss");
+
+sub doit {
+    my $reuseport = shift;
+    my $server = spawn_h2o(<< "EOT");
+num-threads: 4
+tcp-reuseport: $reuseport
+hosts:
+  default:
+    paths:
+      "/":
+        file.dir: @{[ DOC_ROOT ]}
+EOT
+    my $out = `ss -tlnp sport $server->{port} 2>&1 | sed '1d'`;
+    if ($reuseport eq 'ON') {
+        my @lines = split(/\n/, $out);
+        is scalar(@lines), 4, "Found 4 listeners";
+    } else {
+        my @lines = split(/\n/, $out);
+        is scalar(@lines), 1, "Found 1 listener";
+        $out =~ /.*users:(.*)$/;
+        my $u = $1;
+        my @users = split(/,/, $u);
+        is scalar(@users), 12, "Found 4 threads using the same queue, different fds";
+    }
+}
+
+doit('ON');
+doit('OFF');
+done_testing;

--- a/t/40reuse-port.t
+++ b/t/40reuse-port.t
@@ -21,9 +21,7 @@ hosts:
       "/":
         file.dir: @{[ DOC_ROOT ]}
 EOT
-    print(`ss -tlnp`);
     my $out = `ss -tlnp | grep -w \*:$server->{port} 2>&1`;
-    print($out);
     if ($reuseport eq 'ON') {
         my @lines = split(/\n/, $out);
         is scalar(@lines), 4, "Found 4 listeners";

--- a/t/40reuse-port.t
+++ b/t/40reuse-port.t
@@ -18,6 +18,7 @@ hosts:
         file.dir: @{[ DOC_ROOT ]}
 EOT
     my $out = `ss -tlnp sport $server->{port} 2>&1 | sed '1d'`;
+    print($out);
     if ($reuseport eq 'ON') {
         my @lines = split(/\n/, $out);
         is scalar(@lines), 4, "Found 4 listeners";


### PR DESCRIPTION
This is necessary because `bind()` will fail on SO_REUSEPORT listeners if
these binds are made by different uids, from `socket(7)`:

> all of the processes binding to the same address must have the same effective UID.