### PR TITLE
[proxy] [test] t/50reverse-proxy-https.t replace wikipedia.org with localhost.examp1e.net because of connect errors

### DIFF
--- a/t/50reverse-proxy-https.t
+++ b/t/50reverse-proxy-https.t
@@ -40,7 +40,8 @@ hosts:
         proxy.ssl.verify-peer: OFF
       "/examp1e":
         proxy.reverse.url: https://localhost.examp1e.net:$examp1e_server->{tls_port}
-        proxy.ssl.verify-peer: OFF
+        proxy.ssl.verify-peer: ON
+        proxy.ssl.cafile: misc/test-ca/root/ca.crt
 EOT
     run_with_curl($server, sub {
         my ($proto, $port, $curl) = @_;

--- a/t/50reverse-proxy-https.t
+++ b/t/50reverse-proxy-https.t
@@ -20,36 +20,27 @@ my $upstream = spawn_server(
     },
 );
 
-my $examp1e_server = spawn_h2o(<< "EOT");
-hosts:
-  default:
-    paths:
-      "/":
-        file.dir: @{[ DOC_ROOT ]}
-EOT
-
 subtest "reverse-proxy" => sub {
     my $server = spawn_h2o(<< "EOT");
 hosts:
   default:
     paths:
-      "/verify":
+      "/verify-fail":
         proxy.reverse.url: https://127.0.0.1:$upstream_port
       "/no-verify":
         proxy.reverse.url: https://127.0.0.1:$upstream_port
         proxy.ssl.verify-peer: OFF
-      "/examp1e":
-        proxy.reverse.url: https://localhost.examp1e.net:$examp1e_server->{tls_port}
-        proxy.ssl.verify-peer: ON
+      "/verify-success":
+        proxy.reverse.url: https://localhost.examp1e.net:$upstream_port/echo
         proxy.ssl.cafile: misc/test-ca/root/ca.crt
 EOT
     run_with_curl($server, sub {
         my ($proto, $port, $curl) = @_;
-        my $resp = `$curl --silent --dump-header /dev/stderr --max-redirs 0 $proto://127.0.0.1:$port/verify/ 2>&1 > /dev/null`;
+        my $resp = `$curl --silent --dump-header /dev/stderr --max-redirs 0 $proto://127.0.0.1:$port/verify-fail/ 2>&1 > /dev/null`;
         like $resp, qr{^HTTP/[^ ]* 502\s}is;
         $resp = `$curl --silent --dump-header /dev/stderr --max-redirs 0 $proto://127.0.0.1:$port/no-verify/ 2>&1 > /dev/null`;
         unlike $resp, qr{^HTTP/[^ ]* 502\s}is;
-        $resp = `$curl --silent --dump-header /dev/stderr --max-redirs 0 $proto://127.0.0.1:$port/examp1e/ 2>&1 > /dev/null`;
+        $resp = `$curl --silent --dump-header /dev/stderr --max-redirs 0 $proto://localhost.examp1e.net:$port/verify-success 2>&1 > /dev/null`;
         like $resp, qr{^HTTP/[^ ]* 200\s}is;
     });
 };


### PR DESCRIPTION
## Overview

In my test environment, `t/50reverse-proxy-https.t` fails regularly because of connect errors to [wikipedia.org](https://wikipedia.org).

### Example of bug
#### The first run succeeded
```
$ BINARY_DIR=build PERL5LIB=. perl t/50reverse-proxy-https.t
spawning plackup... HTTP::Server::PSGI: Accepting connections at https://0:50590/
done
    # Subtest: reverse-proxy
spawning build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:26061) is ready to serve requests with 6 threads
done
        # Subtest: http/1
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:31:08 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
        ok 3
        1..3
    ok 1 - http/1
        # Subtest: https/1
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:31:08 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
        ok 3
        1..3
    ok 2 - https/1
        # Subtest: https/2
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:31:08 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
        ok 3
        1..3
killing build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
```

#### The second run failed to connect to the host
```
$ BINARY_DIR=build PERL5LIB=. perl t/50reverse-proxy-https.t
spawning plackup... HTTP::Server::PSGI: Accepting connections at https://0:50571/
done
    # Subtest: reverse-proxy
spawning build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:26206) is ready to serve requests with 6 threads
done
        # Subtest: http/1
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:33:12 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
[lib/core/proxy.c] in request:/:connection failure
        not ok 3
        #   Failed test at t/50reverse-proxy-https.t line 43.
        #                   'HTTP/1.1 502 Gateway Error
        # Connection: keep-alive
        # Content-Length: 18
        # Server: h2o/2.3.0-DEV@e44b7bd
        # content-type: text/plain; charset=utf-8
        # 
        # '
        #     doesn't match '(?^si:^HTTP/[^ ]* 200\s)'
        1..3
        # Looks like you failed 1 test of 3.
    not ok 1 - http/1
    #   Failed test 'http/1'
    #   at t/Util.pm line 335.
        # Subtest: https/1
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:33:12 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
[lib/core/proxy.c] in request:/:connection failure
        not ok 3
        #   Failed test at t/50reverse-proxy-https.t line 43.
        #                   'HTTP/1.1 502 Gateway Error
        # Connection: keep-alive
        # Content-Length: 18
        # Server: h2o/2.3.0-DEV@e44b7bd
        # content-type: text/plain; charset=utf-8
        # 
        # '
        #     doesn't match '(?^si:^HTTP/[^ ]* 200\s)'
        1..3
        # Looks like you failed 1 test of 3.
    not ok 3 - https/1
    #   Failed test 'https/1'
    #   at t/Util.pm line 341.
        # Subtest: https/2
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:33:12 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
[lib/core/proxy.c] in request:/:connection failure
        not ok 3
        #   Failed test at t/50reverse-proxy-https.t line 43.
        #                   'HTTP/2 502 
        # server: h2o/2.3.0-DEV@e44b7bd
        # content-type: text/plain; charset=utf-8
        # content-length: 18
        # 
        # '
        #     doesn't match '(?^si:^HTTP/[^ ]* 200\s)'
        1..3
        # Looks like you failed 1 test of 3.
    not ok 3 - https/2
    #   Failed test 'https/2'
    #   at t/Util.pm line 346.
killing build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..3
    # Looks like you failed 3 tests of 3.
not ok 1 - reverse-proxy
#   Failed test 'reverse-proxy'
#   at t/50reverse-proxy-https.t line 45.
```

## Proposal

Instead of attempting to connect to [wikipedia.org](https://wikipedia.org), the test performs better if we use another, more reliable host such as [h2o.examp1e.net](https://h2o.examp1e.net/) or [www.nalramli.com](http://www.nalramli.com/).  A more robust option would be to use the local upstream instance and point to it using the host name [localhost.examp1e.net](https://localhost.examp1e.net), which is already used in other test modules.  I took the latter approach.  Note that this requires this entry in `/etc/hosts`, as is the case in our docker tests:
```
127.0.0.1 localhost.examp1e.net
```

## Test

### Consistently succeeds with this patch

```
$ BINARY_DIR=build PERL5LIB=. perl t/50reverse-proxy-https.t
spawning plackup... HTTP::Server::PSGI: Accepting connections at https://0:50355/
done
spawning build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:26593) is ready to serve requests with 6 threads
done
    # Subtest: reverse-proxy
spawning build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:26607) is ready to serve requests with 6 threads
done
        # Subtest: http/1
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:41:59 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
        ok 3
        1..3
    ok 1 - http/1
        # Subtest: https/1
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:41:59 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
        ok 3
        1..3
    ok 2 - https/1
        # Subtest: https/2
[lib/core/proxy.c] in request:/:unable to get local issuer certificate
        ok 1
127.0.0.1 - - [14/Jul/2021:18:41:59 -0400] "GET / HTTP/1.1" 404 9 "-" "curl/7.77.0-DEV"
        ok 2
        ok 3
        1..3
    ok 3 - https/2
killing build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..3
ok 1 - reverse-proxy
```
