### PR TITLE
Add support for packet timestamping on Linux.

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -110,6 +110,9 @@ struct st_h2o_socket_t {
     void *data;
     struct st_h2o_socket_ssl_t *ssl;
     h2o_buffer_t *input;
+    int timestamping;
+    int needs_timestamp;
+
     /**
      * total bytes read (above the TLS layer)
      */
@@ -200,6 +203,10 @@ void h2o_socket_dispose_export(h2o_socket_export_t *info);
  * closes the socket
  */
 void h2o_socket_close(h2o_socket_t *sock);
+/**
+ * Handles a packet timestamp from an h2o socket on platforms which support it
+ */
+void h2o_socket_handle_timestamp(struct st_h2o_evloop_socket_t *sock, struct msghdr *msg);
 /**
  * Schedules a callback to be notify we the socket can be written to
  */

--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -47,6 +47,7 @@ typedef struct st_h2o_evloop_t {
     struct timeval _tv_at;
     h2o_timerwheel_t *_timeouts;
     h2o_sliding_counter_t exec_time_nanosec_counter;
+    h2o_sliding_counter_t packet_latency_nanosec_counter;
 } h2o_evloop_t;
 
 typedef h2o_evloop_t h2o_loop_t;
@@ -96,6 +97,11 @@ static inline uint64_t h2o_evloop_get_execution_time_millisec(h2o_evloop_t *loop
 static inline uint64_t h2o_evloop_get_execution_time_nanosec(h2o_evloop_t *loop)
 {
     return loop->exec_time_nanosec_counter.average;
+}
+
+static inline uint64_t h2o_evloop_get_packet_kernel_latency_nanosec(h2o_evloop_t *loop)
+{
+    return loop->packet_latency_nanosec_counter.average;
 }
 
 inline void h2o_timer_link(h2o_evloop_t *loop, uint64_t delay_ticks, h2o_timer_t *timer)

--- a/lib/handler/status/durations.c
+++ b/lib/handler/status/durations.c
@@ -40,6 +40,11 @@ struct st_duration_stats_t {
      * average event loop latency per worker thread
      */
     H2O_VECTOR(uint64_t) evloop_latency_nanosec;
+
+    /**
+     * average kernel latency of received packets per worker thread
+     */
+    H2O_VECTOR(uint64_t) packet_kernel_latency_nanosec;
 };
 
 struct st_duration_agg_stats_t {
@@ -75,6 +80,11 @@ static void durations_status_per_thread(void *priv, h2o_context_t *ctx)
         agg_stats->stats.evloop_latency_nanosec.entries[agg_stats->stats.evloop_latency_nanosec.size] =
             h2o_evloop_get_execution_time_nanosec(ctx->loop);
         agg_stats->stats.evloop_latency_nanosec.size++;
+
+        h2o_vector_reserve(NULL, &agg_stats->stats.packet_kernel_latency_nanosec, agg_stats->stats.packet_kernel_latency_nanosec.size + 1);
+        agg_stats->stats.packet_kernel_latency_nanosec.entries[agg_stats->stats.packet_kernel_latency_nanosec.size] =
+            h2o_evloop_get_packet_kernel_latency_nanosec(ctx->loop);
+        agg_stats->stats.packet_kernel_latency_nanosec.size++;
 #endif
         pthread_mutex_unlock(&agg_stats->mutex);
     }
@@ -90,6 +100,7 @@ static void duration_stats_init(struct st_duration_stats_t *stats)
     stats->response_time = gkc_summary_alloc(GK_EPSILON);
     stats->total_time = gkc_summary_alloc(GK_EPSILON);
     memset(&stats->evloop_latency_nanosec, 0, sizeof(stats->evloop_latency_nanosec));
+    memset(&stats->packet_kernel_latency_nanosec, 0, sizeof(stats->packet_kernel_latency_nanosec));
 }
 
 static void *durations_status_init(void)
@@ -114,6 +125,7 @@ static void duration_stats_free(struct st_duration_stats_t *stats)
     gkc_summary_free(stats->response_time);
     gkc_summary_free(stats->total_time);
     free(stats->evloop_latency_nanosec.entries);
+    free(stats->packet_kernel_latency_nanosec.entries);
 }
 
 static h2o_iovec_t durations_status_final(void *priv, h2o_globalconf_t *gconf, h2o_req_t *req)
@@ -154,6 +166,19 @@ static h2o_iovec_t durations_status_final(void *priv, h2o_globalconf_t *gconf, h
         delim = ",";
     }
     ret.len += snprintf(ret.base + ret.len, BUFSIZE - ret.len, "]");
