### PR TITLE
[CI][h2olog] do not return until boot process is complete

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -575,11 +575,13 @@ package H2ologTracer {
         die "failed to spawn $h2olog_prog: $!" unless defined $tracer_pid;
 
         # wait until h2olog and the trace log becomes ready
-        my $stderr_firstline = <$errfh>;
-        if (not defined $stderr_firstline) {
-            Carp::confess("h2olog[$tracer_pid] died unexpectedly");
+        while (1) {
+            my $errline = <$errfh>;
+            Carp::confess("h2olog[$tracer_pid] died unexpectedly")
+                unless defined $errline;
+            Test::More::diag("h2olog[$tracer_pid]: $errline");
+            last if $errline =~ /Attaching pid=/;
         }
-        Test::More::diag("h2olog[$tracer_pid]: $stderr_firstline");
 
         open my $fh, "<", $output_file or die "h2olog[$tracer_pid] does not create the output file ($output_file): $!";
         my $off = 0;


### PR DESCRIPTION
It seems to me that we are starting to see warnings from bcc when running h2olog on GitHub CI.

That breaks our test script, as H2ologTracer assumes that h2olog is attached to h2o when something is emitted by h2olog to stderr.

This PR address the issue. Now, H2ologTracer waits for "Attacting pid=" message before returning the execution to the test script.

Ideally, we should fix the root cause, though I am not sure why we are starting to see these lines. To me it seems like a weird interaction between bcc (in our Docker image) and the kernel source files (in GitHub CI). The latter might have changed recently.

If that's the case, I'm not sure how much we can do, or should do. Hence just fixing the test script.

Below is the output from GitHub CI running the test with proposed changes:
```
2021-06-11T00:33:31.3425569Z t/90h2olog-sampling.t ................................ 
2021-06-11T00:33:31.3432049Z # Subtest: h2olog should be able to start when h2o has no `usdt-selective-tracing: ON`[0m
2021-06-11T00:33:31.4477786Z spawning /home/ci/build/h2o... done
2021-06-11T00:33:31.8389127Z [INFO] raised RLIMIT_NOFILE to 1048576
2021-06-11T00:33:31.8459525Z h2o server (pid:39837) is ready to serve requests with 2 threads
2021-06-11T00:33:31.8764525Z fetch-ocsp-response (using OpenSSL 1.1.1f  31 Mar 2020)
2021-06-11T00:33:31.8792878Z failed to extract ocsp URI from examples/h2o/server.crt
2021-06-11T00:33:31.8849839Z [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2021-06-11T00:33:34.1500451Z     # h2olog[39839]: In file included from <built-in>:2:
2021-06-11T00:33:34.1501939Z     # h2olog[39839]: In file included from /virtual/include/bcc/bpf.h:12:
2021-06-11T00:33:34.1503058Z     # h2olog[39839]: In file included from include/linux/types.h:6:
2021-06-11T00:33:34.1504136Z     # h2olog[39839]: In file included from include/uapi/linux/types.h:14:
2021-06-11T00:33:34.1505231Z     # h2olog[39839]: In file included from ./include/uapi/linux/posix_types.h:5:
2021-06-11T00:33:34.1511554Z     # h2olog[39839]: In file included from include/linux/stddef.h:5:
2021-06-11T00:33:34.1516199Z     # h2olog[39839]: In file included from include/uapi/linux/stddef.h:2:
2021-06-11T00:33:34.1520976Z     # h2olog[39839]: In file included from include/linux/compiler_types.h:63:
2021-06-11T00:33:34.1526441Z     # h2olog[39839]: include/linux/compiler-clang.h:37:9: warning: '__HAVE_BUILTIN_BSWAP32__' macro redefined [-Wmacro-redefined]
2021-06-11T00:33:34.1531397Z     # h2olog[39839]: #define __HAVE_BUILTIN_BSWAP32__
2021-06-11T00:33:34.1536652Z     # h2olog[39839]:         ^
2021-06-11T00:33:34.1544430Z     # h2olog[39839]: <command line>:4:9: note: previous definition is here
2021-06-11T00:33:34.1545446Z     # h2olog[39839]: #define __HAVE_BUILTIN_BSWAP32__ 1
2021-06-11T00:33:34.1556710Z     # h2olog[39839]:         ^
2021-06-11T00:33:34.1557559Z     # h2olog[39839]: In file included from <built-in>:2:
2021-06-11T00:33:34.1558212Z     # h2olog[39839]: In file included from /virtual/include/bcc/bpf.h:12:
2021-06-11T00:33:34.1558882Z     # h2olog[39839]: In file included from include/linux/types.h:6:
2021-06-11T00:33:34.1559536Z     # h2olog[39839]: In file included from include/uapi/linux/types.h:14:
2021-06-11T00:33:34.1567334Z     # h2olog[39839]: In file included from ./include/uapi/linux/posix_types.h:5:
2021-06-11T00:33:34.1568069Z     # h2olog[39839]: In file included from include/linux/stddef.h:5:
2021-06-11T00:33:34.1568738Z     # h2olog[39839]: In file included from include/uapi/linux/stddef.h:2:
2021-06-11T00:33:34.1569451Z     # h2olog[39839]: In file included from include/linux/compiler_types.h:63:
2021-06-11T00:33:34.1570761Z     # h2olog[39839]: include/linux/compiler-clang.h:38:9: warning: '__HAVE_BUILTIN_BSWAP64__' macro redefined [-Wmacro-redefined]
2021-06-11T00:33:34.1571672Z     # h2olog[39839]: #define __HAVE_BUILTIN_BSWAP64__
2021-06-11T00:33:34.1572126Z     # h2olog[39839]:         ^
2021-06-11T00:33:34.1572672Z     # h2olog[39839]: <command line>:5:9: note: previous definition is here
2021-06-11T00:33:34.1582088Z     # h2olog[39839]: #define __HAVE_BUILTIN_BSWAP64__ 1
2021-06-11T00:33:34.1583807Z     # h2olog[39839]:         ^
2021-06-11T00:33:34.1587922Z     # h2olog[39839]: In file included from <built-in>:2:
2021-06-11T00:33:34.1591914Z     # h2olog[39839]: In file included from /virtual/include/bcc/bpf.h:12:
2021-06-11T00:33:34.1598136Z     # h2olog[39839]: In file included from include/linux/types.h:6:
2021-06-11T00:33:34.1598818Z     # h2olog[39839]: In file included from include/uapi/linux/types.h:14:
2021-06-11T00:33:34.1599542Z     # h2olog[39839]: In file included from ./include/uapi/linux/posix_types.h:5:
2021-06-11T00:33:34.1612809Z     # h2olog[39839]: In file included from include/linux/stddef.h:5:
2021-06-11T00:33:34.1613612Z     # h2olog[39839]: In file included from include/uapi/linux/stddef.h:2:
2021-06-11T00:33:34.1614336Z     # h2olog[39839]: In file included from include/linux/compiler_types.h:63:
2021-06-11T00:33:34.1623556Z     # h2olog[39839]: include/linux/compiler-clang.h:39:9: warning: '__HAVE_BUILTIN_BSWAP16__' macro redefined [-Wmacro-redefined]
2021-06-11T00:33:34.1624446Z     # h2olog[39839]: #define __HAVE_BUILTIN_BSWAP16__
2021-06-11T00:33:34.1628472Z     # h2olog[39839]:         ^
2021-06-11T00:33:34.1632637Z     # h2olog[39839]: <command line>:3:9: note: previous definition is here
2021-06-11T00:33:34.1637666Z     # h2olog[39839]: #define __HAVE_BUILTIN_BSWAP16__ 1
2021-06-11T00:33:34.1641302Z     # h2olog[39839]:         ^
2021-06-11T00:33:35.0021212Z     # h2olog[39839]: 3 warnings generated.
2021-06-11T00:33:36.0228074Z     # h2olog[39839]: 2021-06-11T00:33:36Z Attaching pid=39837 (/home/ci/build/h2o -c /tmp/0eEsxs6pF3)
2021-06-11T00:33:36.0339854Z     ok 1 - req: HTTP/1[0m
2021-06-11T00:33:36.0340586Z     ok 2 - h2olog has startded successfully[0m
2021-06-11T00:33:36.0348282Z     # killing h2olog[39839] with SIGTERM
2021-06-11T00:33:37.9063903Z killing /home/ci/build/h2o... received SIGTERM, gracefully shutting down
2021-06-11T00:33:38.0067236Z killed (got 0)
2021-06-11T00:33:38.0079309Z     1..2[0m
2021-06-11T00:33:38.0089616Z ok 1 - h2olog should be able to start when h2o has no `usdt-selective-tracing: ON`[0m
2021-06-11T00:33:38.5091484Z spawning /home/ci/build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
2021-06-11T00:33:38.5177832Z # Subtest: h2olog -S=1.00[0m
2021-06-11T00:33:38.5194181Z done
```