### PR TITLE
[HPACK][QPACK] fix bugs in handling of soft errors

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -680,6 +680,7 @@
 		08819C2C218C9FA90057ED23 /* qif */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = qif; sourceTree = BUILT_PRODUCTS_DIR; };
 		08819C2D218C9FF70057ED23 /* qif.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = qif.c; sourceTree = "<group>"; };
 		08C7C365262AB30F009C944C /* 40mtls.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 40mtls.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		08CEA9CF2662136B00B4BB6B /* 80http3-header-linefeed.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "80http3-header-linefeed.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		08E9CC4D1E41F6660049DD26 /* embedded.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedded.c.h; sourceTree = "<group>"; };
 		100A550C1C22857B00C4E3E0 /* 50mruby-htpasswd.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50mruby-htpasswd.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		100A550E1C2BB15100C4E3E0 /* http_request.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http_request.c; sourceTree = "<group>"; };
@@ -2235,6 +2236,7 @@
 				109EEFE11D77B350001F11D1 /* 80dup-host-headers.t */,
 				E9BC76C51EE4AB6C00EB7A09 /* 80graceful-shutdown.t */,
 				E9AFBF2C212A985E000F5DB8 /* 80http2-idle-timeout-for-zero-window.t */,
+				08CEA9CF2662136B00B4BB6B /* 80http3-header-linefeed.t */,
 				109EEFE21D77B350001F11D1 /* 80invalid-h2-chars-in-headers.t */,
 				105534FE1A46134A00627ECB /* 80issues61.t */,
 				1092E0011BEB1DDC001074BF /* 80issues579.t */,

--- a/include/h2o/http2_common.h
+++ b/include/h2o/http2_common.h
@@ -95,7 +95,7 @@ typedef struct st_h2o_hpack_header_table_t {
 typedef struct st_h2o_hpack_header_table_entry_t {
     h2o_iovec_t *name;
     h2o_iovec_t *value;
-    const char *err_desc; /* the recorded soft error description */
+    unsigned soft_errors;
 } h2o_hpack_header_table_entry_t;
 
 void h2o_hpack_dispose_header_table(h2o_hpack_header_table_t *header_table);

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -174,10 +174,12 @@ static void test_hpack(void)
     {
         h2o_iovec_t huffcode = {H2O_STRLIT("\xf1\xe3\xc2\xe5\xf2\x3a\x6b\xa0\xab\x90\xf4\xff")};
         char buf[32];
+        unsigned soft_errors = 0;
         const char *err_desc = NULL;
-        size_t len = h2o_hpack_decode_huffman(buf, (const uint8_t *)huffcode.base, huffcode.len, 0, &err_desc);
+        size_t len = h2o_hpack_decode_huffman(buf, &soft_errors, (const uint8_t *)huffcode.base, huffcode.len, 0, &err_desc);
         ok(len == sizeof("www.example.com") - 1);
         ok(memcmp(buf, "www.example.com", len) == 0);
+        ok(soft_errors == 0);
         ok(err_desc == NULL);
     }
     h2o_mem_clear_pool(&pool);
@@ -186,12 +188,13 @@ static void test_hpack(void)
     {
         char *str = "\x8c\xf1\xe3\xc2\xe5\xf2\x3a\x6b\xa0\xab\x90\xf4\xff";
         const uint8_t *buf;
+        unsigned soft_errors = 0;
         const char *errstr = NULL;
         size_t len;
         len = strlen(str);
         buf = (const uint8_t *)str;
         /* since we're only passing one byte, decode_string should fail */
-        h2o_iovec_t *decoded = decode_string(&pool, &buf, &buf[1], 0, &errstr);
+        h2o_iovec_t *decoded = decode_string(&pool, &soft_errors, &buf, &buf[1], 0, &errstr);
         ok(decoded == NULL);
     }
     h2o_mem_clear_pool(&pool);

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -482,7 +482,7 @@ static void test_hpack_dynamic_table(void)
     ok(memcmp(encoded, expected.base, expected.len) == 0);
 }
 
