### PR TITLE
[h2o-httpclient] set H2 concurrency limit to 100

### DIFF
--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -504,6 +504,7 @@ int main(int argc, char **argv)
         .first_byte_timeout = IO_TIMEOUT,
         .keepalive_timeout = IO_TIMEOUT,
         .max_buffer_size = H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE * 2,
+        .http2 = {.max_concurrent_streams = 100},
         .http3 = &h3ctx,
     };
     int opt;


### PR DESCRIPTION
Previously, h2o-httpclient had `h2o_httpclient_ctx_t::http2.max_concurrent_streams` set to zero, and therefore H2 connections were never reused even though pooled. This PR changes the maximum to hard-coded value of 100.

Note however that even with this change, h2o-httpclient running with `-2 100 -C x` would open _x_ connections, because it tries to issue all requests simultaneously. At that moment, no HTTP/2 connection has been established and therefore the client cannot assume that the server can speak HTTP/2. Therefore, h2o-httpclient tries to create _x_ connections, each of them specifying both `h2` and `h1` in ALPN.