### PR TITLE
[quic] [stats] Implement http3.* statistics output

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -691,11 +691,11 @@ struct st_h2o_context_t {
              * number of forwarded packets received from another node in a cluster
              */
             uint64_t forwarded_packet_received;
-            /**
-             * number of lost packets
-             */
-            uint64_t packet_lost;
         } events;
+        /**
+         * aggrgegated quicly stats
+         */
+        QUICLY_STATS_PREBUILT_FIELDS;
     } http3;
 
     struct {

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -693,7 +693,7 @@ struct st_h2o_context_t {
             uint64_t forwarded_packet_received;
         } events;
         /**
-         * aggrgegated quicly stats
+         * aggregated quicly stats
          */
         QUICLY_STATS_PREBUILT_FIELDS;
     } http3;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -691,6 +691,10 @@ struct st_h2o_context_t {
              * number of forwarded packets received from another node in a cluster
              */
             uint64_t forwarded_packet_received;
+            /**
+             * number of lost packets
+             */
+            uint64_t packet_lost;
         } events;
     } http3;
 

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -32,9 +32,11 @@ struct st_events_status_ctx_t {
     uint64_t h1_request_timeout;
     uint64_t h1_request_io_timeout;
     uint64_t ssl_errors;
-    uint64_t h3_packet_forwarded;
-    uint64_t h3_forwarded_packet_received;
-    uint64_t h3_packet_lost;
+    struct {
+        uint64_t packet_forwarded;
+        uint64_t forwarded_packet_received;
+        QUICLY_STATS_PREBUILT_FIELDS;
+    } http3;
     pthread_mutex_t mutex;
 };
 
@@ -57,10 +59,66 @@ static void events_status_per_thread(void *priv, h2o_context_t *ctx)
     esc->h2_idle_timeout += ctx->http2.events.idle_timeouts;
     esc->h1_request_timeout += ctx->http1.events.request_timeouts;
     esc->h1_request_io_timeout += ctx->http1.events.request_io_timeouts;
-    esc->h3_packet_forwarded += ctx->http3.events.packet_forwarded;
-    esc->h3_forwarded_packet_received += ctx->http3.events.forwarded_packet_received;
-    esc->h3_packet_lost += ctx->http3.events.packet_lost;
-
+    esc->http3.packet_forwarded += ctx->http3.events.packet_forwarded;
+    esc->http3.forwarded_packet_received += ctx->http3.events.forwarded_packet_received;
+    esc->http3.num_packets.received += ctx->http3.num_packets.received;
+    esc->http3.num_packets.decryption_failed += ctx->http3.num_packets.decryption_failed;
+    esc->http3.num_packets.sent += ctx->http3.num_packets.sent;
+    esc->http3.num_packets.lost += ctx->http3.num_packets.lost;
+    esc->http3.num_packets.lost_time_threshold += ctx->http3.num_packets.lost_time_threshold;
+    esc->http3.num_packets.ack_received += ctx->http3.num_packets.ack_received;
+    esc->http3.num_packets.late_acked += ctx->http3.num_packets.late_acked;
+    esc->http3.num_bytes.received += ctx->http3.num_bytes.received;
+    esc->http3.num_bytes.sent += ctx->http3.num_bytes.sent;
+    esc->http3.num_frames_sent.padding += ctx->http3.num_frames_sent.padding;
+    esc->http3.num_frames_sent.ping += ctx->http3.num_frames_sent.ping;
+    esc->http3.num_frames_sent.ack += ctx->http3.num_frames_sent.ack;
+    esc->http3.num_frames_sent.reset_stream += ctx->http3.num_frames_sent.reset_stream;
+    esc->http3.num_frames_sent.stop_sending += ctx->http3.num_frames_sent.stop_sending;
+    esc->http3.num_frames_sent.crypto += ctx->http3.num_frames_sent.crypto;
+    esc->http3.num_frames_sent.new_token += ctx->http3.num_frames_sent.new_token;
+    esc->http3.num_frames_sent.stream += ctx->http3.num_frames_sent.stream;
+    esc->http3.num_frames_sent.max_data += ctx->http3.num_frames_sent.max_data;
+    esc->http3.num_frames_sent.max_stream_data += ctx->http3.num_frames_sent.max_stream_data;
+    esc->http3.num_frames_sent.max_streams_bidi += ctx->http3.num_frames_sent.max_streams_bidi;
+    esc->http3.num_frames_sent.max_streams_uni += ctx->http3.num_frames_sent.max_streams_uni;
+    esc->http3.num_frames_sent.data_blocked += ctx->http3.num_frames_sent.data_blocked;
+    esc->http3.num_frames_sent.stream_data_blocked += ctx->http3.num_frames_sent.stream_data_blocked;
+    esc->http3.num_frames_sent.streams_blocked += ctx->http3.num_frames_sent.streams_blocked;
+    esc->http3.num_frames_sent.new_connection_id += ctx->http3.num_frames_sent.new_connection_id;
+    esc->http3.num_frames_sent.retire_connection_id += ctx->http3.num_frames_sent.retire_connection_id;
+    esc->http3.num_frames_sent.path_challenge += ctx->http3.num_frames_sent.path_challenge;
+    esc->http3.num_frames_sent.path_response += ctx->http3.num_frames_sent.path_response;
+    esc->http3.num_frames_sent.transport_close += ctx->http3.num_frames_sent.transport_close;
+    esc->http3.num_frames_sent.application_close += ctx->http3.num_frames_sent.application_close;
+    esc->http3.num_frames_sent.handshake_done += ctx->http3.num_frames_sent.handshake_done;
+    esc->http3.num_frames_sent.datagram += ctx->http3.num_frames_sent.datagram;
+    esc->http3.num_frames_sent.ack_frequency += ctx->http3.num_frames_sent.ack_frequency;
+    esc->http3.num_frames_received.padding += ctx->http3.num_frames_received.padding;
+    esc->http3.num_frames_received.ping += ctx->http3.num_frames_received.ping;
+    esc->http3.num_frames_received.ack += ctx->http3.num_frames_received.ack;
+    esc->http3.num_frames_received.reset_stream += ctx->http3.num_frames_received.reset_stream;
+    esc->http3.num_frames_received.stop_sending += ctx->http3.num_frames_received.stop_sending;
+    esc->http3.num_frames_received.crypto += ctx->http3.num_frames_received.crypto;
+    esc->http3.num_frames_received.new_token += ctx->http3.num_frames_received.new_token;
+    esc->http3.num_frames_received.stream += ctx->http3.num_frames_received.stream;
+    esc->http3.num_frames_received.max_data += ctx->http3.num_frames_received.max_data;
+    esc->http3.num_frames_received.max_stream_data += ctx->http3.num_frames_received.max_stream_data;
+    esc->http3.num_frames_received.max_streams_bidi += ctx->http3.num_frames_received.max_streams_bidi;
+    esc->http3.num_frames_received.max_streams_uni += ctx->http3.num_frames_received.max_streams_uni;
+    esc->http3.num_frames_received.data_blocked += ctx->http3.num_frames_received.data_blocked;
+    esc->http3.num_frames_received.stream_data_blocked += ctx->http3.num_frames_received.stream_data_blocked;
+    esc->http3.num_frames_received.streams_blocked += ctx->http3.num_frames_received.streams_blocked;
+    esc->http3.num_frames_received.new_connection_id += ctx->http3.num_frames_received.new_connection_id;
+    esc->http3.num_frames_received.retire_connection_id += ctx->http3.num_frames_received.retire_connection_id;
+    esc->http3.num_frames_received.path_challenge += ctx->http3.num_frames_received.path_challenge;
+    esc->http3.num_frames_received.path_response += ctx->http3.num_frames_received.path_response;
+    esc->http3.num_frames_received.transport_close += ctx->http3.num_frames_received.transport_close;
+    esc->http3.num_frames_received.application_close += ctx->http3.num_frames_received.application_close;
+    esc->http3.num_frames_received.handshake_done += ctx->http3.num_frames_received.handshake_done;
+    esc->http3.num_frames_received.datagram += ctx->http3.num_frames_received.datagram;
+    esc->http3.num_frames_received.ack_frequency += ctx->http3.num_frames_received.ack_frequency;
+    esc->http3.num_ptos += ctx->http3.num_ptos;
     pthread_mutex_unlock(&esc->mutex);
 }
 
