### PR TITLE
Only allow to set the entity header once

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -371,6 +371,8 @@ static const char *init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, co
                                 h2o_iovec_t *connection, h2o_iovec_t *host, h2o_iovec_t *upgrade, h2o_iovec_t *expect,
                                 ssize_t *entity_header_index)
 {
+    ssize_t content_length_index = -1;
+
     *entity_header_index = -1;
 
     assert(headers->size == 0);
@@ -397,9 +399,9 @@ static const char *init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, co
                     } else if (name_token == H2O_TOKEN_CONTENT_LENGTH) {
                         if (*entity_header_index != -1)
                             return "request entity header already set";
-                        *entity_header_index = i;
+                        *entity_header_index = content_length_index = i;
                     } else if (name_token == H2O_TOKEN_TRANSFER_ENCODING) {
-                        if (*entity_header_index != -1)
+                        if (content_length_index != -1)
                             return "request entity header already set";
                         *entity_header_index = i;
                     } else if (name_token == H2O_TOKEN_EXPECT) {

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -395,9 +395,12 @@ static const char *init_headers(h2o_mem_pool_t *pool, h2o_headers_t *headers, co
                         host->base = (char *)src[i].value;
                         host->len = src[i].value_len;
                     } else if (name_token == H2O_TOKEN_CONTENT_LENGTH) {
-                        if (*entity_header_index == -1)
-                            *entity_header_index = i;
+                        if (*entity_header_index != -1)
+                            return "request entity header already set";
+                        *entity_header_index = i;
                     } else if (name_token == H2O_TOKEN_TRANSFER_ENCODING) {
+                        if (*entity_header_index != -1)
+                            return "request entity header already set";
                         *entity_header_index = i;
                     } else if (name_token == H2O_TOKEN_EXPECT) {
                         expect->base = (char *)src[i].value;

--- a/t/40bad-request.t
+++ b/t/40bad-request.t
@@ -34,4 +34,7 @@ like $resp, qr{^HTTP/1\.1 400 .*Content-Length:\s*11.*\r\n\r\nBad Request$}is, "
 $resp = `echo "GET / HTTP/1.1\r\nfoo: FOO\r\n    hoge\r\n\r\n" | nc 127.0.0.1 $server->{port} 2>&1`;
 like $resp, qr{^HTTP/1\.1 400 .*Content-Length:\s*46.*\r\n\r\nline folding of header fields is not supported$}is, "multiline header";
 
+$resp = `echo "GET / HTTP/1.1\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n\r\n" | nc 127.0.0.1 $server->{port} 2>&1`;
+like $resp, qr{^HTTP/1\.1 400 .*Content-Length:\s*33.*\r\n\r\nrequest entity header already set$}is, "content-length and transfer-encoding present";
+
 done_testing;

--- a/t/40bad-request.t
+++ b/t/40bad-request.t
@@ -37,4 +37,10 @@ like $resp, qr{^HTTP/1\.1 400 .*Content-Length:\s*46.*\r\n\r\nline folding of he
 $resp = `echo "GET / HTTP/1.1\r\nContent-Length: 0\r\nTransfer-Encoding: chunked\r\n\r\n" | nc 127.0.0.1 $server->{port} 2>&1`;
 like $resp, qr{^HTTP/1\.1 400 .*Content-Length:\s*33.*\r\n\r\nrequest entity header already set$}is, "content-length and transfer-encoding present";
 
+$resp = `echo "GET / HTTP/1.1\r\nContent-Length: 0\r\nContent-Length: 0\r\n\r\n" | nc 127.0.0.1 $server->{port} 2>&1`;
+like $resp, qr{^HTTP/1\.1 400 .*Content-Length:\s*33.*\r\n\r\nrequest entity header already set$}is, "multiple content-length present";
+
+$resp = `echo "GET / HTTP/1.1\r\nTransfer-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n" | nc 127.0.0.1 $server->{port} 2>&1`;
+like $resp, qr{^HTTP/1\.1 200 OK\r\n}s, "multiple Transfer-Encoding";
+
 done_testing;


### PR DESCRIPTION
If we've already seen the Content-Length or Transfer-Encoding headers, fail if we encounter any of them again.