### PR TITLE
[CONNECT] do not buffer more than 64KB

### DIFF
--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -56,6 +56,10 @@ typedef h2o_timerwheel_cb h2o_timer_cb;
 
 h2o_socket_t *h2o_evloop_socket_create(h2o_evloop_t *loop, int fd, int flags);
 h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *listener);
+/**
+ * Sets number of bytes that can be read at once (default: 1MB).
+ */
+void h2o_evloop_socket_set_max_read_size(h2o_socket_t *sock, size_t max_size);
 
 h2o_evloop_t *h2o_evloop_create(void);
 void h2o_evloop_destroy(h2o_evloop_t *loop);

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -56,6 +56,7 @@ struct st_h2o_evloop_socket_t {
             h2o_iovec_t smallbufs[4];
         };
     } _wreq;
+    size_t max_read_size;
     struct st_h2o_evloop_socket_t *_next_pending;
     struct st_h2o_evloop_socket_t *_next_statechanged;
 };
@@ -115,18 +116,21 @@ static void link_to_statechanged(struct st_h2o_evloop_socket_t *sock)
     }
 }
 
-static const char *on_read_core(int fd, h2o_buffer_t **input)
+static const char *on_read_core(int fd, h2o_buffer_t **input, size_t max_bytes)
 {
     ssize_t read_so_far = 0;
 
     while (1) {
         ssize_t rret;
-        h2o_iovec_t buf = h2o_buffer_try_reserve(input, 4096);
+        h2o_iovec_t buf = h2o_buffer_try_reserve(input, max_bytes < 4096 ? max_bytes : 4096);
         if (buf.base == NULL) {
             /* memory allocation failed */
             return h2o_socket_error_out_of_memory;
         }
-        while ((rret = read(fd, buf.base, buf.len <= INT_MAX / 2 ? buf.len : INT_MAX / 2 + 1)) == -1 && errno == EINTR)
+        size_t read_size = buf.len <= INT_MAX / 2 ? buf.len : INT_MAX / 2 + 1;
+        if (read_size > max_bytes)
+            read_size = max_bytes;
+        while ((rret = read(fd, buf.base, read_size)) == -1 && errno == EINTR)
             ;
         if (rret == -1) {
             if (errno == EAGAIN)
@@ -142,7 +146,7 @@ static const char *on_read_core(int fd, h2o_buffer_t **input)
         if (buf.len != rret)
             break;
         read_so_far += rret;
-        if (read_so_far >= (1024 * 1024))
+        if (read_so_far >= max_bytes)
             break;
     }
     return NULL;
@@ -235,7 +239,8 @@ static void read_on_ready(struct st_h2o_evloop_socket_t *sock)
     if ((sock->_flags & H2O_SOCKET_FLAG_DONT_READ) != 0)
         goto Notify;
 
-    if ((err = on_read_core(sock->fd, sock->super.ssl == NULL ? &sock->super.input : &sock->super.ssl->input.encrypted)) != NULL)
+    if ((err = on_read_core(sock->fd, sock->super.ssl == NULL ? &sock->super.input : &sock->super.ssl->input.encrypted,
+                            sock->max_read_size)) != NULL)
         goto Notify;
 
     if (sock->super.ssl != NULL && sock->super.ssl->handshake.cb == NULL)
@@ -393,6 +398,7 @@ static struct st_h2o_evloop_socket_t *create_socket(h2o_evloop_t *loop, int fd, 
     sock->fd = fd;
     sock->_flags = flags;
     sock->_wreq.bufs = sock->_wreq.smallbufs;
+    sock->max_read_size = 1024 * 1024; /* by default, we read up to 1MB at once */
     sock->_next_pending = sock;
     sock->_next_statechanged = sock;
 
@@ -478,6 +484,12 @@ h2o_socket_t *h2o_socket_connect(h2o_loop_t *loop, struct sockaddr *addr, sockle
 
     h2o_socket_notify_write(&sock->super, cb);
     return &sock->super;
+}
+
+void h2o_evloop_socket_set_max_read_size(h2o_socket_t *_sock, size_t max_size)
+{
+    struct st_h2o_evloop_socket_t *sock = (void *)_sock;
+    sock->max_read_size = max_size;
 }
 
 h2o_evloop_t *create_evloop(size_t sz)

--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -165,6 +165,11 @@ static void start_connect(struct st_connect_request_t *creq)
         /* connect */
         if ((creq->sock = h2o_socket_connect(creq->loop, server_address->sa, server_address->salen, on_connect)) != NULL) {
             creq->sock->data = creq;
+#if !H2O_USE_LIBUV
+            /* This is the maximum amount of data that will be buffered within userspace. It is hard-coded to 64KB to balance
+             * throughput and latency, and because we do not expect the need to change the value. */
+            h2o_evloop_socket_set_max_read_size(creq->sock, 64 * 1024);
+#endif
             return;
         }
     } while (creq->server_addresses.next < creq->server_addresses.size);
@@ -208,6 +213,8 @@ static int on_req(h2o_handler_t *_handler, h2o_req_t *req)
 void h2o_connect_register(h2o_pathconf_t *pathconf, h2o_proxy_config_vars_t *config, h2o_connect_acl_entry_t *acl_entries,
                           size_t num_acl_entries)
 {
+    assert(config->max_buffer_size != 0);
+
     struct st_connect_handler_t *self = (void *)h2o_create_handler(pathconf, offsetof(struct st_connect_handler_t, acl.entries) +
                                                                                  sizeof(*self->acl.entries) * num_acl_entries);
 


### PR DESCRIPTION
CONNECT tunnels have to balance between throughput and latency.

At the moment, h2o_socket_read tries to read at most 1MB, which is too large for slow connections. Not only it is a performance issue, but it is also reliability issue, because reading too much at once ends up in reading too frequently, which in turn leads to the peer believing that the connection might have died, and thereby closing the connection (where it should not).