### PR TITLE
avoid timing issue bet. when response is being received vs. when log is being written

### DIFF
--- a/t/50mruby-error-log.t
+++ b/t/50mruby-error-log.t
@@ -108,6 +108,7 @@ EOT
         my $empty_port = empty_port();
         my ($port, $tls_port) = empty_ports(2, { host => "0.0.0.0" });
         my $server = spawn_h2o_raw(<< "EOT", [$port, $tls_port]);
+num-threads: 1
 hosts:
   "127.0.0.1:$port":
     paths: &paths
@@ -203,6 +204,7 @@ EOT
             });
             my ($port, $tls_port) = empty_ports(2, { host => "0.0.0.0" });
             my $server = spawn_h2o_raw(<< "EOT", [$port, $tls_port]);
+num-threads: 1
 hosts:
   "127.0.0.1:$port":
     paths: &paths

--- a/t/50mruby-error-log.t
+++ b/t/50mruby-error-log.t
@@ -94,6 +94,7 @@ EOT
             my ($headers, $body) = get($proto, $port, $curl, '/');
             like $headers, qr{^HTTP/[0-9.]+ 502}is;
 
+            sleep 1;
             my ($access_logs, $error_logs) = read_logs($access_log_file, $error_log_file);
             note $_ for @$error_logs;
             is scalar(@$access_logs), 1, 'access log count';
@@ -158,6 +159,7 @@ EOT
             my ($headers, $body) = get($proto, $port, $curl, '/');
             like $headers, qr{^HTTP/[0-9.]+ 502}is;
 
+            sleep 1;
             my ($access_logs, $error_logs) = read_logs($access_log_file, $error_log_file);
             note $_ for @$error_logs;
             is scalar(@$access_logs), 1, 'access log count';


### PR DESCRIPTION
fixes CI failures like:
```
t/50mruby-error-log.t ................................ 
# Subtest: middleware
    # Subtest: basic
spawning /home/ci/build/h2o... done
        # Subtest: http/1
[INFO] raised RLIMIT_NOFILE to 1048576
            ok 1
            # h2o server (pid:18753) is ready to serve requests with 1 threads
            # [lib/core/proxy.c] in request:/:connection failure
            not ok 2 - access log count
            ok 3 - error log count
            not ok 4 - access log
            ok 5 - error log
            1..5

            #   Failed test 'access log count'
            #   at t/50mruby-error-log.t line 99.
            #          got: '0'
            #     expected: '1'

            #   Failed test 'access log'
            #   at t/50mruby-error-log.t line 101.
            #          got: undef
            #     expected: '[lib/core/proxy.c] in request:/:connection failure'
            # Looks like you failed 2 tests of 5.
        not ok 1 - http/1
```