### PR TITLE
Always unlink pending write requests when entering close_wait

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -430,6 +430,8 @@ static void set_state(struct st_h2o_http3_server_stream_t *stream, enum h2o_http
         assert(conn->delayed_streams.recv_body_blocked.prev == &stream->link || !"stream is not registered to the recv_body list?");
         break;
     case H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT: {
+        if (h2o_linklist_is_linked(&stream->link))
+            h2o_linklist_unlink(&stream->link);
         pre_dispose_request(stream);
         if (!in_generator) {
             h2o_dispose_request(&stream->req);


### PR DESCRIPTION
Seen on a stream in `H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT`:
```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /build/lib/core/request.c:406:62 in
h2o: /build/lib/http3/server.c:988: void run_delayed(h2o_timer_t *): Assertion `stream->req_body != NULL' failed.
received fatal signal 6
```