### PR TITLE
Extract the rate-limiting mechanism of warning message as reusable concept

### DIFF
--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -57,6 +57,27 @@ typedef struct st_h2o_barrier_t {
 } h2o_barrier_t;
 
 /**
+ * This structure is used to rate-limit the emission of warning messages.
+ * When something succeeds, the user calls `h2o_failure_reporter_record_success`. When something fails, the user calls
+ * `h2o_failure_reporter_record_failure`, along with how long the emission of the warning message should be delayed. When the
+ * delayed timer expires, the cusmo callback (registered using `H2O_FAILURE_REPORTER_INITIALIZER` macro) is invoked, so that
+ * the user can emit whatever message that's necessary, alongside the number of successes and failures within the delayed period.
+ *
+ * Fields that do not start with `_` can be directly accessed / modified by the `report_failures` callback. In other occasions,
+ * modifications MUST be made through the "record" functions. Fields that start with `_` are private and must not be touched by the
+ * user.
+ */
+typedef struct st_h2o_failure_reporter_t {
+    uint64_t cur_failures;
+    uint64_t prev_successes;
+    uintptr_t data;
+    uint64_t _total_successes;
+    pthread_mutex_t _mutex;
+    h2o_timer_t _timer;
+    void (*_report_failures)(struct st_h2o_failure_reporter_t *reporter, uint64_t tocal_succeses, uint64_t cur_successes);
+} h2o_failure_reporter_t;
+
+/**
  * creates a queue that is used for inter-thread communication
  */
 h2o_multithread_queue_t *h2o_multithread_create_queue(h2o_loop_t *loop);
@@ -119,5 +140,22 @@ int h2o_barrier_wait(h2o_barrier_t *barrier);
 int h2o_barrier_done(h2o_barrier_t *barrier);
 void h2o_barrier_add(h2o_barrier_t *barrier, size_t delta);
 void h2o_barrier_destroy(h2o_barrier_t *barrier);
+
+void h2o_failure_reporter__on_timeout(h2o_timer_t *timer);
+#define H2O_FAILURE_REPORTER_INITIALIZER(s) ((h2o_failure_reporter_t){._mutex = PTHREAD_MUTEX_INITIALIZER, ._timer = {.cb = h2o_failure_reporter__on_timeout}, ._report_failures = (s)})
+static void h2o_failure_reporter_record_success(h2o_failure_reporter_t *reporter);
+/**
+ * This function records a failure event, sets a delayed timer (if not yet have been set), replaces the value of
+ * `h2o_falirue_reporter_t::data` with `new_data`, returning the old value.
+ */
+uintptr_t h2o_failure_reporter_record_failure(h2o_loop_t *loop, h2o_failure_reporter_t *reporter, uint64_t delay_ticks,
+                                              uintptr_t new_data);
+
+/* inline functions */
+
+inline void h2o_failure_reporter_record_success(h2o_failure_reporter_t *reporter)
+{
+    __sync_fetch_and_add(&reporter->_total_successes, 1);
+}
 
 #endif

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -57,25 +57,25 @@ typedef struct st_h2o_barrier_t {
 } h2o_barrier_t;
 
 /**
- * This structure is used to rate-limit the emission of warning messages.
- * When something succeeds, the user calls `h2o_failure_reporter_record_success`. When something fails, the user calls
- * `h2o_failure_reporter_record_failure`, along with how long the emission of the warning message should be delayed. When the
- * delayed timer expires, the cusmo callback (registered using `H2O_FAILURE_REPORTER_INITIALIZER` macro) is invoked, so that
- * the user can emit whatever message that's necessary, alongside the number of successes and failures within the delayed period.
+ * This structure is used to rate-limit the emission of error messages.
+ * When something succeeds, the user calls `h2o_error_reporter_record_success`. When something fails, the user calls
+ * `h2o_error_reporter_record_error`, along with how long the emission of the warning message should be delayed. When the delayed
+ * timer expires, the cusmo callback (registered using `H2O_ERROR_REPORTER_INITIALIZER` macro) is invoked, so that the user can emit
+ * whatever message that's necessary, alongside the number of successes and errors within the delayed period.
  *
- * Fields that do not start with `_` can be directly accessed / modified by the `report_failures` callback. In other occasions,
+ * Fields that do not start with `_` can be directly accessed / modified by the `report_errors` callback. In other occasions,
  * modifications MUST be made through the "record" functions. Fields that start with `_` are private and must not be touched by the
  * user.
  */
