### PR TITLE
max-connections should not exceed hard limit of RLIMIT_NOFILE

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3441,29 +3441,35 @@ int main(int argc, char **argv)
     }
 
     {
-        struct rlimit limit = { 0 };
+        struct rlimit limit = {0};
 
         if (getrlimit(RLIMIT_NOFILE, &limit) == 0) {
+            if (conf.max_connections > (int)limit.rlim_max) {
+                fprintf(stderr, "[error] The 'max-connections'=[%d] configuration value "
+                                "should not exceed the file descriptor limit of "
+                                "the process 'RLIMIT_NOFILE'=[%lu]\n",
+                        conf.max_connections, limit.rlim_max);
+                return EX_CONFIG;
+            }
+
             /* raise RLIMIT_NOFILE */
             limit.rlim_cur = limit.rlim_max;
 
             if (setrlimit(RLIMIT_NOFILE, &limit) == 0
-                    #ifdef __APPLE__
-                        || (limit.rlim_cur = OPEN_MAX, setrlimit(RLIMIT_NOFILE, &limit)) == 0
-                    #endif
-            ) {
+#ifdef __APPLE__
+                || (limit.rlim_cur = OPEN_MAX, setrlimit(RLIMIT_NOFILE, &limit)) == 0
+#endif
+                ) {
                 fprintf(stderr, "[INFO] raised RLIMIT_NOFILE to %d\n", (int)limit.rlim_cur);
+            } else {
+                fprintf(stderr, "[warning] setrlimit(RLIMIT_NOFILE) failed "
+                                "with error %d:'%s'\n",
+                        errno, strerror(errno));
             }
-        }
-
-        if (conf.max_connections > (int)limit.rlim_cur) {
-            fprintf(stderr,
-                    "[FATAL] The 'max-connections'=[%d] configuration value "
-                    "should not exceed the file descriptor limit of "
-                    "the process 'RLIMIT_NOFILE'=[%lu]\n",
-                    conf.max_connections,
-                    limit.rlim_cur);
-            return EX_CONFIG;
+        } else {
+            fprintf(stderr, "[warning] getrlimit(RLIMIT_NOFILE) failed "
+                            "with error %d:'%s'\n",
+                    errno, strerror(errno));
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -3444,15 +3444,15 @@ int main(int argc, char **argv)
         struct rlimit limit = {0};
 
         if (getrlimit(RLIMIT_NOFILE, &limit) == 0) {
+            /* raise RLIMIT_NOFILE, making sure that we can reach max_connections */
+
             if (conf.max_connections > (int)limit.rlim_max) {
-                fprintf(stderr, "[error] The 'max-connections'=[%d] configuration value "
-                                "should not exceed the file descriptor limit of "
-                                "the process 'RLIMIT_NOFILE'=[%lu]\n",
+                fprintf(stderr, "[error] The 'max-connections'=[%d] configuration value should not exceed the file descriptor "
+                                "limit of the process 'RLIMIT_NOFILE'=[%lu]\n",
                         conf.max_connections, limit.rlim_max);
                 return EX_CONFIG;
             }
 
-            /* raise RLIMIT_NOFILE */
             limit.rlim_cur = limit.rlim_max;
 
             if (setrlimit(RLIMIT_NOFILE, &limit) == 0
@@ -3462,14 +3462,10 @@ int main(int argc, char **argv)
                 ) {
                 fprintf(stderr, "[INFO] raised RLIMIT_NOFILE to %d\n", (int)limit.rlim_cur);
             } else {
-                fprintf(stderr, "[warning] setrlimit(RLIMIT_NOFILE) failed "
-                                "with error %d:'%s'\n",
-                        errno, strerror(errno));
+                fprintf(stderr, "[warning] setrlimit(RLIMIT_NOFILE) failed:%s\n", strerror(errno));
             }
         } else {
-            fprintf(stderr, "[warning] getrlimit(RLIMIT_NOFILE) failed "
-                            "with error %d:'%s'\n",
-                    errno, strerror(errno));
+            fprintf(stderr, "[warning] getrlimit(RLIMIT_NOFILE) failed:%s\n", strerror(errno));
         }
     }
 


### PR DESCRIPTION
[h2o/h2o/issues/2704](https://github.com/h2o/h2o/issues/2704)

Currently it is possible to configure `h2o` with a `max-connections` value that is greater than the file descriptor limit of the process, `RLIMIT_NOFILE`.  Instead the process should log an error and exit.

Tested with `h2o.conf`:
```
max-connections: 1048577

hosts:
  "www.example.com":
    listen:
      port: 80
    paths:
      "/":
        file.dir: doc-root
```

The log:
```
[FATAL] The 'max-connections'=[1048577] configuration value should not exceed the file descriptor limit of the process 'RLIMIT_NOFILE'=[1048576]
```
