### PR TITLE
Don't switch streams to `SEND_HEADERS` if we can't process them yet

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -544,7 +544,7 @@ static void handle_request_body_chunk(h2o_http2_conn_t *conn, h2o_http2_stream_t
     if (is_end_stream) {
         if (stream->state < H2O_HTTP2_STREAM_STATE_REQ_PENDING) {
             h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_REQ_PENDING);
-            if (req_queued)
+            if (req_queued && can_run_requests(conn))
                 h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_HEADERS);
         }
         if (stream->req.write_req.cb != NULL) {

--- a/t/50timeout-on-max-concurrent-requests.t
+++ b/t/50timeout-on-max-concurrent-requests.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'nghttp not found'
+    unless prog_exists('nghttp');
+
+my $upstream_port = empty_port();
+
+my $upstream = spawn_server(
+    argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+    is_ready =>  sub {
+        check_port($upstream_port);
+    },
+);
+
+
+my $server = spawn_h2o(<< "EOT");
+http2-max-concurrent-requests-per-connection: 12
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+my $huge_file_size = 20 * 1024;
+my $huge_file = create_data_file($huge_file_size);
+
+my $doit = sub {
+    my ($proto, $port) = @_;
+    my $posts = 100;
+    my $cmd = "h2load -N 5s -m $posts -n $posts -d $huge_file $proto://127.0.0.1:$port/echo 2>&1";
+    print($cmd);
+    my $out = `$cmd`;
+    like $out, qr{status codes: $posts 2xx}, "No error on exit";
+};
+
+subtest 'https' => sub {
+    plan skip_all => 'OpenSSL does not support protocol negotiation; it is too old'
+        unless openssl_can_negotiate();
+    $doit->('https', $server->{tls_port});
+};
+done_testing();
+


### PR DESCRIPTION
Without this fix, streams would move to `SEND_HEADERS`, resulting in a
stuck state: `can_run_requests()` would always return false, preventing
`run_pending_requests()` to pickup any more streams.