-typedef struct st_h2o_failure_reporter_t {
-    uint64_t cur_failures;
+typedef struct st_h2o_error_reporter_t {
+    uint64_t cur_errors;
     uint64_t prev_successes;
     uintptr_t data;
     uint64_t _total_successes;
     pthread_mutex_t _mutex;
     h2o_timer_t _timer;
-    void (*_report_failures)(struct st_h2o_failure_reporter_t *reporter, uint64_t tocal_succeses, uint64_t cur_successes);
-} h2o_failure_reporter_t;
+    void (*_report_errors)(struct st_h2o_error_reporter_t *reporter, uint64_t tocal_succeses, uint64_t cur_successes);
+} h2o_error_reporter_t;
 
 /**
  * creates a queue that is used for inter-thread communication
@@ -141,19 +141,21 @@ int h2o_barrier_done(h2o_barrier_t *barrier);
 void h2o_barrier_add(h2o_barrier_t *barrier, size_t delta);
 void h2o_barrier_destroy(h2o_barrier_t *barrier);
 
-void h2o_failure_reporter__on_timeout(h2o_timer_t *timer);
-#define H2O_FAILURE_REPORTER_INITIALIZER(s) ((h2o_failure_reporter_t){._mutex = PTHREAD_MUTEX_INITIALIZER, ._timer = {.cb = h2o_failure_reporter__on_timeout}, ._report_failures = (s)})
-static void h2o_failure_reporter_record_success(h2o_failure_reporter_t *reporter);
+void h2o_error_reporter__on_timeout(h2o_timer_t *timer);
+#define H2O_ERROR_REPORTER_INITIALIZER(s)                                                                                          \
+    ((h2o_error_reporter_t){                                                                                                       \
+        ._mutex = PTHREAD_MUTEX_INITIALIZER, ._timer = {.cb = h2o_error_reporter__on_timeout}, ._report_errors = (s)})
+static void h2o_error_reporter_record_success(h2o_error_reporter_t *reporter);
 /**
- * This function records a failure event, sets a delayed timer (if not yet have been set), replaces the value of
- * `h2o_falirue_reporter_t::data` with `new_data`, returning the old value.
+ * This function records an error event, sets a delayed timer (if not yet have been set), replaces the value of
+ * `h2o_error_reporter_t::data` with `new_data`, returning the old value.
  */
-uintptr_t h2o_failure_reporter_record_failure(h2o_loop_t *loop, h2o_failure_reporter_t *reporter, uint64_t delay_ticks,
-                                              uintptr_t new_data);
+uintptr_t h2o_error_reporter_record_error(h2o_loop_t *loop, h2o_error_reporter_t *reporter, uint64_t delay_ticks,
+                                          uintptr_t new_data);
 
 /* inline functions */
 
-inline void h2o_failure_reporter_record_success(h2o_failure_reporter_t *reporter)
+inline void h2o_error_reporter_record_success(h2o_error_reporter_t *reporter)
 {
     __sync_fetch_and_add(&reporter->_total_successes, 1);
 }

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -324,3 +324,41 @@ void h2o_barrier_destroy(h2o_barrier_t *barrier)
     pthread_mutex_destroy(&barrier->_mutex);
     pthread_cond_destroy(&barrier->_cond);
 }
