### PR TITLE
Frontend-side tunnel close

### DIFF
--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -88,13 +88,12 @@ static void on_connect(h2o_socket_t *sock, const char *err)
     sock->data = NULL;
     creq->sock = NULL;
     h2o_socket_tunnel_t *tunnel = h2o_socket_tunnel_create(sock);
-
+    /* start the tunnel */
+    h2o_socket_tunnel_start(tunnel, 0);
     /* send response to client */
     creq->src_req->res.status = 200;
     creq->src_req->establish_tunnel(creq->src_req, &tunnel->super, creq->handler->config.io_timeout);
 
-    /* start the tunnel */
-    h2o_socket_tunnel_start(tunnel, 0);
 }
 
 static void on_generator_dispose(void *_self)
@@ -141,10 +140,16 @@ static void on_getaddr(h2o_hostinfo_getaddr_req_t *getaddr_req, const char *errs
         assert(res->ai_socktype == SOCK_DGRAM);
         h2o_tunnel_t *tunnel = h2o_open_udp_tunnel_from_sa(creq->loop, res->ai_addr, res->ai_addrlen);
         h2o_req_t *req = creq->src_req;
-        uint64_t timeout = creq->handler->config.io_timeout;
-        req->res.status = 200;
         h2o_timer_unlink(&creq->timeout);
-        req->establish_tunnel(req, tunnel, timeout);
+        if (tunnel != 0) {
+            uint64_t timeout = creq->handler->config.io_timeout;
+            req->res.status = 200;
+            tunnel->proceed_read(tunnel);
+            req->establish_tunnel(req, tunnel, timeout);
+        } else {
+            h2o_req_log_error(req, "lib/handler/connect.c", "Failed to create downstream socket");
+            h2o_send_error_502(req, "Bad Gateway", "Bad Gateway", 0);
+        }
     }
 }
 

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1452,6 +1452,7 @@ static void establish_tunnel(h2o_req_t *req, h2o_tunnel_t *tunnel, uint64_t idle
     h2o_iovec_t datagram_flow_id = {};
 
     if (stream->tunnel == NULL) {
+        tunnel->destroy(tunnel);
         /* the tunnel has been closed in the meantime */
         return;
     }

--- a/lib/udp_tunnel.c
+++ b/lib/udp_tunnel.c
@@ -176,7 +176,7 @@ static void tunnel_on_write(h2o_tunnel_t *_tunnel, const void *bytes, size_t len
     tunnel->super.on_write_complete(&tunnel->super, NULL);
 }
 
-void tunnel_proceed_read(struct st_h2o_tunnel_t *_tunnel)
+static void tunnel_proceed_read(struct st_h2o_tunnel_t *_tunnel)
 {
     struct st_h2o_udp_tunnel_t *tunnel = (void *)_tunnel;
     h2o_socket_read_start(tunnel->sock, tunnel_socket_on_read);
@@ -216,7 +216,6 @@ h2o_tunnel_t *h2o_open_udp_tunnel_from_sa(h2o_loop_t *loop, struct sockaddr *add
 
     tunnel->sock->data = tunnel;
     h2o_buffer_init(&tunnel->egress.buf, &h2o_socket_buffer_prototype);
-    h2o_socket_read_start(tunnel->sock, tunnel_socket_on_read);
 
     return &tunnel->super;
 }


### PR DESCRIPTION
1) Destroy the tunnel in `establish_tunnel()` since `establish_tunnel()`
   might know the stream has closed
2) Since `tunnel` might have been freed by `establish_tunnel()`, move
   `proceed_read()` calls before `establish_tunnel()` is called
3) Remove the udp tunnel read from socket creation, and delay it to
   `on_getaddr()`