### PR TITLE
override docker entrypoint not to exit before accept command

### DIFF
--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -54,7 +54,7 @@ _do-fuzz-extra:
 	./h2o-fuzzer-url -close_fd_mask=3 -runs=1 -max_len=16384 $(SRC_DIR)/fuzz/url-corpus < /dev/null
 
 enter:
-	docker run $(DOCKER_RUN_OPTS) -it $(CONTAINER_NAME) bash
+	docker run $(DOCKER_RUN_OPTS) -it --entrypoint "bash" $(CONTAINER_NAME)
 
 pull:
 	docker pull $(CONTAINER_NAME)


### PR DESCRIPTION
* Problem
"make enter" target exits before accepting command

```
$ make -f misc/docker-ci/check.mk enter
docker run --privileged --ulimit memlock=-1 -v `pwd`:/h2o -v /sys/kernel/debug:/sys/kernel/debug -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro --add-host=127.0.0.1.xip.io:127.0.0.1 -it -it h2oserver/h2o-ci:ubuntu1604 bash
ci@afc887e8ad0d:~$  make: *** [enter] Error 157
```

* Expected behavior
 Bash won't exits before entering the exit command.

* Cause of the problem

https://github.com/h2o/h2o/commit/f9a8bed92ea771c3d3a4750cf00315b8a0d1addc#diff-1655322b6d096254b6927db6f09cdeb2649c8e82ef3102ec5d6efad021b738c3R41
