### PR TITLE
listen quic in spawn_h2o

### DIFF
--- a/t/40http3-forward.t
+++ b/t/40http3-forward.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use File::Temp qw(tempdir);
-use Net::EmptyPort qw(empty_port wait_port);
 use Test::More;
 use Time::HiRes qw(time);
 use t::Util;
@@ -27,19 +26,17 @@ plan skip_all => "macOS has issues https://twitter.com/kazuho/status/12980731105
 #     can still receive packets at 127.0.0.2)
 #  3. check that the slow request completes *after* the new server is up
 
-my $quic_port = empty_port({ host  => "0.0.0.0", proto => "udp" });
-
 # start server1 at 0.0.0.0, check that it is up
 my $server1 = spawn("0.0.0.0", 1);
-is do {my $fh = fetch(""); local $/; join "", <$fh> }, "server=1", "server1 is up";
+is do {my $fh = fetch($server, ""); local $/; join "", <$fh> }, "server=1", "server1 is up";
 
 # initiate the slow request
-my $slow_fh = fetch("-b 1200 -c 20 -i 100");
+my $slow_fh = fetch($server, "-b 1200 -c 20 -i 100");
 sleep 1;
 
 # start server2 at 127.0.0.1, check that it isup
 my $server2 = spawn("127.0.0.1", 2);
-is do {my $fh = fetch(""); local $/; join "", <$fh> }, "server=2", "server2 is up";
+is do {my $fh = fetch($server, ""); local $/; join "", <$fh> }, "server=2", "server2 is up";
 
 # check that the slow request was served, going through $server2
 my $elapsed = time;
@@ -66,15 +63,10 @@ done_testing;
 
 sub spawn {
     my ($listen_ip, $server_id) = @_;
-    my $conf = {opts => [qw(-m worker)], conf => <<"EOT"};
+    my $conf = sub {
+        my ($port, $tls_port, $quic_port) = @_;
+        return +{ opts => [qw(-m worker)], conf => <<"EOT" };
 num-threads: 1
-listen:
-  type: quic
-  host: $listen_ip
-  port: $quic_port
-  ssl:
-    key-file: examples/h2o/server.key
-    certificate-file: examples/h2o/server.crt
 quic-nodes:
   self: $server_id
   mapping:
@@ -95,12 +87,13 @@ hosts:
       "/server-status":
         status: ON
 EOT
-    spawn_h2o($conf);
+    };
+    spawn_h2o($conf, +{ quic => +{ host => $listen_ip } });
 }
 
 sub fetch {
-    my $opts = shift;
-    open my $fh, "-|", "$client_prog -3 100 $opts https://127.0.0.1:$quic_port/ 2> /dev/null"
+    my ($server, $opts) = @_;
+    open my $fh, "-|", "$client_prog -3 100 $opts https://127.0.0.1:$server->{quic_port}/ 2> /dev/null"
         or die "failed to spawn $client_prog:$!";
     $fh;
 }

--- a/t/40http3-reconnect.t
+++ b/t/40http3-reconnect.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use File::Temp qw(tempdir);
 use JSON qw(decode_json);
-use Net::EmptyPort qw(empty_port wait_port);
 use Test::More;
 use t::Util;
 
@@ -11,20 +10,10 @@ plan skip_all => "$client_prog not found"
     unless -e $client_prog;
 
 my $tempdir = tempdir(CLEANUP => 1);
-my $quic_port = empty_port({
-    host  => "127.0.0.1",
-    proto => "udp",
-});
 
 # spawn server
 my $server = spawn_h2o(<< "EOT");
 http3-idle-timeout: 3
-listen:
-  type: quic
-  port: $quic_port
-  ssl:
-    key-file: examples/h2o/server.key
-    certificate-file: examples/h2o/server.crt
 hosts:
   default:
     paths:
@@ -35,7 +24,6 @@ hosts:
       "/status":
         status: ON
 EOT
-wait_port({port => $quic_port, proto => 'udp'});
 
 my $num_conns = sub {
     my $resp = `curl --silent -o /dev/stderr 'http://127.0.0.1:$server->{port}/status/json?show=main' 2>&1 > /dev/null`;
@@ -49,7 +37,7 @@ subtest "idle-timeout-reconnect" => sub {
         unless prog_exists('curl');
 
     # spawn client that fetches twice with an interval greater than the idle timeout
-    open my $client_fh, "-|", "$client_prog -3 100 -d 6000 -t 2 https://127.0.0.1:$quic_port/ 2> /dev/null"
+    open my $client_fh, "-|", "$client_prog -3 100 -d 6000 -t 2 https://127.0.0.1:$server->{quic_port}/ 2> /dev/null"
         or die "failed to spawn $client_prog:$!";
 
     sleep 1;
@@ -69,7 +57,7 @@ subtest "too-early" => sub {
         ],
         is_ready => sub { !! -e "$tempdir/upstream.sock" },
     );
-    open my $client_fh, "-|", "$client_prog -3 100 -d 5000 -t 2 https://127.0.0.1:$quic_port/proxy/425 2>&1"
+    open my $client_fh, "-|", "$client_prog -3 100 -d 5000 -t 2 https://127.0.0.1:$server->{quic_port}/proxy/425 2>&1"
         or die "failed to spawn $client_prog:$!";
     like do {local $/; join "", <$client_fh>}, qr{^HTTP/[0-9\.]+ 200.*\nhello\nHTTP/[0-9\.]+ 425}s, "2nd response is 425";
 };

