### PR TITLE
[h2olog] resolve H2O_ROOT for BCC

### DIFF
--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -370,7 +370,10 @@ int main(int argc, char **argv)
         h2o_root = H2O_TO_STR(H2O_ROOT);
     // BCC does not resolve a relative path, so h2olog does resolve it as an absolute path.
     char h2o_root_resolved[PATH_MAX];
-    realpath(h2o_root, h2o_root_resolved);
+    if (realpath(h2o_root, h2o_root_resolved) == NULL) {
+        h2o_perror("Error: realpath failed for H2O_ROOT");
+        exit(EXIT_FAILURE);
+    }
     std::vector<std::string> cflags({
         std::string("-I") + std::string(h2o_root_resolved) + "/include",
         build_cc_macro_expr("H2OLOG_H2O_PID", h2o_pid),

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -368,8 +368,11 @@ int main(int argc, char **argv)
     const char *h2o_root = getenv("H2O_ROOT");
     if (h2o_root == NULL)
         h2o_root = H2O_TO_STR(H2O_ROOT);
+    // BCC does not resolve a relative path, so h2olog does resolve it as an absolute path.
+    char h2o_root_resolved[PATH_MAX];
+    realpath(h2o_root, h2o_root_resolved);
     std::vector<std::string> cflags({
-        std::string("-I") + std::string(h2o_root) + "/include",
+        std::string("-I") + std::string(h2o_root_resolved) + "/include",
         build_cc_macro_expr("H2OLOG_H2O_PID", h2o_pid),
         CC_MACRO_EXPR(H2O_EBPF_RETURN_MAP_SIZE),
     });


### PR DESCRIPTION
Looks like BCC does not resolve a relative path in `-I`, so h2olog does it for BCC.

This PR is made against https://github.com/h2o/h2o/pull/2706.