### PR TITLE
disable leak sanitizer (detect_leaks=0) in the standalone server by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,7 @@ SET(UNIT_TEST_SOURCE_FILES
     ${LIB_SOURCE_FILES}
     ${LIBYAML_SOURCE_FILES}
     ${BROTLI_SOURCE_FILES}
+    src/asan_opts.c
     deps/picotest/picotest.c
     t/00unit/test.c
     t/00unit/lib/common/balancer/least_conn.c
@@ -614,7 +615,7 @@ IF (WSLAY_FOUND)
     ADD_DEPENDENCIES(lib-examples-evloop examples-websocket-evloop)
 ENDIF (WSLAY_FOUND)
 ADD_EXECUTABLE(examples-latency-optimization-evloop examples/libh2o/latency-optimization.c)
-ADD_EXECUTABLE(h2o-httpclient src/httpclient.c)
+ADD_EXECUTABLE(h2o-httpclient src/httpclient.c src/asan_opts.c)
 ADD_EXECUTABLE(examples-socket-client-evloop examples/libh2o/socket-client.c)
 ADD_EXECUTABLE(examples-simple-evloop examples/libh2o/simple.c)
 ADD_EXECUTABLE(examples-websocket-evloop lib/websocket.c examples/libh2o/websocket.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,7 +680,9 @@ SET(STANDALONE_SOURCE_FILES
     ${BROTLI_SOURCE_FILES}
     deps/neverbleed/neverbleed.c
     src/main.c
-    src/ssl.c)
+    src/ssl.c
+    src/asan_opts.c
+)
 SET(STANDALONE_COMPILE_FLAGS "-DH2O_USE_LIBUV=0 -DH2O_USE_BROTLI=1")
 IF (WITH_MRUBY)
     IF (${CMAKE_C_COMPILER_ID} STREQUAL "Clang")

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,6 +1,6 @@
 # Fuzzing
 
-This directory contains code and test data for fuzz testing h2o with LLVM's [LibFuzzer](http://libfuzzer.info). 
+This directory contains code and test data for fuzz testing h2o with LLVM's [LibFuzzer](http://libfuzzer.info).
 
 ## Building the test drivers
 
@@ -30,9 +30,9 @@ $ cp ./fuzz/http2-corpus.fresh/* ./fuzz/http2-corpus
 
 You will likely want to tailor fuzzer options to your execution environment, but here are basic examples of running each fuzzer:
 
-HTTP/1: `ASAN_OPTIONS=detect_leaks=0 ./h2o-fuzzer-http1 -max_len=$((16 * 1024 )) -dict=fuzz/http.dict fuzz/http1-corpus`
+HTTP/1: `./h2o-fuzzer-http1 -max_len=$((16 * 1024 )) -dict=fuzz/http.dict fuzz/http1-corpus`
 
-HTTP/2: `ASAN_OPTIONS=detect_leaks=0 ./h2o-fuzzer-http2 -max_len=$((16 * 1024 )) -dict=fuzz/http.dict fuzz/http2-corpus`
+HTTP/2: `./h2o-fuzzer-http2 -max_len=$((16 * 1024 )) -dict=fuzz/http.dict fuzz/http2-corpus`
 
 The fuzzer looks at `H2O_FUZZER_CLIENT_TIMEOUT` in order to configure the
 client thread event loop timeout in milli-seconds. It defaults to 10 ms.

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -2,7 +2,6 @@ CONTAINER_NAME=h2oserver/h2o-ci:ubuntu1604
 SRC_DIR=/h2o
 CHECK_MK=$(SRC_DIR)/misc/docker-ci/check.mk
 CMAKE_ARGS=
-FUZZ_ASAN=ASAN_OPTIONS=detect_leaks=0
 DOCKER_RUN_OPTS=--privileged \
 	--ulimit memlock=-1 \
 	-v `pwd`:$(SRC_DIR) \
@@ -45,8 +44,8 @@ _do-check:
 	make check
 
 _fuzz:
-	$(FUZZ_ASAN) CC=clang CXX=clang++ $(MAKE) -f $(CHECK_MK) _check CMAKE_ARGS=-DBUILD_FUZZER=ON
-	$(FUZZ_ASAN) $(MAKE) -f $(CHECK_MK) -C build _do-fuzz-extra
+	CC=clang CXX=clang++ $(MAKE) -f $(CHECK_MK) _check CMAKE_ARGS=-DBUILD_FUZZER=ON
+	$(MAKE) -f $(CHECK_MK) -C build _do-fuzz-extra
 
 _do-fuzz-extra:
 	./h2o-fuzzer-http1 -close_fd_mask=3 -runs=1 -max_len=16384 $(SRC_DIR)/fuzz/http1-corpus < /dev/null

--- a/src/asan_opts.c
+++ b/src/asan_opts.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Goro Fuji, Fastly, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+
+/**
+ * The defaults for ASAN_OPTIONS.
+ * See https://github.com/google/sanitizers/wiki/AddressSanitizerFlags for details.
+ */
+const char *__asan_default_options(void) {
+    return "detect_leaks=0";
+}


### PR DESCRIPTION
This is because it causes some of the tests to fail and it issues false alerts in production services. Thus, (1) we disabled it in tests (see the changes in check.mk), and (2) we disabled it on production. So it's natural to disable it by default. You can enable if by overriding options as `ASAN_OPTIONS=detect_leaks=1` if you want. 