--- a/t/40http3-shutdown-reject-conn.t
+++ b/t/40http3-shutdown-reject-conn.t
@@ -2,18 +2,12 @@ use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
-use Net::EmptyPort qw(empty_port wait_port);
 use Test::More;
 use t::Util;
 
 my $client_prog = bindir() . "/h2o-httpclient";
 plan skip_all => "$client_prog not found"
     unless -e $client_prog;
-
-my $quic_port = empty_port({
-    host  => "127.0.0.1",
-    proto => "udp",
-});
 
 # test scenario:
 # 1. setup a server that responds after 5 seconds
@@ -23,12 +17,6 @@ my $quic_port = empty_port({
 # 5. check that we get the response for the first request
 
 my $server = spawn_h2o(<< "EOT");
-listen:
-  type: quic
-  port: $quic_port
-  ssl:
-    key-file: examples/h2o/server.key
-    certificate-file: examples/h2o/server.crt
 http3-graceful-shutdown-timeout: 60
 hosts:
   default:
@@ -41,15 +29,13 @@ hosts:
           end
 EOT
 
-wait_port({port => $quic_port, proto => 'udp'});
-
-open my $client1, '-|', "$client_prog -3 100 https://127.0.0.1:$quic_port/ 2>&1"
+open my $client1, '-|', "$client_prog -3 100 https://127.0.0.1:$server->{quic_port}/ 2>&1"
     or die "failed to launch $client_prog:$?";
 sleep 1;
 kill 'TERM', $server->{pid};
 sleep 1;
 my $client2_timespent = time;
-open my $client2, '-|', "$client_prog -3 100 https://127.0.0.1:$quic_port/ 2>&1"
+open my $client2, '-|', "$client_prog -3 100 https://127.0.0.1:$server->{quic_port}/ 2>&1"
     or die "failed to launch $client_prog:$?";
 $client2_timespent = time - $client2_timespent;
 

--- a/t/40http3.t
+++ b/t/40http3.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use Digest::MD5 qw(md5_hex);
-use Net::EmptyPort qw(empty_port wait_port);
 use File::Temp qw(tempdir);
 use Test::More;
 use t::Util;
@@ -12,21 +11,9 @@ my $client_prog = bindir() . "/h2o-httpclient";
 plan skip_all => "$client_prog not found"
     unless -e $client_prog;
 
-my $quic_port = empty_port({
-    host  => "127.0.0.1",
-    proto => "udp",
-});
-
-
 sub doit {
     my $num_threads = shift;
     my $conf = << "EOT";
-listen:
-  type: quic
-  port: $quic_port
-  ssl:
-    key-file: examples/h2o/server.key
-    certificate-file: examples/h2o/server.crt
 num-threads: $num_threads
 hosts:
   default:
@@ -43,15 +30,14 @@ EOT
           end
 EOT
     }
-    my $guard = spawn_h2o($conf);
-    wait_port({port => $quic_port, proto => 'udp'});
+    my $server = spawn_h2o($conf);
     for (1..100) {
         subtest "hello world" => sub {
-            my $resp = `$client_prog -3 100 https://127.0.0.1:$quic_port 2>&1`;
+            my $resp = `$client_prog -3 100 https://127.0.0.1:$server->{quic_port} 2>&1`;
             like $resp, qr{^HTTP/.*\n\nhello\n$}s;
         };
         subtest "large file" => sub {
-            my $resp = `$client_prog -3 100 https://127.0.0.1:$quic_port/halfdome.jpg 2> $tempdir/log`;
+            my $resp = `$client_prog -3 100 https://127.0.0.1:$server->{quic_port}/halfdome.jpg 2> $tempdir/log`;
             is $?, 0;
             diag do {
                 open my $fh, "-|", "share/h2o/annotate-backtrace-symbols < $tempdir/log"
@@ -63,14 +49,14 @@ EOT
             is md5_hex($resp), md5_file("t/assets/doc_root/halfdome.jpg");
         };
         subtest "more than stream-concurrency" => sub {
-            my $resp = `$client_prog -3 100 -t 1000 https://127.0.0.1:$quic_port 2> /dev/null`;
+            my $resp = `$client_prog -3 100 -t 1000 https://127.0.0.1:$server->{quic_port} 2> /dev/null`;
             is $resp, "hello\n" x 1000;
         };
         subtest "post" => sub {
             plan skip_all => 'mruby support is off'
                 unless server_features()->{mruby};
             foreach my $cl (1, 100, 10000, 1000000) {
-                my $resp = `$client_prog -3 100 -b $cl -c 100000 https://127.0.0.1:$quic_port/echo 2> /dev/null`;
+                my $resp = `$client_prog -3 100 -b $cl -c 100000 https://127.0.0.1:$server->{quic_port}/echo 2> /dev/null`;
                 is length($resp), $cl;
                 ok +($resp =~ /^a+$/s); # don't use of `like` to avoid excess amount of log lines on mismatch
             }
@@ -90,13 +76,7 @@ subtest "slow-echo-chunked" => sub {
     plan skip_all => 'mruby support is off'
         unless server_features()->{mruby};
 
-    my $guard = spawn_h2o(<< "EOT");
-listen:
-  type: quic
-  port: $quic_port
-  ssl:
-    key-file: examples/h2o/server.key
-    certificate-file: examples/h2o/server.crt
+    my $server = spawn_h2o(<< "EOT");
 hosts:
   default:
     paths:
@@ -107,9 +87,7 @@ hosts:
           end
 EOT
 
-    wait_port({port => $quic_port, proto => 'udp'});
-
-    my $resp = `$client_prog -3 100 -t 5 -d 1000 -b 10 -c 2 -i 1000 https://127.0.0.1:$quic_port/echo 2> /dev/null`;
+    my $resp = `$client_prog -3 100 -t 5 -d 1000 -b 10 -c 2 -i 1000 https://127.0.0.1:$server->{quic_port}/echo 2> /dev/null`;
     is length($resp), 50;
     is $resp, 'a' x 50;
 };
@@ -124,12 +102,6 @@ subtest "body-then-close" => sub {
     );
     my $server = spawn_h2o(<< "EOT");
 http3-idle-timeout: 5
-listen:
-  type: quic
-  port: $quic_port
-  ssl:
-    key-file: examples/h2o/server.key
-    certificate-file: examples/h2o/server.crt
 hosts:
   default:
     paths:
@@ -138,7 +110,7 @@ hosts:
 EOT
     my $fetch = sub {
         my $qp = shift;
-        open my $fh, "-|", "$client_prog -3 100 https://127.0.0.1:$quic_port/suspend-body$qp 2>&1"
+        open my $fh, "-|", "$client_prog -3 100 https://127.0.0.1:$server->{quic_port}/suspend-body$qp 2>&1"
             or die "failed to spawn $client_prog:$!";
         local $/;
         join "", <$fh>;

--- a/t/50server-starter.t
+++ b/t/50server-starter.t
@@ -12,7 +12,7 @@ my $tempdir = tempdir(CLEANUP => 1);
 
 subtest "master-mode" => sub {
     my $server = spawn_h2o({
-        opts => [ qw(--mode=master) ],
+        args => [ qw(--mode=master) ],
         conf => << "EOT",
 pid-file: $tempdir/h2o.pid
 hosts:
@@ -41,7 +41,7 @@ EOT
 
 subtest "daemon-mode" => sub {
     my $server = spawn_h2o({
-        opts => [ qw(--mode=daemon) ],
+        args => [ qw(--mode=daemon) ],
         conf => << "EOT",
 pid-file: $tempdir/h2o.pid
 error-log: $tempdir/h2o.error

--- a/t/90dtrace.t
+++ b/t/90dtrace.t
@@ -14,7 +14,7 @@ plan skip_all => 'curl not found'
 my $tempdir = tempdir(CLEANUP => 1);
 
 my $server = spawn_h2o({
-    opts => [qw(--mode=worker)],
+    args => [qw(--mode=worker)],
     user => "nobody",
     conf => << 'EOT',
 hosts:

--- a/t/90h2olog.t
+++ b/t/90h2olog.t
@@ -3,7 +3,6 @@
 # H2OLOG_DEBUG=1 for more runtime logs
 use strict;
 use warnings FATAL => "all";
-use Net::EmptyPort qw(empty_port);
 use Test::More;
 use JSON;
 use t::Util;
@@ -24,20 +23,9 @@ unless ($ENV{DTRACE_TESTS})  {
       unless server_features()->{dtrace};
 }
 
-my $quic_port = empty_port({
-    host  => "127.0.0.1",
-    proto => "udp",
-});
-
 my $server = spawn_h2o({
-    opts => [qw(--mode=worker)],
+    args => [qw(--mode=worker)],
     conf => << "EOT",
-listen:
-  type: quic
-  port: $quic_port
-  ssl:
-    key-file: examples/h2o/server.key
-    certificate-file: examples/h2o/server.crt
 hosts:
   default:
     paths:
@@ -52,7 +40,7 @@ subtest "h2olog", sub {
     args => [],
   });
 
-  my ($headers, $body) = run_prog("$client_prog -3 https://127.0.0.1:$quic_port/");
+  my ($headers, $body) = run_prog("$client_prog -3 https://127.0.0.1:$server->{quic_port}/");
   like $headers, qr{^HTTP/3 200\n}, "req: HTTP/3";
 
   my $trace;
@@ -72,7 +60,7 @@ subtest "h2olog -H", sub {
     args => ["-H"],
   });
 
-  my ($headers, $body) = run_prog("$client_prog -3 https://127.0.0.1:$quic_port/");
+  my ($headers, $body) = run_prog("$client_prog -3 https://127.0.0.1:$server->{quic_port}/");
   like $headers, qr{^HTTP/3 200\n}, "req: HTTP/3";
 
   my $trace;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -211,58 +211,84 @@ sub spawn_server {
 
 # returns a hash containing `port`, `tls_port`, `guard`
 sub spawn_h2o {
-    my ($conf) = @_;
-    my @opts;
+    my ($conf, $opts) = @_;
+    $opts ||= +{};
+    my @args;
     my $max_ssl_version;
 
     # decide the port numbers
     my ($port, $tls_port) = empty_ports(2, { host => "0.0.0.0" });
+    my $quic = $opts->{quic} || +{ host => '0.0.0.0' };;
+    $quic->{port} ||= empty_port({ host => "0.0.0.0", proto => "udp" });
 
     # setup the configuration file
-    $conf = $conf->($port, $tls_port)
+    $conf = $conf->($port, $tls_port, $quic->{port})
         if ref $conf eq 'CODE';
     my $user = $< == 0 ? "root" : "";
     if (ref $conf eq 'HASH') {
-        @opts = @{$conf->{opts}}
-            if $conf->{opts};
+        @args = @{$conf->{args} || []};
         $max_ssl_version = $conf->{max_ssl_version} || undef;
         $user = $conf->{user} if exists $conf->{user};
         $conf = $conf->{conf};
     }
-    $conf = <<"EOT";
-$conf
+    my $ssl = <<"EOT";
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+    @{[$max_ssl_version ? "max-version: $max_ssl_version" : ""]}
+EOT
+
+    my $user_and_listen = <<"EOT";
+@{[$user ? "user: $user" : ""]}
 listen:
   host: 0.0.0.0
   port: $port
 listen:
   host: 0.0.0.0
   port: $tls_port
-  ssl:
-    key-file: examples/h2o/server.key
-    certificate-file: examples/h2o/server.crt
-    @{[$max_ssl_version ? "max-version: $max_ssl_version" : ""]}
-@{[$user ? "user: $user" : ""]}
+$ssl
 EOT
+    if ($quic) {
+        $user_and_listen .= <<"EOT";
+listen:
+  type: quic
+  host: $quic->{host}
+  port: $quic->{port}
+$ssl
+EOT
+    }
+    my $whole_conf = join("\n", $user_and_listen, $conf);
 
-    my $ret = spawn_h2o_raw($conf, [$port, $tls_port], \@opts);
+    my $port_defs = [
+        +{ port => $port, proto => 'tcp' },
+        +{ port => $tls_port, proto => 'tcp' },
+        ($quic ? (+{ port => $quic->{port}, proto => 'udp' }) : ()),
+    ];
+    my $ret = spawn_h2o_raw($whole_conf, $port_defs, \@args);
     return {
         %$ret,
         port => $port,
         tls_port => $tls_port,
+        quic_port => $quic->{port},
     };
 }
 
 sub spawn_h2o_raw {
-    my ($conf, $check_ports, $opts) = @_;
+    my ($conf, $port_defs, $args) = @_;
 
     my ($conffh, $conffn) = tempfile(UNLINK => 1);
     print $conffh $conf;
 
     # spawn the server
     my ($guard, $pid) = spawn_server(
-        argv     => [ bindir() . "/h2o", "-c", $conffn, @{$opts || []} ],
+        argv     => [ bindir() . "/h2o", "-c", $conffn, @{$args || []} ],
         is_ready => sub {
-            check_port($_) or return for @{ $check_ports || [] };
+            for my $port_def (@{ $port_defs || [] }) {
+                unless (ref $port_def eq 'HASH') {
+                    $port_def = +{ port => $port_def, proto => 'tcp' };
+                }
+                check_port($port_def) or return;
+            }
             1;
         },
     );


### PR DESCRIPTION
This is an attempt to reduce the redundancy in writing QUIC tests, as well as making them consistently wait QUIC listening port to be available.