### PR TITLE
[h2olog] fix a bug in h3s_accept which has two "conn" fields for h2o_conn_t and quicly_conn_t

### DIFF
--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -204,53 +204,53 @@ struct h2olog_event_t {
 
   union {
     struct { // quicly:connect
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint32_t version;
     } connect;
     struct { // quicly:accept
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       char dcid[STR_LEN];
       struct st_quicly_address_token_plaintext_t * address_token;
     } accept;
     struct { // quicly:free
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } free;
     struct { // quicly:send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int state;
       char dcid[STR_LEN];
     } send;
     struct { // quicly:receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       char dcid[STR_LEN];
       uint8_t bytes[STR_LEN];
       size_t bytes_len;
     } receive;
     struct { // quicly:version_switch
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint32_t new_version;
     } version_switch;
     struct { // quicly:idle_timeout
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } idle_timeout;
     struct { // quicly:stateless_reset_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } stateless_reset_receive;
     struct { // quicly:crypto_handshake
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int ret;
     } crypto_handshake;
     struct { // quicly:crypto_update_secret
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int is_enc;
       uint8_t epoch;
@@ -258,30 +258,30 @@ struct h2olog_event_t {
       char secret[STR_LEN]; // appdata
     } crypto_update_secret;
     struct { // quicly:crypto_send_key_update
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t phase;
       char secret[STR_LEN]; // appdata
     } crypto_send_key_update;
     struct { // quicly:crypto_send_key_update_confirmed
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t next_pn;
     } crypto_send_key_update_confirmed;
     struct { // quicly:crypto_receive_key_update
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t phase;
       char secret[STR_LEN]; // appdata
     } crypto_receive_key_update;
     struct { // quicly:crypto_receive_key_update_prepare
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t phase;
       char secret[STR_LEN]; // appdata
     } crypto_receive_key_update_prepare;
     struct { // quicly:packet_sent
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
       size_t len;
@@ -289,7 +289,7 @@ struct h2olog_event_t {
       int ack_only;
     } packet_sent;
     struct { // quicly:packet_received
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
       uint8_t decrypted[STR_LEN]; // appdata
@@ -297,37 +297,37 @@ struct h2olog_event_t {
       uint8_t packet_type;
     } packet_received;
     struct { // quicly:packet_prepare
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t first_octet;
       char dcid[STR_LEN];
     } packet_prepare;
     struct { // quicly:packet_acked
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
       int is_late_ack;
     } packet_acked;
     struct { // quicly:packet_lost
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
       uint8_t packet_type;
     } packet_lost;
     struct { // quicly:packet_decryption_failed
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
     } packet_decryption_failed;
     struct { // quicly:pto
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       size_t inflight;
       uint32_t cwnd;
       int8_t pto_count;
     } pto;
     struct { // quicly:cc_ack_received
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t largest_acked;
       size_t bytes_acked;
@@ -335,166 +335,166 @@ struct h2olog_event_t {
       size_t inflight;
     } cc_ack_received;
     struct { // quicly:cc_congestion
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t max_lost_pn;
       size_t inflight;
       uint32_t cwnd;
     } cc_congestion;
     struct { // quicly:ack_block_received
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t ack_block_begin;
       uint64_t ack_block_end;
     } ack_block_received;
     struct { // quicly:ack_delay_received
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t ack_delay;
     } ack_delay_received;
     struct { // quicly:ack_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t largest_acked;
       uint64_t ack_delay;
     } ack_send;
     struct { // quicly:ping_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } ping_send;
     struct { // quicly:ping_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } ping_receive;
     struct { // quicly:transport_close_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t error_code;
       uint64_t frame_type;
       char reason_phrase[STR_LEN];
     } transport_close_send;
     struct { // quicly:transport_close_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t error_code;
       uint64_t frame_type;
       char reason_phrase[STR_LEN];
     } transport_close_receive;
     struct { // quicly:application_close_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t error_code;
       char reason_phrase[STR_LEN];
     } application_close_send;
     struct { // quicly:application_close_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t error_code;
       char reason_phrase[STR_LEN];
     } application_close_receive;
     struct { // quicly:stream_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       uint64_t off;
       size_t len;
       int is_fin;
     } stream_send;
     struct { // quicly:stream_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       uint64_t off;
       size_t len;
     } stream_receive;
     struct { // quicly:stream_acked
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t off;
       size_t len;
     } stream_acked;
     struct { // quicly:stream_lost
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t off;
       size_t len;
     } stream_lost;
     struct { // quicly:max_data_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
     } max_data_send;
     struct { // quicly:max_data_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
     } max_data_receive;
     struct { // quicly:max_streams_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
       int is_unidirectional;
     } max_streams_send;
     struct { // quicly:max_streams_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
       int is_unidirectional;
     } max_streams_receive;
     struct { // quicly:max_stream_data_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       uint64_t maximum;
     } max_stream_data_send;
     struct { // quicly:max_stream_data_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t maximum;
     } max_stream_data_receive;
     struct { // quicly:new_token_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t token[STR_LEN];
       size_t token_len;
       uint64_t generation;
     } new_token_send;
     struct { // quicly:new_token_acked
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t generation;
     } new_token_acked;
     struct { // quicly:new_token_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t token[STR_LEN];
       size_t token_len;
     } new_token_receive;
     struct { // quicly:handshake_done_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } handshake_done_send;
     struct { // quicly:handshake_done_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } handshake_done_receive;
     struct { // quicly:streams_blocked_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
       int is_unidirectional;
     } streams_blocked_send;
     struct { // quicly:streams_blocked_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
       int is_unidirectional;
     } streams_blocked_receive;
     struct { // quicly:new_connection_id_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
       uint64_t retire_prior_to;
@@ -502,7 +502,7 @@ struct h2olog_event_t {
       char stateless_reset_token[STR_LEN];
     } new_connection_id_send;
     struct { // quicly:new_connection_id_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
       uint64_t retire_prior_to;
@@ -510,51 +510,51 @@ struct h2olog_event_t {
       char stateless_reset_token[STR_LEN];
     } new_connection_id_receive;
     struct { // quicly:retire_connection_id_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
     } retire_connection_id_send;
     struct { // quicly:retire_connection_id_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
     } retire_connection_id_receive;
     struct { // quicly:data_blocked_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t off;
     } data_blocked_send;
     struct { // quicly:data_blocked_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t off;
     } data_blocked_receive;
     struct { // quicly:stream_data_blocked_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t maximum;
     } stream_data_blocked_send;
     struct { // quicly:stream_data_blocked_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t maximum;
     } stream_data_blocked_receive;
     struct { // quicly:datagram_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t payload[STR_LEN]; // appdata
       size_t payload_len;
     } datagram_send;
     struct { // quicly:datagram_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t payload[STR_LEN]; // appdata
       size_t payload_len;
     } datagram_receive;
     struct { // quicly:ack_frequency_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
       uint64_t packet_tolerance;
@@ -562,15 +562,15 @@ struct h2olog_event_t {
       int ignore_order;
     } ack_frequency_receive;
     struct { // quicly:quictrace_send_stream
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       uint64_t off;
       size_t len;
       int fin;
     } quictrace_send_stream;
     struct { // quicly:quictrace_recv_stream
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t off;
@@ -578,71 +578,71 @@ struct h2olog_event_t {
       int fin;
     } quictrace_recv_stream;
     struct { // quicly:quictrace_cc_ack
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_quicly_rtt_t__minimum minimum;
-      typeof_quicly_rtt_t__smoothed smoothed;
-      typeof_quicly_rtt_t__variance variance;
-      typeof_quicly_rtt_t__latest latest;
+      typeof_quicly_rtt_t__minimum rtt_minimum;
+      typeof_quicly_rtt_t__smoothed rtt_smoothed;
+      typeof_quicly_rtt_t__variance rtt_variance;
+      typeof_quicly_rtt_t__latest rtt_latest;
       uint32_t cwnd;
       size_t inflight;
     } quictrace_cc_ack;
     struct { // quicly:quictrace_cc_lost
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_quicly_rtt_t__minimum minimum;
-      typeof_quicly_rtt_t__smoothed smoothed;
-      typeof_quicly_rtt_t__variance variance;
-      typeof_quicly_rtt_t__latest latest;
+      typeof_quicly_rtt_t__minimum rtt_minimum;
+      typeof_quicly_rtt_t__smoothed rtt_smoothed;
+      typeof_quicly_rtt_t__variance rtt_variance;
+      typeof_quicly_rtt_t__latest rtt_latest;
       uint32_t cwnd;
       size_t inflight;
     } quictrace_cc_lost;
     struct { // quicly:stream_on_open
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
     } stream_on_open;
     struct { // quicly:stream_on_destroy
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       int err;
     } stream_on_destroy;
     struct { // quicly:stream_on_send_shift
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       size_t delta;
     } stream_on_send_shift;
     struct { // quicly:stream_on_send_emit
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       size_t off;
       size_t capacity;
     } stream_on_send_emit;
     struct { // quicly:stream_on_send_stop
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       int err;
     } stream_on_send_stop;
     struct { // quicly:stream_on_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       size_t off;
       uint8_t src[STR_LEN]; // appdata
       size_t src_len;
     } stream_on_receive;
     struct { // quicly:stream_on_receive_reset
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       int err;
     } stream_on_receive_reset;
     struct { // quicly:conn_stats
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       struct st_quicly_stats_t * stats;
       size_t size;
@@ -694,7 +694,7 @@ struct h2olog_event_t {
     struct { // h2o:h3s_accept
       uint64_t conn_id;
       struct st_h2o_conn_t * conn;
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id quic_master_id;
     } h3s_accept;
     struct { // h2o:h3s_destroy
       uint64_t conn_id;
@@ -879,7 +879,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("connect"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->connect.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->connect.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->connect.at);
     json_write_pair_c(out_, STR_LIT("version"), event->connect.version);
     break;
@@ -888,7 +888,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("accept"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->accept.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->accept.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->accept.at);
     json_write_pair_c(out_, STR_LIT("dcid"), event->accept.dcid, strlen(event->accept.dcid));
     json_write_pair_c(out_, STR_LIT("address-token"), event->accept.address_token);
@@ -898,7 +898,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("free"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->free.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->free.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->free.at);
     break;
   }
@@ -906,7 +906,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->send.at);
     json_write_pair_c(out_, STR_LIT("state"), event->send.state);
     json_write_pair_c(out_, STR_LIT("dcid"), event->send.dcid, strlen(event->send.dcid));
@@ -916,7 +916,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->receive.at);
     json_write_pair_c(out_, STR_LIT("dcid"), event->receive.dcid, strlen(event->receive.dcid));
     json_write_pair_c(out_, STR_LIT("bytes"), event->receive.bytes, (event->receive.bytes_len < STR_LEN ? event->receive.bytes_len : STR_LEN));
@@ -927,7 +927,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("version-switch"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->version_switch.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->version_switch.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->version_switch.at);
     json_write_pair_c(out_, STR_LIT("new-version"), event->version_switch.new_version);
     break;
@@ -936,7 +936,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("idle-timeout"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->idle_timeout.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->idle_timeout.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->idle_timeout.at);
     break;
   }
@@ -944,7 +944,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stateless-reset-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stateless_reset_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stateless_reset_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stateless_reset_receive.at);
     break;
   }
@@ -952,7 +952,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-handshake"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_handshake.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_handshake.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_handshake.at);
     json_write_pair_c(out_, STR_LIT("ret"), event->crypto_handshake.ret);
     break;
@@ -961,7 +961,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-update-secret"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_update_secret.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_update_secret.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_update_secret.at);
     json_write_pair_c(out_, STR_LIT("is-enc"), event->crypto_update_secret.is_enc);
     json_write_pair_c(out_, STR_LIT("epoch"), event->crypto_update_secret.epoch);
@@ -975,7 +975,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-send-key-update"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_send_key_update.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_send_key_update.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_send_key_update.at);
     json_write_pair_c(out_, STR_LIT("phase"), event->crypto_send_key_update.phase);
     if (include_appdata_) {
@@ -987,7 +987,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-send-key-update-confirmed"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_send_key_update_confirmed.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_send_key_update_confirmed.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_send_key_update_confirmed.at);
     json_write_pair_c(out_, STR_LIT("next-pn"), event->crypto_send_key_update_confirmed.next_pn);
     break;
@@ -996,7 +996,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-receive-key-update"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_receive_key_update.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_receive_key_update.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_receive_key_update.at);
     json_write_pair_c(out_, STR_LIT("phase"), event->crypto_receive_key_update.phase);
     if (include_appdata_) {
@@ -1008,7 +1008,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-receive-key-update-prepare"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_receive_key_update_prepare.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->crypto_receive_key_update_prepare.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_receive_key_update_prepare.at);
     json_write_pair_c(out_, STR_LIT("phase"), event->crypto_receive_key_update_prepare.phase);
     if (include_appdata_) {
@@ -1020,7 +1020,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-sent"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->packet_sent.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->packet_sent.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_sent.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_sent.pn);
     json_write_pair_c(out_, STR_LIT("len"), event->packet_sent.len);
@@ -1032,7 +1032,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-received"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->packet_received.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->packet_received.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_received.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_received.pn);
     if (include_appdata_) {
@@ -1046,7 +1046,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-prepare"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->packet_prepare.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->packet_prepare.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_prepare.at);
     json_write_pair_c(out_, STR_LIT("first-octet"), event->packet_prepare.first_octet);
     json_write_pair_c(out_, STR_LIT("dcid"), event->packet_prepare.dcid, strlen(event->packet_prepare.dcid));
@@ -1056,7 +1056,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-acked"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->packet_acked.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->packet_acked.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_acked.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_acked.pn);
     json_write_pair_c(out_, STR_LIT("is-late-ack"), event->packet_acked.is_late_ack);
@@ -1066,7 +1066,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-lost"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->packet_lost.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->packet_lost.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_lost.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_lost.pn);
     json_write_pair_c(out_, STR_LIT("packet-type"), event->packet_lost.packet_type);
@@ -1076,7 +1076,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-decryption-failed"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->packet_decryption_failed.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->packet_decryption_failed.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_decryption_failed.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_decryption_failed.pn);
     break;
@@ -1085,7 +1085,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("pto"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->pto.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->pto.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->pto.at);
     json_write_pair_c(out_, STR_LIT("inflight"), event->pto.inflight);
     json_write_pair_c(out_, STR_LIT("cwnd"), event->pto.cwnd);
@@ -1096,7 +1096,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("cc-ack-received"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->cc_ack_received.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->cc_ack_received.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->cc_ack_received.at);
     json_write_pair_c(out_, STR_LIT("largest-acked"), event->cc_ack_received.largest_acked);
     json_write_pair_c(out_, STR_LIT("bytes-acked"), event->cc_ack_received.bytes_acked);
@@ -1108,7 +1108,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("cc-congestion"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->cc_congestion.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->cc_congestion.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->cc_congestion.at);
     json_write_pair_c(out_, STR_LIT("max-lost-pn"), event->cc_congestion.max_lost_pn);
     json_write_pair_c(out_, STR_LIT("inflight"), event->cc_congestion.inflight);
@@ -1119,7 +1119,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-block-received"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->ack_block_received.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->ack_block_received.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_block_received.at);
     json_write_pair_c(out_, STR_LIT("ack-block-begin"), event->ack_block_received.ack_block_begin);
     json_write_pair_c(out_, STR_LIT("ack-block-end"), event->ack_block_received.ack_block_end);
@@ -1129,7 +1129,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-delay-received"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->ack_delay_received.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->ack_delay_received.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_delay_received.at);
     json_write_pair_c(out_, STR_LIT("ack-delay"), event->ack_delay_received.ack_delay);
     break;
@@ -1138,7 +1138,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->ack_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->ack_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_send.at);
     json_write_pair_c(out_, STR_LIT("largest-acked"), event->ack_send.largest_acked);
     json_write_pair_c(out_, STR_LIT("ack-delay"), event->ack_send.ack_delay);
@@ -1148,7 +1148,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ping-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->ping_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->ping_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ping_send.at);
     break;
   }
@@ -1156,7 +1156,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ping-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->ping_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->ping_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ping_receive.at);
     break;
   }
@@ -1164,7 +1164,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("transport-close-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->transport_close_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->transport_close_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->transport_close_send.at);
     json_write_pair_c(out_, STR_LIT("error-code"), event->transport_close_send.error_code);
     json_write_pair_c(out_, STR_LIT("frame-type"), event->transport_close_send.frame_type);
@@ -1175,7 +1175,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("transport-close-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->transport_close_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->transport_close_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->transport_close_receive.at);
     json_write_pair_c(out_, STR_LIT("error-code"), event->transport_close_receive.error_code);
     json_write_pair_c(out_, STR_LIT("frame-type"), event->transport_close_receive.frame_type);
@@ -1186,7 +1186,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("application-close-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->application_close_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->application_close_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->application_close_send.at);
     json_write_pair_c(out_, STR_LIT("error-code"), event->application_close_send.error_code);
     json_write_pair_c(out_, STR_LIT("reason-phrase"), event->application_close_send.reason_phrase, strlen(event->application_close_send.reason_phrase));
@@ -1196,7 +1196,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("application-close-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->application_close_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->application_close_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->application_close_receive.at);
     json_write_pair_c(out_, STR_LIT("error-code"), event->application_close_receive.error_code);
     json_write_pair_c(out_, STR_LIT("reason-phrase"), event->application_close_receive.reason_phrase, strlen(event->application_close_receive.reason_phrase));
@@ -1206,9 +1206,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_send.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_send.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_send.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("off"), event->stream_send.off);
     json_write_pair_c(out_, STR_LIT("len"), event->stream_send.len);
     json_write_pair_c(out_, STR_LIT("is-fin"), event->stream_send.is_fin);
@@ -1218,9 +1218,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_receive.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_receive.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_receive.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("off"), event->stream_receive.off);
     json_write_pair_c(out_, STR_LIT("len"), event->stream_receive.len);
     break;
@@ -1229,7 +1229,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-acked"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_acked.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_acked.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_acked.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_acked.stream_id);
     json_write_pair_c(out_, STR_LIT("off"), event->stream_acked.off);
@@ -1240,7 +1240,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-lost"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_lost.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_lost.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_lost.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_lost.stream_id);
     json_write_pair_c(out_, STR_LIT("off"), event->stream_lost.off);
@@ -1251,7 +1251,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-data-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->max_data_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->max_data_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_data_send.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_data_send.maximum);
     break;
@@ -1260,7 +1260,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-data-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->max_data_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->max_data_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_data_receive.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_data_receive.maximum);
     break;
@@ -1269,7 +1269,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-streams-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->max_streams_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->max_streams_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_streams_send.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_streams_send.maximum);
     json_write_pair_c(out_, STR_LIT("is-unidirectional"), event->max_streams_send.is_unidirectional);
@@ -1279,7 +1279,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-streams-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->max_streams_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->max_streams_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_streams_receive.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_streams_receive.maximum);
     json_write_pair_c(out_, STR_LIT("is-unidirectional"), event->max_streams_receive.is_unidirectional);
@@ -1289,9 +1289,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-stream-data-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->max_stream_data_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->max_stream_data_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_stream_data_send.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->max_stream_data_send.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->max_stream_data_send.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_stream_data_send.maximum);
     break;
   }
@@ -1299,7 +1299,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-stream-data-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->max_stream_data_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->max_stream_data_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_stream_data_receive.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->max_stream_data_receive.stream_id);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_stream_data_receive.maximum);
@@ -1309,7 +1309,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->new_token_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->new_token_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_send.at);
     json_write_pair_c(out_, STR_LIT("token"), event->new_token_send.token, (event->new_token_send.token_len < STR_LEN ? event->new_token_send.token_len : STR_LEN));
     json_write_pair_c(out_, STR_LIT("token-len"), event->new_token_send.token_len);
@@ -1320,7 +1320,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-acked"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->new_token_acked.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->new_token_acked.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_acked.at);
     json_write_pair_c(out_, STR_LIT("generation"), event->new_token_acked.generation);
     break;
@@ -1329,7 +1329,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->new_token_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->new_token_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_receive.at);
     json_write_pair_c(out_, STR_LIT("token"), event->new_token_receive.token, (event->new_token_receive.token_len < STR_LEN ? event->new_token_receive.token_len : STR_LEN));
     json_write_pair_c(out_, STR_LIT("token-len"), event->new_token_receive.token_len);
@@ -1339,7 +1339,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("handshake-done-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->handshake_done_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->handshake_done_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->handshake_done_send.at);
     break;
   }
@@ -1347,7 +1347,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("handshake-done-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->handshake_done_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->handshake_done_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->handshake_done_receive.at);
     break;
   }
@@ -1355,7 +1355,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("streams-blocked-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->streams_blocked_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->streams_blocked_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->streams_blocked_send.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->streams_blocked_send.maximum);
     json_write_pair_c(out_, STR_LIT("is-unidirectional"), event->streams_blocked_send.is_unidirectional);
@@ -1365,7 +1365,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("streams-blocked-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->streams_blocked_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->streams_blocked_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->streams_blocked_receive.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->streams_blocked_receive.maximum);
     json_write_pair_c(out_, STR_LIT("is-unidirectional"), event->streams_blocked_receive.is_unidirectional);
@@ -1375,7 +1375,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-connection-id-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->new_connection_id_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->new_connection_id_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_connection_id_send.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->new_connection_id_send.sequence);
     json_write_pair_c(out_, STR_LIT("retire-prior-to"), event->new_connection_id_send.retire_prior_to);
@@ -1387,7 +1387,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-connection-id-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->new_connection_id_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->new_connection_id_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_connection_id_receive.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->new_connection_id_receive.sequence);
     json_write_pair_c(out_, STR_LIT("retire-prior-to"), event->new_connection_id_receive.retire_prior_to);
@@ -1399,7 +1399,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("retire-connection-id-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->retire_connection_id_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->retire_connection_id_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->retire_connection_id_send.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->retire_connection_id_send.sequence);
     break;
@@ -1408,7 +1408,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("retire-connection-id-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->retire_connection_id_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->retire_connection_id_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->retire_connection_id_receive.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->retire_connection_id_receive.sequence);
     break;
@@ -1417,7 +1417,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("data-blocked-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->data_blocked_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->data_blocked_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->data_blocked_send.at);
     json_write_pair_c(out_, STR_LIT("off"), event->data_blocked_send.off);
     break;
@@ -1426,7 +1426,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("data-blocked-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->data_blocked_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->data_blocked_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->data_blocked_receive.at);
     json_write_pair_c(out_, STR_LIT("off"), event->data_blocked_receive.off);
     break;
@@ -1435,7 +1435,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-data-blocked-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_data_blocked_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_data_blocked_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_data_blocked_send.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_data_blocked_send.stream_id);
     json_write_pair_c(out_, STR_LIT("maximum"), event->stream_data_blocked_send.maximum);
@@ -1445,7 +1445,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-data-blocked-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_data_blocked_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_data_blocked_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_data_blocked_receive.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_data_blocked_receive.stream_id);
     json_write_pair_c(out_, STR_LIT("maximum"), event->stream_data_blocked_receive.maximum);
@@ -1455,7 +1455,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("datagram-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->datagram_send.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->datagram_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->datagram_send.at);
     if (include_appdata_) {
       json_write_pair_c(out_, STR_LIT("payload"), event->datagram_send.payload, (event->datagram_send.payload_len < STR_LEN ? event->datagram_send.payload_len : STR_LEN));
@@ -1467,7 +1467,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("datagram-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->datagram_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->datagram_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->datagram_receive.at);
     if (include_appdata_) {
       json_write_pair_c(out_, STR_LIT("payload"), event->datagram_receive.payload, (event->datagram_receive.payload_len < STR_LEN ? event->datagram_receive.payload_len : STR_LEN));
@@ -1479,7 +1479,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-frequency-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->ack_frequency_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->ack_frequency_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_frequency_receive.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->ack_frequency_receive.sequence);
     json_write_pair_c(out_, STR_LIT("packet-tolerance"), event->ack_frequency_receive.packet_tolerance);
@@ -1491,9 +1491,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-send-stream"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_send_stream.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_send_stream.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_send_stream.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->quictrace_send_stream.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->quictrace_send_stream.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("off"), event->quictrace_send_stream.off);
     json_write_pair_c(out_, STR_LIT("len"), event->quictrace_send_stream.len);
     json_write_pair_c(out_, STR_LIT("fin"), event->quictrace_send_stream.fin);
@@ -1503,7 +1503,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-recv-stream"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_recv_stream.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_recv_stream.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_recv_stream.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->quictrace_recv_stream.stream_id);
     json_write_pair_c(out_, STR_LIT("off"), event->quictrace_recv_stream.off);
@@ -1515,12 +1515,12 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-cc-ack"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_cc_ack.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_cc_ack.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_cc_ack.at);
-    json_write_pair_c(out_, STR_LIT("min-rtt"), event->quictrace_cc_ack.minimum);
-    json_write_pair_c(out_, STR_LIT("smoothed-rtt"), event->quictrace_cc_ack.smoothed);
-    json_write_pair_c(out_, STR_LIT("variance-rtt"), event->quictrace_cc_ack.variance);
-    json_write_pair_c(out_, STR_LIT("latest-rtt"), event->quictrace_cc_ack.latest);
+    json_write_pair_c(out_, STR_LIT("min-rtt"), event->quictrace_cc_ack.rtt_minimum);
+    json_write_pair_c(out_, STR_LIT("smoothed-rtt"), event->quictrace_cc_ack.rtt_smoothed);
+    json_write_pair_c(out_, STR_LIT("variance-rtt"), event->quictrace_cc_ack.rtt_variance);
+    json_write_pair_c(out_, STR_LIT("latest-rtt"), event->quictrace_cc_ack.rtt_latest);
     json_write_pair_c(out_, STR_LIT("cwnd"), event->quictrace_cc_ack.cwnd);
     json_write_pair_c(out_, STR_LIT("inflight"), event->quictrace_cc_ack.inflight);
     break;
@@ -1529,12 +1529,12 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-cc-lost"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_cc_lost.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_cc_lost.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_cc_lost.at);
-    json_write_pair_c(out_, STR_LIT("min-rtt"), event->quictrace_cc_lost.minimum);
-    json_write_pair_c(out_, STR_LIT("smoothed-rtt"), event->quictrace_cc_lost.smoothed);
-    json_write_pair_c(out_, STR_LIT("variance-rtt"), event->quictrace_cc_lost.variance);
-    json_write_pair_c(out_, STR_LIT("latest-rtt"), event->quictrace_cc_lost.latest);
+    json_write_pair_c(out_, STR_LIT("min-rtt"), event->quictrace_cc_lost.rtt_minimum);
+    json_write_pair_c(out_, STR_LIT("smoothed-rtt"), event->quictrace_cc_lost.rtt_smoothed);
+    json_write_pair_c(out_, STR_LIT("variance-rtt"), event->quictrace_cc_lost.rtt_variance);
+    json_write_pair_c(out_, STR_LIT("latest-rtt"), event->quictrace_cc_lost.rtt_latest);
     json_write_pair_c(out_, STR_LIT("cwnd"), event->quictrace_cc_lost.cwnd);
     json_write_pair_c(out_, STR_LIT("inflight"), event->quictrace_cc_lost.inflight);
     break;
@@ -1543,18 +1543,18 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-open"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_open.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_open.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_open.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_open.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_open.stream_stream_id);
     break;
   }
   case H2OLOG_EVENT_ID_QUICLY_STREAM_ON_DESTROY: { // quicly:stream_on_destroy
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-destroy"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_destroy.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_destroy.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_destroy.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_destroy.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_destroy.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("err"), event->stream_on_destroy.err);
     break;
   }
@@ -1562,9 +1562,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-shift"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_shift.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_shift.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_shift.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_shift.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_shift.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("delta"), event->stream_on_send_shift.delta);
     break;
   }
@@ -1572,9 +1572,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-emit"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_emit.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_emit.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_emit.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_emit.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_emit.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("off"), event->stream_on_send_emit.off);
     json_write_pair_c(out_, STR_LIT("capacity"), event->stream_on_send_emit.capacity);
     break;
@@ -1583,9 +1583,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-stop"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_stop.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_stop.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_stop.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_stop.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_stop.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("err"), event->stream_on_send_stop.err);
     break;
   }
@@ -1593,9 +1593,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_receive.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_receive.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_receive.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_receive.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("off"), event->stream_on_receive.off);
     if (include_appdata_) {
       json_write_pair_c(out_, STR_LIT("src"), event->stream_on_receive.src, (event->stream_on_receive.src_len < STR_LEN ? event->stream_on_receive.src_len : STR_LEN));
@@ -1607,9 +1607,9 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-receive-reset"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_receive_reset.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_receive_reset.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_receive_reset.at);
-    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_receive_reset.stream_id);
+    json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_receive_reset.stream_stream_id);
     json_write_pair_c(out_, STR_LIT("err"), event->stream_on_receive_reset.err);
     break;
   }
@@ -1617,7 +1617,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("conn-stats"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
-    json_write_pair_c(out_, STR_LIT("conn"), event->conn_stats.master_id);
+    json_write_pair_c(out_, STR_LIT("conn"), event->conn_stats.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->conn_stats.at);
     json_write_pair_c(out_, STR_LIT("stats"), event->conn_stats.stats);
     json_write_pair_c(out_, STR_LIT("size"), event->conn_stats.size);
@@ -1711,7 +1711,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h3s_accept.conn_id);
     json_write_pair_c(out_, STR_LIT("conn"), event->h3s_accept.conn);
-    json_write_pair_c(out_, STR_LIT("conn"), event->h3s_accept.master_id);
+    json_write_pair_c(out_, STR_LIT("quic-master-id"), event->h3s_accept.quic_master_id);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
@@ -1985,53 +1985,53 @@ struct h2olog_event_t {
 
   union {
     struct { // quicly:connect
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint32_t version;
     } connect;
     struct { // quicly:accept
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       char dcid[STR_LEN];
       struct st_quicly_address_token_plaintext_t * address_token;
     } accept;
     struct { // quicly:free
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } free;
     struct { // quicly:send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int state;
       char dcid[STR_LEN];
     } send;
     struct { // quicly:receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       char dcid[STR_LEN];
       uint8_t bytes[STR_LEN];
       size_t bytes_len;
     } receive;
     struct { // quicly:version_switch
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint32_t new_version;
     } version_switch;
     struct { // quicly:idle_timeout
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } idle_timeout;
     struct { // quicly:stateless_reset_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } stateless_reset_receive;
     struct { // quicly:crypto_handshake
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int ret;
     } crypto_handshake;
     struct { // quicly:crypto_update_secret
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int is_enc;
       uint8_t epoch;
@@ -2039,30 +2039,30 @@ struct h2olog_event_t {
       char secret[STR_LEN]; // appdata
     } crypto_update_secret;
     struct { // quicly:crypto_send_key_update
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t phase;
       char secret[STR_LEN]; // appdata
     } crypto_send_key_update;
     struct { // quicly:crypto_send_key_update_confirmed
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t next_pn;
     } crypto_send_key_update_confirmed;
     struct { // quicly:crypto_receive_key_update
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t phase;
       char secret[STR_LEN]; // appdata
     } crypto_receive_key_update;
     struct { // quicly:crypto_receive_key_update_prepare
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t phase;
       char secret[STR_LEN]; // appdata
     } crypto_receive_key_update_prepare;
     struct { // quicly:packet_sent
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
       size_t len;
@@ -2070,7 +2070,7 @@ struct h2olog_event_t {
       int ack_only;
     } packet_sent;
     struct { // quicly:packet_received
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
       uint8_t decrypted[STR_LEN]; // appdata
@@ -2078,37 +2078,37 @@ struct h2olog_event_t {
       uint8_t packet_type;
     } packet_received;
     struct { // quicly:packet_prepare
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t first_octet;
       char dcid[STR_LEN];
     } packet_prepare;
     struct { // quicly:packet_acked
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
       int is_late_ack;
     } packet_acked;
     struct { // quicly:packet_lost
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
       uint8_t packet_type;
     } packet_lost;
     struct { // quicly:packet_decryption_failed
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t pn;
     } packet_decryption_failed;
     struct { // quicly:pto
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       size_t inflight;
       uint32_t cwnd;
       int8_t pto_count;
     } pto;
     struct { // quicly:cc_ack_received
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t largest_acked;
       size_t bytes_acked;
@@ -2116,166 +2116,166 @@ struct h2olog_event_t {
       size_t inflight;
     } cc_ack_received;
     struct { // quicly:cc_congestion
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t max_lost_pn;
       size_t inflight;
       uint32_t cwnd;
     } cc_congestion;
     struct { // quicly:ack_block_received
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t ack_block_begin;
       uint64_t ack_block_end;
     } ack_block_received;
     struct { // quicly:ack_delay_received
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t ack_delay;
     } ack_delay_received;
     struct { // quicly:ack_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t largest_acked;
       uint64_t ack_delay;
     } ack_send;
     struct { // quicly:ping_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } ping_send;
     struct { // quicly:ping_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } ping_receive;
     struct { // quicly:transport_close_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t error_code;
       uint64_t frame_type;
       char reason_phrase[STR_LEN];
     } transport_close_send;
     struct { // quicly:transport_close_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t error_code;
       uint64_t frame_type;
       char reason_phrase[STR_LEN];
     } transport_close_receive;
     struct { // quicly:application_close_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t error_code;
       char reason_phrase[STR_LEN];
     } application_close_send;
     struct { // quicly:application_close_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t error_code;
       char reason_phrase[STR_LEN];
     } application_close_receive;
     struct { // quicly:stream_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       uint64_t off;
       size_t len;
       int is_fin;
     } stream_send;
     struct { // quicly:stream_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       uint64_t off;
       size_t len;
     } stream_receive;
     struct { // quicly:stream_acked
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t off;
       size_t len;
     } stream_acked;
     struct { // quicly:stream_lost
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t off;
       size_t len;
     } stream_lost;
     struct { // quicly:max_data_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
     } max_data_send;
     struct { // quicly:max_data_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
     } max_data_receive;
     struct { // quicly:max_streams_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
       int is_unidirectional;
     } max_streams_send;
     struct { // quicly:max_streams_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
       int is_unidirectional;
     } max_streams_receive;
     struct { // quicly:max_stream_data_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       uint64_t maximum;
     } max_stream_data_send;
     struct { // quicly:max_stream_data_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t maximum;
     } max_stream_data_receive;
     struct { // quicly:new_token_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t token[STR_LEN];
       size_t token_len;
       uint64_t generation;
     } new_token_send;
     struct { // quicly:new_token_acked
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t generation;
     } new_token_acked;
     struct { // quicly:new_token_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t token[STR_LEN];
       size_t token_len;
     } new_token_receive;
     struct { // quicly:handshake_done_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } handshake_done_send;
     struct { // quicly:handshake_done_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
     } handshake_done_receive;
     struct { // quicly:streams_blocked_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
       int is_unidirectional;
     } streams_blocked_send;
     struct { // quicly:streams_blocked_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t maximum;
       int is_unidirectional;
     } streams_blocked_receive;
     struct { // quicly:new_connection_id_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
       uint64_t retire_prior_to;
@@ -2283,7 +2283,7 @@ struct h2olog_event_t {
       char stateless_reset_token[STR_LEN];
     } new_connection_id_send;
     struct { // quicly:new_connection_id_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
       uint64_t retire_prior_to;
@@ -2291,51 +2291,51 @@ struct h2olog_event_t {
       char stateless_reset_token[STR_LEN];
     } new_connection_id_receive;
     struct { // quicly:retire_connection_id_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
     } retire_connection_id_send;
     struct { // quicly:retire_connection_id_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
     } retire_connection_id_receive;
     struct { // quicly:data_blocked_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t off;
     } data_blocked_send;
     struct { // quicly:data_blocked_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t off;
     } data_blocked_receive;
     struct { // quicly:stream_data_blocked_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t maximum;
     } stream_data_blocked_send;
     struct { // quicly:stream_data_blocked_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t maximum;
     } stream_data_blocked_receive;
     struct { // quicly:datagram_send
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t payload[STR_LEN]; // appdata
       size_t payload_len;
     } datagram_send;
     struct { // quicly:datagram_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint8_t payload[STR_LEN]; // appdata
       size_t payload_len;
     } datagram_receive;
     struct { // quicly:ack_frequency_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       uint64_t sequence;
       uint64_t packet_tolerance;
@@ -2343,15 +2343,15 @@ struct h2olog_event_t {
       int ignore_order;
     } ack_frequency_receive;
     struct { // quicly:quictrace_send_stream
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       uint64_t off;
       size_t len;
       int fin;
     } quictrace_send_stream;
     struct { // quicly:quictrace_recv_stream
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       int64_t stream_id;
       uint64_t off;
@@ -2359,71 +2359,71 @@ struct h2olog_event_t {
       int fin;
     } quictrace_recv_stream;
     struct { // quicly:quictrace_cc_ack
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_quicly_rtt_t__minimum minimum;
-      typeof_quicly_rtt_t__smoothed smoothed;
-      typeof_quicly_rtt_t__variance variance;
-      typeof_quicly_rtt_t__latest latest;
+      typeof_quicly_rtt_t__minimum rtt_minimum;
+      typeof_quicly_rtt_t__smoothed rtt_smoothed;
+      typeof_quicly_rtt_t__variance rtt_variance;
+      typeof_quicly_rtt_t__latest rtt_latest;
       uint32_t cwnd;
       size_t inflight;
     } quictrace_cc_ack;
     struct { // quicly:quictrace_cc_lost
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_quicly_rtt_t__minimum minimum;
-      typeof_quicly_rtt_t__smoothed smoothed;
-      typeof_quicly_rtt_t__variance variance;
-      typeof_quicly_rtt_t__latest latest;
+      typeof_quicly_rtt_t__minimum rtt_minimum;
+      typeof_quicly_rtt_t__smoothed rtt_smoothed;
+      typeof_quicly_rtt_t__variance rtt_variance;
+      typeof_quicly_rtt_t__latest rtt_latest;
       uint32_t cwnd;
       size_t inflight;
     } quictrace_cc_lost;
     struct { // quicly:stream_on_open
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
     } stream_on_open;
     struct { // quicly:stream_on_destroy
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       int err;
     } stream_on_destroy;
     struct { // quicly:stream_on_send_shift
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       size_t delta;
     } stream_on_send_shift;
     struct { // quicly:stream_on_send_emit
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       size_t off;
       size_t capacity;
     } stream_on_send_emit;
     struct { // quicly:stream_on_send_stop
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       int err;
     } stream_on_send_stop;
     struct { // quicly:stream_on_receive
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       size_t off;
       uint8_t src[STR_LEN]; // appdata
       size_t src_len;
     } stream_on_receive;
     struct { // quicly:stream_on_receive_reset
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
-      typeof_st_quicly_stream_t__stream_id stream_id;
+      typeof_st_quicly_stream_t__stream_id stream_stream_id;
       int err;
     } stream_on_receive_reset;
     struct { // quicly:conn_stats
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
       struct st_quicly_stats_t * stats;
       size_t size;
@@ -2475,7 +2475,7 @@ struct h2olog_event_t {
     struct { // h2o:h3s_accept
       uint64_t conn_id;
       struct st_h2o_conn_t * conn;
-      typeof_st_quicly_conn_t__master_id master_id;
+      typeof_st_quicly_conn_t__master_id quic_master_id;
     } h3s_accept;
     struct { // h2o:h3s_destroy
       uint64_t conn_id;
@@ -2570,7 +2570,7 @@ int trace_quicly__connect(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.connect.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.connect.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.connect.at);
   // uint32_t version
@@ -2590,7 +2590,7 @@ int trace_quicly__accept(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.accept.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.accept.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.accept.at);
   // const char * dcid
@@ -2613,7 +2613,7 @@ int trace_quicly__free(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.free.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.free.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.free.at);
 
@@ -2631,7 +2631,7 @@ int trace_quicly__send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.send.at);
   // int state
@@ -2654,7 +2654,7 @@ int trace_quicly__receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.receive.at);
   // const char * dcid
@@ -2680,7 +2680,7 @@ int trace_quicly__version_switch(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.version_switch.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.version_switch.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.version_switch.at);
   // uint32_t new_version
@@ -2700,7 +2700,7 @@ int trace_quicly__idle_timeout(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.idle_timeout.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.idle_timeout.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.idle_timeout.at);
 
@@ -2718,7 +2718,7 @@ int trace_quicly__stateless_reset_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stateless_reset_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stateless_reset_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stateless_reset_receive.at);
 
@@ -2736,7 +2736,7 @@ int trace_quicly__crypto_handshake(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.crypto_handshake.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.crypto_handshake.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.crypto_handshake.at);
   // int ret
@@ -2756,7 +2756,7 @@ int trace_quicly__crypto_update_secret(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.crypto_update_secret.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.crypto_update_secret.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.crypto_update_secret.at);
   // int is_enc
@@ -2784,7 +2784,7 @@ int trace_quicly__crypto_send_key_update(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.crypto_send_key_update.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.crypto_send_key_update.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.crypto_send_key_update.at);
   // uint64_t phase
@@ -2807,7 +2807,7 @@ int trace_quicly__crypto_send_key_update_confirmed(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.crypto_send_key_update_confirmed.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.crypto_send_key_update_confirmed.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.crypto_send_key_update_confirmed.at);
   // uint64_t next_pn
@@ -2827,7 +2827,7 @@ int trace_quicly__crypto_receive_key_update(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.crypto_receive_key_update.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.crypto_receive_key_update.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.crypto_receive_key_update.at);
   // uint64_t phase
@@ -2850,7 +2850,7 @@ int trace_quicly__crypto_receive_key_update_prepare(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.crypto_receive_key_update_prepare.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.crypto_receive_key_update_prepare.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.crypto_receive_key_update_prepare.at);
   // uint64_t phase
@@ -2873,7 +2873,7 @@ int trace_quicly__packet_sent(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.packet_sent.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.packet_sent.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.packet_sent.at);
   // uint64_t pn
@@ -2899,7 +2899,7 @@ int trace_quicly__packet_received(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.packet_received.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.packet_received.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.packet_received.at);
   // uint64_t pn
@@ -2926,7 +2926,7 @@ int trace_quicly__packet_prepare(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.packet_prepare.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.packet_prepare.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.packet_prepare.at);
   // uint8_t first_octet
@@ -2949,7 +2949,7 @@ int trace_quicly__packet_acked(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.packet_acked.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.packet_acked.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.packet_acked.at);
   // uint64_t pn
@@ -2971,7 +2971,7 @@ int trace_quicly__packet_lost(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.packet_lost.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.packet_lost.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.packet_lost.at);
   // uint64_t pn
@@ -2993,7 +2993,7 @@ int trace_quicly__packet_decryption_failed(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.packet_decryption_failed.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.packet_decryption_failed.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.packet_decryption_failed.at);
   // uint64_t pn
@@ -3013,7 +3013,7 @@ int trace_quicly__pto(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.pto.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.pto.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.pto.at);
   // size_t inflight
@@ -3037,7 +3037,7 @@ int trace_quicly__cc_ack_received(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.cc_ack_received.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.cc_ack_received.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.cc_ack_received.at);
   // uint64_t largest_acked
@@ -3063,7 +3063,7 @@ int trace_quicly__cc_congestion(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.cc_congestion.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.cc_congestion.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.cc_congestion.at);
   // uint64_t max_lost_pn
@@ -3087,7 +3087,7 @@ int trace_quicly__ack_block_received(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.ack_block_received.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.ack_block_received.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.ack_block_received.at);
   // uint64_t ack_block_begin
@@ -3109,7 +3109,7 @@ int trace_quicly__ack_delay_received(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.ack_delay_received.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.ack_delay_received.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.ack_delay_received.at);
   // int64_t ack_delay
@@ -3129,7 +3129,7 @@ int trace_quicly__ack_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.ack_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.ack_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.ack_send.at);
   // uint64_t largest_acked
@@ -3151,7 +3151,7 @@ int trace_quicly__ping_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.ping_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.ping_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.ping_send.at);
 
@@ -3169,7 +3169,7 @@ int trace_quicly__ping_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.ping_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.ping_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.ping_receive.at);
 
@@ -3187,7 +3187,7 @@ int trace_quicly__transport_close_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.transport_close_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.transport_close_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.transport_close_send.at);
   // uint64_t error_code
@@ -3212,7 +3212,7 @@ int trace_quicly__transport_close_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.transport_close_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.transport_close_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.transport_close_receive.at);
   // uint64_t error_code
@@ -3237,7 +3237,7 @@ int trace_quicly__application_close_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.application_close_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.application_close_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.application_close_send.at);
   // uint64_t error_code
@@ -3260,7 +3260,7 @@ int trace_quicly__application_close_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.application_close_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.application_close_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.application_close_receive.at);
   // uint64_t error_code
@@ -3283,14 +3283,14 @@ int trace_quicly__stream_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_send.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_send.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_send.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // uint64_t off
   bpf_usdt_readarg(4, ctx, &event.stream_send.off);
   // size_t len
@@ -3312,14 +3312,14 @@ int trace_quicly__stream_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_receive.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_receive.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_receive.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // uint64_t off
   bpf_usdt_readarg(4, ctx, &event.stream_receive.off);
   // size_t len
@@ -3339,7 +3339,7 @@ int trace_quicly__stream_acked(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_acked.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_acked.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_acked.at);
   // int64_t stream_id
@@ -3363,7 +3363,7 @@ int trace_quicly__stream_lost(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_lost.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_lost.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_lost.at);
   // int64_t stream_id
@@ -3387,7 +3387,7 @@ int trace_quicly__max_data_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.max_data_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.max_data_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.max_data_send.at);
   // uint64_t maximum
@@ -3407,7 +3407,7 @@ int trace_quicly__max_data_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.max_data_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.max_data_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.max_data_receive.at);
   // uint64_t maximum
@@ -3427,7 +3427,7 @@ int trace_quicly__max_streams_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.max_streams_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.max_streams_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.max_streams_send.at);
   // uint64_t maximum
@@ -3449,7 +3449,7 @@ int trace_quicly__max_streams_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.max_streams_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.max_streams_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.max_streams_receive.at);
   // uint64_t maximum
@@ -3471,14 +3471,14 @@ int trace_quicly__max_stream_data_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.max_stream_data_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.max_stream_data_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.max_stream_data_send.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.max_stream_data_send.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.max_stream_data_send.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // uint64_t maximum
   bpf_usdt_readarg(4, ctx, &event.max_stream_data_send.maximum);
 
@@ -3496,7 +3496,7 @@ int trace_quicly__max_stream_data_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.max_stream_data_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.max_stream_data_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.max_stream_data_receive.at);
   // int64_t stream_id
@@ -3518,7 +3518,7 @@ int trace_quicly__new_token_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.new_token_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.new_token_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.new_token_send.at);
   // uint8_t * token
@@ -3543,7 +3543,7 @@ int trace_quicly__new_token_acked(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.new_token_acked.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.new_token_acked.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.new_token_acked.at);
   // uint64_t generation
@@ -3563,7 +3563,7 @@ int trace_quicly__new_token_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.new_token_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.new_token_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.new_token_receive.at);
   // uint8_t * token
@@ -3586,7 +3586,7 @@ int trace_quicly__handshake_done_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.handshake_done_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.handshake_done_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.handshake_done_send.at);
 
@@ -3604,7 +3604,7 @@ int trace_quicly__handshake_done_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.handshake_done_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.handshake_done_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.handshake_done_receive.at);
 