@@ -82,7 +140,7 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
 
 #define H1_AGG_ERR(status_) esc->emitted_status_errors[H2O_STATUS_ERROR_##status_]
 #define H2_AGG_ERR(err_) esc->h2_protocol_level_errors[-H2O_HTTP2_ERROR_##err_]
-#define BUFSIZE (2 * 1024)
+#define BUFSIZE (8 * 1024)
     ret.base = h2o_mem_alloc_pool(&req->pool, char, BUFSIZE);
     ret.len = snprintf(ret.base, BUFSIZE,
                        ",\n"
@@ -114,7 +172,64 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        " \"http2.idle-timeout\": %" PRIu64 ", \n"
                        " \"http3.packet-forwarded\": %" PRIu64 ", \n"
                        " \"http3.forwarded-packet-received\": %" PRIu64 ", \n"
-                       " \"http3.packet_lost\": %" PRIu64 ", \n"
+                       " \"http3.num_packets.received\": %" PRIu64 ", \n"
+                       " \"http3.num_packets.decryption_failed\": %" PRIu64 ", \n"
+                       " \"http3.num_packets.sent\": %" PRIu64 ", \n"
+                       " \"http3.num_packets.lost\": %" PRIu64 ", \n"
+                       " \"http3.num_packets.lost_time_threshold\": %" PRIu64 ", \n"
+                       " \"http3.num_packets.ack_received\": %" PRIu64 ", \n"
+                       " \"http3.num_packets.late_acked\": %" PRIu64 ", \n"
+                       " \"http3.num_bytes.received\": %" PRIu64 ", \n"
+                       " \"http3.num_bytes.sent\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.padding\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.ping\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.ack\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.reset_stream\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.stop_sending\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.crypto\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.new_token\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.stream\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.max_data\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.max_stream_data\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.max_streams_bidi\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.max_streams_uni\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.data_blocked\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.stream_data_blocked\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.streams_blocked\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.new_connection_id\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.retire_connection_id\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.path_challenge\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.path_response\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.transport_close\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.application_close\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.handshake_done\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.datagram\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_sent.ack_frequency\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.padding\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.ping\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.ack\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.reset_stream\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.stop_sending\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.crypto\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.new_token\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.stream\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.max_data\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.max_stream_data\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.max_streams_bidi\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.max_streams_uni\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.data_blocked\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.stream_data_blocked\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.streams_blocked\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.new_connection_id\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.retire_connection_id\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.path_challenge\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.path_response\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.transport_close\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.application_close\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.handshake_done\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.datagram\": %" PRIu64 ", \n"
+                       " \"http3.num_frames_received.ack_frequency\": %" PRIu64 ", \n"
+                       " \"http3.num_ptos\": %" PRIu64 ", \n"
                        " \"ssl.errors\": %" PRIu64 ", \n"
                        " \"memory.mmap_errors\": %zu\n",
                        H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
@@ -122,8 +237,33 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL), H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT),
                        H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE), H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL),
                        H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT), H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY),
