### PR TITLE
usdt: fix the type of frame.type

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1144,7 +1144,7 @@ ssize_t expect_default(h2o_http2_conn_t *conn, const uint8_t *src, size_t len, c
         if (hret != 0)
             ret = hret;
     } else {
-        H2O_PROBE_CONN(H2_UNKNOWN_FRAME_TYPE, &conn->super, (uint64_t)frame.type);
+        H2O_PROBE_CONN(H2_UNKNOWN_FRAME_TYPE, &conn->super, frame.type);
     }
 
     return ret;


### PR DESCRIPTION
h2olog cannot handle the `h2o:h2_unknown_frame_type.frame_type` field correctly. The type of `frame.type` is `uint8_t`, and the USDT `h2o:h2_unknown_frame_type` has the param `uint8_t frame_type`, so the passed value should be a `uint8_t` expression. 

FWIW I found it because Chrome Canary 92 sent the frame type `135`.


## Refs

* https://gist.github.com/gfx/f42db370eb2296d4806a153479919323
  * the difference in `gcc -S` between master's and this PR's connection.c


