### PR TITLE
add missing mruby guard to tests which reference mruby.handler

### DIFF
--- a/t/40http3-shutdown-reject-conn.t
+++ b/t/40http3-shutdown-reject-conn.t
@@ -6,6 +6,9 @@ use Net::EmptyPort qw(empty_port wait_port);
 use Test::More;
 use t::Util;
 
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
 my $client_prog = bindir() . "/h2o-httpclient";
 plan skip_all => "$client_prog not found"
     unless -e $client_prog;

--- a/t/50date-header.t
+++ b/t/50date-header.t
@@ -6,6 +6,8 @@ use t::Util;
 
 plan skip_all => 'curl not found'
     unless prog_exists('curl');
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
 plan skip_all => 'plackup not found'
     unless prog_exists('plackup');
 plan skip_all => 'Starlet not found'

--- a/t/50priority-headers.t
+++ b/t/50priority-headers.t
@@ -13,6 +13,9 @@ use warnings;
 use Test::More;
 use t::Util;
 
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
 sub test_priority_header {
     my ($input_streams, $expected_order) = @_;
     my $server = spawn_h2o(sub {

--- a/t/50proxy-max-buffer-size.t
+++ b/t/50proxy-max-buffer-size.t
@@ -19,6 +19,9 @@ plan skip_all => 'Starlet not found'
 plan skip_all => 'curl not found'
     unless prog_exists('curl');
 
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
 my $tempdir = tempdir(CLEANUP => 1);
 
 sub create_http1_upstream {

--- a/t/50reverse-proxy-timings.t
+++ b/t/50reverse-proxy-timings.t
@@ -9,6 +9,9 @@ use Time::HiRes qw(sleep);
 plan skip_all => 'curl not found'
     unless prog_exists('curl');
 
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
 my $tempdir = tempdir(CLEANUP => 1);
 
 my $upstream_port = empty_port();

--- a/t/50server-timing.t
+++ b/t/50server-timing.t
@@ -5,6 +5,8 @@ use Test::More;
 use Time::HiRes;
 use t::Util;
 
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
 
 subtest 'basic' => sub {
     my $server = spawn_h2o(<< "EOT");

--- a/t/50stop-opening-new-push-streams.t
+++ b/t/50stop-opening-new-push-streams.t
@@ -4,6 +4,9 @@ use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use t::Util;
 
+plan skip_all => 'mruby support is off'
+    unless server_features()->{mruby};
+
 my $server = spawn_h2o(<< "EOT");
 http2-idle-timeout: 2
 hosts:

--- a/t/50suspend-body.t
+++ b/t/50suspend-body.t
@@ -76,6 +76,9 @@ EOT
 };
 
 subtest 'mruby-http-chunked' => sub {
+    plan skip_all => "mruby support is off"
+        unless server_features()->{mruby};
+
     my $upstream = create_upstream(qw(-s Starlet --max-workers 0));
     my $server = spawn_h2o(<< "EOT");
 hosts:
@@ -91,6 +94,9 @@ EOT
 };
 
 subtest 'mruby-callback-chunked' => sub {
+    plan skip_all => "mruby support is off"
+        unless server_features()->{mruby};
+
     my $upstream = create_upstream(qw(-s Starlet --max-workers 0));
     my $server = spawn_h2o(<< "EOT");
 hosts:
@@ -114,6 +120,9 @@ EOT
 };
 
 subtest 'mruby-middleware-chunked' => sub {
+    plan skip_all => "mruby support is off"
+        unless server_features()->{mruby};
+
     my $upstream = create_upstream(qw(-s Starlet --max-workers 0));
     my $server = spawn_h2o(<< "EOT");
 hosts:


### PR DESCRIPTION
There are some tests that are missing the guard to detect mruby and fail during `make check` when compiled with `WITH_RUBY=OFF` 

If the expectation is that the full suite is only run under CI where all dependencies are known to be installed then kindly disregard this PR.