### PR TITLE
[h2olog] fix a bug that h2olog fails to start if /sys/fs/bpf/h2o_return does not exist

### DIFF
--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -836,7 +836,6 @@ void h2o_raw_tracer::initialize() {
     h2o_tracer::usdt("quicly", "stream_on_receive", "trace_quicly__stream_on_receive"),
     h2o_tracer::usdt("quicly", "stream_on_receive_reset", "trace_quicly__stream_on_receive_reset"),
     h2o_tracer::usdt("quicly", "conn_stats", "trace_quicly__conn_stats"),
-    h2o_tracer::usdt("h2o", "_private_socket_lookup_flags", "trace_h2o___private_socket_lookup_flags"),
     h2o_tracer::usdt("h2o", "receive_request", "trace_h2o__receive_request"),
     h2o_tracer::usdt("h2o", "receive_request_header", "trace_h2o__receive_request_header"),
     h2o_tracer::usdt("h2o", "send_response", "trace_h2o__send_response"),

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -2449,12 +2449,6 @@ struct h2olog_event_t {
 
 BPF_PERF_OUTPUT(events);
 
-// A pinned BPF object to return a value to h2o.
-// The table size must be larger than the number of threads in h2o.
-#if H2OLOG_SELECTIVE_TRACING
-BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
-#endif
-
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
 
@@ -4138,6 +4132,10 @@ int trace_quicly__conn_stats(struct pt_regs *ctx) {
 }
 
 #if H2OLOG_SELECTIVE_TRACING
+// A pinned BPF object to return a value to h2o.
+// The table size must be larger than the number of threads in h2o.
+BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
+
 // h2o:_private_socket_lookup_flags
 int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
   const void *buf = NULL;

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -2452,7 +2452,9 @@ BPF_PERF_OUTPUT(events);
 
 // A pinned BPF object to return a value to h2o.
 // The table size must be larger than the number of threads in h2o.
+#if H2OLOG_SELECTIVE_TRACING
 BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
+#endif
 
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
@@ -4135,6 +4137,8 @@ int trace_quicly__conn_stats(struct pt_regs *ctx) {
 
   return 0;
 }
+
+#if H2OLOG_SELECTIVE_TRACING
 // h2o:_private_socket_lookup_flags
 int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
   const void *buf = NULL;
@@ -4168,6 +4172,8 @@ int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
 
   return 0;
 }
+#endif
+
 // h2o:receive_request
 int trace_h2o__receive_request(struct pt_regs *ctx) {
   const void *buf = NULL;

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -387,14 +387,12 @@ int main(int argc, char **argv)
     ebpf::BPF *bpf = new ebpf::BPF();
     std::vector<ebpf::USDT> probes;
 
-    for (const auto &usdt : tracer->usdt_probes()) {
-        probes.push_back(ebpf::USDT(h2o_pid, usdt.provider, usdt.name, usdt.probe_func));
-    }
-
+    bool selective_tracing = false;
     if (sampling_rate < 1.0) {
         /* eBPF bytecode cannot handle floating point numbers see man bpf(2). We use uint32_t which maps to 0 <= value < 1. */
         cflags.push_back(
             build_cc_macro_expr("H2OLOG_SAMPLING_RATE_U32", static_cast<uint32_t>(sampling_rate * (UINT64_C(1) << 32))));
+        selective_tracing = true;
     }
     if (!sampling_addresses.empty()) {
         std::string expr;
@@ -421,6 +419,18 @@ int main(int argc, char **argv)
             expr += ')';
         }
         cflags.push_back(build_cc_macro_expr("H2OLOG_IS_SAMPLING_ADDRESS(family, addr)", std::string("(") + expr + ")"));
+        selective_tracing = true;
+    }
+
+    if (selective_tracing) {
+        cflags.push_back(build_cc_macro_expr("H2OLOG_SELECTIVE_TRACING", 1));
+    }
+
+    for (const auto &usdt : tracer->usdt_probes()) {
+        if (!selective_tracing && usdt.fully_qualified_name() == "h2o:_private_socket_lookup_flags")
+            continue;
+
+        probes.push_back(ebpf::USDT(h2o_pid, usdt.provider, usdt.name, usdt.probe_func));
     }
 
     if (debug >= 2) {

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -424,12 +424,10 @@ int main(int argc, char **argv)
 
     if (selective_tracing) {
         cflags.push_back(build_cc_macro_expr("H2OLOG_SELECTIVE_TRACING", 1));
+        probes.push_back(ebpf::USDT(h2o_pid, "h2o", "_private_socket_lookup_flags", "trace_h2o___private_socket_lookup_flags"));
     }
 
     for (const auto &usdt : tracer->usdt_probes()) {
-        if (!selective_tracing && usdt.fully_qualified_name() == "h2o:_private_socket_lookup_flags")
-            continue;
-
         probes.push_back(ebpf::USDT(h2o_pid, usdt.provider, usdt.name, usdt.probe_func));
     }
 

--- a/src/h2olog/http_tracer.cc
+++ b/src/h2olog/http_tracer.cc
@@ -53,6 +53,11 @@ typedef struct  st_http_event_t {
 
 BPF_PERF_OUTPUT(events);
 
+int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
+  // TODO: HTTP tracer does not support selective-tracing yet.
+  return 0;
+}
+
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
   const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
   pid_t h2o_pid = task->tgid;

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -464,6 +464,15 @@ int %s(struct pt_regs *ctx) {
   return 0;
 }
 """
+
+  if fully_specified_probe_name == "h2o:_private_socket_lookup_flags":
+    c = r"""
+#if H2OLOG_SELECTIVE_TRACING
+%s
+#endif
+
+""" % c.strip()
+
   return c
 
 
@@ -610,7 +619,9 @@ BPF_PERF_OUTPUT(events);
 
 // A pinned BPF object to return a value to h2o.
 // The table size must be larger than the number of threads in h2o.
+#if H2OLOG_SELECTIVE_TRACING
 BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
+#endif
 
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -468,6 +468,10 @@ int %s(struct pt_regs *ctx) {
   if fully_specified_probe_name == "h2o:_private_socket_lookup_flags":
     c = r"""
 #if H2OLOG_SELECTIVE_TRACING
+// A pinned BPF object to return a value to h2o.
+// The table size must be larger than the number of threads in h2o.
+BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
+
 %s
 #endif
 
@@ -616,12 +620,6 @@ typedef union quicly_address_t {
 %s
 %s
 BPF_PERF_OUTPUT(events);
-
-// A pinned BPF object to return a value to h2o.
-// The table size must be larger than the number of threads in h2o.
-#if H2OLOG_SELECTIVE_TRACING
-BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
-#endif
 
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -647,6 +647,9 @@ void h2o_raw_tracer::initialize() {
 """
   for metadata in probe_metadata.values():
     bpf += build_tracer(context, metadata)
+
+    if metadata["fully_specified_probe_name"] == "h2o:_private_socket_lookup_flags":
+      continue
     usdts_def += """    h2o_tracer::usdt("%s", "%s", "%s"),\n""" % (
         metadata['provider'], metadata['name'], build_tracer_name(metadata))
   usdts_def += r"""


### PR DESCRIPTION
`BPF_TABLE_PINNED()` in BPF programs always fails if the pinned map file does not exist, which makes h2olog fail to run when h2o does not have `usdt-selective-tracing: ON`. This PR fixes the problem by hiding the definition of `h2o_return` and its use when h2olog has no selective-tracing options (i.e. -S and -A). 

Also, this PR happens to pursue that approach (1) https://github.com/h2o/h2o/pull/2706#discussion_r637292863