### PR TITLE
[fuzzer] Set proxy timeouts

### DIFF
--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -356,13 +356,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         config.http2.idle_timeout = 10 * 1000;
         config.http1.req_timeout = 10 * 1000;
         config.proxy.io_timeout = 10 * 1000;
-        config.proxy.connect_timeout = 0;
-        config.proxy.first_byte_timeout = 0;
+        config.proxy.connect_timeout = config.proxy.io_timeout;
+        config.proxy.first_byte_timeout = config.proxy.io_timeout;
         h2o_proxy_config_vars_t proxy_config = {};
 
         proxy_config.io_timeout = 10 * 1000;
-        proxy_config.connect_timeout = 0;
-        proxy_config.first_byte_timeout = 0;
+        proxy_config.connect_timeout = proxy_config.io_timeout;
+        proxy_config.first_byte_timeout = proxy_config.io_timeout;
         hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT(unix_listener)), 65535);
         register_handler(hostconf, "/chunked-test", chunked_test);
         h2o_url_parse(unix_listener, strlen(unix_listener), &upstream);

--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -355,12 +355,14 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         h2o_config_init(&config);
         config.http2.idle_timeout = 10 * 1000;
         config.http1.req_timeout = 10 * 1000;
-        config.proxy.io_timeout = 10 * 1000;
+        /* Assuming the origin is in the same node and is not super busy, we expect 100ms should be enough for proxy timeout.
+         * Having a large value would explode the total runtime of the fuzzer. */
+        config.proxy.io_timeout = 100;
         config.proxy.connect_timeout = config.proxy.io_timeout;
         config.proxy.first_byte_timeout = config.proxy.io_timeout;
         h2o_proxy_config_vars_t proxy_config = {};
 
-        proxy_config.io_timeout = 10 * 1000;
+        proxy_config.io_timeout = config.proxy.io_timeout;
         proxy_config.connect_timeout = proxy_config.io_timeout;
         proxy_config.first_byte_timeout = proxy_config.io_timeout;
         hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT(unix_listener)), 65535);


### PR DESCRIPTION
`connect_timeout` and `first_byte_timeout` need to be explicitly
set to non-zero values.
This patch aligns these values with `io_timeout`, as done in
https://github.com/h2o/h2o/blob/35401aeb71bd9b8f97e543c524aae50af24e0978/lib/handler/configurator/proxy.c#L46