-                       esc->h2_read_closed, esc->h2_write_closed, esc->h2_idle_timeout, esc->h3_packet_forwarded,
-                       esc->h3_forwarded_packet_received, esc->h3_packet_lost, esc->ssl_errors, h2o_mmap_errors);
+                       esc->h2_read_closed, esc->h2_write_closed, esc->h2_idle_timeout, esc->http3.packet_forwarded,
+                       esc->http3.forwarded_packet_received,  esc->http3.num_packets.received, esc->http3.num_packets.decryption_failed,
+                       esc->http3.num_packets.sent, esc->http3.num_packets.lost, esc->http3.num_packets.lost_time_threshold,
+                       esc->http3.num_packets.ack_received, esc->http3.num_packets.late_acked, esc->http3.num_bytes.received,
+                       esc->http3.num_bytes.sent, esc->http3.num_frames_sent.padding, esc->http3.num_frames_sent.ping,
+                       esc->http3.num_frames_sent.ack, esc->http3.num_frames_sent.reset_stream, esc->http3.num_frames_sent.stop_sending,
+                       esc->http3.num_frames_sent.crypto, esc->http3.num_frames_sent.new_token, esc->http3.num_frames_sent.stream,
+                       esc->http3.num_frames_sent.max_data, esc->http3.num_frames_sent.max_stream_data,
+                       esc->http3.num_frames_sent.max_streams_bidi, esc->http3.num_frames_sent.max_streams_uni,
+                       esc->http3.num_frames_sent.data_blocked, esc->http3.num_frames_sent.stream_data_blocked,
+                       esc->http3.num_frames_sent.streams_blocked, esc->http3.num_frames_sent.new_connection_id,
+                       esc->http3.num_frames_sent.retire_connection_id, esc->http3.num_frames_sent.path_challenge,
+                       esc->http3.num_frames_sent.path_response, esc->http3.num_frames_sent.transport_close,
+                       esc->http3.num_frames_sent.application_close, esc->http3.num_frames_sent.handshake_done,
+                       esc->http3.num_frames_sent.datagram, esc->http3.num_frames_sent.ack_frequency,
+                       esc->http3.num_frames_received.padding, esc->http3.num_frames_received.ping, esc->http3.num_frames_received.ack,
+                       esc->http3.num_frames_received.reset_stream, esc->http3.num_frames_received.stop_sending,
+                       esc->http3.num_frames_received.crypto, esc->http3.num_frames_received.new_token,
+                       esc->http3.num_frames_received.stream, esc->http3.num_frames_received.max_data,
+                       esc->http3.num_frames_received.max_stream_data, esc->http3.num_frames_received.max_streams_bidi,
+                       esc->http3.num_frames_received.max_streams_uni, esc->http3.num_frames_received.data_blocked,
+                       esc->http3.num_frames_received.stream_data_blocked, esc->http3.num_frames_received.streams_blocked,
+                       esc->http3.num_frames_received.new_connection_id, esc->http3.num_frames_received.retire_connection_id,
+                       esc->http3.num_frames_received.path_challenge, esc->http3.num_frames_received.path_response,
+                       esc->http3.num_frames_received.transport_close, esc->http3.num_frames_received.application_close,
+                       esc->http3.num_frames_received.handshake_done, esc->http3.num_frames_received.datagram,
+                       esc->http3.num_frames_received.ack_frequency, esc->http3.num_ptos, esc->ssl_errors, h2o_mmap_errors);
     pthread_mutex_destroy(&esc->mutex);
     free(esc);
     return ret;

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -34,6 +34,7 @@ struct st_events_status_ctx_t {
     uint64_t ssl_errors;
     uint64_t h3_packet_forwarded;
     uint64_t h3_forwarded_packet_received;
+    uint64_t h3_packet_lost;
     pthread_mutex_t mutex;
 };
 
@@ -58,6 +59,7 @@ static void events_status_per_thread(void *priv, h2o_context_t *ctx)
     esc->h1_request_io_timeout += ctx->http1.events.request_io_timeouts;
     esc->h3_packet_forwarded += ctx->http3.events.packet_forwarded;
     esc->h3_forwarded_packet_received += ctx->http3.events.forwarded_packet_received;
+    esc->h3_packet_lost += ctx->http3.events.packet_lost;
 
     pthread_mutex_unlock(&esc->mutex);
 }
@@ -112,6 +114,7 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        " \"http2.idle-timeout\": %" PRIu64 ", \n"
                        " \"http3.packet-forwarded\": %" PRIu64 ", \n"
                        " \"http3.forwarded-packet-received\": %" PRIu64 ", \n"
+                       " \"http3.packet_lost\": %" PRIu64 ", \n"
                        " \"ssl.errors\": %" PRIu64 ", \n"
                        " \"memory.mmap_errors\": %zu\n",
                        H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
@@ -120,7 +123,7 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE), H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL),
                        H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT), H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY),
                        esc->h2_read_closed, esc->h2_write_closed, esc->h2_idle_timeout, esc->h3_packet_forwarded,
-                       esc->h3_forwarded_packet_received, esc->ssl_errors, h2o_mmap_errors);
+                       esc->h3_forwarded_packet_received, esc->h3_packet_lost, esc->ssl_errors, h2o_mmap_errors);
     pthread_mutex_destroy(&esc->mutex);
     free(esc);
     return ret;

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -142,128 +142,126 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
 #define H2_AGG_ERR(err_) esc->h2_protocol_level_errors[-H2O_HTTP2_ERROR_##err_]
 #define BUFSIZE (8 * 1024)
     ret.base = h2o_mem_alloc_pool(&req->pool, char, BUFSIZE);