-void test_token_wo_hpack_id(void)
+static void test_token_wo_hpack_id(void)
 {
     h2o_mem_pool_t pool;
     h2o_mem_init_pool(&pool);
@@ -516,10 +516,105 @@ void test_token_wo_hpack_id(void)
     h2o_mem_clear_pool(&pool);
 }
 
+static void do_test_inherit_invalid(h2o_iovec_t first_input, h2o_iovec_t second_input, h2o_iovec_t expected_name,
+                                    h2o_iovec_t expected_first_value, const char *expected_first_err_desc,
+                                    h2o_iovec_t expected_second_value, const char *expected_second_err_desc)
+{
+    h2o_mem_pool_t pool;
+    h2o_hpack_header_table_t table = {.hpack_capacity = 4096};
+
+    h2o_mem_init_pool(&pool);
+
+    { /* add header with invalid name, valid value */
+        int status;
+        h2o_headers_t headers = {};
+        const char *err_desc = NULL;
+        int ret = h2o_hpack_parse_response(&pool, h2o_hpack_decode_header, &table, &status, &headers,
+                                           (const uint8_t *)first_input.base, first_input.len, &err_desc);
+        ok(ret == H2O_HTTP2_ERROR_INVALID_HEADER_CHAR);
+        ok(err_desc == expected_first_err_desc);
+        ok(status == 200);
+        ok(headers.size == 1);
+        ok(h2o_memis(headers.entries[0].name->base, headers.entries[0].name->len, expected_name.base, expected_name.len));
+        ok(h2o_memis(headers.entries[0].value.base, headers.entries[0].value.len, expected_first_value.base,
+                     expected_first_value.len));
+    }
+
+    { /* check that the invalid_name is inherited */
+        int status;
+        h2o_headers_t headers = {};
+        const char *err_desc = NULL;
+        int ret = h2o_hpack_parse_response(&pool, h2o_hpack_decode_header, &table, &status, &headers,
+                                           (const uint8_t *)second_input.base, second_input.len, &err_desc);
+        if (expected_second_err_desc == NULL) {
+            ok(ret == 0);
+        } else {
+            ok(ret == H2O_HTTP2_ERROR_INVALID_HEADER_CHAR);
+            ok(err_desc == expected_second_err_desc);
+        }
+        ok(status == 200);
+        ok(headers.size == 1);
+        ok(h2o_memis(headers.entries[0].name->base, headers.entries[0].name->len, expected_name.base, expected_name.len));
+        ok(h2o_memis(headers.entries[0].value.base, headers.entries[0].value.len, expected_second_value.base,
+                     expected_second_value.len));
+    }
+
+    h2o_mem_clear_pool(&pool);
+}
+
+static void test_inherit_invalid(void)
+{
+    { /* inherit invalid name */
+        static const uint8_t first_input[] = {
+            0x88,                           /* :status: 200 */
+            0x40, 3, 'a', '\n', 'b', 1, '0' /* a\nb: 0 */
+        };
+        static const uint8_t second_input[] = {
+            0x88,        /* :status: 200 */
+            0x7e, 1, '1' /* a\nb: 1 */
+        };
+        do_test_inherit_invalid(h2o_iovec_init(first_input, sizeof(first_input)),
+                                h2o_iovec_init(second_input, sizeof(second_input)), h2o_iovec_init(H2O_STRLIT("a\nb")),
+                                h2o_iovec_init(H2O_STRLIT("0")), h2o_hpack_soft_err_found_invalid_char_in_header_name,
+                                h2o_iovec_init(H2O_STRLIT("1")), h2o_hpack_soft_err_found_invalid_char_in_header_name);
+    }
+
+    { /* inherit invalid name & value */
+        static const uint8_t first_input[] = {
+            0x88,                                      /* :status: 200 */
+            0x40, 3, 'a', '\n', 'b', 3, '0', '\n', '1' /* a\nb: 0\n1 */
+        };
+        static const uint8_t second_input[] = {
+            0x88,        /* :status: 200 */
+            0x7e, 1, '1' /* a\nb: 1 */
+        };
+        do_test_inherit_invalid(h2o_iovec_init(first_input, sizeof(first_input)),
+                                h2o_iovec_init(second_input, sizeof(second_input)), h2o_iovec_init(H2O_STRLIT("a\nb")),
+                                h2o_iovec_init(H2O_STRLIT("0\n1")), h2o_hpack_soft_err_found_invalid_char_in_header_name,
+                                h2o_iovec_init(H2O_STRLIT("1")), h2o_hpack_soft_err_found_invalid_char_in_header_name);
+    }
+
+    { /* do not inherit invalid value */
+        static const uint8_t first_input[] = {
+            0x88,                           /* :status: 200 */
+            0x40, 1, 'a', 3, '0', '\n', '1' /* a: 0\n1 */
+        };
+        static const uint8_t second_input[] = {
+            0x88,        /* :status: 200 */
+            0x7e, 1, '1' /* a: 1 */
+        };
+        do_test_inherit_invalid(h2o_iovec_init(first_input, sizeof(first_input)),
+                                h2o_iovec_init(second_input, sizeof(second_input)), h2o_iovec_init(H2O_STRLIT("a")),
+                                h2o_iovec_init(H2O_STRLIT("0\n1")), h2o_hpack_soft_err_found_invalid_char_in_header_value,
+                                h2o_iovec_init(H2O_STRLIT("1")), NULL);
+    }
+}
+
 void test_lib__http2__hpack(void)
 {
     subtest("hpack", test_hpack);
     subtest("hpack-push", test_hpack_push);
     subtest("hpack-dynamic-table", test_hpack_dynamic_table);
     subtest("token-wo-hpack-id", test_token_wo_hpack_id);
+    subtest("inherit-invalid", test_inherit_invalid);
 }

