### PR TITLE
[test] [bug-fix] t/Util.p path should be preserved in run_as_root()

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -59,7 +59,7 @@ sub bindir {
 
 sub run_as_root {
     return if $< == 0;
-    exec qw(sudo -E env PERL5LIB=.), $^X, $0;
+    exec qw(sudo -E env PERL5LIB=.), "PATH=$ENV{PATH}", $^X, $0;
     die "failed to invoke $0 using sudo:$!";
 }
 


### PR DESCRIPTION
## Overview

Tests that run as root may fail if any tools are installed in non-standard locations.  This is due to `run_as_root()` starting a new shell that does not have the user's original `$PATH`.

For example, I am running a dev build of `curl` in my home directory.  This results in the following test failure:

```
$ BINARY_DIR=build PERL5LIB=. perl t/40running-user.t
    # Subtest: set-user
spawning build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:31580) is ready to serve requests with 6 threads
done
    not ok 1
    #   Failed test at t/40running-user.t line 35.
    #                   'sh: 1: curl: not found
    # '
    #     doesn't match '(?^s:^HTTP/1)'
killing build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..1
    # Looks like you failed 1 test of 1.
not ok 1 - set-user
#   Failed test 'set-user'
#   at t/40running-user.t line 13.
    # Subtest: automatic fallback to nobody
spawning build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:31595) is ready to serve requests with 6 threads
done
    not ok 1
    #   Failed test at t/40running-user.t line 35.
    #                   'sh: 1: curl: not found
    # '
    #     doesn't match '(?^s:^HTTP/1)'
killing build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..1
    # Looks like you failed 1 test of 1.
not ok 2 - automatic fallback to nobody
#   Failed test 'automatic fallback to nobody'
#   at t/40running-user.t line 17.
1..2
# Looks like you failed 2 tests of 2.
```

This patch sets the `$PATH` environment variable in the new shell of `run_as_root()` to fix the issue.

## Test

With this change, the function is able to find `curl` in my home directory and the test passes.

```
$ BINARY_DIR=build PERL5LIB=. perl t/40running-user.t
    # Subtest: set-user
spawning build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:31620) is ready to serve requests with 6 threads
done
    ok 1
killing build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..1
ok 1 - set-user
    # Subtest: automatic fallback to nobody
spawning build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
h2o server (pid:31636) is ready to serve requests with 6 threads
done
    ok 1
killing build/h2o... received SIGTERM, gracefully shutting down
killed (got 0)
    1..1
ok 2 - automatic fallback to nobody
1..2
```
