### PR TITLE
[http2] Implement streaming request counter

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -744,6 +744,10 @@ struct st_h2o_context_t {
              * counter for http2 idle timeouts
              */
             uint64_t idle_timeouts;
+            /**
+             * streaming request counter
+             */
+            uint64_t streaming_requests;
         } events;
     } http2;
 

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -29,6 +29,7 @@ struct st_events_status_ctx_t {
     uint64_t h2_read_closed;
     uint64_t h2_write_closed;
     uint64_t h2_idle_timeout;
+    uint64_t h2_streaming_requests;
     uint64_t h1_request_timeout;
     uint64_t h1_request_io_timeout;
     uint64_t ssl_errors;
@@ -57,6 +58,7 @@ static void events_status_per_thread(void *priv, h2o_context_t *ctx)
     esc->h2_read_closed += ctx->http2.events.read_closed;
     esc->h2_write_closed += ctx->http2.events.write_closed;
     esc->h2_idle_timeout += ctx->http2.events.idle_timeouts;
+    esc->h2_streaming_requests += ctx->http2.events.streaming_requests;
     esc->h1_request_timeout += ctx->http1.events.request_timeouts;
     esc->h1_request_io_timeout += ctx->http1.events.request_io_timeouts;
     esc->http3.packet_forwarded += ctx->http3.events.packet_forwarded;
@@ -90,46 +92,46 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
 #define QUIC_VAL(fld, _unused) , esc->quic.fld
 #define BUFSIZE (8 * 1024)
     ret.base = h2o_mem_alloc_pool(&req->pool, char, BUFSIZE);
-    ret.len =
-        snprintf(ret.base, BUFSIZE,
-                 ",\n"
-                 " \"status-errors.400\": %" PRIu64 ",\n"
-                 " \"status-errors.403\": %" PRIu64 ",\n"
-                 " \"status-errors.404\": %" PRIu64 ",\n"
-                 " \"status-errors.405\": %" PRIu64 ",\n"
-                 " \"status-errors.416\": %" PRIu64 ",\n"
-                 " \"status-errors.417\": %" PRIu64 ",\n"
-                 " \"status-errors.500\": %" PRIu64 ",\n"
-                 " \"status-errors.502\": %" PRIu64 ",\n"
-                 " \"status-errors.503\": %" PRIu64 ",\n"
-                 " \"http1-errors.request-timeout\": %" PRIu64 ",\n"
-                 " \"http1-errors.request-io-timeout\": %" PRIu64 ",\n"
-                 " \"http2-errors.protocol\": %" PRIu64 ",\n"
-                 " \"http2-errors.internal\": %" PRIu64 ",\n"
-                 " \"http2-errors.flow-control\": %" PRIu64 ",\n"
-                 " \"http2-errors.settings-timeout\": %" PRIu64 ",\n"
-                 " \"http2-errors.stream-closed\": %" PRIu64 ",\n"
-                 " \"http2-errors.frame-size\": %" PRIu64 ",\n"
-                 " \"http2-errors.refused-stream\": %" PRIu64 ",\n"
-                 " \"http2-errors.cancel\": %" PRIu64 ",\n"
-                 " \"http2-errors.compression\": %" PRIu64 ",\n"
-                 " \"http2-errors.connect\": %" PRIu64 ",\n"
-                 " \"http2-errors.enhance-your-calm\": %" PRIu64 ",\n"
-                 " \"http2-errors.inadequate-security\": %" PRIu64 ",\n"
-                 " \"http2.read-closed\": %" PRIu64 ",\n"
-                 " \"http2.write-closed\": %" PRIu64 ",\n"
-                 " \"http2.idle-timeout\": %" PRIu64 ",\n"
-                 " \"http3.packet-forwarded\": %" PRIu64 ",\n"
-                 " \"http3.forwarded-packet-received\": %" PRIu64
-                 ",\n" H2O_QUIC_AGGREGATED_STATS_APPLY(QUIC_FMT) " \"ssl.errors\": %" PRIu64 ",\n"
-                                                                 " \"memory.mmap_errors\": %zu\n",
-                 H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
-                 H1_AGG_ERR(500), H1_AGG_ERR(502), H1_AGG_ERR(503), esc->h1_request_timeout, esc->h1_request_io_timeout,
-                 H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL), H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT),
-                 H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE), H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL),
-                 H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT), H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY),
-                 esc->h2_read_closed, esc->h2_write_closed, esc->h2_idle_timeout, esc->http3.packet_forwarded,
-                 esc->http3.forwarded_packet_received H2O_QUIC_AGGREGATED_STATS_APPLY(QUIC_VAL), esc->ssl_errors, h2o_mmap_errors);
+    ret.len = snprintf(ret.base, BUFSIZE, ",\n"
+                                          " \"status-errors.400\": %" PRIu64 ",\n"
+                                          " \"status-errors.403\": %" PRIu64 ",\n"
+                                          " \"status-errors.404\": %" PRIu64 ",\n"
+                                          " \"status-errors.405\": %" PRIu64 ",\n"
+                                          " \"status-errors.416\": %" PRIu64 ",\n"
+                                          " \"status-errors.417\": %" PRIu64 ",\n"
+                                          " \"status-errors.500\": %" PRIu64 ",\n"
+                                          " \"status-errors.502\": %" PRIu64 ",\n"
+                                          " \"status-errors.503\": %" PRIu64 ",\n"
+                                          " \"http1-errors.request-timeout\": %" PRIu64 ",\n"
+                                          " \"http1-errors.request-io-timeout\": %" PRIu64 ",\n"
+                                          " \"http2-errors.protocol\": %" PRIu64 ",\n"
+                                          " \"http2-errors.internal\": %" PRIu64 ",\n"
+                                          " \"http2-errors.flow-control\": %" PRIu64 ",\n"
+                                          " \"http2-errors.settings-timeout\": %" PRIu64 ",\n"
+                                          " \"http2-errors.stream-closed\": %" PRIu64 ",\n"
+                                          " \"http2-errors.frame-size\": %" PRIu64 ",\n"
+                                          " \"http2-errors.refused-stream\": %" PRIu64 ",\n"
+                                          " \"http2-errors.cancel\": %" PRIu64 ",\n"
+                                          " \"http2-errors.compression\": %" PRIu64 ",\n"
+                                          " \"http2-errors.connect\": %" PRIu64 ",\n"
+                                          " \"http2-errors.enhance-your-calm\": %" PRIu64 ",\n"
+                                          " \"http2-errors.inadequate-security\": %" PRIu64 ",\n"
+                                          " \"http2.read-closed\": %" PRIu64 ",\n"
+                                          " \"http2.write-closed\": %" PRIu64 ",\n"
+                                          " \"http2.idle-timeout\": %" PRIu64 ",\n"
+                                          " \"http2.streaming-requests\": %" PRIu64 ",\n"
+                                          " \"http3.packet-forwarded\": %" PRIu64 ",\n"
+                                          " \"http3.forwarded-packet-received\": %" PRIu64
+                                          ",\n" H2O_QUIC_AGGREGATED_STATS_APPLY(QUIC_FMT) " \"ssl.errors\": %" PRIu64 ",\n"
+                                                                                          " \"memory.mmap_errors\": %zu\n",
+                       H1_AGG_ERR(400), H1_AGG_ERR(403), H1_AGG_ERR(404), H1_AGG_ERR(405), H1_AGG_ERR(416), H1_AGG_ERR(417),
+                       H1_AGG_ERR(500), H1_AGG_ERR(502), H1_AGG_ERR(503), esc->h1_request_timeout, esc->h1_request_io_timeout,
+                       H2_AGG_ERR(PROTOCOL), H2_AGG_ERR(INTERNAL), H2_AGG_ERR(FLOW_CONTROL), H2_AGG_ERR(SETTINGS_TIMEOUT),
+                       H2_AGG_ERR(STREAM_CLOSED), H2_AGG_ERR(FRAME_SIZE), H2_AGG_ERR(REFUSED_STREAM), H2_AGG_ERR(CANCEL),
+                       H2_AGG_ERR(COMPRESSION), H2_AGG_ERR(CONNECT), H2_AGG_ERR(ENHANCE_YOUR_CALM), H2_AGG_ERR(INADEQUATE_SECURITY),
+                       esc->h2_read_closed, esc->h2_write_closed, esc->h2_idle_timeout, esc->h2_streaming_requests,
+                       esc->http3.packet_forwarded, esc->http3.forwarded_packet_received H2O_QUIC_AGGREGATED_STATS_APPLY(QUIC_VAL),
+                       esc->ssl_errors, h2o_mmap_errors);
     assert(ret.len < BUFSIZE);
 #undef H1_AGG_ERR
 #undef H2_AGG_ERR

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -202,6 +202,7 @@ static void run_pending_requests(h2o_http2_conn_t *conn)
                     conn->super.ctx->globalconf->http2.max_concurrent_streaming_requests_per_connection)
                     continue;
                 conn->num_streams._req_streaming_in_progress++;
+                conn->super.ctx->http2.events.streaming_requests++;
                 stream->_req_streaming_in_progress = 1;
                 update_stream_input_window(conn, stream,
                                            conn->super.ctx->globalconf->http2.active_stream_window_size -


### PR DESCRIPTION
## Overview
This implements a counter for HTTP/2 streaming requests in statistics output.  We would like to monitor this counter for fluctuations.

Most of the changes were made by `clang-format`.

## Test
```
$ ./h2o-httpclient -H "user-agent: nalramli/1.0" http://127.0.0.1:1444/server-status/json 2>/dev/null | grep "http2.streaming-requests"
 "http2.streaming-requests": 0,
```