### PR TITLE
fix a timing issue in picotls handshake + mTLS

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1076,7 +1076,12 @@ static void proceed_handshake_picotls(h2o_socket_t *sock)
             write_ssl_bytes(sock, wbuf.base, wbuf.off);
             flush_pending_ssl(sock, ret == 0 ? on_handshake_complete : proceed_handshake);
         } else {
-            h2o_socket_read_start(sock, ret == PTLS_ERROR_IN_PROGRESS ? proceed_handshake : on_handshake_complete);
+            if (ret == 0 && sock->ssl->input.encrypted->size > 0) {
+                /* handshake complete and there's encrypted data ready for processing */
+                on_handshake_complete(sock, NULL);
+            } else {
+                h2o_socket_read_start(sock, ret == PTLS_ERROR_IN_PROGRESS ? proceed_handshake : on_handshake_complete);
+            }
         }
         break;
     default:

--- a/t/40mtls.t
+++ b/t/40mtls.t
@@ -11,18 +11,25 @@ my $wrong_client_key_cert = '--key examples/h2o/server.key --cert examples/h2o/s
 my $TLS_RE_OK = qr{hello};
 
 subtest "tls1.2" => sub {
-    my $server = spawn_server("tlsv1.2");
+    my $server = spawn_h2o_server("tlsv1.2");
     run_tests('');
 };
-
-sleep 1; # without this sleep; the server occasionally fails to bind to $tls_port (maybe some sub-process of h2o still hanging
-         # around?)
 
 subtest "tls1.3" => sub {
     plan skip_all => 'curl does not support TLS 1.3'
         unless curl_support_tls13();
-    my $server = spawn_server("tlsv1.3");
+    my $server = spawn_h2o_server("tlsv1.3");
     run_tests('--tlsv1.3');
+};
+
+subtest "tls1.3 with picotls-cli", sub {
+    # regiression test case for https://github.com/h2o/h2o/pull/2679
+    # use picotls-cli because it calls write(2) for the while request at once,
+    # whereas openssl calls write(2) for each TLS record.
+    my $server = spawn_h2o_server("tlsv1.3");
+    like run_picotls_client({ port => $tls_port, opts => "-k t/assets/test_client.key -C t/assets/test_client.crt" }), $TLS_RE_OK, "correct client cert";
+    unlike run_picotls_client({ port => $tls_port }), $TLS_RE_OK, "no client cert";
+    unlike run_picotls_client({ port => $tls_port, opts => "-k examples/h2o/server.key -C examples/h2o/server.crt" }), $TLS_RE_OK, "wrong client cert";
 };
 
 done_testing;
@@ -36,11 +43,11 @@ sub run_tests {
 
 sub run_tls_client {
     my $opts = shift;
-    my $resp = `curl $opts --cacert misc/test-ca/root/ca.crt https://127.0.0.1.xip.io:$tls_port`;
+    my $resp = `curl $opts --cacert misc/test-ca/root/ca.crt --silent --show-error https://127.0.0.1.xip.io:$tls_port`;
     return $resp;
 }
 
-sub spawn_server {
+sub spawn_h2o_server {
     my $tls_max = shift;
     die "invalid arg:$tls_max" unless $tls_max =~ /^tlsv/;
     spawn_h2o_raw(<<"EOT", [ $tls_port ]);
@@ -67,7 +74,7 @@ sub curl_support_tls13 {
         Proto     => "tcp",
         Listen    => 5,
     ) or die "failed to listen to random port:$!";
-    open my $fh, "-|", "curl --tlsv1.3 https://127.0.0.1:@{[$listen->sockport]}/ 2>&1"
+    open my $fh, "-|", "curl --tlsv1.3 --silent --show-error https://127.0.0.1:@{[$listen->sockport]}/ 2>&1"
         or die "failed to launch curl:$!";
     $listen->accept;
     sleep 0.5;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -705,10 +705,8 @@ sub run_picotls_client {
     my $host = $opts->{host} // '127.0.0.1';
     my $path = $opts->{path} // '/';
     my $cli_opts = $opts->{opts} // '';
-    my $connection = $opts->{keep_alive} ? "keep-alive" : "close";
 
     my $cli = bindir() . "/picotls/cli";
-    die "picotls-cli ($cli) not found" unless -e $cli;
 
     my $tempdir = tempdir();
     my $cmd = "exec $cli $cli_opts $host $port > $tempdir/resp.txt 2>&1";
@@ -719,10 +717,10 @@ sub run_picotls_client {
     print $fh <<"EOT";
 GET $path HTTP/1.1\r
 Host: $host:$port\r
-Connection: $connection\r
+Connection: close\r
 \r
 EOT
-    Time::HiRes::sleep(0.1) until -e "$tempdir/resp.txt" && -s "$tempdir/resp.txt" > 0;
+    sleep 1;
     close $fh;
 
     open $fh, "<", "$tempdir/resp.txt"


### PR DESCRIPTION
H2O may hang up when mTLS is used. The added `subtest "tls1.3 with picotls-cli"` reproduces this problem in 10/10 frequency, as picotls-cli sends the request with a single `write(2)`. 

close #2679