+
+void h2o_failure_reporter__on_timeout(h2o_timer_t *_timer)
+{
+    h2o_failure_reporter_t *reporter = H2O_STRUCT_FROM_MEMBER(h2o_failure_reporter_t, _timer, _timer);
+
+    pthread_mutex_lock(&reporter->_mutex);
+
+    uint64_t total_successes = __sync_fetch_and_add(&reporter->_total_successes, 0),
+             cur_successes = total_successes - reporter->prev_successes;
+
+    reporter->_report_failures(reporter, total_successes, cur_successes);
+
+    reporter->prev_successes = total_successes;
+    reporter->cur_failures = 0;
+
+    pthread_mutex_unlock(&reporter->_mutex);
+}
+
+uintptr_t h2o_failure_reporter_record_failure(h2o_loop_t *loop, h2o_failure_reporter_t *reporter, uint64_t delay_ticks,
+                                              uintptr_t new_data)
+{
+    uintptr_t old_data;
+
+    pthread_mutex_lock(&reporter->_mutex);
+
+    if (reporter->cur_failures == 0) {
+        reporter->prev_successes = __sync_fetch_and_add_8(&reporter->_total_successes, 0);
+        assert(!h2o_timer_is_linked(&reporter->_timer));
+        h2o_timer_link(loop, delay_ticks, &reporter->_timer);
+    }
+    ++reporter->cur_failures;
+    old_data = reporter->data;
+    reporter->data = new_data;
+
+    pthread_mutex_unlock(&reporter->_mutex);
+
+    return old_data;
+}

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -325,36 +325,36 @@ void h2o_barrier_destroy(h2o_barrier_t *barrier)
     pthread_cond_destroy(&barrier->_cond);
 }
 
-void h2o_failure_reporter__on_timeout(h2o_timer_t *_timer)
+void h2o_error_reporter__on_timeout(h2o_timer_t *_timer)
 {
-    h2o_failure_reporter_t *reporter = H2O_STRUCT_FROM_MEMBER(h2o_failure_reporter_t, _timer, _timer);
+    h2o_error_reporter_t *reporter = H2O_STRUCT_FROM_MEMBER(h2o_error_reporter_t, _timer, _timer);
 
     pthread_mutex_lock(&reporter->_mutex);
 
     uint64_t total_successes = __sync_fetch_and_add(&reporter->_total_successes, 0),
              cur_successes = total_successes - reporter->prev_successes;
 
-    reporter->_report_failures(reporter, total_successes, cur_successes);
+    reporter->_report_errors(reporter, total_successes, cur_successes);
 
     reporter->prev_successes = total_successes;
-    reporter->cur_failures = 0;
+    reporter->cur_errors = 0;
 
     pthread_mutex_unlock(&reporter->_mutex);
 }
 
