### PR TITLE
Do not start reading on tunnel since h2o_send will call tcp_on_proceed

### DIFF
--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -406,9 +406,6 @@ static void tcp_on_connect(h2o_socket_t *_sock, const char *err)
     if (self->tcp.sendbuf->size != 0 || self->write_closed)
         tcp_do_write(self);
 
-    /* strat the read side */
-    h2o_socket_read_start(self->sock, tcp_on_read);
-
     /* build and submit 200 response */
     self->src_req->res.status = 200;
     h2o_start_response(self->src_req, &self->super);


### PR DESCRIPTION
The `h2o_socket_read_start` is unnecessary because we immediately call `h2o_send`,
which will call `tcp_on_proceed`, which will set the socket in a read
state.

It's a bug to have start reading because we might have
`tcp_on_read` called on its own right before `tcp_on_proceed`
is called, and we will assert in `http2::finalostream_send` in
`h2o_http2_conn_register_for_proceed_callback` because the stream is
already linked