--- a/t/00unit/lib/http3/qpack.c
+++ b/t/00unit/lib/http3/qpack.c
@@ -37,7 +37,7 @@ static h2o_iovec_t get_payload(const char *_src, size_t len)
     return h2o_iovec_init(src, end - src);
 }
 
-static void doit(int use_enc_stream)
+static void do_test_simple(int use_enc_stream)
 {
     h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
     h2o_qpack_encoder_t *enc = h2o_qpack_create_encoder(4096, 10);
@@ -59,7 +59,7 @@ static void doit(int use_enc_stream)
     {
         h2o_headers_t headers = {NULL};
         h2o_add_header_by_str(&pool, &headers, H2O_STRLIT("dnt"), 0, NULL, H2O_STRLIT("1"));
-        h2o_add_header_by_str(&pool, &headers, H2O_STRLIT("x-hoge"), 0, NULL, H2O_STRLIT("\x01\x02\x03")); /* literal, non-huff */
+        h2o_add_header_by_str(&pool, &headers, H2O_STRLIT("x-hoge"), 0, NULL, H2O_STRLIT("A")); /* literal, non-huff */
         h2o_iovec_t headers_frame = h2o_qpack_flatten_request(enc, &pool, 123, enc_stream, h2o_iovec_init(H2O_STRLIT("GET")),
                                                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("example.com")),
                                                               h2o_iovec_init(H2O_STRLIT("/foobar")), headers.entries, headers.size);
@@ -94,7 +94,7 @@ static void doit(int use_enc_stream)
         ok(h2o_memis(headers.entries[0].name->base, headers.entries[0].name->len, H2O_STRLIT("dnt")));
         ok(h2o_memis(headers.entries[0].value.base, headers.entries[0].value.len, H2O_STRLIT("1")));
         ok(h2o_memis(headers.entries[1].name->base, headers.entries[1].name->len, H2O_STRLIT("x-hoge")));
-        ok(h2o_memis(headers.entries[1].value.base, headers.entries[1].value.len, H2O_STRLIT("\x01\x02\x03")));
+        ok(h2o_memis(headers.entries[1].value.base, headers.entries[1].value.len, H2O_STRLIT("A")));
     }
 
     if (enc_stream != NULL) {
@@ -108,8 +108,280 @@ static void doit(int use_enc_stream)
     h2o_qpack_destroy_encoder(enc);
 }
 