-    ret.len = snprintf(ret.base, BUFSIZE,
-                       ",\n"
-                       " \"status-errors.400\": %" PRIu64 ",\n"
-                       " \"status-errors.403\": %" PRIu64 ",\n"
-                       " \"status-errors.404\": %" PRIu64 ",\n"
-                       " \"status-errors.405\": %" PRIu64 ",\n"
-                       " \"status-errors.416\": %" PRIu64 ",\n"
-                       " \"status-errors.417\": %" PRIu64 ",\n"
-                       " \"status-errors.500\": %" PRIu64 ",\n"
-                       " \"status-errors.502\": %" PRIu64 ",\n"
-                       " \"status-errors.503\": %" PRIu64 ",\n"
-                       " \"http1-errors.request-timeout\": %" PRIu64 ",\n"
-                       " \"http1-errors.request-io-timeout\": %" PRIu64 ",\n"
-                       " \"http2-errors.protocol\": %" PRIu64 ", \n"
-                       " \"http2-errors.internal\": %" PRIu64 ", \n"
-                       " \"http2-errors.flow-control\": %" PRIu64 ", \n"
-                       " \"http2-errors.settings-timeout\": %" PRIu64 ", \n"
-                       " \"http2-errors.stream-closed\": %" PRIu64 ", \n"
-                       " \"http2-errors.frame-size\": %" PRIu64 ", \n"
-                       " \"http2-errors.refused-stream\": %" PRIu64 ", \n"
-                       " \"http2-errors.cancel\": %" PRIu64 ", \n"
-                       " \"http2-errors.compression\": %" PRIu64 ", \n"
-                       " \"http2-errors.connect\": %" PRIu64 ", \n"
-                       " \"http2-errors.enhance-your-calm\": %" PRIu64 ", \n"
-                       " \"http2-errors.inadequate-security\": %" PRIu64 ", \n"
-                       " \"http2.read-closed\": %" PRIu64 ", \n"
-                       " \"http2.write-closed\": %" PRIu64 ", \n"
-                       " \"http2.idle-timeout\": %" PRIu64 ", \n"
-                       " \"http3.packet-forwarded\": %" PRIu64 ", \n"
-                       " \"http3.forwarded-packet-received\": %" PRIu64 ", \n"
-                       " \"http3.num_packets.received\": %" PRIu64 ", \n"
-                       " \"http3.num_packets.decryption_failed\": %" PRIu64 ", \n"
-                       " \"http3.num_packets.sent\": %" PRIu64 ", \n"
-                       " \"http3.num_packets.lost\": %" PRIu64 ", \n"
-                       " \"http3.num_packets.lost_time_threshold\": %" PRIu64 ", \n"
-                       " \"http3.num_packets.ack_received\": %" PRIu64 ", \n"
-                       " \"http3.num_packets.late_acked\": %" PRIu64 ", \n"
-                       " \"http3.num_bytes.received\": %" PRIu64 ", \n"
-                       " \"http3.num_bytes.sent\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.padding\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.ping\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.ack\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.reset_stream\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.stop_sending\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.crypto\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.new_token\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.stream\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.max_data\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.max_stream_data\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.max_streams_bidi\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.max_streams_uni\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.data_blocked\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.stream_data_blocked\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.streams_blocked\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.new_connection_id\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.retire_connection_id\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.path_challenge\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.path_response\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.transport_close\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.application_close\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.handshake_done\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.datagram\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_sent.ack_frequency\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.padding\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.ping\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.ack\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.reset_stream\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.stop_sending\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.crypto\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.new_token\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.stream\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.max_data\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.max_stream_data\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.max_streams_bidi\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.max_streams_uni\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.data_blocked\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.stream_data_blocked\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.streams_blocked\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.new_connection_id\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.retire_connection_id\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.path_challenge\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.path_response\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.transport_close\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.application_close\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.handshake_done\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.datagram\": %" PRIu64 ", \n"
-                       " \"http3.num_frames_received.ack_frequency\": %" PRIu64 ", \n"
-                       " \"http3.num_ptos\": %" PRIu64 ", \n"
-                       " \"ssl.errors\": %" PRIu64 ", \n"
-                       " \"memory.mmap_errors\": %zu\n",
-                       H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
-                       H1_AGG_ERR(500), H1_AGG_ERR(502), H1_AGG_ERR(503), esc->h1_request_timeout, esc->h1_request_io_timeout,
-                       H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL), H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT),
-                       H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE), H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL),
-                       H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT), H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY),
-                       esc->h2_read_closed, esc->h2_write_closed, esc->h2_idle_timeout, esc->http3.packet_forwarded,
-                       esc->http3.forwarded_packet_received,  esc->http3.num_packets.received, esc->http3.num_packets.decryption_failed,
-                       esc->http3.num_packets.sent, esc->http3.num_packets.lost, esc->http3.num_packets.lost_time_threshold,
-                       esc->http3.num_packets.ack_received, esc->http3.num_packets.late_acked, esc->http3.num_bytes.received,
-                       esc->http3.num_bytes.sent, esc->http3.num_frames_sent.padding, esc->http3.num_frames_sent.ping,
-                       esc->http3.num_frames_sent.ack, esc->http3.num_frames_sent.reset_stream, esc->http3.num_frames_sent.stop_sending,
-                       esc->http3.num_frames_sent.crypto, esc->http3.num_frames_sent.new_token, esc->http3.num_frames_sent.stream,
-                       esc->http3.num_frames_sent.max_data, esc->http3.num_frames_sent.max_stream_data,
-                       esc->http3.num_frames_sent.max_streams_bidi, esc->http3.num_frames_sent.max_streams_uni,
-                       esc->http3.num_frames_sent.data_blocked, esc->http3.num_frames_sent.stream_data_blocked,
-                       esc->http3.num_frames_sent.streams_blocked, esc->http3.num_frames_sent.new_connection_id,
-                       esc->http3.num_frames_sent.retire_connection_id, esc->http3.num_frames_sent.path_challenge,
-                       esc->http3.num_frames_sent.path_response, esc->http3.num_frames_sent.transport_close,
-                       esc->http3.num_frames_sent.application_close, esc->http3.num_frames_sent.handshake_done,
-                       esc->http3.num_frames_sent.datagram, esc->http3.num_frames_sent.ack_frequency,
-                       esc->http3.num_frames_received.padding, esc->http3.num_frames_received.ping, esc->http3.num_frames_received.ack,
-                       esc->http3.num_frames_received.reset_stream, esc->http3.num_frames_received.stop_sending,
-                       esc->http3.num_frames_received.crypto, esc->http3.num_frames_received.new_token,
-                       esc->http3.num_frames_received.stream, esc->http3.num_frames_received.max_data,
-                       esc->http3.num_frames_received.max_stream_data, esc->http3.num_frames_received.max_streams_bidi,
-                       esc->http3.num_frames_received.max_streams_uni, esc->http3.num_frames_received.data_blocked,
-                       esc->http3.num_frames_received.stream_data_blocked, esc->http3.num_frames_received.streams_blocked,
-                       esc->http3.num_frames_received.new_connection_id, esc->http3.num_frames_received.retire_connection_id,
-                       esc->http3.num_frames_received.path_challenge, esc->http3.num_frames_received.path_response,
-                       esc->http3.num_frames_received.transport_close, esc->http3.num_frames_received.application_close,
-                       esc->http3.num_frames_received.handshake_done, esc->http3.num_frames_received.datagram,
-                       esc->http3.num_frames_received.ack_frequency, esc->http3.num_ptos, esc->ssl_errors, h2o_mmap_errors);
+    ret.len = snprintf(
+        ret.base, BUFSIZE, ",\n"
+                           " \"status-errors.400\": %" PRIu64 ",\n"
+                           " \"status-errors.403\": %" PRIu64 ",\n"
+                           " \"status-errors.404\": %" PRIu64 ",\n"
+                           " \"status-errors.405\": %" PRIu64 ",\n"
+                           " \"status-errors.416\": %" PRIu64 ",\n"
+                           " \"status-errors.417\": %" PRIu64 ",\n"
+                           " \"status-errors.500\": %" PRIu64 ",\n"
+                           " \"status-errors.502\": %" PRIu64 ",\n"
+                           " \"status-errors.503\": %" PRIu64 ",\n"
+                           " \"http1-errors.request-timeout\": %" PRIu64 ",\n"
+                           " \"http1-errors.request-io-timeout\": %" PRIu64 ",\n"
+                           " \"http2-errors.protocol\": %" PRIu64 ", \n"
+                           " \"http2-errors.internal\": %" PRIu64 ", \n"
+                           " \"http2-errors.flow-control\": %" PRIu64 ", \n"
+                           " \"http2-errors.settings-timeout\": %" PRIu64 ", \n"
+                           " \"http2-errors.stream-closed\": %" PRIu64 ", \n"
+                           " \"http2-errors.frame-size\": %" PRIu64 ", \n"
+                           " \"http2-errors.refused-stream\": %" PRIu64 ", \n"
+                           " \"http2-errors.cancel\": %" PRIu64 ", \n"
+                           " \"http2-errors.compression\": %" PRIu64 ", \n"
+                           " \"http2-errors.connect\": %" PRIu64 ", \n"
+                           " \"http2-errors.enhance-your-calm\": %" PRIu64 ", \n"
+                           " \"http2-errors.inadequate-security\": %" PRIu64 ", \n"
+                           " \"http2.read-closed\": %" PRIu64 ", \n"
+                           " \"http2.write-closed\": %" PRIu64 ", \n"
+                           " \"http2.idle-timeout\": %" PRIu64 ", \n"
+                           " \"http3.packet-forwarded\": %" PRIu64 ", \n"
+                           " \"http3.forwarded-packet-received\": %" PRIu64 ", \n"
+                           " \"http3.num_packets.received\": %" PRIu64 ", \n"
+                           " \"http3.num_packets.decryption_failed\": %" PRIu64 ", \n"
+                           " \"http3.num_packets.sent\": %" PRIu64 ", \n"
+                           " \"http3.num_packets.lost\": %" PRIu64 ", \n"
+                           " \"http3.num_packets.lost_time_threshold\": %" PRIu64 ", \n"
+                           " \"http3.num_packets.ack_received\": %" PRIu64 ", \n"
+                           " \"http3.num_packets.late_acked\": %" PRIu64 ", \n"
+                           " \"http3.num_bytes.received\": %" PRIu64 ", \n"
+                           " \"http3.num_bytes.sent\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.padding\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.ping\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.ack\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.reset_stream\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.stop_sending\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.crypto\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.new_token\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.stream\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.max_data\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.max_stream_data\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.max_streams_bidi\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.max_streams_uni\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.data_blocked\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.stream_data_blocked\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.streams_blocked\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.new_connection_id\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.retire_connection_id\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.path_challenge\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.path_response\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.transport_close\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.application_close\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.handshake_done\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.datagram\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_sent.ack_frequency\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.padding\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.ping\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.ack\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.reset_stream\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.stop_sending\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.crypto\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.new_token\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.stream\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.max_data\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.max_stream_data\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.max_streams_bidi\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.max_streams_uni\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.data_blocked\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.stream_data_blocked\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.streams_blocked\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.new_connection_id\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.retire_connection_id\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.path_challenge\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.path_response\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.transport_close\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.application_close\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.handshake_done\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.datagram\": %" PRIu64 ", \n"
+                           " \"http3.num_frames_received.ack_frequency\": %" PRIu64 ", \n"
+                           " \"http3.num_ptos\": %" PRIu64 ", \n"
+                           " \"ssl.errors\": %" PRIu64 ", \n"
+                           " \"memory.mmap_errors\": %zu\n",
+        H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417), H1_AGG_ERR(500),
+        H1_AGG_ERR(502), H1_AGG_ERR(503), esc->h1_request_timeout, esc->h1_request_io_timeout, H2_AGG_ERR(PROTOCOL),
+        H2_AGG_ERR(INTERNAL), H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT), H2_AGG_ERR(STREAM_CLOSED),
+        H2_AGG_ERR(FRAME_SIZE), H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL), H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT),
+        H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY), esc->h2_read_closed, esc->h2_write_closed,
+        esc->h2_idle_timeout, esc->http3.packet_forwarded, esc->http3.forwarded_packet_received, esc->http3.num_packets.received,
+        esc->http3.num_packets.decryption_failed, esc->http3.num_packets.sent, esc->http3.num_packets.lost,
+        esc->http3.num_packets.lost_time_threshold, esc->http3.num_packets.ack_received, esc->http3.num_packets.late_acked,
+        esc->http3.num_bytes.received, esc->http3.num_bytes.sent, esc->http3.num_frames_sent.padding,
+        esc->http3.num_frames_sent.ping, esc->http3.num_frames_sent.ack, esc->http3.num_frames_sent.reset_stream,
+        esc->http3.num_frames_sent.stop_sending, esc->http3.num_frames_sent.crypto, esc->http3.num_frames_sent.new_token,
+        esc->http3.num_frames_sent.stream, esc->http3.num_frames_sent.max_data, esc->http3.num_frames_sent.max_stream_data,
+        esc->http3.num_frames_sent.max_streams_bidi, esc->http3.num_frames_sent.max_streams_uni,
+        esc->http3.num_frames_sent.data_blocked, esc->http3.num_frames_sent.stream_data_blocked,
+        esc->http3.num_frames_sent.streams_blocked, esc->http3.num_frames_sent.new_connection_id,
+        esc->http3.num_frames_sent.retire_connection_id, esc->http3.num_frames_sent.path_challenge,
+        esc->http3.num_frames_sent.path_response, esc->http3.num_frames_sent.transport_close,
+        esc->http3.num_frames_sent.application_close, esc->http3.num_frames_sent.handshake_done,
+        esc->http3.num_frames_sent.datagram, esc->http3.num_frames_sent.ack_frequency, esc->http3.num_frames_received.padding,
+        esc->http3.num_frames_received.ping, esc->http3.num_frames_received.ack, esc->http3.num_frames_received.reset_stream,
+        esc->http3.num_frames_received.stop_sending, esc->http3.num_frames_received.crypto,
+        esc->http3.num_frames_received.new_token, esc->http3.num_frames_received.stream, esc->http3.num_frames_received.max_data,
+        esc->http3.num_frames_received.max_stream_data, esc->http3.num_frames_received.max_streams_bidi,
+        esc->http3.num_frames_received.max_streams_uni, esc->http3.num_frames_received.data_blocked,
+        esc->http3.num_frames_received.stream_data_blocked, esc->http3.num_frames_received.streams_blocked,
+        esc->http3.num_frames_received.new_connection_id, esc->http3.num_frames_received.retire_connection_id,
+        esc->http3.num_frames_received.path_challenge, esc->http3.num_frames_received.path_response,
+        esc->http3.num_frames_received.transport_close, esc->http3.num_frames_received.application_close,
+        esc->http3.num_frames_received.handshake_done, esc->http3.num_frames_received.datagram,
+        esc->http3.num_frames_received.ack_frequency, esc->http3.num_ptos, esc->ssl_errors, h2o_mmap_errors);
     pthread_mutex_destroy(&esc->mutex);
     free(esc);
     return ret;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1702,12 +1702,70 @@ static void on_h3_destroy(h2o_quic_conn_t *h3_)
 {
     h2o_http3_conn_t *h3 = (h2o_http3_conn_t *)h3_;
     struct st_h2o_http3_server_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_conn_t, h3, h3);
