### PR TITLE
[h2olog] add timestamp to each hX_accept to identify a particular HTTP connection

### DIFF
--- a/h2o-probes.d
+++ b/h2o-probes.d
@@ -62,12 +62,20 @@ provider h2o {
     /**
      * HTTP/1 server-level event, indicating that a connection has been accepted.
      */
-    probe h1_accept(uint64_t conn_id, struct st_h2o_socket_t *sock, struct st_h2o_conn_t *conn);
+    probe h1_accept(uint64_t conn_id, struct st_h2o_socket_t *sock, struct st_h2o_conn_t *conn, struct timeval connected_at);
     /**
      * HTTP/1 server-level event, indicating that a connection has been closed.
      */
     probe h1_close(uint64_t conn_id);
 
+    /**
+     * HTTP/2 server-level event, indicating that a connection has been accepted.
+     */
+    probe h2_accept(uint64_t conn_id, struct st_h2o_socket_t *sock, struct st_h2o_conn_t *conn, struct timeval connected_at);
+    /**
+     * HTTP/2 server-level event, indicating that a connection has been closed.
+     */
+    probe h2_close(uint64_t conn_id);
     /**
      * HTTP/2 server-level event, indicating that a frame of unknown type has been received.
      */
@@ -76,7 +84,7 @@ provider h2o {
     /**
      * HTTP/3 server-level event, indicating that a new connection has been accepted
      */
-    probe h3s_accept(uint64_t conn_id, struct st_h2o_conn_t *conn, struct st_quicly_conn_t *quic);
+    probe h3s_accept(uint64_t conn_id, struct st_h2o_conn_t *conn, struct st_quicly_conn_t *quic, struct timeval connected_at);
     /**
      * HTTP/3 server-level event, indicating that a connection has been destroyed
      */

--- a/h2o-probes.d
+++ b/h2o-probes.d
@@ -62,7 +62,7 @@ provider h2o {
     /**
      * HTTP/1 server-level event, indicating that a connection has been accepted.
      */
-    probe h1_accept(uint64_t conn_id, struct st_h2o_socket_t *sock, struct st_h2o_conn_t *conn, struct timeval connected_at);
+    probe h1_accept(uint64_t conn_id, struct st_h2o_socket_t *sock, struct st_h2o_conn_t *conn, struct timeval *connected_at);
     /**
      * HTTP/1 server-level event, indicating that a connection has been closed.
      */
@@ -71,7 +71,7 @@ provider h2o {
     /**
      * HTTP/2 server-level event, indicating that a connection has been accepted.
      */
-    probe h2_accept(uint64_t conn_id, struct st_h2o_socket_t *sock, struct st_h2o_conn_t *conn, struct timeval connected_at);
+    probe h2_accept(uint64_t conn_id, struct st_h2o_socket_t *sock, struct st_h2o_conn_t *conn, struct timeval *connected_at);
     /**
      * HTTP/2 server-level event, indicating that a connection has been closed.
      */
@@ -84,7 +84,7 @@ provider h2o {
     /**
      * HTTP/3 server-level event, indicating that a new connection has been accepted
      */
-    probe h3s_accept(uint64_t conn_id, struct st_h2o_conn_t *conn, struct st_quicly_conn_t *quic, struct timeval connected_at);
+    probe h3s_accept(uint64_t conn_id, struct st_h2o_conn_t *conn, struct st_quicly_conn_t *quic, struct timeval *connected_at);
     /**
      * HTTP/3 server-level event, indicating that a connection has been destroyed
      */

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -1337,7 +1337,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
     sock->data = conn;
     h2o_linklist_insert(&ctx->ctx->http1._conns, &conn->_conns);
 
-    H2O_PROBE_CONN(H1_ACCEPT, &conn->super, conn->sock, &conn->super, connected_at);
+    H2O_PROBE_CONN(H1_ACCEPT, &conn->super, conn->sock, &conn->super, &connected_at);
 
     init_request(conn);
     reqread_start(conn);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -1337,7 +1337,7 @@ void h2o_http1_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
     sock->data = conn;
     h2o_linklist_insert(&ctx->ctx->http1._conns, &conn->_conns);
 
-    H2O_PROBE_CONN(H1_ACCEPT, &conn->super, conn->sock, &conn->super);
+    H2O_PROBE_CONN(H1_ACCEPT, &conn->super, conn->sock, &conn->super, connected_at);
 
     init_request(conn);
     reqread_start(conn);

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -341,6 +341,8 @@ void close_connection_now(h2o_http2_conn_t *conn)
 
     assert(!h2o_timer_is_linked(&conn->_write.timeout_entry));
 
+    H2O_PROBE_CONN0(H2_CLOSE, &conn->super);
+
     kh_foreach_value(conn->streams, stream, { h2o_http2_stream_close(conn, stream); });
 
     assert(conn->num_streams.pull.open == 0);
@@ -1743,6 +1745,9 @@ void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
     h2o_http2_conn_t *conn = create_conn(ctx->ctx, ctx->hosts, sock, connected_at);
     conn->http2_origin_frame = ctx->http2_origin_frame;
     sock->data = conn;
+
+    H2O_PROBE_CONN(H2_ACCEPT, &conn->super, conn->sock, &conn->super, connected_at);
+
     h2o_socket_read_start(conn->sock, on_read);
     update_idle_timeout(conn);
     if (sock->input->size != 0)

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1746,7 +1746,7 @@ void h2o_http2_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock, struct timeval 
     conn->http2_origin_frame = ctx->http2_origin_frame;
     sock->data = conn;
 
-    H2O_PROBE_CONN(H2_ACCEPT, &conn->super, conn->sock, &conn->super, connected_at);
+    H2O_PROBE_CONN(H2_ACCEPT, &conn->super, conn->sock, &conn->super, &connected_at);
 
     h2o_socket_read_start(conn->sock, on_read);
     update_idle_timeout(conn);

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1761,8 +1761,9 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
     };
 
     /* setup the structure */
+    struct timeval connected_at = h2o_gettimeofday(ctx->accept_ctx->ctx->loop);
     struct st_h2o_http3_server_conn_t *conn = (void *)h2o_create_connection(
-        sizeof(*conn), ctx->accept_ctx->ctx, ctx->accept_ctx->hosts, h2o_gettimeofday(ctx->accept_ctx->ctx->loop), &conn_callbacks);
+        sizeof(*conn), ctx->accept_ctx->ctx, ctx->accept_ctx->hosts, connected_at, &conn_callbacks);
     h2o_http3_init_conn(&conn->h3, &ctx->super, h3_callbacks, &ctx->qpack);
     conn->handshake_properties = (ptls_handshake_properties_t){{{{NULL}}}};
     h2o_linklist_init_anchor(&conn->delayed_streams.recv_body_blocked);
@@ -1799,7 +1800,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
     h2o_linklist_insert(&ctx->accept_ctx->ctx->http3._conns, &conn->_conns);
     h2o_http3_setup(&conn->h3, qconn);
 
-    H2O_PROBE_CONN(H3S_ACCEPT, &conn->super, &conn->super, conn->h3.super.quic);
+    H2O_PROBE_CONN(H3S_ACCEPT, &conn->super, &conn->super, conn->h3.super.quic, connected_at);
 
     h2o_quic_send(&conn->h3.super);
 

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1800,7 +1800,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
     h2o_linklist_insert(&ctx->accept_ctx->ctx->http3._conns, &conn->_conns);
     h2o_http3_setup(&conn->h3, qconn);
 
-    H2O_PROBE_CONN(H3S_ACCEPT, &conn->super, &conn->super, conn->h3.super.quic, connected_at);
+    H2O_PROBE_CONN(H3S_ACCEPT, &conn->super, &conn->super, conn->h3.super.quic, &connected_at);
 
     h2o_quic_send(&conn->h3.super);
 

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -179,6 +179,8 @@ enum h2olog_event_id_t {
   H2OLOG_EVENT_ID_H2O_SEND_RESPONSE_HEADER,
   H2OLOG_EVENT_ID_H2O_H1_ACCEPT,
   H2OLOG_EVENT_ID_H2O_H1_CLOSE,
+  H2OLOG_EVENT_ID_H2O_H2_ACCEPT,
+  H2OLOG_EVENT_ID_H2O_H2_CLOSE,
   H2OLOG_EVENT_ID_H2O_H2_UNKNOWN_FRAME_TYPE,
   H2OLOG_EVENT_ID_H2O_H3S_ACCEPT,
   H2OLOG_EVENT_ID_H2O_H3S_DESTROY,
@@ -683,10 +685,20 @@ struct h2olog_event_t {
       uint64_t conn_id;
       struct st_h2o_socket_t * sock;
       struct st_h2o_conn_t * conn;
+      struct timeval connected_at;
     } h1_accept;
     struct { // h2o:h1_close
       uint64_t conn_id;
     } h1_close;
+    struct { // h2o:h2_accept
+      uint64_t conn_id;
+      struct st_h2o_socket_t * sock;
+      struct st_h2o_conn_t * conn;
+      struct timeval connected_at;
+    } h2_accept;
+    struct { // h2o:h2_close
+      uint64_t conn_id;
+    } h2_close;
     struct { // h2o:h2_unknown_frame_type
       uint64_t conn_id;
       uint8_t frame_type;
@@ -695,6 +707,7 @@ struct h2olog_event_t {
       uint64_t conn_id;
       struct st_h2o_conn_t * conn;
       typeof_st_quicly_conn_t__master_id quic_master_id;
+      struct timeval connected_at;
     } h3s_accept;
     struct { // h2o:h3s_destroy
       uint64_t conn_id;
@@ -843,6 +856,8 @@ void h2o_raw_tracer::initialize() {
     h2o_tracer::usdt("h2o", "send_response_header", "trace_h2o__send_response_header"),
     h2o_tracer::usdt("h2o", "h1_accept", "trace_h2o__h1_accept"),
     h2o_tracer::usdt("h2o", "h1_close", "trace_h2o__h1_close"),
+    h2o_tracer::usdt("h2o", "h2_accept", "trace_h2o__h2_accept"),
+    h2o_tracer::usdt("h2o", "h2_close", "trace_h2o__h2_close"),
     h2o_tracer::usdt("h2o", "h2_unknown_frame_type", "trace_h2o__h2_unknown_frame_type"),
     h2o_tracer::usdt("h2o", "h3s_accept", "trace_h2o__h3s_accept"),
     h2o_tracer::usdt("h2o", "h3s_destroy", "trace_h2o__h3s_destroy"),
@@ -1685,6 +1700,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h1_accept.conn_id);
     json_write_pair_c(out_, STR_LIT("sock"), event->h1_accept.sock);
     json_write_pair_c(out_, STR_LIT("conn"), event->h1_accept.conn);
+    json_write_pair_c(out_, STR_LIT("connected-at"), event->h1_accept.connected_at);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
@@ -1693,6 +1709,25 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h1_close.conn_id);
+    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
+    break;
+  }
+  case H2OLOG_EVENT_ID_H2O_H2_ACCEPT: { // h2o:h2_accept
+    json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h2-accept"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
+    json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("conn-id"), event->h2_accept.conn_id);
+    json_write_pair_c(out_, STR_LIT("sock"), event->h2_accept.sock);
+    json_write_pair_c(out_, STR_LIT("conn"), event->h2_accept.conn);
+    json_write_pair_c(out_, STR_LIT("connected-at"), event->h2_accept.connected_at);
+    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
+    break;
+  }
+  case H2OLOG_EVENT_ID_H2O_H2_CLOSE: { // h2o:h2_close
+    json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h2-close"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
+    json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("conn-id"), event->h2_close.conn_id);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
@@ -1712,6 +1747,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h3s_accept.conn_id);
     json_write_pair_c(out_, STR_LIT("conn"), event->h3s_accept.conn);
     json_write_pair_c(out_, STR_LIT("quic-master-id"), event->h3s_accept.quic_master_id);
+    json_write_pair_c(out_, STR_LIT("connected-at"), event->h3s_accept.connected_at);
     json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
@@ -1960,6 +1996,8 @@ enum h2olog_event_id_t {
   H2OLOG_EVENT_ID_H2O_SEND_RESPONSE_HEADER,
   H2OLOG_EVENT_ID_H2O_H1_ACCEPT,
   H2OLOG_EVENT_ID_H2O_H1_CLOSE,
+  H2OLOG_EVENT_ID_H2O_H2_ACCEPT,
+  H2OLOG_EVENT_ID_H2O_H2_CLOSE,
   H2OLOG_EVENT_ID_H2O_H2_UNKNOWN_FRAME_TYPE,
   H2OLOG_EVENT_ID_H2O_H3S_ACCEPT,
   H2OLOG_EVENT_ID_H2O_H3S_DESTROY,
@@ -2464,10 +2502,20 @@ struct h2olog_event_t {
       uint64_t conn_id;
       struct st_h2o_socket_t * sock;
       struct st_h2o_conn_t * conn;
+      struct timeval connected_at;
     } h1_accept;
     struct { // h2o:h1_close
       uint64_t conn_id;
     } h1_close;
+    struct { // h2o:h2_accept
+      uint64_t conn_id;
+      struct st_h2o_socket_t * sock;
+      struct st_h2o_conn_t * conn;
+      struct timeval connected_at;
+    } h2_accept;
+    struct { // h2o:h2_close
+      uint64_t conn_id;
+    } h2_close;
     struct { // h2o:h2_unknown_frame_type
       uint64_t conn_id;
       uint8_t frame_type;
@@ -2476,6 +2524,7 @@ struct h2olog_event_t {
       uint64_t conn_id;
       struct st_h2o_conn_t * conn;
       typeof_st_quicly_conn_t__master_id quic_master_id;
+      struct timeval connected_at;
     } h3s_accept;
     struct { // h2o:h3s_destroy
       uint64_t conn_id;
@@ -4369,6 +4418,8 @@ int trace_h2o__h1_accept(struct pt_regs *ctx) {
   bpf_usdt_readarg(2, ctx, &event.h1_accept.sock);
   // struct st_h2o_conn_t * conn
   bpf_usdt_readarg(3, ctx, &event.h1_accept.conn);
+  // struct timeval connected_at
+  bpf_usdt_readarg(4, ctx, &event.h1_accept.connected_at);
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_h2o__h1_accept\n");
@@ -4385,6 +4436,38 @@ int trace_h2o__h1_close(struct pt_regs *ctx) {
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_h2o__h1_close\n");
+
+  return 0;
+}
+// h2o:h2_accept
+int trace_h2o__h2_accept(struct pt_regs *ctx) {
+  const void *buf = NULL;
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H2_ACCEPT, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
+
+  // uint64_t conn_id
+  bpf_usdt_readarg(1, ctx, &event.h2_accept.conn_id);
+  // struct st_h2o_socket_t * sock
+  bpf_usdt_readarg(2, ctx, &event.h2_accept.sock);
+  // struct st_h2o_conn_t * conn
+  bpf_usdt_readarg(3, ctx, &event.h2_accept.conn);
+  // struct timeval connected_at
+  bpf_usdt_readarg(4, ctx, &event.h2_accept.connected_at);
+
+  if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
+    bpf_trace_printk("failed to perf_submit in trace_h2o__h2_accept\n");
+
+  return 0;
+}
+// h2o:h2_close
+int trace_h2o__h2_close(struct pt_regs *ctx) {
+  const void *buf = NULL;
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O_H2_CLOSE, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
+
+  // uint64_t conn_id
+  bpf_usdt_readarg(1, ctx, &event.h2_close.conn_id);
+
+  if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
+    bpf_trace_printk("failed to perf_submit in trace_h2o__h2_close\n");
 
   return 0;
 }
@@ -4417,6 +4500,8 @@ int trace_h2o__h3s_accept(struct pt_regs *ctx) {
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&quic, sizeof_st_quicly_conn_t, buf);
   event.h3s_accept.quic_master_id = get_st_quicly_conn_t__master_id(quic);
+  // struct timeval connected_at
+  bpf_usdt_readarg(4, ctx, &event.h3s_accept.connected_at);
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_h2o__h3s_accept\n");

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -90,6 +90,8 @@ static std::string gen_bpf_header() {
 
   bpf += "#define sizeof_sockaddr_in6 " + std::to_string(std::min<size_t>(sizeof(struct sockaddr_in6), 100)) + "\n";
 
+  bpf += "#define sizeof_timeval " + std::to_string(std::min<size_t>(sizeof(struct timeval), 100)) + "\n";
+
   bpf += GEN_FIELD_INFO(struct sockaddr, sa_family, "sockaddr__sa_family");
   bpf += "#define AF_INET  " + std::to_string(AF_INET) + "\n";
   bpf += "#define AF_INET6 " + std::to_string(AF_INET6) + "\n";
@@ -4418,8 +4420,9 @@ int trace_h2o__h1_accept(struct pt_regs *ctx) {
   bpf_usdt_readarg(2, ctx, &event.h1_accept.sock);
   // struct st_h2o_conn_t * conn
   bpf_usdt_readarg(3, ctx, &event.h1_accept.conn);
-  // struct timeval connected_at
-  bpf_usdt_readarg(4, ctx, &event.h1_accept.connected_at);
+  // struct timeval * connected_at
+  bpf_usdt_readarg(4, ctx, &buf);
+  bpf_probe_read(&event.h1_accept.connected_at, sizeof_timeval, buf);
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_h2o__h1_accept\n");
@@ -4450,8 +4453,9 @@ int trace_h2o__h2_accept(struct pt_regs *ctx) {
   bpf_usdt_readarg(2, ctx, &event.h2_accept.sock);
   // struct st_h2o_conn_t * conn
   bpf_usdt_readarg(3, ctx, &event.h2_accept.conn);
-  // struct timeval connected_at
-  bpf_usdt_readarg(4, ctx, &event.h2_accept.connected_at);
+  // struct timeval * connected_at
+  bpf_usdt_readarg(4, ctx, &buf);
+  bpf_probe_read(&event.h2_accept.connected_at, sizeof_timeval, buf);
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_h2o__h2_accept\n");
@@ -4500,8 +4504,9 @@ int trace_h2o__h3s_accept(struct pt_regs *ctx) {
   bpf_usdt_readarg(3, ctx, &buf);
   bpf_probe_read(&quic, sizeof_st_quicly_conn_t, buf);
   event.h3s_accept.quic_master_id = get_st_quicly_conn_t__master_id(quic);
-  // struct timeval connected_at
-  bpf_usdt_readarg(4, ctx, &event.h3s_accept.connected_at);
+  // struct timeval * connected_at
+  bpf_usdt_readarg(4, ctx, &buf);
+  bpf_probe_read(&event.h3s_accept.connected_at, sizeof_timeval, buf);
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_h2o__h3s_accept\n");

--- a/src/h2olog/json.cc
+++ b/src/h2olog/json.cc
@@ -150,6 +150,16 @@ void json_write_pair_c(FILE *out, const char *name, size_t name_len, const quicl
     fputc('"', out);
 }
 
+// write a `struct timeval` in microseconds
+void json_write_pair_c(FILE *out, const char *name, size_t name_len, struct timeval value)
+{
+    int64_t usec = (static_cast<int64_t>(value.tv_sec) * 1000000L) + static_cast<int64_t>(value.tv_usec);
+
+    fputc(',', out);
+    json_write_name_value(out, name, name_len);
+    fprintf(out, "%" PRIi64, usec);
+}
+
 void json_write_pair_c(FILE *out, const char *name, size_t name_len, const void *value)
 {
     fputc(',', out);

--- a/src/h2olog/json.h
+++ b/src/h2olog/json.h
@@ -19,6 +19,7 @@ void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const 
 void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const std::int32_t value);
 void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const std::uint32_t value);
 void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const quicly_address_t &value);
+void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const struct timeval value);
 void json_write_pair_c(std::FILE *out, const char *name, size_t name_len, const void *value);
 
 #endif

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -81,6 +81,7 @@ struct_map = OrderedDict([
     ["sockaddr", []],
     ["sockaddr_in", []],
     ["sockaddr_in6", []],
+    ["timeval", []],
 ])
 
 # The block list for probes.


### PR DESCRIPTION
To identify an HTTP (not QUIC) connection with `hX_accept`, I need a timestamp for each `hX_accept` event. In practice, `$hostname-$h2o_pid-$h2o_conn_id-$connected_at` is the identifier.

BTW I'm adding `h2_accept` and `h2_close` with the same fields with H1's just for consistency.

## example row

```
{"type":"h3s-accept","tid":18833,"seq":13,"conn-id":2,"conn":107133664502144,"quic-master-id":0,"connected-at":1623032571650185,"time":1623032571656}
```

