### PR TITLE
fix a flaky test to ensure an upstream port to cause "connection failure"

### DIFF
--- a/t/40error-log-escape.t
+++ b/t/40error-log-escape.t
@@ -4,13 +4,21 @@ use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 use File::Temp qw(tempfile);
+use IO::Socket::INET;
 
 my ($ignored, $fn) = tempfile(UNLINK => 1);
 
 plan skip_all => 'curl not found'
     unless prog_exists('curl') and curl_supports_http2();
 
-my $upstream_port = empty_port();
+# create a socket to keep an empty port in use
+my $upstream = IO::Socket::INET->new(
+    LocalAddr => '127.0.0.1',
+    LocalPort => 0,
+    Proto     => 'tcp',
+);
+
+my $upstream_port = $upstream->sockport();
 my $server = spawn_h2o(<< "EOT");
 error-log: $fn
 hosts:


### PR DESCRIPTION
Found `t/40error-log-escape.t ` failed  in https://travis-ci.org/github/h2o/h2o/jobs/767003907 

The test uses an empty port as an upstream that is expected to cause "connection failure", but sometimes it causes "first byte timeout". I guess that's because someone uses the port so that connect() succeeds.