### PR TITLE
[handler] bug-fix: cookie_cmd() can result in empty 'cookie' header

### DIFF
--- a/lib/handler/headers_util.c
+++ b/lib/handler/headers_util.c
@@ -73,6 +73,8 @@ static void cookie_cmd(h2o_mem_pool_t *pool, h2o_headers_t *headers, h2o_headers
     for (header_index = -1; (header_index = h2o_find_header(headers, H2O_TOKEN_COOKIE, header_index)) != -1;) {
         h2o_header_t *header = headers->entries + header_index;
         filter_cookie(pool, &header->value.base, &header->value.len, cmd);
+        if (header->value.len == 0)
+            h2o_delete_header(headers, header_index);
     }
 }
 


### PR DESCRIPTION
## Overview
With the changes introduced in #2757, it's possible for [build_request()](https://github.com/h2o/h2o/blob/babd505298b73f3cf501f80f326237243bb24555/lib/core/proxy.c#L135) to result in an empty cookie header, because the call to [h2o_rewrite_headers](https://github.com/h2o/h2o/blob/babd505298b73f3cf501f80f326237243bb24555/lib/core/proxy.c#L276) and then to `cookie_cmd()` happens after [the length of cookie has been checked](https://github.com/h2o/h2o/blob/babd505298b73f3cf501f80f326237243bb24555/lib/core/proxy.c#L240).

This change ensures that `cookie_cmd()` removes the cookie header if its length becomes zero.
