### PR TITLE
[tls13 client auth] send alert when handshake fails

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1069,26 +1069,30 @@ static void proceed_handshake_picotls(h2o_socket_t *sock)
     int ret = ptls_handshake(sock->ssl->ptls, &wbuf, sock->ssl->input.encrypted->bytes, &consumed, NULL);
     h2o_buffer_consume(&sock->ssl->input.encrypted, consumed);
 
+    /* determine the next action */
+    h2o_socket_cb next_cb;
     switch (ret) {
     case 0:
+        next_cb = on_handshake_complete;
+        break;
     case PTLS_ERROR_IN_PROGRESS:
-        if (wbuf.off != 0) {
-            h2o_socket_read_stop(sock);
-            write_ssl_bytes(sock, wbuf.base, wbuf.off);
-            flush_pending_ssl(sock, ret == 0 ? on_handshake_complete : proceed_handshake);
-        } else {
-            if (ret == 0 && sock->ssl->input.encrypted->size > 0) {
-                /* handshake complete and there's encrypted data ready for processing */
-                on_handshake_complete(sock, NULL);
-            } else {
-                h2o_socket_read_start(sock, ret == PTLS_ERROR_IN_PROGRESS ? proceed_handshake : on_handshake_complete);
-            }
-        }
+        next_cb = proceed_handshake;
         break;
     default:
-        /* FIXME send alert in wbuf before calling the callback */
-        on_handshake_complete(sock, "picotls handshake error");
+        next_cb = on_handshake_fail_complete;
         break;
+    }
+
+    /* When something is to be sent, send it and then take the next action. If there's nothing to be sent and the handshake is still
+     * in progress, wait for more bytes to arrive; otherwise, take the action immediately. */
+    if (wbuf.off != 0) {
+        h2o_socket_read_stop(sock);
+        write_ssl_bytes(sock, wbuf.base, wbuf.off);
+        flush_pending_ssl(sock, next_cb);
+    } else if (ret == PTLS_ERROR_IN_PROGRESS) {
+        h2o_socket_read_start(sock, next_cb);
+    } else {
+        next_cb(sock, NULL);
     }
 
     ptls_buffer_dispose(&wbuf);


### PR DESCRIPTION
Up until now, when TLS 1.3 is being used, h2o has been dropping the TLS fatal alert generated when receiving 2nd handshake flight from the client.

As we added support for client authentication in #2670, this issue has become a practical shortcoming, because there's chance that clients might not be possible to generate 2nd flight satisfying the expectation of server (i.e. send correct client certificate).

This PR addresses the issue.

Note that the impact of the problem has been limited to TLS 1.3 client authentication, because h2o has always been sending TLS alerts in the following two cases:
* when OpenSSL backend is used for pre-1.3 TLS handshake,
* when first flight of TLShandshake received from the client,  regardless of the TLS version, cannot be accepted.