### PR TITLE
make h2o_socket_getsockname cache the result

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -91,7 +91,7 @@ typedef void (*h2o_socket_cb)(h2o_socket_t *sock, const char *err);
 #include "socket/evloop.h"
 #endif
 
-struct st_h2o_socket_peername_t {
+struct st_h2o_socket_addr_t {
     socklen_t len;
     struct sockaddr addr;
 };
@@ -130,7 +130,8 @@ struct st_h2o_socket_t {
         h2o_socket_cb read;
         h2o_socket_cb write;
     } _cb;
-    struct st_h2o_socket_peername_t *_peername;
+    struct st_h2o_socket_addr_t *_peername;
+    struct st_h2o_socket_addr_t *_sockname;
     struct {
         uint8_t state; /* one of H2O_SOCKET_LATENCY_STATE_* */
         uint8_t notsent_is_minimized : 1;

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -340,7 +340,6 @@ static void dispose_socket(h2o_socket_t *sock, const char *err)
         free(sock->_peername);
         sock->_peername = NULL;
     }
-
     if (sock->_sockname != NULL) {
         free(sock->_sockname);
         sock->_sockname = NULL;

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -364,7 +364,7 @@ h2o_loop_t *h2o_socket_get_loop(h2o_socket_t *_sock)
     return sock->loop;
 }
 
-socklen_t h2o_socket_getsockname(h2o_socket_t *_sock, struct sockaddr *sa)
+socklen_t get_sockname_uncached(h2o_socket_t *_sock, struct sockaddr *sa)
 {
     struct st_h2o_evloop_socket_t *sock = (void *)_sock;
     socklen_t len = sizeof(struct sockaddr_storage);

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -309,7 +309,7 @@ h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, sockle
     return &sock->super;
 }
 
-socklen_t h2o_socket_getsockname(h2o_socket_t *_sock, struct sockaddr *sa)
+socklen_t get_sockname_uncached(h2o_socket_t *_sock, struct sockaddr *sa)
 {
     struct st_h2o_uv_socket_t *sock = (void *)_sock;
     assert(sock->handle->type == UV_TCP);


### PR DESCRIPTION
Make `h2o_socket_getsockname` cache the result (just like `h2o_socket_getpeername`). This should reduce the number of syscalls in certain code paths.

being extra pedantic, would it make sense to also invert the order of the functions `get_peername_uncached` and `get_sockname_uncached` in both evloop and uv-binding files.