### PR TITLE
[do-not-merge] tweak 40mtls.t to reproduce errors in high probability

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1076,7 +1076,12 @@ static void proceed_handshake_picotls(h2o_socket_t *sock)
             write_ssl_bytes(sock, wbuf.base, wbuf.off);
             flush_pending_ssl(sock, ret == 0 ? on_handshake_complete : proceed_handshake);
         } else {
-            h2o_socket_read_start(sock, ret == PTLS_ERROR_IN_PROGRESS ? proceed_handshake : on_handshake_complete);
+            if (ret == 0 && sock->ssl->input.encrypted->size > 0) {
+                /* handshake complete and there's unencrypted data ready for processing */
+                on_handshake_complete(sock, NULL);
+            } else {
+                h2o_socket_read_start(sock, ret == PTLS_ERROR_IN_PROGRESS ? proceed_handshake : on_handshake_complete);
+            }
         }
         break;
     default:

--- a/t/40mtls.t
+++ b/t/40mtls.t
@@ -19,8 +19,8 @@ my $TLS_RE_OK = qr{hello};
 #          # around?)
 
 subtest "tls1.3" => sub {
-    # plan skip_all => 'curl does not support TLS 1.3'
-    #     unless curl_support_tls13();
+    plan skip_all => 'curl does not support TLS 1.3'
+        unless curl_support_tls13();
     my $server = spawn_server("tlsv1.3");
     run_tests('--tlsv1.3') for 1 .. 100;
 };
@@ -30,8 +30,8 @@ done_testing;
 sub run_tests {
     my $opts = shift;
     like run_tls_client("$opts $good_client_key_cert"), $TLS_RE_OK, "correct client cert" or die "test failed";
-    # unlike run_tls_client($opts), $TLS_RE_OK, "no client cert";
-    # unlike run_tls_client("$opts $wrong_client_key_cert"), $TLS_RE_OK, "wrong client cert";
+    unlike run_tls_client($opts), $TLS_RE_OK, "no client cert";
+    unlike run_tls_client("$opts $wrong_client_key_cert"), $TLS_RE_OK, "wrong client cert";
 }
 
 sub run_tls_client {

--- a/t/40mtls.t
+++ b/t/40mtls.t
@@ -10,33 +10,33 @@ my $good_client_key_cert = '--key t/assets/test_client.key --cert t/assets/test_
 my $wrong_client_key_cert = '--key examples/h2o/server.key --cert examples/h2o/server.crt';
 my $TLS_RE_OK = qr{hello};
 
-subtest "tls1.2" => sub {
-    my $server = spawn_server("tlsv1.2");
-    run_tests('');
-};
-
-sleep 1; # without this sleep; the server occasionally fails to bind to $tls_port (maybe some sub-process of h2o still hanging
-         # around?)
+# subtest "tls1.2" => sub {
+#     my $server = spawn_server("tlsv1.2");
+#     run_tests('');
+# };
+#
+# sleep 1; # without this sleep; the server occasionally fails to bind to $tls_port (maybe some sub-process of h2o still hanging
+#          # around?)
 
 subtest "tls1.3" => sub {
-    plan skip_all => 'curl does not support TLS 1.3'
-        unless curl_support_tls13();
+    # plan skip_all => 'curl does not support TLS 1.3'
+    #     unless curl_support_tls13();
     my $server = spawn_server("tlsv1.3");
-    run_tests('--tlsv1.3');
+    run_tests('--tlsv1.3') for 1 .. 100;
 };
 
 done_testing;
 
 sub run_tests {
     my $opts = shift;
-    like run_tls_client("$opts $good_client_key_cert"), $TLS_RE_OK, "correct client cert";
-    unlike run_tls_client($opts), $TLS_RE_OK, "no client cert";
-    unlike run_tls_client("$opts $wrong_client_key_cert"), $TLS_RE_OK, "wrong client cert";
+    like run_tls_client("$opts $good_client_key_cert"), $TLS_RE_OK, "correct client cert" or die "test failed";
+    # unlike run_tls_client($opts), $TLS_RE_OK, "no client cert";
+    # unlike run_tls_client("$opts $wrong_client_key_cert"), $TLS_RE_OK, "wrong client cert";
 }
 
 sub run_tls_client {
     my $opts = shift;
-    my $resp = `curl $opts --cacert misc/test-ca/root/ca.crt https://127.0.0.1.xip.io:$tls_port`;
+    my $resp = `curl --max-time 1 --http1.1 --silent --show-error $opts --cacert misc/test-ca/root/ca.crt https://127.0.0.1.xip.io:$tls_port`;
     return $resp;
 }
 
@@ -67,7 +67,7 @@ sub curl_support_tls13 {
         Proto     => "tcp",
         Listen    => 5,
     ) or die "failed to listen to random port:$!";
-    open my $fh, "-|", "curl --tlsv1.3 https://127.0.0.1:@{[$listen->sockport]}/ 2>&1"
+    open my $fh, "-|", "curl --silent --show-error --tlsv1.3 https://127.0.0.1:@{[$listen->sockport]}/ 2>&1"
         or die "failed to launch curl:$!";
     $listen->accept;
     sleep 0.5;


### PR DESCRIPTION
It seems that something wrong happens in TLS handshake, but I'm still not sure what is different between success and failure.

curl's error messages on failure patterns:

```
curl: (52) Empty reply from server
```

It seems a timeout error.