-    quicly_stats_t stats = {0};
+    quicly_stats_t stats;
     
     H2O_PROBE_CONN0(H3S_DESTROY, &conn->super);
 
-    if (quicly_get_stats(h3_->quic, &stats) == 0)
-        conn->super.ctx->http3.events.packet_lost += stats.num_packets.lost;
+    if (quicly_get_stats(h3_->quic, &stats) == 0) {
+        conn->super.ctx->http3.num_packets.received += stats.num_packets.received;
+        conn->super.ctx->http3.num_packets.decryption_failed += stats.num_packets.decryption_failed;
+        conn->super.ctx->http3.num_packets.sent += stats.num_packets.sent;
+        conn->super.ctx->http3.num_packets.lost += stats.num_packets.lost;
+        conn->super.ctx->http3.num_packets.lost_time_threshold += stats.num_packets.lost_time_threshold;
+        conn->super.ctx->http3.num_packets.ack_received += stats.num_packets.ack_received;
+        conn->super.ctx->http3.num_packets.late_acked += stats.num_packets.late_acked;
+        conn->super.ctx->http3.num_bytes.received += stats.num_bytes.received;
+        conn->super.ctx->http3.num_bytes.sent += stats.num_bytes.sent;
+        conn->super.ctx->http3.num_frames_sent.padding += stats.num_frames_sent.padding;
+        conn->super.ctx->http3.num_frames_sent.ping += stats.num_frames_sent.ping;
+        conn->super.ctx->http3.num_frames_sent.ack += stats.num_frames_sent.ack;
+        conn->super.ctx->http3.num_frames_sent.reset_stream += stats.num_frames_sent.reset_stream;
+        conn->super.ctx->http3.num_frames_sent.stop_sending += stats.num_frames_sent.stop_sending;
+        conn->super.ctx->http3.num_frames_sent.crypto += stats.num_frames_sent.crypto;
+        conn->super.ctx->http3.num_frames_sent.new_token += stats.num_frames_sent.new_token;
+        conn->super.ctx->http3.num_frames_sent.stream += stats.num_frames_sent.stream;
+        conn->super.ctx->http3.num_frames_sent.max_data += stats.num_frames_sent.max_data;
+        conn->super.ctx->http3.num_frames_sent.max_stream_data += stats.num_frames_sent.max_stream_data;
+        conn->super.ctx->http3.num_frames_sent.max_streams_bidi += stats.num_frames_sent.max_streams_bidi;
+        conn->super.ctx->http3.num_frames_sent.max_streams_uni += stats.num_frames_sent.max_streams_uni;
+        conn->super.ctx->http3.num_frames_sent.data_blocked += stats.num_frames_sent.data_blocked;
+        conn->super.ctx->http3.num_frames_sent.stream_data_blocked += stats.num_frames_sent.stream_data_blocked;
+        conn->super.ctx->http3.num_frames_sent.streams_blocked += stats.num_frames_sent.streams_blocked;
+        conn->super.ctx->http3.num_frames_sent.new_connection_id += stats.num_frames_sent.new_connection_id;
+        conn->super.ctx->http3.num_frames_sent.retire_connection_id += stats.num_frames_sent.retire_connection_id;
+        conn->super.ctx->http3.num_frames_sent.path_challenge += stats.num_frames_sent.path_challenge;
+        conn->super.ctx->http3.num_frames_sent.path_response += stats.num_frames_sent.path_response;
+        conn->super.ctx->http3.num_frames_sent.transport_close += stats.num_frames_sent.transport_close;
+        conn->super.ctx->http3.num_frames_sent.application_close += stats.num_frames_sent.application_close;
+        conn->super.ctx->http3.num_frames_sent.handshake_done += stats.num_frames_sent.handshake_done;
+        conn->super.ctx->http3.num_frames_sent.datagram += stats.num_frames_sent.datagram;
+        conn->super.ctx->http3.num_frames_sent.ack_frequency += stats.num_frames_sent.ack_frequency;
+        conn->super.ctx->http3.num_frames_received.padding += stats.num_frames_received.padding;
+        conn->super.ctx->http3.num_frames_received.ping += stats.num_frames_received.ping;
+        conn->super.ctx->http3.num_frames_received.ack += stats.num_frames_received.ack;
+        conn->super.ctx->http3.num_frames_received.reset_stream += stats.num_frames_received.reset_stream;
+        conn->super.ctx->http3.num_frames_received.stop_sending += stats.num_frames_received.stop_sending;
+        conn->super.ctx->http3.num_frames_received.crypto += stats.num_frames_received.crypto;
+        conn->super.ctx->http3.num_frames_received.new_token += stats.num_frames_received.new_token;
+        conn->super.ctx->http3.num_frames_received.stream += stats.num_frames_received.stream;
+        conn->super.ctx->http3.num_frames_received.max_data += stats.num_frames_received.max_data;
+        conn->super.ctx->http3.num_frames_received.max_stream_data += stats.num_frames_received.max_stream_data;
+        conn->super.ctx->http3.num_frames_received.max_streams_bidi += stats.num_frames_received.max_streams_bidi;
+        conn->super.ctx->http3.num_frames_received.max_streams_uni += stats.num_frames_received.max_streams_uni;
+        conn->super.ctx->http3.num_frames_received.data_blocked += stats.num_frames_received.data_blocked;
+        conn->super.ctx->http3.num_frames_received.stream_data_blocked += stats.num_frames_received.stream_data_blocked;
+        conn->super.ctx->http3.num_frames_received.streams_blocked += stats.num_frames_received.streams_blocked;
+        conn->super.ctx->http3.num_frames_received.new_connection_id += stats.num_frames_received.new_connection_id;
+        conn->super.ctx->http3.num_frames_received.retire_connection_id += stats.num_frames_received.retire_connection_id;
+        conn->super.ctx->http3.num_frames_received.path_challenge += stats.num_frames_received.path_challenge;
+        conn->super.ctx->http3.num_frames_received.path_response += stats.num_frames_received.path_response;
+        conn->super.ctx->http3.num_frames_received.transport_close += stats.num_frames_received.transport_close;
+        conn->super.ctx->http3.num_frames_received.application_close += stats.num_frames_received.application_close;
+        conn->super.ctx->http3.num_frames_received.handshake_done += stats.num_frames_received.handshake_done;
+        conn->super.ctx->http3.num_frames_received.datagram += stats.num_frames_received.datagram;
+        conn->super.ctx->http3.num_frames_received.ack_frequency += stats.num_frames_received.ack_frequency;
+        conn->super.ctx->http3.num_ptos += stats.num_ptos;
+    }
 
     /* unlink and dispose */
     h2o_linklist_unlink(&conn->_conns);

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1703,7 +1703,7 @@ static void on_h3_destroy(h2o_quic_conn_t *h3_)
     h2o_http3_conn_t *h3 = (h2o_http3_conn_t *)h3_;
     struct st_h2o_http3_server_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_conn_t, h3, h3);
     quicly_stats_t stats;
