### PR TITLE
h2olog: add tid to identify QUIC connections (QUIC conn master_id + tid)

### DIFF
--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -2548,11 +2548,6 @@ BPF_PERF_OUTPUT(events);
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
 
-static pid_t get_h2o_tid(void) {
-  u64 pid_tgid = bpf_get_current_pid_tgid();
-  return (pid_t)(pid_tgid & 0xffffffff);
-}
-
 // tracepoint sched:sched_process_exit
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
   const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
@@ -2569,7 +2564,7 @@ int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) 
 // quicly:connect
 int trace_quicly__connect(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CONNECT, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CONNECT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2589,7 +2584,7 @@ int trace_quicly__connect(struct pt_regs *ctx) {
 // quicly:accept
 int trace_quicly__accept(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACCEPT, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACCEPT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2612,7 +2607,7 @@ int trace_quicly__accept(struct pt_regs *ctx) {
 // quicly:free
 int trace_quicly__free(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_FREE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_FREE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2630,7 +2625,7 @@ int trace_quicly__free(struct pt_regs *ctx) {
 // quicly:send
 int trace_quicly__send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2653,7 +2648,7 @@ int trace_quicly__send(struct pt_regs *ctx) {
 // quicly:receive
 int trace_quicly__receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2679,7 +2674,7 @@ int trace_quicly__receive(struct pt_regs *ctx) {
 // quicly:version_switch
 int trace_quicly__version_switch(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_VERSION_SWITCH, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_VERSION_SWITCH, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2699,7 +2694,7 @@ int trace_quicly__version_switch(struct pt_regs *ctx) {
 // quicly:idle_timeout
 int trace_quicly__idle_timeout(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_IDLE_TIMEOUT, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_IDLE_TIMEOUT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2717,7 +2712,7 @@ int trace_quicly__idle_timeout(struct pt_regs *ctx) {
 // quicly:stateless_reset_receive
 int trace_quicly__stateless_reset_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STATELESS_RESET_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STATELESS_RESET_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2735,7 +2730,7 @@ int trace_quicly__stateless_reset_receive(struct pt_regs *ctx) {
 // quicly:crypto_handshake
 int trace_quicly__crypto_handshake(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_HANDSHAKE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_HANDSHAKE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2755,7 +2750,7 @@ int trace_quicly__crypto_handshake(struct pt_regs *ctx) {
 // quicly:crypto_update_secret
 int trace_quicly__crypto_update_secret(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_UPDATE_SECRET, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_UPDATE_SECRET, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2783,7 +2778,7 @@ int trace_quicly__crypto_update_secret(struct pt_regs *ctx) {
 // quicly:crypto_send_key_update
 int trace_quicly__crypto_send_key_update(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2806,7 +2801,7 @@ int trace_quicly__crypto_send_key_update(struct pt_regs *ctx) {
 // quicly:crypto_send_key_update_confirmed
 int trace_quicly__crypto_send_key_update_confirmed(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE_CONFIRMED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE_CONFIRMED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2826,7 +2821,7 @@ int trace_quicly__crypto_send_key_update_confirmed(struct pt_regs *ctx) {
 // quicly:crypto_receive_key_update
 int trace_quicly__crypto_receive_key_update(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2849,7 +2844,7 @@ int trace_quicly__crypto_receive_key_update(struct pt_regs *ctx) {
 // quicly:crypto_receive_key_update_prepare
 int trace_quicly__crypto_receive_key_update_prepare(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE_PREPARE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE_PREPARE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2872,7 +2867,7 @@ int trace_quicly__crypto_receive_key_update_prepare(struct pt_regs *ctx) {
 // quicly:packet_sent
 int trace_quicly__packet_sent(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_SENT, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_SENT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2898,7 +2893,7 @@ int trace_quicly__packet_sent(struct pt_regs *ctx) {
 // quicly:packet_received
 int trace_quicly__packet_received(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_RECEIVED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_RECEIVED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2925,7 +2920,7 @@ int trace_quicly__packet_received(struct pt_regs *ctx) {
 // quicly:packet_prepare
 int trace_quicly__packet_prepare(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_PREPARE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_PREPARE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2948,7 +2943,7 @@ int trace_quicly__packet_prepare(struct pt_regs *ctx) {
 // quicly:packet_acked
 int trace_quicly__packet_acked(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_ACKED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_ACKED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2970,7 +2965,7 @@ int trace_quicly__packet_acked(struct pt_regs *ctx) {
 // quicly:packet_lost
 int trace_quicly__packet_lost(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_LOST, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_LOST, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2992,7 +2987,7 @@ int trace_quicly__packet_lost(struct pt_regs *ctx) {
 // quicly:packet_decryption_failed
 int trace_quicly__packet_decryption_failed(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_DECRYPTION_FAILED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_DECRYPTION_FAILED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3012,7 +3007,7 @@ int trace_quicly__packet_decryption_failed(struct pt_regs *ctx) {
 // quicly:pto
 int trace_quicly__pto(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PTO, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PTO, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3036,7 +3031,7 @@ int trace_quicly__pto(struct pt_regs *ctx) {
 // quicly:cc_ack_received
 int trace_quicly__cc_ack_received(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CC_ACK_RECEIVED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CC_ACK_RECEIVED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3062,7 +3057,7 @@ int trace_quicly__cc_ack_received(struct pt_regs *ctx) {
 // quicly:cc_congestion
 int trace_quicly__cc_congestion(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CC_CONGESTION, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CC_CONGESTION, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3086,7 +3081,7 @@ int trace_quicly__cc_congestion(struct pt_regs *ctx) {
 // quicly:ack_block_received
 int trace_quicly__ack_block_received(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_BLOCK_RECEIVED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_BLOCK_RECEIVED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3108,7 +3103,7 @@ int trace_quicly__ack_block_received(struct pt_regs *ctx) {
 // quicly:ack_delay_received
 int trace_quicly__ack_delay_received(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_DELAY_RECEIVED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_DELAY_RECEIVED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3128,7 +3123,7 @@ int trace_quicly__ack_delay_received(struct pt_regs *ctx) {
 // quicly:ack_send
 int trace_quicly__ack_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3150,7 +3145,7 @@ int trace_quicly__ack_send(struct pt_regs *ctx) {
 // quicly:ping_send
 int trace_quicly__ping_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PING_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PING_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3168,7 +3163,7 @@ int trace_quicly__ping_send(struct pt_regs *ctx) {
 // quicly:ping_receive
 int trace_quicly__ping_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PING_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PING_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3186,7 +3181,7 @@ int trace_quicly__ping_receive(struct pt_regs *ctx) {
 // quicly:transport_close_send
 int trace_quicly__transport_close_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3211,7 +3206,7 @@ int trace_quicly__transport_close_send(struct pt_regs *ctx) {
 // quicly:transport_close_receive
 int trace_quicly__transport_close_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3236,7 +3231,7 @@ int trace_quicly__transport_close_receive(struct pt_regs *ctx) {
 // quicly:application_close_send
 int trace_quicly__application_close_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3259,7 +3254,7 @@ int trace_quicly__application_close_send(struct pt_regs *ctx) {
 // quicly:application_close_receive
 int trace_quicly__application_close_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3282,7 +3277,7 @@ int trace_quicly__application_close_receive(struct pt_regs *ctx) {
 // quicly:stream_send
 int trace_quicly__stream_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3311,7 +3306,7 @@ int trace_quicly__stream_send(struct pt_regs *ctx) {
 // quicly:stream_receive
 int trace_quicly__stream_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3338,7 +3333,7 @@ int trace_quicly__stream_receive(struct pt_regs *ctx) {
 // quicly:stream_acked
 int trace_quicly__stream_acked(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ACKED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ACKED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3362,7 +3357,7 @@ int trace_quicly__stream_acked(struct pt_regs *ctx) {
 // quicly:stream_lost
 int trace_quicly__stream_lost(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_LOST, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_LOST, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3386,7 +3381,7 @@ int trace_quicly__stream_lost(struct pt_regs *ctx) {
 // quicly:max_data_send
 int trace_quicly__max_data_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_DATA_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_DATA_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3406,7 +3401,7 @@ int trace_quicly__max_data_send(struct pt_regs *ctx) {
 // quicly:max_data_receive
 int trace_quicly__max_data_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_DATA_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_DATA_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3426,7 +3421,7 @@ int trace_quicly__max_data_receive(struct pt_regs *ctx) {
 // quicly:max_streams_send
 int trace_quicly__max_streams_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3448,7 +3443,7 @@ int trace_quicly__max_streams_send(struct pt_regs *ctx) {
 // quicly:max_streams_receive
 int trace_quicly__max_streams_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3470,7 +3465,7 @@ int trace_quicly__max_streams_receive(struct pt_regs *ctx) {
 // quicly:max_stream_data_send
 int trace_quicly__max_stream_data_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3495,7 +3490,7 @@ int trace_quicly__max_stream_data_send(struct pt_regs *ctx) {
 // quicly:max_stream_data_receive
 int trace_quicly__max_stream_data_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3517,7 +3512,7 @@ int trace_quicly__max_stream_data_receive(struct pt_regs *ctx) {
 // quicly:new_token_send
 int trace_quicly__new_token_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3542,7 +3537,7 @@ int trace_quicly__new_token_send(struct pt_regs *ctx) {
 // quicly:new_token_acked
 int trace_quicly__new_token_acked(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_ACKED, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_ACKED, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3562,7 +3557,7 @@ int trace_quicly__new_token_acked(struct pt_regs *ctx) {
 // quicly:new_token_receive
 int trace_quicly__new_token_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3585,7 +3580,7 @@ int trace_quicly__new_token_receive(struct pt_regs *ctx) {
 // quicly:handshake_done_send
 int trace_quicly__handshake_done_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3603,7 +3598,7 @@ int trace_quicly__handshake_done_send(struct pt_regs *ctx) {
 // quicly:handshake_done_receive
 int trace_quicly__handshake_done_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3621,7 +3616,7 @@ int trace_quicly__handshake_done_receive(struct pt_regs *ctx) {
 // quicly:streams_blocked_send
 int trace_quicly__streams_blocked_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3643,7 +3638,7 @@ int trace_quicly__streams_blocked_send(struct pt_regs *ctx) {
 // quicly:streams_blocked_receive
 int trace_quicly__streams_blocked_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3665,7 +3660,7 @@ int trace_quicly__streams_blocked_receive(struct pt_regs *ctx) {
 // quicly:new_connection_id_send
 int trace_quicly__new_connection_id_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3693,7 +3688,7 @@ int trace_quicly__new_connection_id_send(struct pt_regs *ctx) {
 // quicly:new_connection_id_receive
 int trace_quicly__new_connection_id_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3721,7 +3716,7 @@ int trace_quicly__new_connection_id_receive(struct pt_regs *ctx) {
 // quicly:retire_connection_id_send
 int trace_quicly__retire_connection_id_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3741,7 +3736,7 @@ int trace_quicly__retire_connection_id_send(struct pt_regs *ctx) {
 // quicly:retire_connection_id_receive
 int trace_quicly__retire_connection_id_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3761,7 +3756,7 @@ int trace_quicly__retire_connection_id_receive(struct pt_regs *ctx) {
 // quicly:data_blocked_send
 int trace_quicly__data_blocked_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3781,7 +3776,7 @@ int trace_quicly__data_blocked_send(struct pt_regs *ctx) {
 // quicly:data_blocked_receive
 int trace_quicly__data_blocked_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3801,7 +3796,7 @@ int trace_quicly__data_blocked_receive(struct pt_regs *ctx) {
 // quicly:stream_data_blocked_send
 int trace_quicly__stream_data_blocked_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3823,7 +3818,7 @@ int trace_quicly__stream_data_blocked_send(struct pt_regs *ctx) {
 // quicly:stream_data_blocked_receive
 int trace_quicly__stream_data_blocked_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3845,7 +3840,7 @@ int trace_quicly__stream_data_blocked_receive(struct pt_regs *ctx) {
 // quicly:datagram_send
 int trace_quicly__datagram_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATAGRAM_SEND, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATAGRAM_SEND, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3868,7 +3863,7 @@ int trace_quicly__datagram_send(struct pt_regs *ctx) {
 // quicly:datagram_receive
 int trace_quicly__datagram_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATAGRAM_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATAGRAM_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3891,7 +3886,7 @@ int trace_quicly__datagram_receive(struct pt_regs *ctx) {
 // quicly:ack_frequency_receive
 int trace_quicly__ack_frequency_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_FREQUENCY_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_FREQUENCY_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3917,7 +3912,7 @@ int trace_quicly__ack_frequency_receive(struct pt_regs *ctx) {
 // quicly:quictrace_send_stream
 int trace_quicly__quictrace_send_stream(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_SEND_STREAM, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_SEND_STREAM, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3946,7 +3941,7 @@ int trace_quicly__quictrace_send_stream(struct pt_regs *ctx) {
 // quicly:quictrace_recv_stream
 int trace_quicly__quictrace_recv_stream(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_RECV_STREAM, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_RECV_STREAM, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3972,7 +3967,7 @@ int trace_quicly__quictrace_recv_stream(struct pt_regs *ctx) {
 // quicly:quictrace_cc_ack
 int trace_quicly__quictrace_cc_ack(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_ACK, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_ACK, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4002,7 +3997,7 @@ int trace_quicly__quictrace_cc_ack(struct pt_regs *ctx) {
 // quicly:quictrace_cc_lost
 int trace_quicly__quictrace_cc_lost(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_LOST, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_LOST, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4032,7 +4027,7 @@ int trace_quicly__quictrace_cc_lost(struct pt_regs *ctx) {
 // quicly:stream_on_open
 int trace_quicly__stream_on_open(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_OPEN, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_OPEN, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4055,7 +4050,7 @@ int trace_quicly__stream_on_open(struct pt_regs *ctx) {
 // quicly:stream_on_destroy
 int trace_quicly__stream_on_destroy(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_DESTROY, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_DESTROY, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4080,7 +4075,7 @@ int trace_quicly__stream_on_destroy(struct pt_regs *ctx) {
 // quicly:stream_on_send_shift
 int trace_quicly__stream_on_send_shift(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_SHIFT, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_SHIFT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4105,7 +4100,7 @@ int trace_quicly__stream_on_send_shift(struct pt_regs *ctx) {
 // quicly:stream_on_send_emit
 int trace_quicly__stream_on_send_emit(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_EMIT, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_EMIT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4132,7 +4127,7 @@ int trace_quicly__stream_on_send_emit(struct pt_regs *ctx) {
 // quicly:stream_on_send_stop
 int trace_quicly__stream_on_send_stop(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_STOP, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_STOP, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4157,7 +4152,7 @@ int trace_quicly__stream_on_send_stop(struct pt_regs *ctx) {
 // quicly:stream_on_receive
 int trace_quicly__stream_on_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4187,7 +4182,7 @@ int trace_quicly__stream_on_receive(struct pt_regs *ctx) {
 // quicly:stream_on_receive_reset
 int trace_quicly__stream_on_receive_reset(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE_RESET, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE_RESET, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4212,7 +4207,7 @@ int trace_quicly__stream_on_receive_reset(struct pt_regs *ctx) {
 // quicly:conn_stats
 int trace_quicly__conn_stats(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CONN_STATS, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CONN_STATS, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4240,7 +4235,7 @@ BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SI
 // h2o:_private_socket_lookup_flags
 int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // pid_t tid
   bpf_usdt_readarg(1, ctx, &event._private_socket_lookup_flags.tid);
@@ -4275,7 +4270,7 @@ int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
 // h2o:receive_request
 int trace_h2o__receive_request(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.receive_request.conn_id);
@@ -4292,7 +4287,7 @@ int trace_h2o__receive_request(struct pt_regs *ctx) {
 // h2o:receive_request_header
 int trace_h2o__receive_request_header(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST_HEADER, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST_HEADER, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.receive_request_header.conn_id);
@@ -4317,7 +4312,7 @@ int trace_h2o__receive_request_header(struct pt_regs *ctx) {
 // h2o:send_response
 int trace_h2o__send_response(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SEND_RESPONSE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SEND_RESPONSE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.send_response.conn_id);
@@ -4336,7 +4331,7 @@ int trace_h2o__send_response(struct pt_regs *ctx) {
 // h2o:send_response_header
 int trace_h2o__send_response_header(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SEND_RESPONSE_HEADER, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SEND_RESPONSE_HEADER, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.send_response_header.conn_id);
@@ -4366,7 +4361,7 @@ int trace_h2o__send_response_header(struct pt_regs *ctx) {
 // h2o:h1_accept
 int trace_h2o__h1_accept(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H1_ACCEPT, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H1_ACCEPT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h1_accept.conn_id);
@@ -4383,7 +4378,7 @@ int trace_h2o__h1_accept(struct pt_regs *ctx) {
 // h2o:h1_close
 int trace_h2o__h1_close(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H1_CLOSE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H1_CLOSE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h1_close.conn_id);
@@ -4396,7 +4391,7 @@ int trace_h2o__h1_close(struct pt_regs *ctx) {
 // h2o:h2_unknown_frame_type
 int trace_h2o__h2_unknown_frame_type(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H2_UNKNOWN_FRAME_TYPE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H2_UNKNOWN_FRAME_TYPE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h2_unknown_frame_type.conn_id);
@@ -4411,7 +4406,7 @@ int trace_h2o__h2_unknown_frame_type(struct pt_regs *ctx) {
 // h2o:h3s_accept
 int trace_h2o__h3s_accept(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_ACCEPT, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_ACCEPT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h3s_accept.conn_id);
@@ -4431,7 +4426,7 @@ int trace_h2o__h3s_accept(struct pt_regs *ctx) {
 // h2o:h3s_destroy
 int trace_h2o__h3s_destroy(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_DESTROY, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_DESTROY, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h3s_destroy.conn_id);
@@ -4444,7 +4439,7 @@ int trace_h2o__h3s_destroy(struct pt_regs *ctx) {
 // h2o:h3s_stream_set_state
 int trace_h2o__h3s_stream_set_state(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_STREAM_SET_STATE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_STREAM_SET_STATE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h3s_stream_set_state.conn_id);
@@ -4461,7 +4456,7 @@ int trace_h2o__h3s_stream_set_state(struct pt_regs *ctx) {
 // h2o:h3_frame_receive
 int trace_h2o__h3_frame_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_FRAME_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_FRAME_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // uint64_t frame_type
   bpf_usdt_readarg(1, ctx, &event.h3_frame_receive.frame_type);
@@ -4479,7 +4474,7 @@ int trace_h2o__h3_frame_receive(struct pt_regs *ctx) {
 // h2o:h3_packet_receive
 int trace_h2o__h3_packet_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_PACKET_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_PACKET_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct sockaddr * dest
   bpf_usdt_readarg(1, ctx, &buf);
@@ -4511,7 +4506,7 @@ int trace_h2o__h3_packet_receive(struct pt_regs *ctx) {
 // h2o:h3_packet_forward
 int trace_h2o__h3_packet_forward(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_PACKET_FORWARD, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_PACKET_FORWARD, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct sockaddr * dest
   bpf_usdt_readarg(1, ctx, &buf);
@@ -4544,7 +4539,7 @@ int trace_h2o__h3_packet_forward(struct pt_regs *ctx) {
 // h2o:h3_forwarded_packet_receive
 int trace_h2o__h3_forwarded_packet_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_FORWARDED_PACKET_RECEIVE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_FORWARDED_PACKET_RECEIVE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct sockaddr * dest
   bpf_usdt_readarg(1, ctx, &buf);
@@ -4573,7 +4568,7 @@ int trace_h2o__h3_forwarded_packet_receive(struct pt_regs *ctx) {
 // h2o:h3c_tunnel_create
 int trace_h2o__h3c_tunnel_create(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3C_TUNNEL_CREATE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3C_TUNNEL_CREATE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.h3c_tunnel_create.tunnel);
@@ -4586,7 +4581,7 @@ int trace_h2o__h3c_tunnel_create(struct pt_regs *ctx) {
 // h2o:tunnel_on_destroy
 int trace_h2o__tunnel_on_destroy(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_DESTROY, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_DESTROY, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_on_destroy.tunnel);
@@ -4599,7 +4594,7 @@ int trace_h2o__tunnel_on_destroy(struct pt_regs *ctx) {
 // h2o:tunnel_on_read
 int trace_h2o__tunnel_on_read(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_READ, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_READ, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_on_read.tunnel);
@@ -4620,7 +4615,7 @@ int trace_h2o__tunnel_on_read(struct pt_regs *ctx) {
 // h2o:tunnel_proceed_read
 int trace_h2o__tunnel_proceed_read(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_PROCEED_READ, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_PROCEED_READ, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_proceed_read.tunnel);
@@ -4633,7 +4628,7 @@ int trace_h2o__tunnel_proceed_read(struct pt_regs *ctx) {
 // h2o:tunnel_write
 int trace_h2o__tunnel_write(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_WRITE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_WRITE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_write.tunnel);
@@ -4651,7 +4646,7 @@ int trace_h2o__tunnel_write(struct pt_regs *ctx) {
 // h2o:tunnel_on_write_complete
 int trace_h2o__tunnel_on_write_complete(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_WRITE_COMPLETE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_WRITE_COMPLETE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_on_write_complete.tunnel);
@@ -4667,7 +4662,7 @@ int trace_h2o__tunnel_on_write_complete(struct pt_regs *ctx) {
 // h2o:socket_tunnel_create
 int trace_h2o__socket_tunnel_create(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_CREATE, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_CREATE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.socket_tunnel_create.tunnel);
@@ -4680,7 +4675,7 @@ int trace_h2o__socket_tunnel_create(struct pt_regs *ctx) {
 // h2o:socket_tunnel_start
 int trace_h2o__socket_tunnel_start(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_START, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_START, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.socket_tunnel_start.tunnel);

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -200,6 +200,7 @@ enum h2olog_event_id_t {
 
 struct h2olog_event_t {
   enum h2olog_event_id_t id;
+  uint32_t tid;
 
   union {
     struct { // quicly:connect
@@ -876,6 +877,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   switch (event->id) {
   case H2OLOG_EVENT_ID_QUICLY_CONNECT: { // quicly:connect
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("connect"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->connect.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->connect.at);
@@ -884,6 +886,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_ACCEPT: { // quicly:accept
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("accept"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->accept.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->accept.at);
@@ -893,6 +896,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_FREE: { // quicly:free
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("free"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->free.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->free.at);
@@ -900,6 +904,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_SEND: { // quicly:send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->send.at);
@@ -909,6 +914,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_RECEIVE: { // quicly:receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->receive.at);
@@ -919,6 +925,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_VERSION_SWITCH: { // quicly:version_switch
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("version-switch"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->version_switch.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->version_switch.at);
@@ -927,6 +934,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_IDLE_TIMEOUT: { // quicly:idle_timeout
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("idle-timeout"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->idle_timeout.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->idle_timeout.at);
@@ -934,6 +942,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STATELESS_RESET_RECEIVE: { // quicly:stateless_reset_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stateless-reset-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stateless_reset_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stateless_reset_receive.at);
@@ -941,6 +950,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CRYPTO_HANDSHAKE: { // quicly:crypto_handshake
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-handshake"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_handshake.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_handshake.at);
@@ -949,6 +959,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CRYPTO_UPDATE_SECRET: { // quicly:crypto_update_secret
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-update-secret"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_update_secret.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_update_secret.at);
@@ -962,6 +973,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE: { // quicly:crypto_send_key_update
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-send-key-update"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_send_key_update.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_send_key_update.at);
@@ -973,6 +985,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE_CONFIRMED: { // quicly:crypto_send_key_update_confirmed
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-send-key-update-confirmed"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_send_key_update_confirmed.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_send_key_update_confirmed.at);
@@ -981,6 +994,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE: { // quicly:crypto_receive_key_update
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-receive-key-update"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_receive_key_update.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_receive_key_update.at);
@@ -992,6 +1006,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE_PREPARE: { // quicly:crypto_receive_key_update_prepare
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-receive-key-update-prepare"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_receive_key_update_prepare.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_receive_key_update_prepare.at);
@@ -1003,6 +1018,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PACKET_SENT: { // quicly:packet_sent
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-sent"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_sent.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_sent.at);
@@ -1014,6 +1030,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PACKET_RECEIVED: { // quicly:packet_received
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-received"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_received.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_received.at);
@@ -1027,6 +1044,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PACKET_PREPARE: { // quicly:packet_prepare
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-prepare"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_prepare.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_prepare.at);
@@ -1036,6 +1054,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PACKET_ACKED: { // quicly:packet_acked
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-acked"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_acked.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_acked.at);
@@ -1045,6 +1064,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PACKET_LOST: { // quicly:packet_lost
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-lost"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_lost.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_lost.at);
@@ -1054,6 +1074,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PACKET_DECRYPTION_FAILED: { // quicly:packet_decryption_failed
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-decryption-failed"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_decryption_failed.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_decryption_failed.at);
@@ -1062,6 +1083,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PTO: { // quicly:pto
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("pto"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->pto.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->pto.at);
@@ -1072,6 +1094,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CC_ACK_RECEIVED: { // quicly:cc_ack_received
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("cc-ack-received"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->cc_ack_received.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->cc_ack_received.at);
@@ -1083,6 +1106,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CC_CONGESTION: { // quicly:cc_congestion
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("cc-congestion"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->cc_congestion.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->cc_congestion.at);
@@ -1093,6 +1117,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_ACK_BLOCK_RECEIVED: { // quicly:ack_block_received
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-block-received"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->ack_block_received.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_block_received.at);
@@ -1102,6 +1127,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_ACK_DELAY_RECEIVED: { // quicly:ack_delay_received
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-delay-received"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->ack_delay_received.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_delay_received.at);
@@ -1110,6 +1136,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_ACK_SEND: { // quicly:ack_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->ack_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_send.at);
@@ -1119,6 +1146,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PING_SEND: { // quicly:ping_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ping-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->ping_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ping_send.at);
@@ -1126,6 +1154,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_PING_RECEIVE: { // quicly:ping_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ping-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->ping_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ping_receive.at);
@@ -1133,6 +1162,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_SEND: { // quicly:transport_close_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("transport-close-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->transport_close_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->transport_close_send.at);
@@ -1143,6 +1173,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_RECEIVE: { // quicly:transport_close_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("transport-close-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->transport_close_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->transport_close_receive.at);
@@ -1153,6 +1184,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_SEND: { // quicly:application_close_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("application-close-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->application_close_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->application_close_send.at);
@@ -1162,6 +1194,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_RECEIVE: { // quicly:application_close_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("application-close-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->application_close_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->application_close_receive.at);
@@ -1171,6 +1204,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_SEND: { // quicly:stream_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_send.at);
@@ -1182,6 +1216,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_RECEIVE: { // quicly:stream_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_receive.at);
@@ -1192,6 +1227,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ACKED: { // quicly:stream_acked
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-acked"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_acked.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_acked.at);
@@ -1202,6 +1238,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_LOST: { // quicly:stream_lost
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-lost"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_lost.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_lost.at);
@@ -1212,6 +1249,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_MAX_DATA_SEND: { // quicly:max_data_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-data-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->max_data_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_data_send.at);
@@ -1220,6 +1258,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_MAX_DATA_RECEIVE: { // quicly:max_data_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-data-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->max_data_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_data_receive.at);
@@ -1228,6 +1267,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_SEND: { // quicly:max_streams_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-streams-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->max_streams_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_streams_send.at);
@@ -1237,6 +1277,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_RECEIVE: { // quicly:max_streams_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-streams-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->max_streams_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_streams_receive.at);
@@ -1246,6 +1287,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_SEND: { // quicly:max_stream_data_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-stream-data-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->max_stream_data_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_stream_data_send.at);
@@ -1255,6 +1297,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_RECEIVE: { // quicly:max_stream_data_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-stream-data-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->max_stream_data_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_stream_data_receive.at);
@@ -1264,6 +1307,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_SEND: { // quicly:new_token_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->new_token_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_send.at);
@@ -1274,6 +1318,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_ACKED: { // quicly:new_token_acked
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-acked"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->new_token_acked.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_acked.at);
@@ -1282,6 +1327,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_RECEIVE: { // quicly:new_token_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->new_token_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_receive.at);
@@ -1291,6 +1337,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_SEND: { // quicly:handshake_done_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("handshake-done-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->handshake_done_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->handshake_done_send.at);
@@ -1298,6 +1345,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_RECEIVE: { // quicly:handshake_done_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("handshake-done-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->handshake_done_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->handshake_done_receive.at);
@@ -1305,6 +1353,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_SEND: { // quicly:streams_blocked_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("streams-blocked-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->streams_blocked_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->streams_blocked_send.at);
@@ -1314,6 +1363,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_RECEIVE: { // quicly:streams_blocked_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("streams-blocked-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->streams_blocked_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->streams_blocked_receive.at);
@@ -1323,6 +1373,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_SEND: { // quicly:new_connection_id_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-connection-id-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->new_connection_id_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_connection_id_send.at);
@@ -1334,6 +1385,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_RECEIVE: { // quicly:new_connection_id_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-connection-id-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->new_connection_id_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_connection_id_receive.at);
@@ -1345,6 +1397,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_SEND: { // quicly:retire_connection_id_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("retire-connection-id-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->retire_connection_id_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->retire_connection_id_send.at);
@@ -1353,6 +1406,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_RECEIVE: { // quicly:retire_connection_id_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("retire-connection-id-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->retire_connection_id_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->retire_connection_id_receive.at);
@@ -1361,6 +1415,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_SEND: { // quicly:data_blocked_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("data-blocked-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->data_blocked_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->data_blocked_send.at);
@@ -1369,6 +1424,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_RECEIVE: { // quicly:data_blocked_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("data-blocked-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->data_blocked_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->data_blocked_receive.at);
@@ -1377,6 +1433,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_SEND: { // quicly:stream_data_blocked_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-data-blocked-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_data_blocked_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_data_blocked_send.at);
@@ -1386,6 +1443,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_RECEIVE: { // quicly:stream_data_blocked_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-data-blocked-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_data_blocked_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_data_blocked_receive.at);
@@ -1395,6 +1453,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_DATAGRAM_SEND: { // quicly:datagram_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("datagram-send"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->datagram_send.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->datagram_send.at);
@@ -1406,6 +1465,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_DATAGRAM_RECEIVE: { // quicly:datagram_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("datagram-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->datagram_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->datagram_receive.at);
@@ -1417,6 +1477,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_ACK_FREQUENCY_RECEIVE: { // quicly:ack_frequency_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-frequency-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->ack_frequency_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_frequency_receive.at);
@@ -1428,6 +1489,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_QUICTRACE_SEND_STREAM: { // quicly:quictrace_send_stream
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-send-stream"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_send_stream.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_send_stream.at);
@@ -1439,6 +1501,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_QUICTRACE_RECV_STREAM: { // quicly:quictrace_recv_stream
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-recv-stream"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_recv_stream.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_recv_stream.at);
@@ -1450,6 +1513,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_ACK: { // quicly:quictrace_cc_ack
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-cc-ack"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_cc_ack.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_cc_ack.at);
@@ -1463,6 +1527,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_LOST: { // quicly:quictrace_cc_lost
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-cc-lost"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_cc_lost.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_cc_lost.at);
@@ -1476,6 +1541,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ON_OPEN: { // quicly:stream_on_open
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-open"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_open.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_open.at);
@@ -1484,6 +1550,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ON_DESTROY: { // quicly:stream_on_destroy
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-destroy"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_destroy.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_destroy.at);
@@ -1493,6 +1560,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_SHIFT: { // quicly:stream_on_send_shift
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-shift"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_shift.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_shift.at);
@@ -1502,6 +1570,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_EMIT: { // quicly:stream_on_send_emit
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-emit"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_emit.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_emit.at);
@@ -1512,6 +1581,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_STOP: { // quicly:stream_on_send_stop
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-stop"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_stop.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_stop.at);
@@ -1521,6 +1591,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE: { // quicly:stream_on_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_receive.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_receive.at);
@@ -1534,6 +1605,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE_RESET: { // quicly:stream_on_receive_reset
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-receive-reset"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_receive_reset.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_receive_reset.at);
@@ -1543,6 +1615,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_QUICLY_CONN_STATS: { // quicly:conn_stats
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("conn-stats"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn"), event->conn_stats.master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->conn_stats.at);
@@ -1552,6 +1625,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST: { // h2o:receive_request
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("receive-request"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->receive_request.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->receive_request.req_id);
@@ -1561,6 +1635,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST_HEADER: { // h2o:receive_request_header
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("receive-request-header"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->receive_request_header.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->receive_request_header.req_id);
@@ -1577,6 +1652,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_SEND_RESPONSE: { // h2o:send_response
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("send-response"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->send_response.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->send_response.req_id);
@@ -1587,6 +1663,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_SEND_RESPONSE_HEADER: { // h2o:send_response_header
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("send-response-header"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->send_response_header.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->send_response_header.req_id);
@@ -1603,6 +1680,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H1_ACCEPT: { // h2o:h1_accept
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h1-accept"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h1_accept.conn_id);
     json_write_pair_c(out_, STR_LIT("sock"), event->h1_accept.sock);
@@ -1612,6 +1690,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H1_CLOSE: { // h2o:h1_close
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h1-close"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h1_close.conn_id);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
@@ -1619,6 +1698,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H2_UNKNOWN_FRAME_TYPE: { // h2o:h2_unknown_frame_type
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h2-unknown-frame-type"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h2_unknown_frame_type.conn_id);
     json_write_pair_c(out_, STR_LIT("frame-type"), event->h2_unknown_frame_type.frame_type);
@@ -1627,6 +1707,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H3S_ACCEPT: { // h2o:h3s_accept
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3s-accept"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h3s_accept.conn_id);
     json_write_pair_c(out_, STR_LIT("conn"), event->h3s_accept.conn);
@@ -1636,6 +1717,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H3S_DESTROY: { // h2o:h3s_destroy
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3s-destroy"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h3s_destroy.conn_id);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
@@ -1643,6 +1725,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H3S_STREAM_SET_STATE: { // h2o:h3s_stream_set_state
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3s-stream-set-state"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h3s_stream_set_state.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->h3s_stream_set_state.req_id);
@@ -1652,6 +1735,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H3_FRAME_RECEIVE: { // h2o:h3_frame_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-frame-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("frame-type"), event->h3_frame_receive.frame_type);
     if (include_appdata_) {
@@ -1663,6 +1747,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H3_PACKET_RECEIVE: { // h2o:h3_packet_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-packet-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("dest"), event->h3_packet_receive.dest);
     json_write_pair_c(out_, STR_LIT("src"), event->h3_packet_receive.src);
@@ -1673,6 +1758,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H3_PACKET_FORWARD: { // h2o:h3_packet_forward
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-packet-forward"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("dest"), event->h3_packet_forward.dest);
     json_write_pair_c(out_, STR_LIT("src"), event->h3_packet_forward.src);
@@ -1684,6 +1770,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H3_FORWARDED_PACKET_RECEIVE: { // h2o:h3_forwarded_packet_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-forwarded-packet-receive"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("dest"), event->h3_forwarded_packet_receive.dest);
     json_write_pair_c(out_, STR_LIT("src"), event->h3_forwarded_packet_receive.src);
@@ -1693,6 +1780,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_H3C_TUNNEL_CREATE: { // h2o:h3c_tunnel_create
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3c-tunnel-create"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->h3c_tunnel_create.tunnel);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
@@ -1700,6 +1788,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_ON_DESTROY: { // h2o:tunnel_on_destroy
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-on-destroy"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_on_destroy.tunnel);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
@@ -1707,6 +1796,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_ON_READ: { // h2o:tunnel_on_read
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-on-read"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_on_read.tunnel);
     json_write_pair_c(out_, STR_LIT("err"), event->tunnel_on_read.err, strlen(event->tunnel_on_read.err));
@@ -1719,6 +1809,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_PROCEED_READ: { // h2o:tunnel_proceed_read
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-proceed-read"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_proceed_read.tunnel);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
@@ -1726,6 +1817,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_WRITE: { // h2o:tunnel_write
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-write"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_write.tunnel);
     if (include_appdata_) {
@@ -1737,6 +1829,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_ON_WRITE_COMPLETE: { // h2o:tunnel_on_write_complete
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-on-write-complete"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_on_write_complete.tunnel);
     json_write_pair_c(out_, STR_LIT("err"), event->tunnel_on_write_complete.err, strlen(event->tunnel_on_write_complete.err));
@@ -1745,6 +1838,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_CREATE: { // h2o:socket_tunnel_create
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("socket-tunnel-create"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->socket_tunnel_create.tunnel);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
@@ -1752,6 +1846,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
   case H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_START: { // h2o:socket_tunnel_start
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("socket-tunnel-start"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->socket_tunnel_start.tunnel);
     json_write_pair_c(out_, STR_LIT("bytes-to-consume"), event->socket_tunnel_start.bytes_to_consume);
@@ -1886,6 +1981,7 @@ enum h2olog_event_id_t {
 
 struct h2olog_event_t {
   enum h2olog_event_id_t id;
+  uint32_t tid;
 
   union {
     struct { // quicly:connect
@@ -2452,6 +2548,11 @@ BPF_PERF_OUTPUT(events);
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
 
+static pid_t get_h2o_tid(void) {
+  u64 pid_tgid = bpf_get_current_pid_tgid();
+  return (pid_t)(pid_tgid & 0xffffffff);
+}
+
 // tracepoint sched:sched_process_exit
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
   const struct task_struct *task = (const struct task_struct*)bpf_get_current_task();
@@ -2468,7 +2569,7 @@ int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) 
 // quicly:connect
 int trace_quicly__connect(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CONNECT };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CONNECT, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2488,7 +2589,7 @@ int trace_quicly__connect(struct pt_regs *ctx) {
 // quicly:accept
 int trace_quicly__accept(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACCEPT };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACCEPT, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2511,7 +2612,7 @@ int trace_quicly__accept(struct pt_regs *ctx) {
 // quicly:free
 int trace_quicly__free(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_FREE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_FREE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2529,7 +2630,7 @@ int trace_quicly__free(struct pt_regs *ctx) {
 // quicly:send
 int trace_quicly__send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2552,7 +2653,7 @@ int trace_quicly__send(struct pt_regs *ctx) {
 // quicly:receive
 int trace_quicly__receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2578,7 +2679,7 @@ int trace_quicly__receive(struct pt_regs *ctx) {
 // quicly:version_switch
 int trace_quicly__version_switch(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_VERSION_SWITCH };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_VERSION_SWITCH, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2598,7 +2699,7 @@ int trace_quicly__version_switch(struct pt_regs *ctx) {
 // quicly:idle_timeout
 int trace_quicly__idle_timeout(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_IDLE_TIMEOUT };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_IDLE_TIMEOUT, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2616,7 +2717,7 @@ int trace_quicly__idle_timeout(struct pt_regs *ctx) {
 // quicly:stateless_reset_receive
 int trace_quicly__stateless_reset_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STATELESS_RESET_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STATELESS_RESET_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2634,7 +2735,7 @@ int trace_quicly__stateless_reset_receive(struct pt_regs *ctx) {
 // quicly:crypto_handshake
 int trace_quicly__crypto_handshake(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_HANDSHAKE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_HANDSHAKE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2654,7 +2755,7 @@ int trace_quicly__crypto_handshake(struct pt_regs *ctx) {
 // quicly:crypto_update_secret
 int trace_quicly__crypto_update_secret(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_UPDATE_SECRET };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_UPDATE_SECRET, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2682,7 +2783,7 @@ int trace_quicly__crypto_update_secret(struct pt_regs *ctx) {
 // quicly:crypto_send_key_update
 int trace_quicly__crypto_send_key_update(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2705,7 +2806,7 @@ int trace_quicly__crypto_send_key_update(struct pt_regs *ctx) {
 // quicly:crypto_send_key_update_confirmed
 int trace_quicly__crypto_send_key_update_confirmed(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE_CONFIRMED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_SEND_KEY_UPDATE_CONFIRMED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2725,7 +2826,7 @@ int trace_quicly__crypto_send_key_update_confirmed(struct pt_regs *ctx) {
 // quicly:crypto_receive_key_update
 int trace_quicly__crypto_receive_key_update(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2748,7 +2849,7 @@ int trace_quicly__crypto_receive_key_update(struct pt_regs *ctx) {
 // quicly:crypto_receive_key_update_prepare
 int trace_quicly__crypto_receive_key_update_prepare(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE_PREPARE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CRYPTO_RECEIVE_KEY_UPDATE_PREPARE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2771,7 +2872,7 @@ int trace_quicly__crypto_receive_key_update_prepare(struct pt_regs *ctx) {
 // quicly:packet_sent
 int trace_quicly__packet_sent(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_SENT };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_SENT, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2797,7 +2898,7 @@ int trace_quicly__packet_sent(struct pt_regs *ctx) {
 // quicly:packet_received
 int trace_quicly__packet_received(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_RECEIVED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_RECEIVED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2824,7 +2925,7 @@ int trace_quicly__packet_received(struct pt_regs *ctx) {
 // quicly:packet_prepare
 int trace_quicly__packet_prepare(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_PREPARE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_PREPARE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2847,7 +2948,7 @@ int trace_quicly__packet_prepare(struct pt_regs *ctx) {
 // quicly:packet_acked
 int trace_quicly__packet_acked(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_ACKED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_ACKED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2869,7 +2970,7 @@ int trace_quicly__packet_acked(struct pt_regs *ctx) {
 // quicly:packet_lost
 int trace_quicly__packet_lost(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_LOST };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_LOST, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2891,7 +2992,7 @@ int trace_quicly__packet_lost(struct pt_regs *ctx) {
 // quicly:packet_decryption_failed
 int trace_quicly__packet_decryption_failed(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_DECRYPTION_FAILED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PACKET_DECRYPTION_FAILED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2911,7 +3012,7 @@ int trace_quicly__packet_decryption_failed(struct pt_regs *ctx) {
 // quicly:pto
 int trace_quicly__pto(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PTO };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PTO, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2935,7 +3036,7 @@ int trace_quicly__pto(struct pt_regs *ctx) {
 // quicly:cc_ack_received
 int trace_quicly__cc_ack_received(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CC_ACK_RECEIVED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CC_ACK_RECEIVED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2961,7 +3062,7 @@ int trace_quicly__cc_ack_received(struct pt_regs *ctx) {
 // quicly:cc_congestion
 int trace_quicly__cc_congestion(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CC_CONGESTION };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CC_CONGESTION, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -2985,7 +3086,7 @@ int trace_quicly__cc_congestion(struct pt_regs *ctx) {
 // quicly:ack_block_received
 int trace_quicly__ack_block_received(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_BLOCK_RECEIVED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_BLOCK_RECEIVED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3007,7 +3108,7 @@ int trace_quicly__ack_block_received(struct pt_regs *ctx) {
 // quicly:ack_delay_received
 int trace_quicly__ack_delay_received(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_DELAY_RECEIVED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_DELAY_RECEIVED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3027,7 +3128,7 @@ int trace_quicly__ack_delay_received(struct pt_regs *ctx) {
 // quicly:ack_send
 int trace_quicly__ack_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3049,7 +3150,7 @@ int trace_quicly__ack_send(struct pt_regs *ctx) {
 // quicly:ping_send
 int trace_quicly__ping_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PING_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PING_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3067,7 +3168,7 @@ int trace_quicly__ping_send(struct pt_regs *ctx) {
 // quicly:ping_receive
 int trace_quicly__ping_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PING_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_PING_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3085,7 +3186,7 @@ int trace_quicly__ping_receive(struct pt_regs *ctx) {
 // quicly:transport_close_send
 int trace_quicly__transport_close_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3110,7 +3211,7 @@ int trace_quicly__transport_close_send(struct pt_regs *ctx) {
 // quicly:transport_close_receive
 int trace_quicly__transport_close_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_TRANSPORT_CLOSE_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3135,7 +3236,7 @@ int trace_quicly__transport_close_receive(struct pt_regs *ctx) {
 // quicly:application_close_send
 int trace_quicly__application_close_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3158,7 +3259,7 @@ int trace_quicly__application_close_send(struct pt_regs *ctx) {
 // quicly:application_close_receive
 int trace_quicly__application_close_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_APPLICATION_CLOSE_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3181,7 +3282,7 @@ int trace_quicly__application_close_receive(struct pt_regs *ctx) {
 // quicly:stream_send
 int trace_quicly__stream_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3210,7 +3311,7 @@ int trace_quicly__stream_send(struct pt_regs *ctx) {
 // quicly:stream_receive
 int trace_quicly__stream_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3237,7 +3338,7 @@ int trace_quicly__stream_receive(struct pt_regs *ctx) {
 // quicly:stream_acked
 int trace_quicly__stream_acked(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ACKED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ACKED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3261,7 +3362,7 @@ int trace_quicly__stream_acked(struct pt_regs *ctx) {
 // quicly:stream_lost
 int trace_quicly__stream_lost(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_LOST };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_LOST, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3285,7 +3386,7 @@ int trace_quicly__stream_lost(struct pt_regs *ctx) {
 // quicly:max_data_send
 int trace_quicly__max_data_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_DATA_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_DATA_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3305,7 +3406,7 @@ int trace_quicly__max_data_send(struct pt_regs *ctx) {
 // quicly:max_data_receive
 int trace_quicly__max_data_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_DATA_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_DATA_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3325,7 +3426,7 @@ int trace_quicly__max_data_receive(struct pt_regs *ctx) {
 // quicly:max_streams_send
 int trace_quicly__max_streams_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3347,7 +3448,7 @@ int trace_quicly__max_streams_send(struct pt_regs *ctx) {
 // quicly:max_streams_receive
 int trace_quicly__max_streams_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAMS_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3369,7 +3470,7 @@ int trace_quicly__max_streams_receive(struct pt_regs *ctx) {
 // quicly:max_stream_data_send
 int trace_quicly__max_stream_data_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3394,7 +3495,7 @@ int trace_quicly__max_stream_data_send(struct pt_regs *ctx) {
 // quicly:max_stream_data_receive
 int trace_quicly__max_stream_data_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_MAX_STREAM_DATA_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3416,7 +3517,7 @@ int trace_quicly__max_stream_data_receive(struct pt_regs *ctx) {
 // quicly:new_token_send
 int trace_quicly__new_token_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3441,7 +3542,7 @@ int trace_quicly__new_token_send(struct pt_regs *ctx) {
 // quicly:new_token_acked
 int trace_quicly__new_token_acked(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_ACKED };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_ACKED, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3461,7 +3562,7 @@ int trace_quicly__new_token_acked(struct pt_regs *ctx) {
 // quicly:new_token_receive
 int trace_quicly__new_token_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_TOKEN_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3484,7 +3585,7 @@ int trace_quicly__new_token_receive(struct pt_regs *ctx) {
 // quicly:handshake_done_send
 int trace_quicly__handshake_done_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3502,7 +3603,7 @@ int trace_quicly__handshake_done_send(struct pt_regs *ctx) {
 // quicly:handshake_done_receive
 int trace_quicly__handshake_done_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_HANDSHAKE_DONE_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3520,7 +3621,7 @@ int trace_quicly__handshake_done_receive(struct pt_regs *ctx) {
 // quicly:streams_blocked_send
 int trace_quicly__streams_blocked_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3542,7 +3643,7 @@ int trace_quicly__streams_blocked_send(struct pt_regs *ctx) {
 // quicly:streams_blocked_receive
 int trace_quicly__streams_blocked_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAMS_BLOCKED_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3564,7 +3665,7 @@ int trace_quicly__streams_blocked_receive(struct pt_regs *ctx) {
 // quicly:new_connection_id_send
 int trace_quicly__new_connection_id_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3592,7 +3693,7 @@ int trace_quicly__new_connection_id_send(struct pt_regs *ctx) {
 // quicly:new_connection_id_receive
 int trace_quicly__new_connection_id_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_NEW_CONNECTION_ID_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3620,7 +3721,7 @@ int trace_quicly__new_connection_id_receive(struct pt_regs *ctx) {
 // quicly:retire_connection_id_send
 int trace_quicly__retire_connection_id_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3640,7 +3741,7 @@ int trace_quicly__retire_connection_id_send(struct pt_regs *ctx) {
 // quicly:retire_connection_id_receive
 int trace_quicly__retire_connection_id_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_RETIRE_CONNECTION_ID_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3660,7 +3761,7 @@ int trace_quicly__retire_connection_id_receive(struct pt_regs *ctx) {
 // quicly:data_blocked_send
 int trace_quicly__data_blocked_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3680,7 +3781,7 @@ int trace_quicly__data_blocked_send(struct pt_regs *ctx) {
 // quicly:data_blocked_receive
 int trace_quicly__data_blocked_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3700,7 +3801,7 @@ int trace_quicly__data_blocked_receive(struct pt_regs *ctx) {
 // quicly:stream_data_blocked_send
 int trace_quicly__stream_data_blocked_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3722,7 +3823,7 @@ int trace_quicly__stream_data_blocked_send(struct pt_regs *ctx) {
 // quicly:stream_data_blocked_receive
 int trace_quicly__stream_data_blocked_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3744,7 +3845,7 @@ int trace_quicly__stream_data_blocked_receive(struct pt_regs *ctx) {
 // quicly:datagram_send
 int trace_quicly__datagram_send(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATAGRAM_SEND };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATAGRAM_SEND, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3767,7 +3868,7 @@ int trace_quicly__datagram_send(struct pt_regs *ctx) {
 // quicly:datagram_receive
 int trace_quicly__datagram_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATAGRAM_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_DATAGRAM_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3790,7 +3891,7 @@ int trace_quicly__datagram_receive(struct pt_regs *ctx) {
 // quicly:ack_frequency_receive
 int trace_quicly__ack_frequency_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_FREQUENCY_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ACK_FREQUENCY_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3816,7 +3917,7 @@ int trace_quicly__ack_frequency_receive(struct pt_regs *ctx) {
 // quicly:quictrace_send_stream
 int trace_quicly__quictrace_send_stream(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_SEND_STREAM };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_SEND_STREAM, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3845,7 +3946,7 @@ int trace_quicly__quictrace_send_stream(struct pt_regs *ctx) {
 // quicly:quictrace_recv_stream
 int trace_quicly__quictrace_recv_stream(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_RECV_STREAM };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_RECV_STREAM, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3871,7 +3972,7 @@ int trace_quicly__quictrace_recv_stream(struct pt_regs *ctx) {
 // quicly:quictrace_cc_ack
 int trace_quicly__quictrace_cc_ack(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_ACK };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_ACK, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3901,7 +4002,7 @@ int trace_quicly__quictrace_cc_ack(struct pt_regs *ctx) {
 // quicly:quictrace_cc_lost
 int trace_quicly__quictrace_cc_lost(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_LOST };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_QUICTRACE_CC_LOST, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3931,7 +4032,7 @@ int trace_quicly__quictrace_cc_lost(struct pt_regs *ctx) {
 // quicly:stream_on_open
 int trace_quicly__stream_on_open(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_OPEN };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_OPEN, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3954,7 +4055,7 @@ int trace_quicly__stream_on_open(struct pt_regs *ctx) {
 // quicly:stream_on_destroy
 int trace_quicly__stream_on_destroy(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_DESTROY };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_DESTROY, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -3979,7 +4080,7 @@ int trace_quicly__stream_on_destroy(struct pt_regs *ctx) {
 // quicly:stream_on_send_shift
 int trace_quicly__stream_on_send_shift(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_SHIFT };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_SHIFT, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4004,7 +4105,7 @@ int trace_quicly__stream_on_send_shift(struct pt_regs *ctx) {
 // quicly:stream_on_send_emit
 int trace_quicly__stream_on_send_emit(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_EMIT };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_EMIT, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4031,7 +4132,7 @@ int trace_quicly__stream_on_send_emit(struct pt_regs *ctx) {
 // quicly:stream_on_send_stop
 int trace_quicly__stream_on_send_stop(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_STOP };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_SEND_STOP, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4056,7 +4157,7 @@ int trace_quicly__stream_on_send_stop(struct pt_regs *ctx) {
 // quicly:stream_on_receive
 int trace_quicly__stream_on_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4086,7 +4187,7 @@ int trace_quicly__stream_on_receive(struct pt_regs *ctx) {
 // quicly:stream_on_receive_reset
 int trace_quicly__stream_on_receive_reset(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE_RESET };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE_RESET, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4111,7 +4212,7 @@ int trace_quicly__stream_on_receive_reset(struct pt_regs *ctx) {
 // quicly:conn_stats
 int trace_quicly__conn_stats(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CONN_STATS };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_CONN_STATS, .tid = get_h2o_tid(), };
 
   // struct st_quicly_conn_t * conn
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
@@ -4139,7 +4240,7 @@ BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SI
 // h2o:_private_socket_lookup_flags
 int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS, .tid = get_h2o_tid(), };
 
   // pid_t tid
   bpf_usdt_readarg(1, ctx, &event._private_socket_lookup_flags.tid);
@@ -4174,7 +4275,7 @@ int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
 // h2o:receive_request
 int trace_h2o__receive_request(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.receive_request.conn_id);
@@ -4191,7 +4292,7 @@ int trace_h2o__receive_request(struct pt_regs *ctx) {
 // h2o:receive_request_header
 int trace_h2o__receive_request_header(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST_HEADER };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST_HEADER, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.receive_request_header.conn_id);
@@ -4216,7 +4317,7 @@ int trace_h2o__receive_request_header(struct pt_regs *ctx) {
 // h2o:send_response
 int trace_h2o__send_response(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SEND_RESPONSE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SEND_RESPONSE, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.send_response.conn_id);
@@ -4235,7 +4336,7 @@ int trace_h2o__send_response(struct pt_regs *ctx) {
 // h2o:send_response_header
 int trace_h2o__send_response_header(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SEND_RESPONSE_HEADER };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SEND_RESPONSE_HEADER, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.send_response_header.conn_id);
@@ -4265,7 +4366,7 @@ int trace_h2o__send_response_header(struct pt_regs *ctx) {
 // h2o:h1_accept
 int trace_h2o__h1_accept(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H1_ACCEPT };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H1_ACCEPT, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h1_accept.conn_id);
@@ -4282,7 +4383,7 @@ int trace_h2o__h1_accept(struct pt_regs *ctx) {
 // h2o:h1_close
 int trace_h2o__h1_close(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H1_CLOSE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H1_CLOSE, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h1_close.conn_id);
@@ -4295,7 +4396,7 @@ int trace_h2o__h1_close(struct pt_regs *ctx) {
 // h2o:h2_unknown_frame_type
 int trace_h2o__h2_unknown_frame_type(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H2_UNKNOWN_FRAME_TYPE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H2_UNKNOWN_FRAME_TYPE, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h2_unknown_frame_type.conn_id);
@@ -4310,7 +4411,7 @@ int trace_h2o__h2_unknown_frame_type(struct pt_regs *ctx) {
 // h2o:h3s_accept
 int trace_h2o__h3s_accept(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_ACCEPT };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_ACCEPT, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h3s_accept.conn_id);
@@ -4330,7 +4431,7 @@ int trace_h2o__h3s_accept(struct pt_regs *ctx) {
 // h2o:h3s_destroy
 int trace_h2o__h3s_destroy(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_DESTROY };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_DESTROY, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h3s_destroy.conn_id);
@@ -4343,7 +4444,7 @@ int trace_h2o__h3s_destroy(struct pt_regs *ctx) {
 // h2o:h3s_stream_set_state
 int trace_h2o__h3s_stream_set_state(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_STREAM_SET_STATE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3S_STREAM_SET_STATE, .tid = get_h2o_tid(), };
 
   // uint64_t conn_id
   bpf_usdt_readarg(1, ctx, &event.h3s_stream_set_state.conn_id);
@@ -4360,7 +4461,7 @@ int trace_h2o__h3s_stream_set_state(struct pt_regs *ctx) {
 // h2o:h3_frame_receive
 int trace_h2o__h3_frame_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_FRAME_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_FRAME_RECEIVE, .tid = get_h2o_tid(), };
 
   // uint64_t frame_type
   bpf_usdt_readarg(1, ctx, &event.h3_frame_receive.frame_type);
@@ -4378,7 +4479,7 @@ int trace_h2o__h3_frame_receive(struct pt_regs *ctx) {
 // h2o:h3_packet_receive
 int trace_h2o__h3_packet_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_PACKET_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_PACKET_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct sockaddr * dest
   bpf_usdt_readarg(1, ctx, &buf);
@@ -4410,7 +4511,7 @@ int trace_h2o__h3_packet_receive(struct pt_regs *ctx) {
 // h2o:h3_packet_forward
 int trace_h2o__h3_packet_forward(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_PACKET_FORWARD };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_PACKET_FORWARD, .tid = get_h2o_tid(), };
 
   // struct sockaddr * dest
   bpf_usdt_readarg(1, ctx, &buf);
@@ -4443,7 +4544,7 @@ int trace_h2o__h3_packet_forward(struct pt_regs *ctx) {
 // h2o:h3_forwarded_packet_receive
 int trace_h2o__h3_forwarded_packet_receive(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_FORWARDED_PACKET_RECEIVE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3_FORWARDED_PACKET_RECEIVE, .tid = get_h2o_tid(), };
 
   // struct sockaddr * dest
   bpf_usdt_readarg(1, ctx, &buf);
@@ -4472,7 +4573,7 @@ int trace_h2o__h3_forwarded_packet_receive(struct pt_regs *ctx) {
 // h2o:h3c_tunnel_create
 int trace_h2o__h3c_tunnel_create(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3C_TUNNEL_CREATE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H3C_TUNNEL_CREATE, .tid = get_h2o_tid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.h3c_tunnel_create.tunnel);
@@ -4485,7 +4586,7 @@ int trace_h2o__h3c_tunnel_create(struct pt_regs *ctx) {
 // h2o:tunnel_on_destroy
 int trace_h2o__tunnel_on_destroy(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_DESTROY };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_DESTROY, .tid = get_h2o_tid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_on_destroy.tunnel);
@@ -4498,7 +4599,7 @@ int trace_h2o__tunnel_on_destroy(struct pt_regs *ctx) {
 // h2o:tunnel_on_read
 int trace_h2o__tunnel_on_read(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_READ };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_READ, .tid = get_h2o_tid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_on_read.tunnel);
@@ -4519,7 +4620,7 @@ int trace_h2o__tunnel_on_read(struct pt_regs *ctx) {
 // h2o:tunnel_proceed_read
 int trace_h2o__tunnel_proceed_read(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_PROCEED_READ };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_PROCEED_READ, .tid = get_h2o_tid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_proceed_read.tunnel);
@@ -4532,7 +4633,7 @@ int trace_h2o__tunnel_proceed_read(struct pt_regs *ctx) {
 // h2o:tunnel_write
 int trace_h2o__tunnel_write(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_WRITE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_WRITE, .tid = get_h2o_tid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_write.tunnel);
@@ -4550,7 +4651,7 @@ int trace_h2o__tunnel_write(struct pt_regs *ctx) {
 // h2o:tunnel_on_write_complete
 int trace_h2o__tunnel_on_write_complete(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_WRITE_COMPLETE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_TUNNEL_ON_WRITE_COMPLETE, .tid = get_h2o_tid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.tunnel_on_write_complete.tunnel);
@@ -4566,7 +4667,7 @@ int trace_h2o__tunnel_on_write_complete(struct pt_regs *ctx) {
 // h2o:socket_tunnel_create
 int trace_h2o__socket_tunnel_create(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_CREATE };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_CREATE, .tid = get_h2o_tid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.socket_tunnel_create.tunnel);
@@ -4579,7 +4680,7 @@ int trace_h2o__socket_tunnel_create(struct pt_regs *ctx) {
 // h2o:socket_tunnel_start
 int trace_h2o__socket_tunnel_start(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_START };
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_START, .tid = get_h2o_tid(), };
 
   // struct st_h2o_tunnel_t * tunnel
   bpf_usdt_readarg(1, ctx, &event.socket_tunnel_start.tunnel);

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -374,7 +374,7 @@ def build_tracer(context, metadata):
   c = r"""// %s
 int %s(struct pt_regs *ctx) {
   const void *buf = NULL;
-  struct h2olog_event_t event = { .id = %s, .tid = get_h2o_tid(), };
+  struct h2olog_event_t event = { .id = %s, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
 
 """ % (fully_specified_probe_name, tracer_name, metadata['id'])
   appdata_field_set = metadata["appdata_field_set"]  # type: set[str]
@@ -624,11 +624,6 @@ BPF_PERF_OUTPUT(events);
 
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
-
-static pid_t get_h2o_tid(void) {
-  u64 pid_tgid = bpf_get_current_pid_tgid();
-  return (pid_t)(pid_tgid & 0xffffffff);
-}
 
 // tracepoint sched:sched_process_exit
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {

--- a/t/90h2olog.t
+++ b/t/90h2olog.t
@@ -62,7 +62,8 @@ subtest "h2olog", sub {
     diag "h2olog output:\n", $trace;
   }
 
-  ok( (map { decode_json($_) } split /\n/, $trace), "h2olog output is valid JSON Lines");
+  my @events = map { decode_json($_) } split /\n/, $trace;
+  is scalar(grep { $_->{type} && $_->{tid} && $_->{seq} } @events), scalar(@events), "each event has type, tid and seq";
 };
 
 subtest "h2olog -H", sub {


### PR DESCRIPTION
Alternative to #2719. Adding a common field `tid` for h2o's tid. 