### PR TITLE
If instructed, sleep forever when facing a crash, to allow users debug the issue

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -894,7 +894,7 @@
 		10A3D3FA1B4FAAF500327CF9 /* strerror.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = strerror.c; sourceTree = "<group>"; };
 		10A3D3FE1B4FAAF500327CF9 /* yrmcds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yrmcds.h; sourceTree = "<group>"; };
 		10A3D40E1B584BEC00327CF9 /* standalone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = standalone.h; sourceTree = "<group>"; };
-		10A60DE91B0D87FE006E38EC /* annotate-backtrace-symbols */ = {isa = PBXFileReference; lastKnownFileType = text; path = "annotate-backtrace-symbols"; sourceTree = "<group>"; };
+		10A60DE91B0D87FE006E38EC /* annotate-backtrace-symbols */ = {isa = PBXFileReference; lastKnownFileType = text; path = "annotate-backtrace-symbols"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		10AA2E931A80A592004322AC /* time_.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = time_.h; sourceTree = "<group>"; };
 		10AA2E951A80A612004322AC /* time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = time.c; sourceTree = "<group>"; };
 		10AA2E981A81F68A004322AC /* time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = time.c; sourceTree = "<group>"; };

--- a/src/main.c
+++ b/src/main.c
@@ -2187,24 +2187,38 @@ static int popen_crash_handler(void)
     return pipefds[1];
 }
 
-static int crash_handler_fd = -1;
+static struct {
+    int fd;
+    unsigned halt_on_crash : 1;
+} crash_handler = {-1, -1};
 
 static void on_sigfatal(int signo)
 {
-    fprintf(stderr, "received fatal signal %d\n", signo);
+    char buf[256];
+
+    sprintf(buf, "received fatal signal %d\n", signo);
+    write(2, buf, strlen(buf));
 
     h2o_set_signal_handler(signo, SIG_DFL);
 
     void *frames[128];
     int framecnt = backtrace(frames, sizeof(frames) / sizeof(frames[0]));
-    backtrace_symbols_fd(frames, framecnt, crash_handler_fd);
+    backtrace_symbols_fd(frames, framecnt, crash_handler.fd);
 
     if (conf.crash_handler_wait_pipe_close) {
         struct pollfd pfd[1];
-        pfd[0].fd = crash_handler_fd;
+        pfd[0].fd = crash_handler.fd;
         pfd[0].events = POLLERR | POLLHUP;
         while (poll(pfd, 1, -1) == -1 && errno == EINTR)
             ;
+    }
+
+    if (crash_handler.halt_on_crash) {
+        sprintf(buf, "**** pid:%d on halt ****\n", (int)getpid());
+        write(2, buf, strlen(buf));
+        while (1) {
+            sleep(60);
+        }
     }
 
     raise(signo);
@@ -2216,14 +2230,17 @@ static void setup_signal_handlers(void)
 {
     h2o_set_signal_handler(SIGTERM, on_sigterm);
     h2o_set_signal_handler(SIGPIPE, SIG_IGN);
+
 #ifdef LIBC_HAS_BACKTRACE
-    if ((crash_handler_fd = popen_crash_handler()) == -1)
-        crash_handler_fd = 2;
+    if ((crash_handler.fd = popen_crash_handler()) == -1)
+        crash_handler.fd = 2;
     h2o_set_signal_handler(SIGABRT, on_sigfatal);
     h2o_set_signal_handler(SIGBUS, on_sigfatal);
     h2o_set_signal_handler(SIGFPE, on_sigfatal);
     h2o_set_signal_handler(SIGILL, on_sigfatal);
     h2o_set_signal_handler(SIGSEGV, on_sigfatal);
+    if (getenv("H2O_HALT_ON_CRASH") != NULL)
+        crash_handler.halt_on_crash = 1;
 #endif
 }
 


### PR DESCRIPTION
At the moment, when `on_fatal` signal handler is called, h2o dumps the stack trace. After that h2o either:
* immediately raises the captured signal (default), or
* waits for an external process to close the pipe to which d2o is writing the stack trace (see `crash-handler.wait-pipe-close`), then raise the captured signal.

This PR adds a new option, that instructs h2o to, instead of raising the captured signal, sleep forever. This new option can be turned on by setting an environment variable called `H2O_HALT_ON_CRASH`.

The intended use-case is to set this environment variable during development, and connect the debugger to the crashed process.

As an example, it is possible to run `H2O_HALT_ON_CRASH=1 make check`, then if there's a crash while running one of the tests, connect debugger to analyze the cause.

I'm not sure if I like the idea of adding new options to the crash handler, but hopefully we can live with this extra complexity, based on the premise that this feature is going to be considered non-stable and that we might remove it at any given time.