### PR TITLE
[h2olog] stop filtering quicly:debug_message out (+ some code cleanups)

### DIFF
--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -80,12 +80,6 @@ struct_map = OrderedDict([
     ["sockaddr_in6", []],
 ])
 
-# The block list for probes.
-# All the probes are handled by default in JSON mode
-block_probes = set([
-    "quicly:debug_message",
-])
-
 # To rename field names for compatibility with:
 # https://github.com/h2o/quicly/blob/master/quictrace-adapter.py
 rename_map = {
@@ -281,8 +275,6 @@ def parse_and_analyze(context: dict, d_file: Path):
     id = ("H2OLOG_EVENT_ID_%s_%s" % (provider, name)).upper()
 
     fully_specified_probe_name = "%s:%s" % (provider, name)
-    if block_probes and fully_specified_probe_name in block_probes:
-      continue
 
     metadata = {
         "id": id,

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -597,9 +597,6 @@ BPF_PERF_OUTPUT(events);
 // The table size must be larger than the number of threads in h2o.
 BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
 
-// HTTP/3 tracing
-BPF_HASH(h2o_to_quicly_conn, u64, u32);
-
 // tracepoint sched:sched_process_exit
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
   const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -50,9 +50,6 @@ from copy import deepcopy
 
 DEBUG = os.getenv("DEBUG")
 
-quicly_probes_d = "deps/quicly/quicly-probes.d"
-h2o_probes_d = "h2o-probes.d"
-
 # An allow-list to gather data from USDT probes.
 # Only fields listed here are handled in BPF.
 struct_map = OrderedDict([


### PR DESCRIPTION
`quicly:debug_message` (guts of `quicly_debug_printf()`) is not a tracing event but useful for debugging, so there's no need to filter it out. 

Plus, removed some unused variables in h2olog. 