### PR TITLE
Handle QUICLY_ERROR_STATE_EXHAUSTION errors

### DIFF
--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -5866,6 +5866,8 @@ Exit:
             conn->egress.loss.alarm_at = conn->stash.now;
         assert_consistency(conn, 0);
         break;
+    case PTLS_ERROR_NO_MEMORY:
+    case QUICLY_ERROR_STATE_EXHAUSTION:
     case QUICLY_ERROR_PACKET_IGNORED:
         break;
     default: /* close connection */

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -633,11 +633,11 @@ static void process_packets(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, qui
             if (i != accepted_packet_index) {
                 int ret = quicly_receive(conn->quic, &destaddr->sa, &srcaddr->sa, packets + i);
                 switch (ret) {
-                    case QUICLY_ERROR_STATE_EXHAUSTION:
-                    case PTLS_ERROR_NO_MEMORY:
-                        fprintf(stderr, "%s: `quicly_receive()` returned ret:%d\n", __func__, ret);
-                        conn->callbacks->destroy_connection(conn);
-                        return;
+                case QUICLY_ERROR_STATE_EXHAUSTION:
+                case PTLS_ERROR_NO_MEMORY:
+                    fprintf(stderr, "%s: `quicly_receive()` returned ret:%d\n", __func__, ret);
+                    conn->callbacks->destroy_connection(conn);
+                    return;
                 }
             }
         }

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -630,9 +630,16 @@ static void process_packets(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, qui
         size_t i;
     Receive:
         for (i = 0; i != num_packets; ++i) {
-            /* FIXME process errors? */
-            if (i != accepted_packet_index)
-                quicly_receive(conn->quic, &destaddr->sa, &srcaddr->sa, packets + i);
+            if (i != accepted_packet_index) {
+                int ret = quicly_receive(conn->quic, &destaddr->sa, &srcaddr->sa, packets + i);
+                switch (ret) {
+                    case QUICLY_ERROR_STATE_EXHAUSTION:
+                    case PTLS_ERROR_NO_MEMORY:
+                        fprintf(stderr, "%s: `quicly_receive()` returned ret:%d\n", __func__, ret);
+                        conn->callbacks->destroy_connection(conn);
+                        return;
+                }
+            }
         }
     }
 
@@ -1086,6 +1093,7 @@ int h2o_quic_send(h2o_quic_conn_t *conn)
                 break;
             }
             break;
+        case QUICLY_ERROR_STATE_EXHAUSTION:
         case QUICLY_ERROR_FREE_CONNECTION:
             conn->callbacks->destroy_connection(conn);
             return 0;


### PR DESCRIPTION
This is a rebase of #2763 against master, with tweaks.

For background, see https://github.com/h2o/quicly/pull/467.