### PR TITLE
[test fix] Single thread 50access-log.t

### DIFF
--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -19,6 +19,7 @@ sub doit {
         unless ref $args;
 
     my $server = spawn_h2o({conf => <<"EOT", max_ssl_version => 'TLSv1.2'});
+num-threads: 1
 ssl-session-resumption:
   mode: cache
   cache-store: internal


### PR DESCRIPTION
The test sometimes fails spuriously because curl requests end up being
interleaved
```
    not ok 1

    #   Failed test at t/50access-log.t line 63.
    #
'GET::/query?abc=d::HTTP/1.1::127.0.0.1:41975::default'
    #     doesn't match
'(?^:^GET::/::HTTP/1\.1::127\.0\.0\.1:[0-9]+::default$)'
    not ok 2
    1..2
not ok 5 - ltsv-related
    # Subtest: timings
        # Subtest: http1

    #   Failed test at t/50access-log.t line 63.
    #                   'GET::/::HTTP/1.1::127.0.0.1:41975::default'
    #     doesn't match
'(?^:^GET::/query\?abc=d::HTTP/1\.1::127\.0\.0\.1:[0-9]+::default$)'
    # Looks like you failed 2 tests of 2.
```