### PR TITLE
adjust regex in t/40reuse-port.t to only match bind address port

### DIFF
--- a/t/40reuse-port.t
+++ b/t/40reuse-port.t
@@ -21,7 +21,7 @@ hosts:
       "/":
         file.dir: @{[ DOC_ROOT ]}
 EOT
-    my $out = `ss -tlnp | grep -w \*:$server->{port} 2>&1`;
+    my $out = `ss -tlnp | grep ":$port" 2>&1`;
     if ($reuseport eq 'ON') {
         my @lines = split(/\n/, $out);
         is scalar(@lines), 4, "Found 4 listeners";


### PR DESCRIPTION
`t/40reuse_port.t` fails when the output of `ss` is differs in how it reports the bind address, on some platforms it might be `*:12345` and on others `0.0.0.0:12345`. This change makes the match less restrictive.