+
+    delim = "";
+    ret.len += sprintf(ret.base + ret.len, ",\n\"kernel-packet-latency-nanosec\": [");
+    for(int i = 0; i < agg_stats->stats.packet_kernel_latency_nanosec.size; i++) {
+        size_t len = snprintf(NULL, 0, "%s%" PRIu64, delim, agg_stats->stats.packet_kernel_latency_nanosec.entries[i]);
+        if (ret.len + len + 1 >= BUFSIZE)
+            break;
+        ret.len += snprintf(ret.base + ret.len, BUFSIZE - ret.len, "%s%" PRIu64,
+                delim, agg_stats->stats.packet_kernel_latency_nanosec.entries[i]);
+        delim = ",";
+    }
+    ret.len += snprintf(ret.base + ret.len, BUFSIZE - ret.len, "]");
+
 #undef BUFSIZE
     duration_stats_free(&agg_stats->stats);
     pthread_mutex_destroy(&agg_stats->mutex);

--- a/src/main.c
+++ b/src/main.c
@@ -151,6 +151,7 @@ struct listener_config_t {
         h2o_http3_qpack_context_t qpack;
     } quic;
     int proxy_protocol;
+    int timestamping;
     h2o_iovec_t tcp_congestion_controller; /* default CC for this address */
 };
 
@@ -1208,7 +1209,7 @@ static struct listener_config_t *find_listener(struct sockaddr *addr, socklen_t 
     return NULL;
 }
 
-static struct listener_config_t *add_listener(int fd, struct sockaddr *addr, socklen_t addrlen, int is_global, int proxy_protocol)
+static struct listener_config_t *add_listener(int fd, struct sockaddr *addr, socklen_t addrlen, int is_global, int proxy_protocol, int timestamping)
 {
     struct listener_config_t *listener = h2o_mem_alloc(sizeof(*listener));
 
@@ -1225,6 +1226,13 @@ static struct listener_config_t *add_listener(int fd, struct sockaddr *addr, soc
     }
     memset(&listener->ssl, 0, sizeof(listener->ssl));
     memset(&listener->quic, 0, sizeof(listener->quic));
+
+#if defined(__linux__)
+    listener->timestamping = timestamping;
+#else /* !defined(__linux__) */
+    listener->timestamping = 0;
+#endif /* defined(__linux__) */
+
     listener->quic.qpack = (h2o_http3_qpack_context_t){.encoder_table_capacity = 4096 /* our default */};
     listener->proxy_protocol = proxy_protocol;
     listener->tcp_congestion_controller = h2o_iovec_init(NULL, 0);
@@ -1343,13 +1351,27 @@ static void socket_reuseport(int fd)
 /**
  * Opens an INET or INET6 socket for accepting connections. When the protocol is UDP, SO_REUSEPORT is set if available.
  */
-static int open_listener(int domain, int type, int protocol, struct sockaddr *addr, socklen_t addrlen)
+static int open_listener(int domain, int type, int protocol, struct sockaddr *addr, socklen_t addrlen, int timestamping)
 {
     int fd;
 
     if ((fd = socket(domain, type, protocol)) == -1)
         goto Error;
     set_cloexec(fd);
+
+   {
+        int flag = 1;
+
+        if (timestamping) {
+#if defined(__linux__)
+            if (setsockopt(fd, SOL_SOCKET, SO_TIMESTAMPNS, &flag, sizeof(flag)) != 0) {
+                goto Error;
+            }
+#else /* !defined(__linux__) */
+            fprintf(stderr, "[warning] cannot set SO_TIMESTAMPNS because the platform does not support it\n");
+#endif /* defined(__linux__) */
+        }
+    }
 
     /* set SO_*, IP_* options */
 #ifdef IPV6_V6ONLY
@@ -1431,11 +1453,11 @@ Error:
 }
 
 static int open_inet_listener(h2o_configurator_command_t *cmd, yoml_t *node, const char *hostname, const char *servname, int domain,
-                              int type, int protocol, struct sockaddr *addr, socklen_t addrlen)
+                              int type, int protocol, struct sockaddr *addr, socklen_t addrlen, int timestamping)
 {
     int fd;
 
-    if ((fd = open_listener(domain, type, protocol, addr, addrlen)) == -1)
+    if ((fd = open_listener(domain, type, protocol, addr, addrlen, timestamping)) == -1)
         h2o_configurator_errprintf(cmd, node, "failed to listen to %s port %s:%s: %s", protocol == IPPROTO_TCP ? "TCP" : "UDP",
                                    hostname != NULL ? hostname : "ANY", servname, strerror(errno));
 
@@ -1531,6 +1553,7 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
     yoml_t **ssl_node = NULL, **owner_node = NULL, **permission_node = NULL, **quic_node = NULL, **cc_node = NULL,
            **initcwnd_node = NULL;
     int proxy_protocol = 0;
+    int packet_timestamping_enabled = 0;
 
     /* fetch servname (and hostname) */
     switch (node->type) {
@@ -1538,11 +1561,11 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
         servname = node->data.scalar;
         break;
     case YOML_TYPE_MAPPING: {
-        yoml_t **port_node, **host_node, **type_node, **proxy_protocol_node;
+        yoml_t **port_node, **host_node, **type_node, **proxy_protocol_node, **packet_timestamping_node;
         if (h2o_configurator_parse_mapping(cmd, node, "port:s",
-                                           "host:s,type:s,owner:s,permission:*,ssl:m,proxy-protocol:*,quic:m,cc:s,initcwnd:s",
+                                           "host:s,type:s,owner:s,permission:*,ssl:m,proxy-protocol:*,quic:m,cc:s,initcwnd:s,packet-timestamping:s",
                                            &port_node, &host_node, &type_node, &owner_node, &permission_node, &ssl_node,
-                                           &proxy_protocol_node, &quic_node, &cc_node, &initcwnd_node) != 0)
+                                           &proxy_protocol_node, &quic_node, &cc_node, &initcwnd_node, &packet_timestamping_node) != 0)
             return -1;
         servname = (*port_node)->data.scalar;
         if (host_node != NULL)
@@ -1555,6 +1578,21 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
         if (proxy_protocol_node != NULL &&
             (proxy_protocol = (int)h2o_configurator_get_one_of(cmd, *proxy_protocol_node, "OFF,ON")) == -1)
             return -1;
+
+        if (packet_timestamping_node != NULL) {
+            if ((*packet_timestamping_node)->type != YOML_TYPE_SCALAR) {
+                h2o_configurator_errprintf(cmd, node, "`packet-timestamping` must be a string");
+                return -1;
+            }
+            if (strcasecmp((*packet_timestamping_node)->data.scalar, "ON") == 0) {
+                packet_timestamping_enabled = 1;
+            } else if (strcasecmp((*packet_timestamping_node)->data.scalar, "OFF") == 0) {
+                packet_timestamping_enabled = 0;
+            } else {
+                h2o_configurator_errprintf(cmd, node, "value of `packet-timestamping` must be either of: ON,OFF");
+                return -1;
+            }
+        }
     } break;
     default:
         h2o_configurator_errprintf(cmd, node, "value must be a string or a mapping (with keys: `port` and optionally `host`)");
