### PR TITLE
[h2olog] fix rounding errors in sampling rate calculation

### DIFF
--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -4153,7 +4153,7 @@ int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
 
 #ifdef H2OLOG_SAMPLING_RATE_U32
   uint64_t flags = event._private_socket_lookup_flags.original_flags;
-  int skip_tracing = bpf_get_prandom_u32() > H2OLOG_SAMPLING_RATE_U32;
+  int skip_tracing = (bpf_get_prandom_u32() & 0x7fffffff) >= H2OLOG_SAMPLING_RATE_U32;
   if (skip_tracing) {
     flags |= H2O_EBPF_FLAGS_SKIP_TRACING_BIT;
   }

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -381,9 +381,9 @@ int main(int argc, char **argv)
     }
 
     if (sampling_rate >= 0) {
-        /* To give the calculated rate in U32 because eBPF bytecode has no floating point numbers,
-         * See the bpf(2) manpage. */
-        cflags.push_back(build_cc_macro_expr("H2OLOG_SAMPLING_RATE_U32", static_cast<uint32_t>(sampling_rate * UINT32_MAX)));
+        /* eBPF bytecode cannot handle floating point numbers see man bpf(2). We use uint32_t from 0 to 0x80000000 (which maps to
+         * 0.0 to 1.0). */
+        cflags.push_back(build_cc_macro_expr("H2OLOG_SAMPLING_RATE_U32", static_cast<uint32_t>(sampling_rate * 0x80000000)));
     }
 
     ebpf::StatusTuple ret = bpf->init(tracer->bpf_text(), cflags, probes);

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -438,7 +438,7 @@ int %s(struct pt_regs *ctx) {
     c += r"""
 #ifdef H2OLOG_SAMPLING_RATE_U32
   uint64_t flags = event._private_socket_lookup_flags.original_flags;
-  int skip_tracing = bpf_get_prandom_u32() > H2OLOG_SAMPLING_RATE_U32;
+  int skip_tracing = (bpf_get_prandom_u32() & 0x7fffffff) >= H2OLOG_SAMPLING_RATE_U32;
   if (skip_tracing) {
     flags |= H2O_EBPF_FLAGS_SKIP_TRACING_BIT;
   }


### PR DESCRIPTION
Existing code has discrepancy where this floating point range is mapped to

* 0..0xffffffff (h2olog.cc)
* 0..0x100000000 (generated_raw_tracer.cc)

Notice that in the latter case, `bpf_get_prandom_u32` is assumed to return 0.0 <= rand < 1.0.