### PR TITLE
strerror_r does not always write the result to provided buffer

### DIFF
--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -56,9 +56,9 @@ const ptls_iovec_t h2o_http3_alpn[2] = {{(void *)H2O_STRLIT("h3-29")}, {(void *)
 static void report_sendmsg_errors(h2o_error_reporter_t *reporter, uint64_t total_successes, uint64_t cur_successes)
 {
     char errstr[256];
-    strerror_r((int)reporter->data, errstr, sizeof(errstr));
     fprintf(stderr, "sendmsg failed %" PRIu64 " time%s, succeeded: %" PRIu64 " time%s, over the last minute: %s\n",
-            reporter->cur_errors, reporter->cur_errors > 1 ? "s" : "", cur_successes, cur_successes > 1 ? "s" : "", errstr);
+            reporter->cur_errors, reporter->cur_errors > 1 ? "s" : "", cur_successes, cur_successes > 1 ? "s" : "",
+            h2o_strerror_r((int)reporter->data, errstr, sizeof(errstr)));
 }
 
 static h2o_error_reporter_t track_sendmsg = H2O_ERROR_REPORTER_INITIALIZER(report_sendmsg_errors);


### PR DESCRIPTION
And we have `h2o_strerror_r` as the wrapper. Fixes regression in #2675.