### PR TITLE
support both TLS and plaintext on the same port

### DIFF
--- a/examples/h2o/h2o.conf
+++ b/examples/h2o/h2o.conf
@@ -2,7 +2,7 @@
 
 listen: 8080
 listen: &ssl_listen
-  port: 8081
+  port: 8080
   ssl:
     certificate-file: examples/h2o/server.crt
     key-file: examples/h2o/server.key
@@ -15,14 +15,14 @@ listen: &ssl_listen
 #listen:
 #  <<: *ssl_listen
 #  type: quic
-#header.set: "Alt-Svc: h3-25=\":8081\""
+#header.set: "Alt-Svc: h3-25=\":8080\""
 hosts:
   "127.0.0.1.xip.io:8080":
     paths:
       /:
         file.dir: examples/doc_root
     access-log: /dev/stdout
-  "alternate.127.0.0.1.xip.io:8081":
+  "alternate.127.0.0.1.xip.io:8080":
     paths:
       /:
         file.dir: examples/doc_root.alternate

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1294,6 +1294,7 @@ typedef struct st_h2o_accept_ctx_t {
     h2o_iovec_t *http2_origin_frame;
     int expect_proxy_line;
     h2o_multithread_receiver_t *libmemcached_receiver;
+    int accept_both;
 } h2o_accept_ctx_t;
 
 /* util */

--- a/src/main.c
+++ b/src/main.c
@@ -152,6 +152,7 @@ struct listener_config_t {
     } quic;
     int proxy_protocol;
     h2o_iovec_t tcp_congestion_controller; /* default CC for this address */
+    int accept_both; /* plaintext and TLS */
 };
 
 struct listener_ctx_t {
@@ -850,14 +851,8 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
     ptls_cipher_suite_t **cipher_suite_tls13 = NULL;
 
     if (!listener_is_new) {
-        if (listener->ssl.size != 0 && ssl_node == NULL) {
-            h2o_configurator_errprintf(cmd, listen_node, "cannot accept HTTP; already defined to accept HTTPS");
-            return -1;
-        }
-        if (listener->ssl.size == 0 && ssl_node != NULL) {
-            h2o_configurator_errprintf(cmd, *ssl_node, "cannot accept HTTPS; already defined to accept HTTP");
-            return -1;
-        }
+        if (!!listener->ssl.size != !!ssl_node)
+            listener->accept_both = 1;
     }
 
     if (ssl_node == NULL)
@@ -2795,6 +2790,7 @@ static void *run_loop(void *_thread_index)
         if (listener_config->ssl.size != 0) {
             listeners[i].accept_ctx.ssl_ctx = listener_config->ssl.entries[0]->ctx;
             listeners[i].accept_ctx.http2_origin_frame = listener_config->ssl.entries[0]->http2_origin_frame;
+            listeners[i].accept_ctx.accept_both = listener_config->accept_both;
         }
         listeners[i].sock = h2o_evloop_socket_create(conf.threads[thread_index].ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
         listeners[i].sock->data = listeners + i;


### PR DESCRIPTION
Closes h2o/h2o#2663

I wasn't able to run the test suite on this, possibly because of dependency issues. It works fine in my local testing using `examples/h2o`, which is updated to demonstrate this feature.