@@ -3622,7 +3622,7 @@ int trace_quicly__streams_blocked_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.streams_blocked_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.streams_blocked_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.streams_blocked_send.at);
   // uint64_t maximum
@@ -3644,7 +3644,7 @@ int trace_quicly__streams_blocked_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.streams_blocked_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.streams_blocked_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.streams_blocked_receive.at);
   // uint64_t maximum
@@ -3666,7 +3666,7 @@ int trace_quicly__new_connection_id_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.new_connection_id_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.new_connection_id_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.new_connection_id_send.at);
   // uint64_t sequence
@@ -3694,7 +3694,7 @@ int trace_quicly__new_connection_id_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.new_connection_id_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.new_connection_id_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.new_connection_id_receive.at);
   // uint64_t sequence
@@ -3722,7 +3722,7 @@ int trace_quicly__retire_connection_id_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.retire_connection_id_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.retire_connection_id_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.retire_connection_id_send.at);
   // uint64_t sequence
@@ -3742,7 +3742,7 @@ int trace_quicly__retire_connection_id_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.retire_connection_id_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.retire_connection_id_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.retire_connection_id_receive.at);
   // uint64_t sequence
@@ -3762,7 +3762,7 @@ int trace_quicly__data_blocked_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.data_blocked_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.data_blocked_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.data_blocked_send.at);
   // uint64_t off
