### PR TITLE
[httpclient] [quic] Implement --max-udp-payload-size option to control the corresponding transport parameter

### DIFF
--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -469,6 +469,8 @@ static void usage(const char *progname)
             "  -x <host:port>\n"
             "               specifies the destination of the CONNECT request; implies\n"
             "               `-m CONNECT`\n"
+            "  --max-udp-payload-size <bytes>\n"
+            "               specifies the max_udp_payload_size transport parameter to send\n"
             "  -h           prints this help\n"
             "\n",
             progname);
@@ -553,12 +555,14 @@ int main(int argc, char **argv)
     }
 #endif
 
+    int is_opt_max_udp_payload_size = 0;
+    struct option longopts[] = {{"max-udp-payload-size", required_argument, &is_opt_max_udp_payload_size, 1}, {NULL}};
     const char *optstring = "t:m:o:b:x:C:c:d:H:i:k2:W:h3:"
 #ifdef __GNUC__
                             ":" /* for backward compatibility, optarg of -3 is optional when using glibc */
 #endif
         ;
-    while ((opt = getopt(argc, argv, optstring)) != -1) {
+    while ((opt = getopt_long(argc, argv, optstring, longopts, NULL)) != -1) {
         switch (opt) {
         case 't':
             if (sscanf(optarg, "%u", &cnt_left) != 1 || cnt_left < 1) {
@@ -670,6 +674,12 @@ int main(int argc, char **argv)
         case 'h':
             usage(argv[0]);
             exit(0);
+            break;
+        case 0:
+            if (is_opt_max_udp_payload_size == 1) {
+                h3ctx.quic.initial_egress_max_udp_payload_size = (uint16_t)strtoul(optarg, NULL, 10);
+                h3ctx.quic.transport_params.max_udp_payload_size = (uint64_t)strtoull(optarg, NULL, 10);
+            }
             break;
         default:
             exit(EXIT_FAILURE);


### PR DESCRIPTION
## Overview
Currently, there is no way to control the `max_udp_payload_size` transport parameter of `h2o-httpclient`.  The client always sends the initial message size equal to [DEFAULT_INITIAL_EGRESS_MAX_UDP_PAYLOAD_SIZE](https://github.com/h2o/quicly/blob/345b8e16d5a323b1568b11318ab7992be0be740f/lib/defaults.c#L25) and that dictates the entire conversation as of the current implementation of [h2o/quicly](https://github.com/h2o/quicly), so it is not easy to control or test that aspect of the protocol.  This change allows a user to specify the option which is used to both set the size of the initial handshake message as well as the advertised `max_udp_payload_size` transport parameter.

When used alongside #2710 the packet size in both directions can be controlled.

## Test
### Without this patch
```
$ ./h2o-httpclient.9d9a993 -k -3 100 -H "user-agen: nalramli/1.0" -b 2800 -c 1400 https://127.0.0.2/index.html 1>/dev/null
HTTP/3 200
server: h2o/2.3.0-DEV@98518fb
content-length: 177
date: Thu, 27 May 2021 18:36:21 GMT
content-type: text/html
last-modified: Wed, 12 May 2021 20:09:50 GMT
etag: "609c360e-b1"
accept-ranges: bytes

$ sudo /usr/sbin/tcpdump -i any udp and dst port 443
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on any, link-type LINUX_SLL (Linux cooked), capture size 262144 bytes
14:46:24.499242 IP localhost.37832 > 127.0.0.2.https: UDP, length 1280
14:46:24.502680 IP localhost.37832 > 127.0.0.2.https: UDP, length 1280
14:46:24.502744 IP localhost.37832 > 127.0.0.2.https: UDP, length 443
14:46:24.502826 IP localhost.37832 > 127.0.0.2.https: UDP, length 1280
14:46:24.502835 IP localhost.37832 > 127.0.0.2.https: UDP, length 189
14:46:24.503428 IP localhost.37832 > 127.0.0.2.https: UDP, length 32
^C
6 packets captured
12 packets received by filter
0 packets dropped by kernel
```

### With this patch
```
$ ./h2o-httpclient.98518fb -k -3 100 -H "user-agen: nalramli/1.0" -b 2800 -c 1400 --max-udp-payload-size 1400 https://127.0.0.2/index.html 1>/dev/null
HTTP/3 200
server: h2o/2.3.0-DEV@98518fb
content-length: 177
date: Thu, 27 May 2021 18:38:14 GMT
content-type: text/html
last-modified: Wed, 12 May 2021 20:09:50 GMT
etag: "609c360e-b1"
accept-ranges: bytes

$ sudo /usr/sbin/tcpdump -i any udp and dst port 443
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on any, link-type LINUX_SLL (Linux cooked), capture size 262144 bytes
14:38:14.979823 IP localhost.41773 > 127.0.0.2.https: UDP, length 1400
14:38:14.985265 IP localhost.41773 > 127.0.0.2.https: UDP, length 1400
14:38:14.985323 IP localhost.41773 > 127.0.0.2.https: UDP, length 323
14:38:14.985351 IP localhost.41773 > 127.0.0.2.https: UDP, length 1400
14:38:14.985876 IP localhost.41773 > 127.0.0.2.https: UDP, length 32
^C
5 packets captured
12 packets received by filter
1 packet dropped by kernel
```

## Related
* [\[h2o/quic\] lib: apply remote.transport_params.max_udp_payload_size once learned (#453)](https://github.com/h2o/quicly/pull/453)
* #2710
