### PR TITLE
small fixes from pr 2607

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -247,12 +247,12 @@ DECL_ENTITY_READ_SEND_ERROR_XXX(502)
 
 static void handle_one_body_fragment(struct st_h2o_http1_conn_t *conn, size_t fragment_size, size_t extra_bytes, int complete)
 {
-    clear_timeouts(conn);
-
     if (fragment_size == 0 && !complete) {
         h2o_buffer_consume(&conn->sock->input, extra_bytes);
         return;
     }
+
+    clear_timeouts(conn);
 
     h2o_socket_read_stop(conn->sock);
     if (conn->req.write_req.cb(conn->req.write_req.ctx, h2o_iovec_init(conn->sock->input->bytes, fragment_size), complete) != 0) {

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -969,18 +969,18 @@ static void run_delayed(h2o_timer_t *timer)
         while (!h2o_linklist_is_empty(&conn->delayed_streams.req_streaming)) {
             struct st_h2o_http3_server_stream_t *stream =
                 H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_stream_t, link, conn->delayed_streams.req_streaming.next);
+            int is_end_stream = quicly_recvstate_transfer_complete(&stream->quic->recvstate);
             assert(stream->req.process_called);
             assert(stream->req.write_req.cb != NULL);
             assert(stream->req_body != NULL);
-            assert(stream->req_body->size != 0);
+            assert(stream->req_body->size != 0 || is_end_stream);
             assert(!stream->read_blocked);
             h2o_linklist_unlink(&stream->link);
             stream->read_blocked = 1;
             made_progress = 1;
             if (stream->req.write_req.cb(stream->req.write_req.ctx, h2o_iovec_init(stream->req_body->bytes, stream->req_body->size),
-                                         quicly_recvstate_transfer_complete(&stream->quic->recvstate)) != 0) {
+                                         is_end_stream) != 0)
                 shutdown_stream(stream, H2O_HTTP3_ERROR_INTERNAL, H2O_HTTP3_ERROR_INTERNAL, 0);
-            }
         }
 
         /* process the requests (not in streaming mode); TODO cap concurrency? */


### PR DESCRIPTION
This PR cherry-picks two bug fixes from upcoming PR #2607.

Commit 5e0232c fixes a bug in the http1 protocol handler that disarms the idle timer without rearming it, when receiving bytes that consists of only the chunk header of a chunked encoding.
Commit 30cf4e0 fixes a bug in the http3 protocol handler that erroneously raises an assertion failure when receiving FIN at the end of request body without any data being accompanied.