### PR TITLE
[fix] amends #2590; cmake does nothing for a phoney target with no dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -948,7 +948,7 @@ IF (WITH_H2OLOG)
 
     # This phony target is required to force to trigger a custom command.
     # If DEPENDS is empty, the custom command won't be triggered when OUTPUT files exist.
-    ADD_CUSTOM_TARGET(phony_force_trigger_command COMMAND echo -n)
+    ADD_CUSTOM_COMMAND(OUTPUT phony_force_trigger_command COMMAND echo -n)
 
     ADD_CUSTOM_COMMAND(
         OUTPUT  "${CMAKE_CURRENT_SOURCE_DIR}/src/h2olog/generated_raw_tracer.cc"


### PR DESCRIPTION
 amends #2590. 

## How to check the behavior

I'm not sure why I was confident that #2590 worked, but anyway it was wrong, so I've noted how I've tested this PR.

```shell
# git clean -dfx or making a clean worktree
rm -rf build.cmaketest
cmake -Bbuild.cmaketest .
make -Cbuild.cmaketest h2olog

# run it twice
make -Cbuild.cmaketest h2olog
```

And then make sure the following two targets are shown:

```
[ 93%] Generating phony_force_trigger_command
[ 93%] Generating ../src/h2olog/generated_raw_tracer.cc
```



