### PR TITLE
Always unlink pending write requests when entering close_wait

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -432,6 +432,8 @@ static void set_state(struct st_h2o_http3_server_stream_t *stream, enum h2o_http
         assert(conn->delayed_streams.recv_body_blocked.prev == &stream->link || !"stream is not registered to the recv_body list?");
         break;
     case H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT: {
+        if (h2o_linklist_is_linked(&stream->link))
+            h2o_linklist_unlink(&stream->link);
         pre_dispose_request(stream);
         if (!in_generator) {
             h2o_dispose_request(&stream->req);


### PR DESCRIPTION
* Retarget #2748 against master.
* Remove invocations of `h2o_linklist_unlink` that become redundant.