@@ -1600,7 +1638,7 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
             default:
                 break;
             }
-            listener = add_listener(fd, (struct sockaddr *)&sa, sizeof(sa), ctx->hostconf == NULL, proxy_protocol);
+            listener = add_listener(fd, (struct sockaddr *)&sa, sizeof(sa), ctx->hostconf == NULL, proxy_protocol, 0);
             listener_is_new = 1;
         } else if (listener->proxy_protocol != proxy_protocol) {
             goto ProxyConflict;
@@ -1639,7 +1677,7 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
                         }
                     } else {
                         if ((fd = open_inet_listener(cmd, node, hostname, servname, ai->ai_family, ai->ai_socktype, ai->ai_protocol,
-                                                     ai->ai_addr, ai->ai_addrlen)) == -1) {
+                                                     ai->ai_addr, ai->ai_addrlen, packet_timestamping_enabled)) == -1) {
                             freeaddrinfo(res);
                             return -1;
                         }
@@ -1648,7 +1686,7 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
                 default:
                     break;
                 }
-                listener = add_listener(fd, ai->ai_addr, ai->ai_addrlen, ctx->hostconf == NULL, proxy_protocol);
+                listener = add_listener(fd, ai->ai_addr, ai->ai_addrlen, ctx->hostconf == NULL, proxy_protocol, packet_timestamping_enabled);
                 if (cc_node != NULL)
                     listener->tcp_congestion_controller = h2o_strdup(NULL, (*cc_node)->data.scalar, SIZE_MAX);
                 listener_is_new = 1;
