### PR TITLE
test: make "user" configuration overridable in spawn_h2o()

### DIFF
--- a/t/40running-user.t
+++ b/t/40running-user.t
@@ -9,9 +9,7 @@ plan skip_all => "user 'nobody' does not exist"
     unless defined getpwnam("nobody");
 
 subtest "set-user" => sub {
-    doit(<< 'EOT');
-user: nobody
-EOT
+    doit("nobody");
 };
 
 subtest "automatic fallback to nobody" => sub {
@@ -21,15 +19,17 @@ subtest "automatic fallback to nobody" => sub {
 done_testing;
 
 sub doit {
-    my $conf = shift;
-    my $server = spawn_h2o(<< "EOT");
-$conf
+    my $user = shift;
+    my $server = spawn_h2o({
+      user => $user,
+      conf => << "EOT",
 hosts:
   default:
     paths:
       /:
         file.dir: @{[ DOC_ROOT ]}
 EOT
+    });
 
     my $resp = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/ 2>&1 > /dev/null`;
     like $resp, qr{^HTTP/1}s;

--- a/t/90dtrace.t
+++ b/t/90dtrace.t
@@ -15,8 +15,8 @@ my $tempdir = tempdir(CLEANUP => 1);
 
 my $server = spawn_h2o({
     opts => [qw(--mode=worker)],
+    user => "nobody",
     conf => << 'EOT',
-user: nobody
 hosts:
   default:
     paths:

--- a/t/90root-fastcgi-php.t
+++ b/t/90root-fastcgi-php.t
@@ -27,8 +27,9 @@ sub check_resp {
 }
 
 subtest 'user-in-global-conf' => sub {
-    my $server = spawn_h2o(<< "EOT");
-user: nobody
+    my $server = spawn_h2o({
+      user => "nobody",
+      conf => << "EOT",
 file.custom-handler:
   extension: .php
   fastcgi.spawn: "exec php-cgi"
@@ -38,12 +39,14 @@ hosts:
       "/":
         file.dir: @{[ DOC_ROOT ]}
 EOT
+    });
     check_resp($server->{port});
 };
 
 subtest 'user-in-fastcgi.spawn' => sub {
-    my $server = spawn_h2o(<< "EOT");
-user: nobody
+    my $server = spawn_h2o({
+      user => "nobody",
+      conf => << "EOT",
 file.custom-handler:
   extension: .php
   fastcgi.spawn:
@@ -55,12 +58,14 @@ hosts:
       "/":
         file.dir: @{[ DOC_ROOT ]}
 EOT
+    });
     check_resp($server->{port});
 };
 
 subtest 'user-not-in-map-style-fastcgi.spawn' => sub {
-    my $server = spawn_h2o(<< "EOT");
-user: nobody
+    my $server = spawn_h2o({
+      user => "nobody",
+      conf => << "EOT",
 file.custom-handler:
   extension: .php
   fastcgi.spawn:
@@ -71,6 +76,7 @@ hosts:
       "/":
         file.dir: @{[ DOC_ROOT ]}
 EOT
+    });
     check_resp($server->{port});
 };
 

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -220,17 +220,13 @@ sub spawn_h2o {
     # setup the configuration file
     $conf = $conf->($port, $tls_port)
         if ref $conf eq 'CODE';
+    my $user = $< == 0 ? "user: root" : "";
     if (ref $conf eq 'HASH') {
         @opts = @{$conf->{opts}}
             if $conf->{opts};
         $max_ssl_version = $conf->{max_ssl_version} || undef;
+        $user = $conf->{user} if exists $conf->{user};
         $conf = $conf->{conf};
-    }
-    my $user;
-    if ($conf =~ /^user:/) { # do not override the specified user
-        $user = "";
-    } else {
-        $user = $< == 0 ? "user: root" : "";
     }
     $conf = <<"EOT";
 $conf
@@ -244,7 +240,7 @@ listen:
     key-file: examples/h2o/server.key
     certificate-file: examples/h2o/server.crt
     @{[$max_ssl_version ? "max-version: $max_ssl_version" : ""]}
-$user
+@{[$user ? "user: $user" : ""]}
 EOT
 
     my $ret = spawn_h2o_raw($conf, [$port, $tls_port], \@opts);

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -220,7 +220,7 @@ sub spawn_h2o {
     # setup the configuration file
     $conf = $conf->($port, $tls_port)
         if ref $conf eq 'CODE';
-    my $user = $< == 0 ? "user: root" : "";
+    my $user = $< == 0 ? "root" : "";
     if (ref $conf eq 'HASH') {
         @opts = @{$conf->{opts}}
             if $conf->{opts};

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -227,7 +227,6 @@ sub spawn_h2o {
         $conf = $conf->{conf};
     }
     $conf = <<"EOT";
-$conf
 listen:
   host: 0.0.0.0
   port: $port
@@ -239,6 +238,7 @@ listen:
     certificate-file: examples/h2o/server.crt
     @{[$max_ssl_version ? "max-version: $max_ssl_version" : ""]}
 @{[$< == 0 ? "user: root" : ""]}
+$conf
 EOT
 
     my $ret = spawn_h2o_raw($conf, [$port, $tls_port], \@opts);

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -226,7 +226,14 @@ sub spawn_h2o {
         $max_ssl_version = $conf->{max_ssl_version} || undef;
         $conf = $conf->{conf};
     }
+    my $user;
+    if ($conf =~ /^user:/) { # do not override the specified user
+        $user = "";
+    } else {
+        $user = $< == 0 ? "user: root" : "";
+    }
     $conf = <<"EOT";
+$conf
 listen:
   host: 0.0.0.0
   port: $port
@@ -237,8 +244,7 @@ listen:
     key-file: examples/h2o/server.key
     certificate-file: examples/h2o/server.crt
     @{[$max_ssl_version ? "max-version: $max_ssl_version" : ""]}
-@{[$< == 0 ? "user: root" : ""]}
-$conf
+$user
 EOT
 
     my $ret = spawn_h2o_raw($conf, [$port, $tls_port], \@opts);


### PR DESCRIPTION
This is required by https://github.com/h2o/h2o/pull/2655 but I've made a separate PR here to make sure this change does not break existing tests.