### PR TITLE
[fuzzer] Use timeout specified by envvar

### DIFF
--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -406,7 +406,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 
     /* Loop until the connection is closed by the client or server */
     while (is_valid_fd(c)) {
-        h2o_evloop_run(ctx.loop, 10);
+        h2o_evloop_run(ctx.loop, client_timeout_ms);
     }
 
     h2o_barrier_wait(end);


### PR DESCRIPTION
H2O_FUZZER_CLIENT_TIMEOUT is read from environment but never used.
This patch actually uses it so the behavior matches what README says.