@@ -1690,7 +1728,7 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
                             return -1;
                         }
                     } else if ((fd = open_inet_listener(cmd, node, hostname, servname, ai->ai_family, ai->ai_socktype,
-                                                        ai->ai_protocol, ai->ai_addr, ai->ai_addrlen)) == -1) {
+                                                        ai->ai_protocol, ai->ai_addr, ai->ai_addrlen, packet_timestamping_enabled)) == -1) {
                         freeaddrinfo(res);
                         return -1;
                     }
@@ -1703,7 +1741,7 @@ static int on_config_listen(h2o_configurator_command_t *cmd, h2o_configurator_co
                 *quic = quicly_spec_context;
                 quic->cid_encryptor = &quic_cid_encryptor;
                 quic->generate_resumption_token = &quic_resumption_token_generator;
-                listener = add_listener(fd, ai->ai_addr, ai->ai_addrlen, ctx->hostconf == NULL, 0);
+                listener = add_listener(fd, ai->ai_addr, ai->ai_addrlen, ctx->hostconf == NULL, 0, packet_timestamping_enabled);
                 listener->quic.ctx = quic;
                 if (quic_node != NULL) {
                     yoml_t **retry_node, **sndbuf, **rcvbuf, **amp_limit, **qpack_encoder_table_capacity, **max_streams_bidi;
@@ -2537,6 +2575,9 @@ static void on_accept(h2o_socket_t *listener, const char *err)
         sock->on_close.cb = on_socketclose;
         sock->on_close.data = ctx->accept_ctx.ctx;
 
+        sock->timestamping = listener->timestamping;
+        sock->needs_timestamp = 1;
+
         set_tcp_congestion_controller(sock, conf.listeners[ctx->listener_index]->tcp_congestion_controller);
 
         h2o_accept(&ctx->accept_ctx, sock);
@@ -2720,7 +2761,7 @@ static void *run_loop(void *_thread_index)
     h2o_multithread_register_receiver(conf.threads[thread_index].ctx.queue, &conf.threads[thread_index].memcached,
                                       h2o_memcached_receiver);
 
-    if (conf.thread_map.entries[thread_index] >= 0) {
+	if (conf.thread_map.entries[thread_index] >= 0) {
 #ifdef H2O_HAS_PTHREAD_SETAFFINITY_NP
 #ifndef __NetBSD__
         cpu_set_t cpu_set;
@@ -2761,6 +2802,8 @@ static void *run_loop(void *_thread_index)
             listeners[i].accept_ctx.http2_origin_frame = listener_config->ssl.entries[0]->http2_origin_frame;
         }
         listeners[i].sock = h2o_evloop_socket_create(conf.threads[thread_index].ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
+        listeners[i].sock->timestamping = listener_config->timestamping;
+
         listeners[i].sock->data = listeners + i;
         /* setup quic context and the unix socket to receive forwarded packets */
         if (thread_index < conf.quic.num_threads && listener_config->quic.ctx != NULL) {
@@ -3137,7 +3180,7 @@ static void setup_configurators(void)
     h2o_config_register_status_handler(&conf.globalconf, &extra_status_handler);
 }
 
-static int dup_listener(int listener)
+static int dup_listener(int listener, int timestamping)
 {
     int reuseport = 0;
 
@@ -3167,7 +3210,7 @@ static int dup_listener(int listener)
             abort();
         }
         if ((fd = open_listener(ss.ss_family, type, type == SOCK_STREAM ? IPPROTO_TCP : IPPROTO_UDP, (struct sockaddr *)&ss,
-                                sslen)) != -1) {
+                                sslen, timestamping)) != -1) {
             if (type == SOCK_DGRAM)
                 setsockopt_recvpktinfo(fd, ss.ss_family);
         } else {
@@ -3190,7 +3233,7 @@ static void create_per_thread_listeners(void)
         struct listener_config_t *listener_config = conf.listeners[i];
         h2o_vector_reserve(NULL, &listener_config->fds, conf.thread_map.size);
         while (listener_config->fds.size < conf.thread_map.size) {
-            int fd = dup_listener(listener_config->fds.entries[0]);
+            int fd = dup_listener(listener_config->fds.entries[0], listener_config->timestamping);
             listener_config->fds.entries[listener_config->fds.size++] = fd;
         }
     }


### PR DESCRIPTION
This change allows the user to specify the option "packet-timestamping" to turn
on packet timestamping on supported platforms (this change implements this for
Linux).

The data is exported in nanoseconds per thread via "duration-stats" (if enabled).