-uintptr_t h2o_failure_reporter_record_failure(h2o_loop_t *loop, h2o_failure_reporter_t *reporter, uint64_t delay_ticks,
-                                              uintptr_t new_data)
+uintptr_t h2o_error_reporter_record_error(h2o_loop_t *loop, h2o_error_reporter_t *reporter, uint64_t delay_ticks,
+                                          uintptr_t new_data)
 {
     uintptr_t old_data;
 
     pthread_mutex_lock(&reporter->_mutex);
 
-    if (reporter->cur_failures == 0) {
+    if (reporter->cur_errors == 0) {
         reporter->prev_successes = __sync_fetch_and_add_8(&reporter->_total_successes, 0);
         assert(!h2o_timer_is_linked(&reporter->_timer));
         h2o_timer_link(loop, delay_ticks, &reporter->_timer);
     }
-    ++reporter->cur_failures;
+    ++reporter->cur_errors;
     old_data = reporter->data;
     reporter->data = new_data;
 

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -53,44 +53,15 @@ struct st_h2o_http3_ingress_unistream_t {
 
 const ptls_iovec_t h2o_http3_alpn[2] = {{(void *)H2O_STRLIT("h3-29")}, {(void *)H2O_STRLIT("h3-27")}};
 
-static void on_track_sendmsg_timer(h2o_timer_t *timeout);
-
-static struct {
-    /**
-     * counts number of successful invocations of `sendmsg` since the process was launched
-     */
-    uint64_t total_successes;
-    /**
-     * struct that retains information since previous log emission. Needs locked access using `locked.mutex`.
-     */
-    struct {
-        pthread_mutex_t mutex;
-        uint64_t prev_successes;
-        uint64_t cur_failures;
-        int last_errno;
-        h2o_timer_t timer;
-    } locked;
-} track_sendmsg = {.locked = {PTHREAD_MUTEX_INITIALIZER, .timer = {.cb = on_track_sendmsg_timer}}};
-
-void on_track_sendmsg_timer(h2o_timer_t *timeout)
+static void report_sendmsg_failures(h2o_failure_reporter_t *reporter, uint64_t total_successes, uint64_t cur_successes)
 {
     char errstr[256];
-
-    pthread_mutex_lock(&track_sendmsg.locked.mutex);
-
-    uint64_t total_successes = __sync_fetch_and_add(&track_sendmsg.total_successes, 0),
-             cur_successes = total_successes - track_sendmsg.locked.prev_successes;
-
+    strerror_r((int)reporter->data, errstr, sizeof(errstr));
     fprintf(stderr, "sendmsg failed %" PRIu64 " time%s, succeeded: %" PRIu64 " time%s, over the last minute: %s\n",
-            track_sendmsg.locked.cur_failures, track_sendmsg.locked.cur_failures > 1 ? "s" : "", cur_successes,
-            cur_successes > 1 ? "s" : "", h2o_strerror_r(track_sendmsg.locked.last_errno, errstr, sizeof(errstr)));
-
-    track_sendmsg.locked.prev_successes = total_successes;
-    track_sendmsg.locked.cur_failures = 0;
-    track_sendmsg.locked.last_errno = 0;
-
-    pthread_mutex_unlock(&track_sendmsg.locked.mutex);
+            reporter->cur_failures, reporter->cur_failures > 1 ? "s" : "", cur_successes, cur_successes > 1 ? "s" : "", errstr);
 }
+
+static h2o_failure_reporter_t track_sendmsg = H2O_FAILURE_REPORTER_INITIALIZER(report_sendmsg_failures);
 
 /**
  * Sends a packet, returns if the connection is still maintainable (false is returned when not being able to send a packet from the
@@ -177,7 +148,7 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
         if (ret == -1)
             goto SendmsgError;
     }
-    __sync_fetch_and_add(&track_sendmsg.total_successes, 1);
+    h2o_failure_reporter_record_success(&track_sendmsg);
 
     return 1;
 
@@ -191,12 +162,7 @@ SendmsgError:
      * specific?) */
 
     /* Log the number of failed invocations once per minute, if there has been such a failure. */
-    pthread_mutex_lock(&track_sendmsg.locked.mutex);
-    ++track_sendmsg.locked.cur_failures;
-    track_sendmsg.locked.last_errno = errno;
-    if (!h2o_timer_is_linked(&track_sendmsg.locked.timer))
-        h2o_timer_link(ctx->loop, 60000, &track_sendmsg.locked.timer);
-    pthread_mutex_unlock(&track_sendmsg.locked.mutex);
+    h2o_failure_reporter_record_failure(ctx->loop, &track_sendmsg, 60000, errno);
 
     return 1;
 }


### PR DESCRIPTION
In #2259, we introduced a mechanism for rate-limiting a particular warning message, that has turned to be pretty useful. In #2655, we figured out that we need something similar, and reimplemented it.

While reviewing #2655, I noticed that existing code has a tiny race condition. `h2o_quic_send_datagrams` invoked from multiple threads test if `track_sendmsg.locked.timer` is being linked while taking the mutex. But `h2o_timerwheel_run` does not take a lock when it clears the link.

As unlinking an object from a double-linked list is not an atomic operation, we have a theoretical race condition that might end up breaking the linked list.

Being aware that such subtle mistakes can go into the source tree unnoticed, I'm inclined to fix the issue as well as making the concept reusable, so that we do not fall into the same problem when reimplementing something similar.