### PR TITLE
[http3] Revert connection count on Initial decryption failure

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2672,11 +2672,10 @@ static h2o_quic_conn_t *on_http3_accept(h2o_quic_ctx_t *_ctx, quicly_address_t *
     num_sessions(1);
 
 Exit:
-    if (conn == NULL) {
+    if (conn == NULL || &conn->super == H2O_QUIC_ACCEPT_CONN_DECRYPTION_FAILED) {
         /* revert the changes to the connection counts */
         num_connections(-1);
         num_quic_connections(-1);
-        return NULL;
     }
     return &conn->super;
 }


### PR DESCRIPTION
Upon receiving a QUIC Initial packet, the current logic first increments
the connection counter, but fails to decrement it when it turns out to be
a non-decryptable Initial. This would cause a "leak" of the counter when
such a packet is received.