### PR TITLE
replace xip.io with vcap.me

### DIFF
--- a/examples/h2o/h2o.conf
+++ b/examples/h2o/h2o.conf
@@ -17,12 +17,12 @@ listen: &ssl_listen
 #  type: quic
 #header.set: "Alt-Svc: h3-25=\":8081\""
 hosts:
-  "127.0.0.1.xip.io:8080":
+  "127.0.0.1.vcap.me:8080":
     paths:
       /:
         file.dir: examples/doc_root
     access-log: /dev/stdout
-  "alternate.127.0.0.1.xip.io:8081":
+  "alternate.127.0.0.1.vcap.me:8081":
     paths:
       /:
         file.dir: examples/doc_root.alternate

--- a/examples/h2o/wildcard.crt
+++ b/examples/h2o/wildcard.crt
@@ -7,7 +7,7 @@ Certificate:
         Validity
             Not Before: Jun  9 21:40:42 2018 GMT
             Not After : Jun  6 21:40:42 2028 GMT
-        Subject: CN=*.127.0.0.1.xip.io
+        Subject: CN=*.127.0.0.1.vcap.me
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)

--- a/examples/h2o_mruby/h2o.conf
+++ b/examples/h2o_mruby/h2o.conf
@@ -12,7 +12,7 @@ listen:
     # Oldest compatible clients: Firefox 27, Chrome 30, IE 11 on Windows 7, Edge, Opera 17, Safari 9, Android 5.0, and Java 8
     # see: https://wiki.mozilla.org/Security/Server_Side_TLS
 hosts:
-  "127.0.0.1.xip.io:8080":
+  "127.0.0.1.vcap.me:8080":
     paths:
       /:
         file.dir: examples/doc_root
@@ -23,7 +23,7 @@ hosts:
             H2O::Prometheus.new(H2O.next)
         - status: ON
     access-log: /dev/stdout
-  "alternate.127.0.0.1.xip.io:8081":
+  "alternate.127.0.0.1.vcap.me:8081":
     listen:
       port: 8081
       ssl:

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -9,7 +9,7 @@ DOCKER_RUN_OPTS=--privileged \
 	-v /sys/kernel/debug:/sys/kernel/debug \
 	-v /lib/modules:/lib/modules:ro \
 	-v /usr/src:/usr/src:ro \
-	--add-host=127.0.0.1.xip.io:127.0.0.1 \
+	--add-host=127.0.0.1.vcap.me:127.0.0.1 \
 	-it
 
 ALL:

--- a/misc/test-ca/root/demoCA/index.txt
+++ b/misc/test-ca/root/demoCA/index.txt
@@ -1,3 +1,3 @@
-V	241207193305Z		01	unknown	/CN=127.0.0.1.xip.io
-V	241207201102Z		02	unknown	/CN=alternate.127.0.0.1.xip.io
+V	241207193305Z		01	unknown	/CN=127.0.0.1.vcap.me
+V	241207201102Z		02	unknown	/CN=alternate.127.0.0.1.vcap.me
 V	310417051942Z		03	unknown	/CN=H2O Intermediate CA

--- a/t/00unit/lib/http2/cache_digests.c
+++ b/t/00unit/lib/http2/cache_digests.c
@@ -44,9 +44,9 @@ static void test_decode(void)
     ok(digests->fresh.url_only.entries[0].keys.entries[0] == 0x0b);
     ok(!digests->fresh.complete);
 
