### PR TITLE
fix startup failure on macOS

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3485,7 +3485,7 @@ int main(int argc, char **argv)
                 || (limit.rlim_cur = OPEN_MAX, setrlimit(RLIMIT_NOFILE, &limit)) == 0
 #endif
                 ) {
-                fprintf(stderr, "[INFO] raised RLIMIT_NOFILE to %d\n", (int)limit.rlim_cur);
+                fprintf(stderr, "[INFO] raised RLIMIT_NOFILE to %llu\n", (unsigned long long)limit.rlim_cur);
             } else {
                 fprintf(stderr, "[warning] setrlimit(RLIMIT_NOFILE) failed:%s\n", strerror(errno));
             }

--- a/src/main.c
+++ b/src/main.c
@@ -3473,10 +3473,10 @@ int main(int argc, char **argv)
         struct rlimit limit = {0};
         if (getrlimit(RLIMIT_NOFILE, &limit) == 0) {
             /* raise RLIMIT_NOFILE, making sure that we can reach max_connections */
-            if (conf.max_connections > (int)limit.rlim_max) {
-                fprintf(stderr, "[error] The 'max-connections'=[%d] configuration value should not exceed the file descriptor "
-                                "limit of the process 'RLIMIT_NOFILE'=[%lu]\n",
-                        conf.max_connections, limit.rlim_max);
+            if (conf.max_connections > limit.rlim_max) {
+                fprintf(stderr, "[error] 'max-connections'=[%d] configuration value should not exceed the hard limit of file "
+                                "descriptors 'RLIMIT_NOFILE'=[%llu]\n",
+                        conf.max_connections, (unsigned long long)limit.rlim_max);
                 return EX_CONFIG;
             }
             limit.rlim_cur = limit.rlim_max;

--- a/src/main.c
+++ b/src/main.c
@@ -3471,19 +3471,15 @@ int main(int argc, char **argv)
 
     {
         struct rlimit limit = {0};
-
         if (getrlimit(RLIMIT_NOFILE, &limit) == 0) {
             /* raise RLIMIT_NOFILE, making sure that we can reach max_connections */
-
             if (conf.max_connections > (int)limit.rlim_max) {
                 fprintf(stderr, "[error] The 'max-connections'=[%d] configuration value should not exceed the file descriptor "
                                 "limit of the process 'RLIMIT_NOFILE'=[%lu]\n",
                         conf.max_connections, limit.rlim_max);
                 return EX_CONFIG;
             }
-
             limit.rlim_cur = limit.rlim_max;
-
             if (setrlimit(RLIMIT_NOFILE, &limit) == 0
 #ifdef __APPLE__
                 || (limit.rlim_cur = OPEN_MAX, setrlimit(RLIMIT_NOFILE, &limit)) == 0


### PR DESCRIPTION
On macOS, `rlim_t` is `uint64_t`, and the default value of RLIMIT_NOFILE (hard limit) is 2<<63-1. Therefore, `conf.max_connections > (int)limit.rlim_max` always return false.

Amends #2704.