### PR TITLE
[http3] Add intra-cluster forwarding event counter 

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -682,6 +682,16 @@ struct st_h2o_context_t {
          * timeout entry used for graceful shutdown
          */
         h2o_timer_t _graceful_shutdown_timeout;
+        struct {
+            /**
+             * number of packets forwarded to another node in a cluster
+             */
+            uint64_t packet_forwarded;
+            /**
+             * number of forwarded packets received from another node in a cluster
+             */
+            uint64_t forwarded_packet_received;
+        } events;
     } http3;
 
     struct {

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -32,6 +32,8 @@ struct st_events_status_ctx_t {
     uint64_t h1_request_timeout;
     uint64_t h1_request_io_timeout;
     uint64_t ssl_errors;
+    uint64_t h3_packet_forwarded;
+    uint64_t h3_forwarded_packet_received;
     pthread_mutex_t mutex;
 };
 
@@ -54,6 +56,8 @@ static void events_status_per_thread(void *priv, h2o_context_t *ctx)
     esc->h2_idle_timeout += ctx->http2.events.idle_timeouts;
     esc->h1_request_timeout += ctx->http1.events.request_timeouts;
     esc->h1_request_io_timeout += ctx->http1.events.request_io_timeouts;
+    esc->h3_packet_forwarded += ctx->http3.events.packet_forwarded;
+    esc->h3_forwarded_packet_received += ctx->http3.events.forwarded_packet_received;
 
     pthread_mutex_unlock(&esc->mutex);
 }
@@ -106,6 +110,8 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        " \"http2.read-closed\": %" PRIu64 ", \n"
                        " \"http2.write-closed\": %" PRIu64 ", \n"
                        " \"http2.idle-timeout\": %" PRIu64 ", \n"
+                       " \"http3.packet-forwarded\": %" PRIu64 ", \n"
+                       " \"http3.forwarded-packet-received\": %" PRIu64 ", \n"
                        " \"ssl.errors\": %" PRIu64 ", \n"
                        " \"memory.mmap_errors\": %zu\n",
                        H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
@@ -113,7 +119,8 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL), H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT),
                        H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE), H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL),
                        H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT), H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY),
-                       esc->h2_read_closed, esc->h2_write_closed, esc->h2_idle_timeout, esc->ssl_errors, h2o_mmap_errors);
+                       esc->h2_read_closed, esc->h2_write_closed, esc->h2_idle_timeout, esc->h3_packet_forwarded,
+                       esc->h3_forwarded_packet_received, esc->ssl_errors, h2o_mmap_errors);
     pthread_mutex_destroy(&esc->mutex);
     free(esc);
     return ret;