+static void test_simple(void)
+{
+    do_test_simple(0);
+    do_test_simple(1);
+}
+
+static void do_test_decode_request(h2o_qpack_decoder_t *dec, int64_t stream_id, h2o_iovec_t input, int expected_ret,
+                                   const char *expected_err_desc, h2o_iovec_t expected_method,
+                                   const h2o_url_scheme_t *expected_scheme, h2o_iovec_t expected_authority,
+                                   h2o_iovec_t expected_path, size_t expected_content_length, const h2o_header_t *expected_headers,
+                                   size_t expected_num_headers, h2o_iovec_t expected_header_ack)
+{
+    h2o_mem_pool_t pool;
+    h2o_iovec_t method = {}, authority = {}, path = {};
+    const h2o_url_scheme_t *scheme = NULL;
+    h2o_headers_t headers = {};
+    int pseudo_header_exists_map = 0;
+    size_t content_length = SIZE_MAX;
+    const char *err_desc = NULL;
+    uint8_t header_ack[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
+    size_t header_ack_len;
+
+    h2o_mem_init_pool(&pool);
+
+    int ret = h2o_qpack_parse_request(&pool, dec, stream_id, &method, &scheme, &authority, &path, &headers,
+                                      &pseudo_header_exists_map, &content_length, NULL, header_ack, &header_ack_len,
+                                      (const uint8_t *)input.base, input.len, &err_desc);
+
+    ok(ret == expected_ret);
+    ok(err_desc == expected_err_desc);
+    if (ret != 0 && ret != H2O_HTTP2_ERROR_INVALID_HEADER_CHAR)
+        return;
+
+    ok(pseudo_header_exists_map == (H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS | H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS |
+                                    H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS | H2O_HPACK_PARSE_HEADERS_PATH_EXISTS));
+    ok(h2o_memis(method.base, method.len, expected_method.base, expected_method.len));
+    ok(scheme == expected_scheme);
+    ok(h2o_memis(authority.base, authority.len, expected_authority.base, expected_authority.len));
+    ok(h2o_memis(path.base, path.len, expected_path.base, expected_path.len));
+    ok(content_length == expected_content_length);
+    ok(headers.size == expected_num_headers);
+    for (size_t i = 0; i < expected_num_headers; ++i) {
+        if (i < headers.size) {
+            ok(h2o_iovec_is_token(headers.entries[i].name) == h2o_iovec_is_token(expected_headers[i].name));
+            ok(h2o_memis(headers.entries[i].name->base, headers.entries[i].name->len, expected_headers[i].name->base,
+                         expected_headers[i].name->len));
+            ok(h2o_memis(headers.entries[i].value.base, headers.entries[i].value.len, expected_headers[i].value.base,
+                         expected_headers[i].value.len));
+        }
+    }
+
+    ok(h2o_memis(header_ack, header_ack_len, expected_header_ack.base, expected_header_ack.len));
+
+    h2o_mem_clear_pool(&pool);
+}
+
+static void test_decode_literal_invalid_name(void)
+{
+    h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+
+    static const uint8_t input[] = {
+        0,    0,                        /* required_inesrt_count=0, base=0 */
+        0xd1,                           /* :method: GET */
+        0xd7,                           /* :scheme: https */
+        0x50, 1,   'a',                 /* :authority: a */
+        0xc1,                           /* :path: / */
+        0x23, 'a', '\n', 'b', 0x1, '0', /* a\nb: 0 */
+    };
+    static h2o_iovec_t invalid_header_name = {H2O_STRLIT("a\nb")};
+    static const h2o_header_t expected_header = {.name = &invalid_header_name, .orig_name = "a\nb", .value = {H2O_STRLIT("0")}};
+
+    do_test_decode_request(dec, 0, h2o_iovec_init(input, sizeof(input)), H2O_HTTP2_ERROR_INVALID_HEADER_CHAR,
+                           h2o_hpack_soft_err_found_invalid_char_in_header_name, h2o_iovec_init(H2O_STRLIT("GET")),
+                           &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                           &expected_header, 1, h2o_iovec_init(NULL, 0));
+
+    h2o_qpack_destroy_decoder(dec);
+}
+
+static void test_decode_literal_invalid_value(void)
+{
+    h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+
+    static const uint8_t input[] = {
+        0,    0,                 /* required_inesrt_count=0, base=0 */
+        0xd1,                    /* :method: GET */
+        0xd7,                    /* :scheme: https */
+        0x50, 3, 'a', '\n', 'b', /* :authority: a\nb */
+        0xc1,                    /* :path: / */
+    };
+    do_test_decode_request(dec, 0, h2o_iovec_init(input, sizeof(input)), H2O_HTTP2_ERROR_INVALID_HEADER_CHAR,
+                           h2o_hpack_soft_err_found_invalid_char_in_header_value, h2o_iovec_init(H2O_STRLIT("GET")),
+                           &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a\nb")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                           NULL, 0, h2o_iovec_init(NULL, 0));
+
+    h2o_qpack_destroy_decoder(dec);
+}
+
+static void test_decode_referred(void)
+{
+    h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+
+    static const uint8_t instructions[] = {
+        0xc8, 3,   'a',  '\n', 'b',                 /* if-modified-since: a\nb (insert-with-static-nameref) */
+        0x43, 'c', '\n', 'd',  3,   'e', '\n', 'f', /* c\nd: e\nf              (insert-with-literal-name) */
+        0x81, 1,   '0',                             /* if-modified-since: 0    (insert-with-dynamic-nameref) */
+        0x81, 1,   '1',                             /* c\nd: 1                 (insert-with-dynamic-nameref) */
+    };
+
+    { /* feed the instructions */
+        int64_t *unblocked_stream_ids;
+        size_t num_unblocked;
+        const uint8_t *p = instructions;
+        const char *err_desc;
+        int ret =
+            h2o_qpack_decoder_handle_input(dec, &unblocked_stream_ids, &num_unblocked, &p, p + sizeof(instructions), &err_desc);
+        ok(ret == 0);
+        ok(p == instructions + sizeof(instructions));
+        ok(num_unblocked == 0);
+    }
+
+    note("use indexed(0)");
+    {
+        static const uint8_t input[] = {
+            2,    0,      /* required_insert_count=1, base=1 */
+            0xd1,         /* :method: GET */
+            0xd7,         /* :scheme: https */
+            0x50, 1, 'a', /* :authority: a */
+            0xc1,         /* :path: / */
+            0x80          /* dynamic entry = 0 */
+        };
+        static const h2o_header_t invalid_header = {.name = &H2O_TOKEN_IF_MODIFIED_SINCE->buf, .value = {H2O_STRLIT("a\nb")}};
+        static const uint8_t expected_ack[] = {0x80};
+        do_test_decode_request(dec, 0, h2o_iovec_init(input, sizeof(input)), H2O_HTTP2_ERROR_INVALID_HEADER_CHAR,
+                               h2o_hpack_soft_err_found_invalid_char_in_header_value, h2o_iovec_init(H2O_STRLIT("GET")),
+                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                               &invalid_header, 1, h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+    }
+
+    note("use indexed(1)");
+    {
+        static const uint8_t input[] = {
+            3,    0,      /* required_insert_count=2, base=2 */
+            0xd1,         /* :method: GET */
+            0xd7,         /* :scheme: https */
+            0x50, 1, 'a', /* :authority: a */
+            0xc1,         /* :path: / */
+            0x80          /* dynamic entry = 1 */
+        };
+        static h2o_iovec_t invalid_name = {H2O_STRLIT("c\nd")};
+        static const h2o_header_t invalid_header = {.name = &invalid_name, .value = {H2O_STRLIT("e\nf")}};
+        static const uint8_t expected_ack[] = {0x84};
+        do_test_decode_request(dec, 4, h2o_iovec_init(input, sizeof(input)), H2O_HTTP2_ERROR_INVALID_HEADER_CHAR,
+                               h2o_hpack_soft_err_found_invalid_char_in_header_name, h2o_iovec_init(H2O_STRLIT("GET")),
+                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                               &invalid_header, 1, h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+    }
+
+    note("use indexed(2)");
+    {
+        static const uint8_t input[] = {
+            4,    0,      /* required_insert_count=3, base=3 */
+            0xd1,         /* :method: GET */
+            0xd7,         /* :scheme: https */
+            0x50, 1, 'a', /* :authority: a */
+            0xc1,         /* :path: / */
+            0x80          /* dynamic entry = 2 */
+        };
+        static const h2o_header_t header = {.name = &H2O_TOKEN_IF_MODIFIED_SINCE->buf, .value = {H2O_STRLIT("0")}};
+        static const uint8_t expected_ack[] = {0x88};
+        do_test_decode_request(dec, 8, h2o_iovec_init(input, sizeof(input)), 0, NULL, h2o_iovec_init(H2O_STRLIT("GET")),
+                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                               &header, 1, h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+    }
+
+    note("use indexed(3)");
+    {
+        static const uint8_t input[] = {
+            5,    0,      /* required_insert_count=4, base=4 */
+            0xd1,         /* :method: GET */
+            0xd7,         /* :scheme: https */
+            0x50, 1, 'a', /* :authority: a */
+            0xc1,         /* :path: / */
+            0x80          /* dynamic entry = 3 */
+        };
+        static h2o_iovec_t invalid_name = {H2O_STRLIT("c\nd")};
+        static const h2o_header_t invalid_header = {.name = &invalid_name, .value = {H2O_STRLIT("1")}};
+        static const uint8_t expected_ack[] = {0x8c};
+        do_test_decode_request(dec, 12, h2o_iovec_init(input, sizeof(input)), H2O_HTTP2_ERROR_INVALID_HEADER_CHAR,
+                               h2o_hpack_soft_err_found_invalid_char_in_header_name, h2o_iovec_init(H2O_STRLIT("GET")),
+                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                               &invalid_header, 1, h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+    }
+
+    note("use name-ref(0)");
+    {
+        static const uint8_t input[] = {
+            2,    0,      /* required_insert_count=1, base=1 */
+            0xd1,         /* :method: GET */
+            0xd7,         /* :scheme: https */
+            0x50, 1, 'a', /* :authority: a */
+            0xc1,         /* :path: / */
+            0x40, 1, '1', /* if-modified-since: 1 (dynamic entry = 0) */
+        };
+        static const h2o_header_t header = {.name = &H2O_TOKEN_IF_MODIFIED_SINCE->buf, .value = {H2O_STRLIT("1")}};
+        static const uint8_t expected_ack[] = {0x90};
+        do_test_decode_request(dec, 16, h2o_iovec_init(input, sizeof(input)), 0, NULL, h2o_iovec_init(H2O_STRLIT("GET")),
+                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                               &header, 1, h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+    }
+
+    note("use name-ref(1)");
+    {
+        static const uint8_t input[] = {
+            3,    0,      /* required_insert_count=2, base=2 */
+            0xd1,         /* :method: GET */
+            0xd7,         /* :scheme: https */
+            0x50, 1, 'a', /* :authority: a */
+            0xc1,         /* :path: / */
+            0x40, 1, '1', /* c\nd: 1 (dynamic entry = 1) */
+        };
+        static h2o_iovec_t invalid_name = {H2O_STRLIT("c\nd")};
+        static const h2o_header_t header = {.name = &invalid_name, .value = {H2O_STRLIT("1")}};
+        static const uint8_t expected_ack[] = {0x94};
+        do_test_decode_request(dec, 20, h2o_iovec_init(input, sizeof(input)), H2O_HTTP2_ERROR_INVALID_HEADER_CHAR,
+                               h2o_hpack_soft_err_found_invalid_char_in_header_name, h2o_iovec_init(H2O_STRLIT("GET")),
+                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                               &header, 1, h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+    }
+
+    note("use post-base indexed(0)");
+    {
+        static const uint8_t input[] = {
+            2,    0x80,      /* required_insert_count=1, base=0 */
+            0xd1,            /* :method: GET */
+            0xd7,            /* :scheme: https */
+            0x50, 1,    'a', /* :authority: a */
+            0xc1,            /* :path: / */
+            0x10             /* dynamic entry = 0 */
+        };
+        static const h2o_header_t invalid_header = {.name = &H2O_TOKEN_IF_MODIFIED_SINCE->buf, .value = {H2O_STRLIT("a\nb")}};
+        static const uint8_t expected_ack[] = {0x98};
+        do_test_decode_request(dec, 24, h2o_iovec_init(input, sizeof(input)), H2O_HTTP2_ERROR_INVALID_HEADER_CHAR,
+                               h2o_hpack_soft_err_found_invalid_char_in_header_value, h2o_iovec_init(H2O_STRLIT("GET")),
+                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                               &invalid_header, 1, h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+    }
+
+    note("use post-base name-ref(1)");
+    {
+        static const uint8_t input[] = {
+            3,    0x80,      /* required_insert_count=2, base=1 */
+            0xd1,            /* :method: GET */
+            0xd7,            /* :scheme: https */
+            0x50, 1,    'a', /* :authority: a */
+            0xc1,            /* :path: / */
+            0,    1,    '1', /* c\nd: 1 (dynamic entry = 1) */
+        };
+        static h2o_iovec_t invalid_name = {H2O_STRLIT("c\nd")};
+        static const h2o_header_t header = {.name = &invalid_name, .value = {H2O_STRLIT("1")}};
+        static const uint8_t expected_ack[] = {0x9c};
+        do_test_decode_request(dec, 28, h2o_iovec_init(input, sizeof(input)), H2O_HTTP2_ERROR_INVALID_HEADER_CHAR,
+                               h2o_hpack_soft_err_found_invalid_char_in_header_name, h2o_iovec_init(H2O_STRLIT("GET")),
+                               &H2O_URL_SCHEME_HTTPS, h2o_iovec_init(H2O_STRLIT("a")), h2o_iovec_init(H2O_STRLIT("/")), SIZE_MAX,
+                               &header, 1, h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+    }
+
+    h2o_qpack_destroy_decoder(dec);
+}
+
 void test_lib__http3_qpack(void)
 {
-    doit(0);
-    doit(1);
+    subtest("simple", test_simple);
+    subtest("decode-literal-invalid-name", test_decode_literal_invalid_name);
+    subtest("decode-literal-invalid-value", test_decode_literal_invalid_value);
+    subtest("decode-referred", test_decode_referred);
 }


### PR DESCRIPTION
* QPACK: report invalid characters found in the header fields. Up until now, the decoder has passed through header fields containing line feeds that lead to response splitting when the reverse proxy handler connects upstream using H1.
* HPACK: do not inherit the invalid flag when receiving a literal header field that uses an indexed "name", of which the corresponding "value" was invalid.