-    ok(h2o_cache_digests_lookup_by_url(digests, H2O_STRLIT("https://127.0.0.1.xip.io:8081/cache-digests.cgi/hello.js")) ==
+    ok(h2o_cache_digests_lookup_by_url(digests, H2O_STRLIT("https://127.0.0.1.vcap.me:8081/cache-digests.cgi/hello.js")) ==
        H2O_CACHE_DIGESTS_STATE_FRESH);
-    ok(h2o_cache_digests_lookup_by_url(digests, H2O_STRLIT("https://127.0.0.1.xip.io:8081/notfound.js")) ==
+    ok(h2o_cache_digests_lookup_by_url(digests, H2O_STRLIT("https://127.0.0.1.vcap.me:8081/notfound.js")) ==
        H2O_CACHE_DIGESTS_STATE_UNKNOWN);
 
     h2o_cache_digests_load_header(&digests, H2O_STRLIT("FOO; stale, AcA; validators; complete"));
@@ -56,9 +56,9 @@ static void test_decode(void)
     ok(digests->fresh.url_and_etag.entries[0].keys.size == 0);
     ok(digests->fresh.complete);
 
-    ok(h2o_cache_digests_lookup_by_url(digests, H2O_STRLIT("https://127.0.0.1.xip.io:8081/notfound.js")) ==
+    ok(h2o_cache_digests_lookup_by_url(digests, H2O_STRLIT("https://127.0.0.1.vcap.me:8081/notfound.js")) ==
        H2O_CACHE_DIGESTS_STATE_NOT_CACHED);
-    ok(h2o_cache_digests_lookup_by_url(digests, H2O_STRLIT("https://127.0.0.1.xip.io:8081/cache-digests.cgi/hello.js")) ==
+    ok(h2o_cache_digests_lookup_by_url(digests, H2O_STRLIT("https://127.0.0.1.vcap.me:8081/cache-digests.cgi/hello.js")) ==
        H2O_CACHE_DIGESTS_STATE_FRESH);
 
     h2o_cache_digests_load_header(&digests, H2O_STRLIT("AcA; reset"));

--- a/t/40mtls.t
+++ b/t/40mtls.t
@@ -51,7 +51,7 @@ sub run_tests {
 
 sub run_tls_client {
     my $opts = shift;
-    my $resp = `curl $opts --cacert misc/test-ca/root/ca.crt --silent --show-error https://127.0.0.1.xip.io:$tls_port`;
+    my $resp = `curl $opts --cacert misc/test-ca/root/ca.crt --silent --show-error https://127.0.0.1.vcap.me:$tls_port`;
     return $resp;
 }
 

--- a/t/40server-push.t
+++ b/t/40server-push.t
@@ -269,14 +269,14 @@ hosts:
             case env["PATH_INFO"]
             when "/index.txt"
               push_paths = []
-              push_paths << "https://127.0.0.1.xip.io/index.js"
+              push_paths << "https://127.0.0.1.vcap.me/index.js"
               [399, push_paths.empty? ? {} : {"link" => push_paths.map{|p| "<#{p}>; rel=preload"}.join("\\n")}, []]
             else
               [399, {}, []]
             end
           end
         file.dir: t/assets/doc_root
-  "127.0.0.1.xip.io:$tls_port":
+  "127.0.0.1.vcap.me:$tls_port":
     paths:
       /:
         file.dir: t/assets/doc_root

--- a/t/50date-header.t
+++ b/t/50date-header.t
@@ -31,9 +31,9 @@ hosts:
   default:
     paths:
       /proxy-date:
-        proxy.reverse.url: http://127.0.0.1.xip.io:$date_upstream_port
+        proxy.reverse.url: http://127.0.0.1.vcap.me:$date_upstream_port
       /proxy-no-date:
-        proxy.reverse.url: http://127.0.0.1.xip.io:$no_date_upstream_port
+        proxy.reverse.url: http://127.0.0.1.vcap.me:$no_date_upstream_port
       /mruby-date:
         mruby.handler: |
           Proc.new do |env|
@@ -55,9 +55,9 @@ hosts:
   default:
     paths:
       /proxy-date:
-        proxy.reverse.url: http://127.0.0.1.xip.io:$date_upstream_port
+        proxy.reverse.url: http://127.0.0.1.vcap.me:$date_upstream_port
       /proxy-no-date:
-        proxy.reverse.url: http://127.0.0.1.xip.io:$no_date_upstream_port
+        proxy.reverse.url: http://127.0.0.1.vcap.me:$no_date_upstream_port
       /mruby-date:
         mruby.handler: |
           Proc.new do |env|

--- a/t/50http1-proxy-full-uri.t
+++ b/t/50http1-proxy-full-uri.t
@@ -28,7 +28,7 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.url: http://127.0.0.1.xip.io:$upstream_port
+        proxy.reverse.url: http://127.0.0.1.vcap.me:$upstream_port
         proxy.preserve-host: $preserve
 EOT
     my $port = $server->{port};
@@ -46,7 +46,7 @@ EOT
 }
 
 doit("ON", "");
-doit("OFF", ".xip.io");
+doit("OFF", ".vcap.me");
 
 
 done_testing();

--- a/t/50origin-frame.t
+++ b/t/50origin-frame.t
@@ -17,7 +17,7 @@ listen:
     certificate-file: examples/h2o/wildcard.crt
     $origin_conf
 hosts:
-  "*.127.0.0.1.xip.io:$tls_port":
+  "*.127.0.0.1.vcap.me:$tls_port":
     paths:
       /:
         file.dir: examples/doc_root
@@ -54,6 +54,6 @@ EOR
 
 test_origin_frame('', '');
 test_origin_frame('http2-origin-frame: [ ]', "0\n\"\"");
-test_origin_frame('http2-origin-frame: [ "https://a.127.0.0.1.xip.io" ]', "28\n\"\\000\\032https://a.127.0.0.1.xip.io\"");
-test_origin_frame('http2-origin-frame: [ "https://a.127.0.0.1.xip.io", "https://b.127.0.0.1.xip.io" ]', "56\n\"\\000\\032https://a.127.0.0.1.xip.io\\000\\032https://b.127.0.0.1.xip.io\"");
+test_origin_frame('http2-origin-frame: [ "https://a.127.0.0.1.vcap.me" ]', "28\n\"\\000\\032https://a.127.0.0.1.vcap.me\"");
+test_origin_frame('http2-origin-frame: [ "https://a.127.0.0.1.vcap.me", "https://b.127.0.0.1.vcap.me" ]', "56\n\"\\000\\032https://a.127.0.0.1.vcap.me\\000\\032https://b.127.0.0.1.vcap.me\"");
 done_testing();

--- a/t/50priority-headers.t
+++ b/t/50priority-headers.t
@@ -24,7 +24,7 @@ listen:
     key-file: examples/h2o/wildcard.key
     certificate-file: examples/h2o/wildcard.crt
 hosts:
-  "*.127.0.0.1.xip.io:$tls_port":
+  "*.127.0.0.1.vcap.me:$tls_port":
     paths:
       /:
         file.dir: examples/doc_root

--- a/t/50priority-overwrite.t
+++ b/t/50priority-overwrite.t
@@ -10,7 +10,7 @@ my $server = spawn_h2o(sub {
 		my ($port, $tls_port) = @_;
 		return << "EOT";
 hosts:
-  "*.127.0.0.1.xip.io:$tls_port":
+  "*.127.0.0.1.vcap.me:$tls_port":
     paths:
       /:
         file.dir: examples/doc_root

--- a/t/50reverse-proxy-added-headers.t
+++ b/t/50reverse-proxy-added-headers.t
@@ -33,7 +33,7 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.url: http://127.0.0.1.xip.io:$upstream_port
+        proxy.reverse.url: http://127.0.0.1.vcap.me:$upstream_port
 EOT
 
     run_with_curl($server, sub {

--- a/t/50reverse-proxy-drop-headers.t
+++ b/t/50reverse-proxy-drop-headers.t
@@ -28,7 +28,7 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.url: http://127.0.0.1.xip.io:$upstream_port
+        proxy.reverse.url: http://127.0.0.1.vcap.me:$upstream_port
 EOT
 
     my $curl = 'curl --silent --dump-header /dev/stderr';
@@ -46,7 +46,7 @@ hosts:
   default:
     paths:
       /:
-        proxy.reverse.url: http://127.0.0.1.xip.io:$upstream_port
+        proxy.reverse.url: http://127.0.0.1.vcap.me:$upstream_port
 EOT
 
     my $curl = 'curl --silent --dump-header /dev/stderr';

--- a/t/50reverse-proxy-multiple-backends-with-down.t
+++ b/t/50reverse-proxy-multiple-backends-with-down.t
@@ -30,8 +30,8 @@ hosts:
       /:
         proxy.reverse.url:
           backends:
-            - http://127.0.0.1.xip.io:$unused_port/echo-server-port
-            - http://127.0.0.1.xip.io:$upstream_port/echo-server-port
+            - http://127.0.0.1.vcap.me:$unused_port/echo-server-port
+            - http://127.0.0.1.vcap.me:$upstream_port/echo-server-port
           balancer: $balancer
 EOT
     

--- a/t/50reverse-proxy-multiple-backends.t
+++ b/t/50reverse-proxy-multiple-backends.t
@@ -85,8 +85,8 @@ hosts:
       /:
         proxy.reverse.url:
           backends:
-            - http://127.0.0.1.xip.io:$upstream_port1/echo-server-port
-            - http://127.0.0.1.xip.io:$upstream_port2/echo-server-port
+            - http://127.0.0.1.vcap.me:$upstream_port1/echo-server-port
+            - http://127.0.0.1.vcap.me:$upstream_port2/echo-server-port
 EOT
 };
 
@@ -145,7 +145,7 @@ hosts:
       /:
         proxy.reverse.url:
           backends:
-            - http://127.0.0.1.xip.io:$upstream_port/echo-server-port
+            - http://127.0.0.1.vcap.me:$upstream_port/echo-server-port
             - http://[unix:$upstream_file]/echo-server-port
 EOT
 };

--- a/t/50reverse-proxy-multiple-balancers.t
+++ b/t/50reverse-proxy-multiple-balancers.t
@@ -26,13 +26,13 @@ hosts:
       /least-conn/:
         proxy.reverse.url:
           backends:
-            - url: http://127.0.0.1.xip.io:$upstream_port/
-            - http://127.0.0.1.xip.io:$upstream_port/subdir/
+            - url: http://127.0.0.1.vcap.me:$upstream_port/
+            - http://127.0.0.1.vcap.me:$upstream_port/subdir/
           balancer: least-conn
       /:
         proxy.reverse.url:
-          - http://127.0.0.1.xip.io:$upstream_port/
-          - http://127.0.0.1.xip.io:$upstream_port/subdir/
+          - http://127.0.0.1.vcap.me:$upstream_port/
+          - http://127.0.0.1.vcap.me:$upstream_port/subdir/
 EOT
 
 my $expected1 = do {

--- a/t/50reverse-proxy-round-robin-weighted.t
+++ b/t/50reverse-proxy-round-robin-weighted.t
@@ -38,9 +38,9 @@ hosts:
     paths:
       /:
         proxy.reverse.url:
-          - http://127.0.0.1.XIP.IO:$upstream_port1/echo-server-port
+          - http://127.0.0.1.vcap.me:$upstream_port1/echo-server-port
           -
-            url: http://127.0.0.1.XIP.IO:$upstream_port2/echo-server-port
+            url: http://127.0.0.1.vcap.me:$upstream_port2/echo-server-port
             weight: 2
 EOT
 

--- a/t/50reverse-proxy-round-robin.t
+++ b/t/50reverse-proxy-round-robin.t
@@ -25,8 +25,8 @@ hosts:
     paths:
       /:
         proxy.reverse.url:
-          - http://127.0.0.1.xip.io:$upstream_port/
-          - http://127.0.0.1.xip.io:$upstream_port/subdir/
+          - http://127.0.0.1.vcap.me:$upstream_port/
+          - http://127.0.0.1.vcap.me:$upstream_port/subdir/
 EOT
 
 my $expected1 = do {

--- a/t/90live-sni.t
+++ b/t/90live-sni.t
@@ -21,11 +21,11 @@ subtest "basic" => sub {
         my ($port, $tls_port) = @_;
         return << "EOT";
 hosts:
-  "127.0.0.1.xip.io:$tls_port":
+  "127.0.0.1.vcap.me:$tls_port":
     paths:
       /:
         file.dir: examples/doc_root
-  "alternate.127.0.0.1.xip.io:$tls_port":
+  "alternate.127.0.0.1.vcap.me:$tls_port":
     listen:
       port: $tls_port
       ssl:
@@ -38,12 +38,12 @@ EOT
     });
 
     do_test(
-        "127.0.0.1.xip.io:$server->{tls_port}",
+        "127.0.0.1.vcap.me:$server->{tls_port}",
         md5_file("examples/doc_root/index.html"),
     );
 
     do_test(
-        "alternate.127.0.0.1.xip.io:$server->{tls_port}",
+        "alternate.127.0.0.1.vcap.me:$server->{tls_port}",
         md5_file("examples/doc_root.alternate/index.txt"),
     );
 };
@@ -53,11 +53,11 @@ subtest "wildcard" => sub {
         my ($port, $tls_port) = @_;
         return << "EOT";
 hosts:
-  "127.0.0.1.xip.io:$tls_port":
+  "127.0.0.1.vcap.me:$tls_port":
     paths:
       /:
         file.dir: examples/doc_root
-  "*.127.0.0.1.xip.io:$tls_port":
+  "*.127.0.0.1.vcap.me:$tls_port":
     listen:
       port: $tls_port
       ssl:
@@ -70,12 +70,12 @@ EOT
     });
 
     do_test(
-        "127.0.0.1.xip.io:$server->{tls_port}",
+        "127.0.0.1.vcap.me:$server->{tls_port}",
         md5_file("examples/doc_root/index.html"),
     );
 
     do_test(
-        "alternate.127.0.0.1.xip.io:$server->{tls_port}",
+        "alternate.127.0.0.1.vcap.me:$server->{tls_port}",
         md5_file("examples/doc_root.alternate/index.txt"),
     );
 };


### PR DESCRIPTION
Basecamp runs `xip.io` and it seems to be down, similar services that run generic wildcard dns services also typically get banned or shutdown because they tend to be abused for phishing scams (eg. links to your_bank.1.2.3.4.xip.io).

Two alternatives are:
 * `vcap.me` run by VMware for their service offerings, but only resolves to `127.0.0.1`
 * `nip.io` run by [XP-Dev](https://XP-Dev.com) but has feature parity with `xip.io`

Given the test suite only needs dns back to `127.0.0.1` and assuming that VMware will have more longevity, I ran
`sed -i s/xip\.io/vcap.me/ig <file>` 
on all affected files. Even though `vcap.me` only resolves to `127.0.0.1`, I left the `127.0.0.1` prefix to minimize changes and allow switching to another service if required down the line.