### PR TITLE
[http3] Count conns_accepting alone for quic_num_connections

### DIFF
--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -970,7 +970,8 @@ void h2o_quic_close_all_connections(h2o_quic_ctx_t *ctx)
     h2o_quic_conn_t *conn;
 
     kh_foreach_value(ctx->conns_by_id, conn, { h2o_quic_close_connection(conn, 0, NULL); });
-    kh_foreach_value(ctx->conns_accepting, conn, { h2o_quic_close_connection(conn, 0, NULL); });
+    /* closing a connection should also remove an entry from conns_accepting */
+    assert(kh_size(ctx->conns_accepting) == 0);
 }
 
 size_t h2o_quic_num_connections(h2o_quic_ctx_t *ctx)

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -975,7 +975,9 @@ void h2o_quic_close_all_connections(h2o_quic_ctx_t *ctx)
 
 size_t h2o_quic_num_connections(h2o_quic_ctx_t *ctx)
 {
-    return kh_size(ctx->conns_by_id) + kh_size(ctx->conns_accepting);
+    /* throughout its lifetime, a connection is always registered to both conns_by_id and conns_accepting,
+       thus counting conns_by_id is enough */
+    return kh_size(ctx->conns_by_id);
 }
 
 void h2o_quic_init_conn(h2o_quic_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_quic_conn_callbacks_t *callbacks)


### PR DESCRIPTION
Because a connection is always registered to both `conns_by_id` and
`conns_accepting` throughout its lifetime, counting `conns_by_id`
is enough to know the total number of connections.