@@ -3782,7 +3782,7 @@ int trace_quicly__data_blocked_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.data_blocked_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.data_blocked_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.data_blocked_receive.at);
   // uint64_t off
@@ -3802,7 +3802,7 @@ int trace_quicly__stream_data_blocked_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_data_blocked_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_data_blocked_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_data_blocked_send.at);
   // int64_t stream_id
@@ -3824,7 +3824,7 @@ int trace_quicly__stream_data_blocked_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_data_blocked_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_data_blocked_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_data_blocked_receive.at);
   // int64_t stream_id
@@ -3846,7 +3846,7 @@ int trace_quicly__datagram_send(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.datagram_send.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.datagram_send.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.datagram_send.at);
   // const void * payload (appdata)
@@ -3869,7 +3869,7 @@ int trace_quicly__datagram_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.datagram_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.datagram_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.datagram_receive.at);
   // const void * payload (appdata)
@@ -3892,7 +3892,7 @@ int trace_quicly__ack_frequency_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.ack_frequency_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.ack_frequency_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.ack_frequency_receive.at);
   // uint64_t sequence
@@ -3918,14 +3918,14 @@ int trace_quicly__quictrace_send_stream(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.quictrace_send_stream.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.quictrace_send_stream.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.quictrace_send_stream.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.quictrace_send_stream.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.quictrace_send_stream.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // uint64_t off
   bpf_usdt_readarg(4, ctx, &event.quictrace_send_stream.off);
   // size_t len
@@ -3947,7 +3947,7 @@ int trace_quicly__quictrace_recv_stream(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.quictrace_recv_stream.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.quictrace_recv_stream.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.quictrace_recv_stream.at);
   // int64_t stream_id
@@ -3973,17 +3973,17 @@ int trace_quicly__quictrace_cc_ack(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.quictrace_cc_ack.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.quictrace_cc_ack.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.quictrace_cc_ack.at);
   // struct quicly_rtt_t * rtt
   uint8_t rtt[sizeof_quicly_rtt_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&rtt, sizeof_quicly_rtt_t, buf);
-  event.quictrace_cc_ack.minimum = get_quicly_rtt_t__minimum(rtt);
-  event.quictrace_cc_ack.smoothed = get_quicly_rtt_t__smoothed(rtt);
-  event.quictrace_cc_ack.variance = get_quicly_rtt_t__variance(rtt);
-  event.quictrace_cc_ack.latest = get_quicly_rtt_t__latest(rtt);
+  event.quictrace_cc_ack.rtt_minimum = get_quicly_rtt_t__minimum(rtt);
+  event.quictrace_cc_ack.rtt_smoothed = get_quicly_rtt_t__smoothed(rtt);
+  event.quictrace_cc_ack.rtt_variance = get_quicly_rtt_t__variance(rtt);
+  event.quictrace_cc_ack.rtt_latest = get_quicly_rtt_t__latest(rtt);
   // uint32_t cwnd
   bpf_usdt_readarg(4, ctx, &event.quictrace_cc_ack.cwnd);
   // size_t inflight
@@ -4003,17 +4003,17 @@ int trace_quicly__quictrace_cc_lost(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.quictrace_cc_lost.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.quictrace_cc_lost.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.quictrace_cc_lost.at);
   // struct quicly_rtt_t * rtt
   uint8_t rtt[sizeof_quicly_rtt_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&rtt, sizeof_quicly_rtt_t, buf);
-  event.quictrace_cc_lost.minimum = get_quicly_rtt_t__minimum(rtt);
-  event.quictrace_cc_lost.smoothed = get_quicly_rtt_t__smoothed(rtt);
-  event.quictrace_cc_lost.variance = get_quicly_rtt_t__variance(rtt);
-  event.quictrace_cc_lost.latest = get_quicly_rtt_t__latest(rtt);
+  event.quictrace_cc_lost.rtt_minimum = get_quicly_rtt_t__minimum(rtt);
+  event.quictrace_cc_lost.rtt_smoothed = get_quicly_rtt_t__smoothed(rtt);
+  event.quictrace_cc_lost.rtt_variance = get_quicly_rtt_t__variance(rtt);
+  event.quictrace_cc_lost.rtt_latest = get_quicly_rtt_t__latest(rtt);
   // uint32_t cwnd
   bpf_usdt_readarg(4, ctx, &event.quictrace_cc_lost.cwnd);
   // size_t inflight
@@ -4033,14 +4033,14 @@ int trace_quicly__stream_on_open(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_on_open.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_on_open.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_on_open.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_on_open.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_on_open.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_quicly__stream_on_open\n");
@@ -4056,14 +4056,14 @@ int trace_quicly__stream_on_destroy(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_on_destroy.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_on_destroy.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_on_destroy.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_on_destroy.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_on_destroy.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // int err
   bpf_usdt_readarg(4, ctx, &event.stream_on_destroy.err);
 
@@ -4081,14 +4081,14 @@ int trace_quicly__stream_on_send_shift(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_on_send_shift.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_on_send_shift.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_on_send_shift.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_on_send_shift.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_on_send_shift.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // size_t delta
   bpf_usdt_readarg(4, ctx, &event.stream_on_send_shift.delta);
 
@@ -4106,14 +4106,14 @@ int trace_quicly__stream_on_send_emit(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_on_send_emit.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_on_send_emit.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_on_send_emit.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_on_send_emit.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_on_send_emit.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // size_t off
   bpf_usdt_readarg(4, ctx, &event.stream_on_send_emit.off);
   // size_t capacity
@@ -4133,14 +4133,14 @@ int trace_quicly__stream_on_send_stop(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_on_send_stop.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_on_send_stop.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_on_send_stop.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_on_send_stop.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_on_send_stop.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // int err
   bpf_usdt_readarg(4, ctx, &event.stream_on_send_stop.err);
 
@@ -4158,14 +4158,14 @@ int trace_quicly__stream_on_receive(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_on_receive.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_on_receive.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_on_receive.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_on_receive.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_on_receive.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // size_t off
   bpf_usdt_readarg(4, ctx, &event.stream_on_receive.off);
   // const void * src (appdata)
@@ -4188,14 +4188,14 @@ int trace_quicly__stream_on_receive_reset(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.stream_on_receive_reset.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.stream_on_receive_reset.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.stream_on_receive_reset.at);
   // struct st_quicly_stream_t * stream
   uint8_t stream[sizeof_st_quicly_stream_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&stream, sizeof_st_quicly_stream_t, buf);
-  event.stream_on_receive_reset.stream_id = get_st_quicly_stream_t__stream_id(stream);
+  event.stream_on_receive_reset.stream_stream_id = get_st_quicly_stream_t__stream_id(stream);
   // int err
   bpf_usdt_readarg(4, ctx, &event.stream_on_receive_reset.err);
 
@@ -4213,7 +4213,7 @@ int trace_quicly__conn_stats(struct pt_regs *ctx) {
   uint8_t conn[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(1, ctx, &buf);
   bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
-  event.conn_stats.master_id = get_st_quicly_conn_t__master_id(conn);
+  event.conn_stats.conn_master_id = get_st_quicly_conn_t__master_id(conn);
   // int64_t at
   bpf_usdt_readarg(2, ctx, &event.conn_stats.at);
   // struct st_quicly_stats_t * stats
@@ -4416,7 +4416,7 @@ int trace_h2o__h3s_accept(struct pt_regs *ctx) {
   uint8_t quic[sizeof_st_quicly_conn_t] = {};
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&quic, sizeof_st_quicly_conn_t, buf);
-  event.h3s_accept.master_id = get_st_quicly_conn_t__master_id(quic);
+  event.h3s_accept.quic_master_id = get_st_quicly_conn_t__master_id(quic);
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_h2o__h3s_accept\n");


### PR DESCRIPTION
`gen_raw_tracer.py` has a problem that it discards an original parameter name in a USDT if it's a pointer to a struct, for example, if there is `struct st_quicly_conn_t *` in a USDT, `gen_raw_tracer.py` always uses a pre-defined name  "conn" whatever the parameter name is. This results in a problem that `h2o:h3s_accept` emits such a JSON line:

```json
{"type":"h3s-accept","seq":13,"conn-id":2,"conn":107133664429568,"conn":0,"time":1618988758393}
```

where the definition of the USDT is:

```
probe h3s_accept(uint64_t conn_id, struct st_h2o_conn_t *conn, struct st_quicly_conn_t *quic);
```

In the above JSON, the first "conn" is the pointer value of `struct st_h2o_conn_t *conn`, and the second "conn"  is `quic->super.local.cid_set.plaintext.master_id`, which should not be named as "conn".

This PR fixes the naming algorithm to include the original parameter name in a generated field name. This change only affects `h2o:h3s_accept`. The new JSON line becomes something like the following:

```json
{"type":"h3s-accept","tid":1310770,"seq":13,"conn-id":2,"conn":107133664388352,"quic-master-id":0,"time":1622527831553}
```