-    
+
     H2O_PROBE_CONN0(H3S_DESTROY, &conn->super);
 
     if (quicly_get_stats(h3_->quic, &stats) == 0) {

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1702,8 +1702,12 @@ static void on_h3_destroy(h2o_quic_conn_t *h3_)
 {
     h2o_http3_conn_t *h3 = (h2o_http3_conn_t *)h3_;
     struct st_h2o_http3_server_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_conn_t, h3, h3);
-
+    quicly_stats_t stats = {0};
+    
     H2O_PROBE_CONN0(H3S_DESTROY, &conn->super);
+
+    if (quicly_get_stats(h3_->quic, &stats) == 0)
+        conn->super.ctx->http3.events.packet_lost += stats.num_packets.lost;
 
     /* unlink and dispose */
     h2o_linklist_unlink(&conn->_conns);


### PR DESCRIPTION
## Overview
We currently keep track of packet statistics at the connection level, for example in [on_loss_detected()](https://github.com/h2o/quicly/blob/f2d244f5d7b6df9849d3d108333933febbefbb6c/lib/quicly.c#L3600), but we do not include those counts in the statistics output.  This patch implements this output.

## Test
```
$ ./h2o-httpclient -k -3 100 -C 100 -t 1000 -H "user-agen: nalramli/1.0" -b 2800 -c 1400 https://127.0.0.2:1443/Fastly.html 1>/dev/null 2>&1

$ ./h2o-httpclient -H "user-agen: nalramli/1.0" http://127.0.0.1:1444/server-status/json 2>/dev/null | grep "http3"
 "http3.packet-forwarded": 0, 
 "http3.forwarded-packet-received": 0, 
 "http3.num_packets.received": 10445, 
 "http3.num_packets.decryption_failed": 0, 
 "http3.num_packets.sent": 571860, 
 "http3.num_packets.lost": 215, 
 "http3.num_packets.lost_time_threshold": 0, 
 "http3.num_packets.ack_received": 571595, 
 "http3.num_packets.late_acked": 0, 
 "http3.num_bytes.received": 3252190, 
 "http3.num_bytes.sent": 731861580, 
 "http3.num_frames_sent.padding": 0, 
 "http3.num_frames_sent.ping": 0, 
 "http3.num_frames_sent.ack": 981, 
 "http3.num_frames_sent.reset_stream": 0, 
 "http3.num_frames_sent.stop_sending": 0, 
 "http3.num_frames_sent.crypto": 4, 
 "http3.num_frames_sent.new_token": 1, 
 "http3.num_frames_sent.stream": 582666, 
 "http3.num_frames_sent.max_data": 0, 
 "http3.num_frames_sent.max_stream_data": 0, 
 "http3.num_frames_sent.max_streams_bidi": 54581, 
 "http3.num_frames_sent.max_streams_uni": 0, 
 "http3.num_frames_sent.data_blocked": 0, 
 "http3.num_frames_sent.stream_data_blocked": 0, 
 "http3.num_frames_sent.streams_blocked": 0, 
 "http3.num_frames_sent.new_connection_id": 3, 
 "http3.num_frames_sent.retire_connection_id": 0, 
 "http3.num_frames_sent.path_challenge": 0, 
 "http3.num_frames_sent.path_response": 0, 
 "http3.num_frames_sent.transport_close": 0, 
 "http3.num_frames_sent.application_close": 0, 
 "http3.num_frames_sent.handshake_done": 1, 
 "http3.num_frames_sent.datagram": 0, 
 "http3.num_frames_sent.ack_frequency": 42, 
 "http3.num_frames_received.padding": 1003, 
 "http3.num_frames_received.ping": 0, 
 "http3.num_frames_received.ack": 7331, 
 "http3.num_frames_received.reset_stream": 0, 
 "http3.num_frames_received.stop_sending": 0, 
 "http3.num_frames_received.crypto": 2, 
 "http3.num_frames_received.new_token": 0, 
 "http3.num_frames_received.stream": 4032, 
 "http3.num_frames_received.max_data": 84, 
 "http3.num_frames_received.max_stream_data": 970, 
 "http3.num_frames_received.max_streams_bidi": 0, 
 "http3.num_frames_received.max_streams_uni": 0, 
 "http3.num_frames_received.data_blocked": 0, 
 "http3.num_frames_received.stream_data_blocked": 0, 
 "http3.num_frames_received.streams_blocked": 797, 
 "http3.num_frames_received.new_connection_id": 3, 
 "http3.num_frames_received.retire_connection_id": 0, 
 "http3.num_frames_received.path_challenge": 0, 
 "http3.num_frames_received.path_response": 0, 
 "http3.num_frames_received.transport_close": 1, 
 "http3.num_frames_received.application_close": 0, 
 "http3.num_frames_received.handshake_done": 0, 
 "http3.num_frames_received.datagram": 0, 
 "http3.num_frames_received.ack_frequency": 49, 
 "http3.num_ptos": 0, 
```