--- a/src/main.c
+++ b/src/main.c
@@ -2463,6 +2463,7 @@ static int forward_quic_packets(h2o_quic_ctx_t *h3ctx, const uint64_t *node_id, 
 {
     struct listener_ctx_t *ctx = H2O_STRUCT_FROM_MEMBER(struct listener_ctx_t, http3.ctx.super, h3ctx);
     int fd;
+    h2o_context_t *h2octx = ctx->accept_ctx.ctx;
 
     /* determine the file descriptor to which the packets should be forwarded, or return */
     if (node_id != NULL && *node_id != ctx->http3.ctx.super.next_cid.node_id) {
@@ -2510,6 +2511,7 @@ static int forward_quic_packets(h2o_quic_ctx_t *h3ctx, const uint64_t *node_id, 
         H2O_PROBE(H3_PACKET_FORWARD, &destaddr->sa, &srcaddr->sa, num_packets, num_bytes, fd);
     }
 #endif
+    ++h2octx->http3.events.packet_forwarded;
 
     return 1;
 }
@@ -2522,6 +2524,8 @@ static int rewrite_forwarded_quic_datagram(h2o_quic_ctx_t *h3ctx, struct msghdr 
         uint8_t ttl;
         size_t offset;
     } encapsulated;
+    struct listener_ctx_t *lctx = H2O_STRUCT_FROM_MEMBER(struct listener_ctx_t, http3.ctx.super, h3ctx);
+    h2o_context_t *h2octx = lctx->accept_ctx.ctx;
 
     assert(msg->msg_iovlen == 1);
 
@@ -2551,6 +2555,7 @@ static int rewrite_forwarded_quic_datagram(h2o_quic_ctx_t *h3ctx, struct msghdr 
     *destaddr = encapsulated.destaddr;
     *srcaddr = encapsulated.srcaddr;
     *ttl = encapsulated.ttl;
+    ++h2octx->http3.events.forwarded_packet_received;
     H2O_PROBE(H3_FORWARDED_PACKET_RECEIVE, &destaddr->sa, &srcaddr->sa, msg->msg_iov[0].iov_len);
     return 1;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2501,6 +2501,7 @@ static int forward_quic_packets(h2o_quic_ctx_t *h3ctx, const uint64_t *node_id, 
     for (size_t i = 0; i != num_packets; ++i) {
         struct iovec vec[2] = {{header_buf, header_len}, {packets[i].octets.base, packets[i].octets.len}};
         writev(fd, vec, 2);
+        ++h2octx->http3.events.packet_forwarded;
     }
 
 #if H2O_USE_DTRACE
@@ -2511,7 +2512,6 @@ static int forward_quic_packets(h2o_quic_ctx_t *h3ctx, const uint64_t *node_id, 
         H2O_PROBE(H3_PACKET_FORWARD, &destaddr->sa, &srcaddr->sa, num_packets, num_bytes, fd);
     }
 #endif
-    ++h2octx->http3.events.packet_forwarded;
 
     return 1;
 }

--- a/t/40http3-forward.t
+++ b/t/40http3-forward.t
@@ -60,7 +60,7 @@ $jresp = decode_json("$resp");
 my $num_forwarded = $jresp->{'http3.packet-forwarded'};
 
 cmp_ok($num_forwarded, '>', 0, "some packets were forwarded through event counter");
-is($num_forwarded, num_forwarded_received, "packets forwarded == packets received");
+is($num_forwarded, $num_forwarded_received, "packets forwarded == packets received");
 
 done_testing;
 

--- a/t/40http3-forward.t
+++ b/t/40http3-forward.t
@@ -59,7 +59,7 @@ $resp = `curl --silent -o /dev/stderr http://127.0.0.1:${server2_port}/server-st
 $jresp = decode_json("$resp");
 my $num_forwarded = $jresp->{'http3.packet-forwarded'};
 
-cmp_ok($num_forwarded, '>', 0, "some packets were forwarded through event counter");
+cmp_ok($num_forwarded, '>', 0, "some packets were forwarded");
 is($num_forwarded, $num_forwarded_received, "packets forwarded == packets received");
 
 done_testing;

--- a/t/40http3-forward.t
+++ b/t/40http3-forward.t
@@ -59,8 +59,8 @@ $resp = `curl --silent -o /dev/stderr http://127.0.0.1:${server2_port}/server-st
 $jresp = decode_json("$resp");
 my $num_forwarded = $jresp->{'http3.packet-forwarded'};
 
-ok($num_forwarded > 0, "some packets were forwarded through event counter");
-ok($num_forwarded == $num_forwarded_received, "packets forwarded == packets received");
+cmp_ok($num_forwarded, '>', 0, "some packets were forwarded through event counter");
+is($num_forwarded, num_forwarded_received, "packets forwarded == packets received");
 
 done_testing;
 

--- a/t/40http3-forward.t
+++ b/t/40http3-forward.t
@@ -5,6 +5,7 @@ use Net::EmptyPort qw(empty_port wait_port);
 use Test::More;
 use Time::HiRes qw(time);
 use t::Util;
+use JSON;
 
 plan skip_all => 'mruby support is off'
     unless server_features()->{mruby};
@@ -46,6 +47,21 @@ is do {local $/; join "", <$slow_fh>}, "server=1", "slow request succeeded";
 $elapsed = time - $elapsed;
 cmp_ok $elapsed, '>=', 3, "slow request is so slow that the packets should have gone through server2";
 
+# check that some packets were actually forwarded, and the event counter captured them
+my $server1_port = ${server1}->{port};
+my $server2_port = ${server2}->{port};
+
+my $resp = `curl --silent -o /dev/stderr http://127.0.0.1:${server1_port}/server-status/json?show=events 2>&1 > /dev/null`;
+my $jresp = decode_json("$resp");
+my $num_forwarded_received = $jresp->{'http3.forwarded-packet-received'};
+
+$resp = `curl --silent -o /dev/stderr http://127.0.0.1:${server2_port}/server-status/json?show=events 2>&1 > /dev/null`;
+$jresp = decode_json("$resp");
+my $num_forwarded = $jresp->{'http3.packet-forwarded'};
+
+ok($num_forwarded > 0, "some packets were forwarded through event counter");
+ok($num_forwarded == $num_forwarded_received, "packets forwarded == packets received");
+
 done_testing;
 
 sub spawn {
@@ -76,6 +92,8 @@ hosts:
           Proc.new do |env|
             [200, {}, ["server=$server_id"]]
           end
+      "/server-status":
+        status: ON
 EOT
     spawn_h2o($conf);
 }


### PR DESCRIPTION
This PR adds two event counters, `http3.packet-forwarded` and
`http3.forwarded-packet-received` to track intra-cluster QUIC packet
forwarding.