### PR TITLE
zero-clear, as `recvmsg` might not provide destination address through CMSG

### DIFF
--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -715,6 +715,7 @@ void h2o_quic_read_socket(h2o_quic_ctx_t *ctx, h2o_socket_t *sock)
             .msg_control = &dgrams[i].controlbuf,                                                                                  \
             .msg_controllen = sizeof(dgrams[i].controlbuf),                                                                        \
         };                                                                                                                         \
+        memset(&dgrams[i].destaddr, 0, sizeof(dgrams[i].destaddr));                                                                \
         dgrams[i].vec.iov_base = dgrams[i].buf;                                                                                    \
         dgrams[i].vec.iov_len = sizeof(dgrams[i].buf);                                                                             \
     } while (0)


### PR DESCRIPTION
Fixes regression introduced by #2794.

Previously, we have been zero-clearing everything except the buffer to which we read the payload (see https://github.com/h2o/h2o/blob/462a44e0ae8f08fd24f3a67bc88d295b0d8fdb7b/lib/http3/common.c#L711).

But with #2794, as a side-effect of the structure being refactored (to support `recvmmsg`), we have switched the approach to initialize the individual fields that we have to, rather than zero-clearing everything.

Unfortunately, we forgot to initialize `destaddr` used for conveying the destination address of the datagram, even though `recvmsg` / `recvmmsg` might not provide the address through CMSG.

This PR addresses this behavioral change by zero-clearing `destaddr`.