### PR TITLE
[h2olog] -N option for SNI-based sampling

### DIFF
--- a/h2o-probes.d
+++ b/h2o-probes.d
@@ -39,6 +39,10 @@ provider h2o {
      * Do not use it for a tracing event.
      */
     probe _private_socket_lookup_flags(pid_t tid, uint64_t original_flags, struct st_h2o_ebpf_map_key_t *info);
+    /**
+     * Same as `_private_socket_lookup_flags`, expect that this probe is invoked when SNI is being obtained.
+     */
+    probe _private_socket_lookup_flags_sni(pid_t tid, uint64_t original_flags, const char *server_name, size_t server_name_len);
 
     /**
      * HTTP-level event, indicating that a request has been received.

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -372,6 +372,10 @@ int h2o_socket_set_df_bit(int fd, int domain);
  * helper to check if socket the socket is target of tracing
  */
 static int h2o_socket_skip_tracing(h2o_socket_t *sock);
+/**
+ *
+ */
+void h2o_socket_set_skip_tracing(h2o_socket_t *sock, int skip_tracing);
 
 /**
  * Prepares eBPF maps. Requires root privileges and thus should be called before dropping the privileges. Returns a boolean
@@ -382,6 +386,10 @@ int h2o_socket_ebpf_setup(void);
  * Function to lookup if the connection is tagged for special treatment. The result is a union of `H2O_EBPF_FLAGS_*`.
  */
 uint64_t h2o_socket_ebpf_lookup_flags(h2o_loop_t *loop, int (*init_key)(h2o_ebpf_map_key_t *key, void *cbdata), void *cbdata);
+/**
+ *
+ */
+uint64_t h2o_socket_ebpf_lookup_flags_sni(h2o_loop_t *loop, uint64_t flags, const char *server_name, size_t server_name_len);
 /**
  * function for initializing the ebpf lookup key from raw information
  */

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1922,4 +1922,9 @@ uint64_t h2o_socket_ebpf_lookup_flags(h2o_loop_t *loop, int (*init_key)(h2o_ebpf
     return 0;
 }
 
+uint64_t h2o_socket_ebpf_lookup_flags_sni(h2o_loop_t *loop, uint64_t flags, const char *server_name, size_t server_name_len)
+{
+    return flags;
+}
+
 #endif

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1572,6 +1572,13 @@ int h2o_socket_set_df_bit(int fd, int domain)
 #undef SETSOCKOPT
 }
 
+void h2o_socket_set_skip_tracing(h2o_socket_t *sock, int skip_tracing)
+{
+    sock->_skip_tracing = skip_tracing;
+    if (sock->ssl != NULL && sock->ssl->ptls != NULL)
+        ptls_set_skip_tracing(sock->ssl->ptls, skip_tracing);
+}
+
 void h2o_sliding_counter_stop(h2o_sliding_counter_t *counter, uint64_t now)
 {
     uint64_t elapsed;
@@ -1836,6 +1843,37 @@ static void report_ebpf_lookup_errors(h2o_error_reporter_t *reporter, uint64_t t
 
 static h2o_error_reporter_t track_ebpf_lookup = H2O_ERROR_REPORTER_INITIALIZER(report_ebpf_lookup_errors);
 
+#define DO_EBPF_RETURN_LOOKUP(func)                                                                                                \
+    do {                                                                                                                           \
+        if (return_map_fd >= 0) {                                                                                                  \
+            pid_t tid = (pid_t)syscall(SYS_gettid); /* gettid() was not available until glibc 2.30 (2019) */                       \
+            /* Make sure old flags do not exist, otherwise the subsequent logic will be unreliable. */                             \
+            if (ebpf_map_delete(return_map_fd, &tid) == 0 || errno == ENOENT) {                                                    \
+                do {                                                                                                               \
+                    func                                                                                                           \
+                } while (0);                                                                                                       \
+                if (ebpf_map_lookup(return_map_fd, &tid, &flags) == 0) {                                                           \
+                    h2o_error_reporter_record_success(&track_ebpf_lookup);                                                         \
+                } else {                                                                                                           \
+                    if (errno == ENOENT) {                                                                                         \
+                        /* ENOENT could be issued in some reasons even if BPF tries to insert the entry, for example:              \
+                         *  * the entry in LRU hash was evicted                                                                    \
+                         *  * the insert operation in BPF program failed with ENOMEM                                               \
+                         * We don't know the frequency for this ENOENT, so cap the number of logs.                                 \
+                         *                                                                                                         \
+                         * Other than the above reasons, ENOENT is issued when the tracer does not set the flags via h2o_return    \
+                         * map, See h2o:_private_socket_lookup_flags handler in h2olog for details. */                             \
+                        h2o_error_reporter_record_error(loop, &track_ebpf_lookup, 60000, 0);                                       \
+                    } else {                                                                                                       \
+                        h2o_perror("BPF_MAP_LOOKUP failed");                                                                       \
+                    }                                                                                                              \
+                }                                                                                                                  \
+            } else {                                                                                                               \
+                h2o_perror("BPF_MAP_DELETE failed");                                                                               \
+            }                                                                                                                      \
+        }                                                                                                                          \
+    } while (0)
+
 uint64_t h2o_socket_ebpf_lookup_flags(h2o_loop_t *loop, int (*init_key)(h2o_ebpf_map_key_t *key, void *cbdata), void *cbdata)
 {
     uint64_t flags = 0;
@@ -1846,37 +1884,21 @@ uint64_t h2o_socket_ebpf_lookup_flags(h2o_loop_t *loop, int (*init_key)(h2o_ebpf
         if (tracing_map_fd >= 0)
             ebpf_map_lookup(tracing_map_fd, &key, &flags);
 
-        if (H2O__PRIVATE_SOCKET_LOOKUP_FLAGS_ENABLED() && return_map_fd >= 0) {
-            pid_t tid = (pid_t)syscall(SYS_gettid); /* gettid() was not available until glibc 2.30 (2019) */
-
-            /* Make sure old flags do not exist, otherwise the subsequent logic will be unreliable. */
-            if (ebpf_map_delete(return_map_fd, &tid) == 0 || errno == ENOENT) {
-                H2O__PRIVATE_SOCKET_LOOKUP_FLAGS(tid, flags, &key);
-
-                if (ebpf_map_lookup(return_map_fd, &tid, &flags) == 0) {
-                    h2o_error_reporter_record_success(&track_ebpf_lookup);
-                } else {
-                    if (errno == ENOENT) {
-                        /* ENOENT could be issued in some reasons even if BPF tries to insert the entry, for example:
-                         *  * the entry in LRU hash was evicted
-                         *  * the insert operation in BPF program failed with ENOMEM
-                         * We don't know the frequency for this ENOENT, so cap the number of logs.
-                         *
-                         * Other than the above reasons, ENOENT is issued when the tracer does not set the flags via h2o_return
-                         * map, See h2o:_private_socket_lookup_flags handler in h2olog for details. */
-                        h2o_error_reporter_record_error(loop, &track_ebpf_lookup, 60000, 0);
-                    } else {
-                        h2o_perror("BPF_MAP_LOOKUP failed");
-                    }
-                }
-            } else {
-                h2o_perror("BPF_MAP_DELETE failed");
-            }
-        }
+        if (H2O__PRIVATE_SOCKET_LOOKUP_FLAGS_ENABLED())
+            DO_EBPF_RETURN_LOOKUP({ H2O__PRIVATE_SOCKET_LOOKUP_FLAGS(tid, flags, &key); });
     }
 
     return flags;
 }
+
+uint64_t h2o_socket_ebpf_lookup_flags_sni(h2o_loop_t *loop, uint64_t flags, const char *server_name, size_t server_name_len)
+{
+    if (H2O__PRIVATE_SOCKET_LOOKUP_FLAGS_SNI_ENABLED())
+        DO_EBPF_RETURN_LOOKUP({ H2O__PRIVATE_SOCKET_LOOKUP_FLAGS_SNI(tid, flags, server_name, server_name_len); });
+    return flags;
+}
+
+#undef DO_EBPF_RETURN_LOOKUP
 
 #else
 

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -1881,7 +1881,6 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
 
   fprintf(out_, "}\n");
-  fflush(out_);
 }
 
 

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -173,6 +173,7 @@ enum h2olog_event_id_t {
   H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE_RESET,
   H2OLOG_EVENT_ID_QUICLY_CONN_STATS,
   H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS,
+  H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS_SNI,
   H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST,
   H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST_HEADER,
   H2OLOG_EVENT_ID_H2O_SEND_RESPONSE,
@@ -652,6 +653,12 @@ struct h2olog_event_t {
       uint64_t original_flags;
       struct st_h2o_ebpf_map_key_t info;
     } _private_socket_lookup_flags;
+    struct { // h2o:_private_socket_lookup_flags_sni
+      pid_t tid;
+      uint64_t original_flags;
+      char server_name[STR_LEN];
+      size_t server_name_len;
+    } _private_socket_lookup_flags_sni;
     struct { // h2o:receive_request
       uint64_t conn_id;
       uint64_t req_id;
@@ -1625,6 +1632,17 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_c(out_, STR_LIT("size"), event->conn_stats.size);
     break;
   }
+  case H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS_SNI: { // h2o:_private_socket_lookup_flags_sni
+    json_write_pair_n(out_, STR_LIT("type"), STR_LIT("-private-socket-lookup-flags-sni"));
+    json_write_pair_c(out_, STR_LIT("tid"), event->tid);
+    json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("tid"), event->_private_socket_lookup_flags_sni.tid);
+    json_write_pair_c(out_, STR_LIT("original-flags"), event->_private_socket_lookup_flags_sni.original_flags);
+    json_write_pair_c(out_, STR_LIT("server-name"), event->_private_socket_lookup_flags_sni.server_name, (event->_private_socket_lookup_flags_sni.server_name_len < STR_LEN ? event->_private_socket_lookup_flags_sni.server_name_len : STR_LEN));
+    json_write_pair_c(out_, STR_LIT("server-name-len"), event->_private_socket_lookup_flags_sni.server_name_len);
+    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
+    break;
+  }
   case H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST: { // h2o:receive_request
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("receive-request"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
@@ -1958,6 +1976,7 @@ enum h2olog_event_id_t {
   H2OLOG_EVENT_ID_QUICLY_STREAM_ON_RECEIVE_RESET,
   H2OLOG_EVENT_ID_QUICLY_CONN_STATS,
   H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS,
+  H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS_SNI,
   H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST,
   H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST_HEADER,
   H2OLOG_EVENT_ID_H2O_SEND_RESPONSE,
@@ -2437,6 +2456,12 @@ struct h2olog_event_t {
       uint64_t original_flags;
       struct st_h2o_ebpf_map_key_t info;
     } _private_socket_lookup_flags;
+    struct { // h2o:_private_socket_lookup_flags_sni
+      pid_t tid;
+      uint64_t original_flags;
+      char server_name[STR_LEN];
+      size_t server_name_len;
+    } _private_socket_lookup_flags_sni;
     struct { // h2o:receive_request
       uint64_t conn_id;
       uint64_t req_id;
@@ -2553,6 +2578,12 @@ BPF_PERF_OUTPUT(events);
 
 // HTTP/3 tracing
 BPF_HASH(h2o_to_quicly_conn, u64, u32);
+
+#if H2OLOG_SELECTIVE_TRACING
+// A pinned BPF object to return a value to h2o.
+// The table size must be larger than the number of threads in h2o.
+BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
+#endif
 
 // tracepoint sched:sched_process_exit
 int trace_sched_process_exit(struct tracepoint__sched__sched_process_exit *ctx) {
@@ -4234,10 +4265,6 @@ int trace_quicly__conn_stats(struct pt_regs *ctx) {
 }
 
 #if H2OLOG_SELECTIVE_TRACING
-// A pinned BPF object to return a value to h2o.
-// The table size must be larger than the number of threads in h2o.
-BPF_TABLE_PINNED("lru_hash", pid_t, uint64_t, h2o_return, H2O_EBPF_RETURN_MAP_SIZE, H2O_EBPF_RETURN_MAP_PATH);
-
 // h2o:_private_socket_lookup_flags
 int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
   const void *buf = NULL;
@@ -4268,6 +4295,45 @@ int trace_h2o___private_socket_lookup_flags(struct pt_regs *ctx) {
   int64_t ret = h2o_return.insert(&event._private_socket_lookup_flags.tid, &flags);
   if (ret != 0)
     bpf_trace_printk("failed to insert 0x%llx in trace_h2o___private_socket_lookup_flags with errno=%lld\n", flags, -ret);
+
+  return 0;
+}
+#endif
+
+
+#if H2OLOG_SELECTIVE_TRACING
+// h2o:_private_socket_lookup_flags_sni
+int trace_h2o___private_socket_lookup_flags_sni(struct pt_regs *ctx) {
+  const void *buf = NULL;
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_H2O__PRIVATE_SOCKET_LOOKUP_FLAGS_SNI, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
+
+  // pid_t tid
+  bpf_usdt_readarg(1, ctx, &event._private_socket_lookup_flags_sni.tid);
+  // uint64_t original_flags
+  bpf_usdt_readarg(2, ctx, &event._private_socket_lookup_flags_sni.original_flags);
+  // const char * server_name
+  bpf_usdt_readarg(3, ctx, &buf);
+  bpf_probe_read(&event._private_socket_lookup_flags_sni.server_name, sizeof(event._private_socket_lookup_flags_sni.server_name), buf);
+  // size_t server_name_len
+  bpf_usdt_readarg(4, ctx, &event._private_socket_lookup_flags_sni.server_name_len);
+
+  uint64_t flags  = event._private_socket_lookup_flags_sni.original_flags;
+  if ((flags & H2O_EBPF_FLAGS_SKIP_TRACING_BIT) != 0) {
+#ifdef H2OLOG_IS_SAMPLING_SNI
+    size_t server_name_len = event._private_socket_lookup_flags_sni.server_name_len;
+    if (server_name_len > sizeof(event._private_socket_lookup_flags_sni.server_name))
+      server_name_len = sizeof(event._private_socket_lookup_flags_sni.server_name);
+    if (H2OLOG_IS_SAMPLING_SNI(event._private_socket_lookup_flags_sni.server_name, server_name_len)
+#ifdef H2OLOG_SAMPLING_RATE_U32
+        && bpf_get_prandom_u32() < H2OLOG_SAMPLING_RATE_U32
+#endif
+      )
+      flags &= ~H2O_EBPF_FLAGS_SKIP_TRACING_BIT;
+#endif
+  }
+  int64_t ret = h2o_return.insert(&event._private_socket_lookup_flags_sni.tid, &flags);
+  if (ret != 0)
+    bpf_trace_printk("failed to insert 0x%lx in trace_h2o___private_socket_lookup_flags_sni with errno=%lld\n", flags, -ret);
 
   return 0;
 }

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -1881,6 +1881,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
 
   fprintf(out_, "}\n");
+  fflush(out_);
 }
 
 

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -46,23 +46,27 @@ static void usage(void)
     printf(R"(h2olog (h2o v%s)
 Usage: h2olog -p PID
 Optional arguments:
-    -d Print debugging information (-dd shows more)
-    -h Print this help and exit
-    -l Print the list of available tracepoints and exit
-    -H Trace HTTP requests and responses in varnishlog-like format
-    -s RESPONSE_HEADER_NAME A response header name to show, e.g. "content-type"
-    -t TRACEPOINT A tracepoint, or fully-qualified probe name, to show,
-                  including a glob pattern, e.g. "quicly:accept", "h2o:*"
-    -S RATE Enable random sampling per connection (0.0-1.0)
-            Requires for h2o to have `usdt-selective-tracing: ON` in its config file
-    -a Include application data which are omitted by default
-    -r Run without dropping root privilege
-    -w Path to write the output (default: stdout)
+  -d                Print debugging information (-dd shows more).
+  -h                Print this help and exit.
+  -l                Print the list of available tracepoints and exit.
+  -H                Trace HTTP requests and responses in varnishlog-like format.
+  -s <header-name>  A response header name to show, e.g. "content-type".
+  -t <tracepoint>   A tracepoint, or fully-qualified probe name to trace. Glob
+                    patterns can be used; e.g., "quicly:accept", "h2o:*".
+  -S <rate>         Enable random sampling per connection (0.0-1.0). Requires
+                    `usdt-selective-tracing: ON` must be specified in the h2o
+                    config file.
+  -A <ip-address>   Limit connections being traced to those coming from the
+                    specified address. Requries use of `usdt-selective-tracing`.
+  -a                Include application data which are omitted by default.
+  -r                Run without dropping root privilege.
+  -w <path>         Path to write the output (default: stdout).
 
 Examples:
-    h2olog -p $(pgrep -o h2o) -H
-    h2olog -p $(pgrep -o h2o) -t quicly:accept -t quicly:free
-    h2olog -p $(pgrep -o h2o) -t h2o:send_response_header -t h2o:h3s_accept -t h2o:h3s_destroy -s alt-svc
+  h2olog -p $(pgrep -o h2o) -H
+  h2olog -p $(pgrep -o h2o) -t quicly:accept -t quicly:free
+  h2olog -p $(pgrep -o h2o) -t h2o:send_response_header -t h2o:h3s_accept \
+         -t h2o:h3s_destroy -s alt-svc
 )",
            H2O_VERSION);
     return;

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Fastly, Inc., Toru Maesaka, Goro Fuji
+ * Copyright (c) 2019-2021 Fastly, Inc., Toru Maesaka, Goro Fuji, Kazuho Oku
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -755,6 +755,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
 
   fprintf(out_, "}\n");
+  fflush(out_);
 """
   handle_event_func += "}\n"
 

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -755,7 +755,6 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
   }
 
   fprintf(out_, "}\n");
-  fflush(out_);
 """
   handle_event_func += "}\n"
 

--- a/src/main.c
+++ b/src/main.c
@@ -315,6 +315,35 @@ static void setup_ecc_key(SSL_CTX *ssl_ctx)
 #endif
 }
 
+static void on_sni_update_tracing(void *conn, int is_quic, const char *server_name, size_t server_name_len)
+{
+    h2o_loop_t *loop;
+    int cur_skip_tracing;
+
+    if (is_quic) {
+        h2o_http3_conn_t *h3conn = *quicly_get_data(conn);
+        loop = h3conn->super.ctx->loop;
+        cur_skip_tracing = ptls_skip_tracing(quicly_get_tls(conn));
+    } else {
+        h2o_socket_t *sock = conn;
+        loop = h2o_socket_get_loop(sock);
+        cur_skip_tracing = h2o_socket_skip_tracing(sock);
+    }
+
+    uint64_t flags = cur_skip_tracing ? H2O_EBPF_FLAGS_SKIP_TRACING_BIT : 0;
+    flags = h2o_socket_ebpf_lookup_flags_sni(loop, flags, server_name, server_name_len);
+
+    int new_skip_tracing = (flags & H2O_EBPF_FLAGS_SKIP_TRACING_BIT) != 0;
+
+    if (cur_skip_tracing != new_skip_tracing) {
+        if (is_quic) {
+            ptls_set_skip_tracing(quicly_get_tls(conn), new_skip_tracing);
+        } else {
+            h2o_socket_set_skip_tracing(conn, new_skip_tracing);
+        }
+    }
+}
+
 static struct listener_ssl_config_t *resolve_sni(struct listener_config_t *listener, const char *name, size_t name_len)
 {
     size_t i, j;
@@ -357,10 +386,13 @@ static int on_sni_callback(SSL *ssl, int *ad, void *arg)
     const char *server_name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
 
     if (server_name != NULL) {
-        struct listener_ssl_config_t *resolved = resolve_sni(listener, server_name, strlen(server_name));
+        size_t server_name_len = strlen(server_name);
+        h2o_socket_t *sock = SSL_get_app_data(ssl);
+        on_sni_update_tracing(sock, 0, server_name, server_name_len);
+        struct listener_ssl_config_t *resolved = resolve_sni(listener, server_name, server_name_len);
         if (resolved->ctx != SSL_get_SSL_CTX(ssl)) {
             SSL_set_SSL_CTX(ssl, resolved->ctx);
-            set_tcp_congestion_controller(SSL_get_app_data(ssl), resolved->tcp_congestion_controller);
+            set_tcp_congestion_controller(sock, resolved->tcp_congestion_controller);
         }
     }
 
@@ -380,12 +412,15 @@ static int on_client_hello_ptls(ptls_on_client_hello_t *_self, ptls_t *tls, ptls
 
     /* handle SNI */
     if (params->server_name.base != NULL) {
+        void *conn = *ptls_get_data_ptr(tls);
+        on_sni_update_tracing(conn, self->listener->quic.ctx != NULL, (const char *)params->server_name.base,
+                              params->server_name.len);
         ssl_config = resolve_sni(self->listener, (const char *)params->server_name.base, params->server_name.len);
         ptls_context_t *newctx = h2o_socket_ssl_get_picotls_context(ssl_config->ctx);
         ptls_set_context(tls, newctx);
         ptls_set_server_name(tls, (const char *)params->server_name.base, params->server_name.len);
         if (self->listener->quic.ctx == NULL)
-            set_tcp_congestion_controller(*ptls_get_data_ptr(tls), ssl_config->tcp_congestion_controller);
+            set_tcp_congestion_controller(conn, ssl_config->tcp_congestion_controller);
     } else {
         ssl_config = self->listener->ssl.entries[0];
         assert(ssl_config != NULL);


### PR DESCRIPTION
This PR adds `-N` option to h2olog so that we can limit the traces being obtained to specific hosts.

* For connections being selected by `-N`, events prior to processing the SNI is not recorded.
* `-N` option can be repeated multiple times. All entries specified by `-A` and `-N` are logically ORed. Ratio specified by `-S` is applied to the set of connections specified by `-A` and `-N`. To give an example, when `-A 127.0.0.1/32 -N www.example.com -S 0.25` is specified, 25% of connections that either originate from 127.0.0.1 or carry an SNI value of www.example.com will be traced.