### PR TITLE
Make `h2o_httpclient__tunnel_is_ready` `static inline`

### DIFF
--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -391,7 +391,7 @@ static int h2o_httpclient__tunnel_is_ready(h2o_httpclient_t *client, int status)
 
 /* inline definitions */
 
-int h2o_httpclient__tunnel_is_ready(h2o_httpclient_t *client, int status)
+inline int h2o_httpclient__tunnel_is_ready(h2o_httpclient_t *client, int status)
 {
     if (client->upgrade_to != NULL) {
         if (client->upgrade_to == h2o_httpclient_upgrade_to_connect && 200 <= status && status <= 299)


### PR DESCRIPTION
Not doing so breaks the compilation of standalone programs that include `h2o.h`:
```
/usr/bin/ld: /tmp/ccghrRPU.o: warning: relocation against `h2o_httpclient_upgrade_to_connect' in read-only section `.text'
/usr/bin/ld: /tmp/ccghrRPU.o: in function `h2o_httpclient__tunnel_is_ready':
test.c:(.text+0x29): undefined reference to `h2o_httpclient_upgrade_to_connect'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
```