### PR TITLE
Kazuho/no time in h2olog

### DIFF
--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -932,6 +932,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("connect"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->connect.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->connect.at);
     json_write_pair_c(out_, STR_LIT("version"), event->connect.version);
@@ -941,6 +942,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("accept"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->accept.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->accept.at);
     json_write_pair_c(out_, STR_LIT("dcid"), event->accept.dcid, strlen(event->accept.dcid));
@@ -951,6 +953,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("free"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->free.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->free.at);
     break;
@@ -959,6 +962,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->send.at);
     json_write_pair_c(out_, STR_LIT("state"), event->send.state);
@@ -969,6 +973,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->receive.at);
     json_write_pair_c(out_, STR_LIT("dcid"), event->receive.dcid, strlen(event->receive.dcid));
@@ -980,6 +985,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("version-switch"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->version_switch.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->version_switch.at);
     json_write_pair_c(out_, STR_LIT("new-version"), event->version_switch.new_version);
@@ -989,6 +995,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("idle-timeout"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->idle_timeout.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->idle_timeout.at);
     break;
@@ -997,6 +1004,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stateless-reset-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stateless_reset_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stateless_reset_receive.at);
     break;
@@ -1005,6 +1013,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-handshake"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_handshake.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_handshake.at);
     json_write_pair_c(out_, STR_LIT("ret"), event->crypto_handshake.ret);
@@ -1014,6 +1023,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-update-secret"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_update_secret.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_update_secret.at);
     json_write_pair_c(out_, STR_LIT("is-enc"), event->crypto_update_secret.is_enc);
@@ -1028,6 +1038,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-send-key-update"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_send_key_update.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_send_key_update.at);
     json_write_pair_c(out_, STR_LIT("phase"), event->crypto_send_key_update.phase);
@@ -1040,6 +1051,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-send-key-update-confirmed"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_send_key_update_confirmed.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_send_key_update_confirmed.at);
     json_write_pair_c(out_, STR_LIT("next-pn"), event->crypto_send_key_update_confirmed.next_pn);
@@ -1049,6 +1061,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-receive-key-update"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_receive_key_update.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_receive_key_update.at);
     json_write_pair_c(out_, STR_LIT("phase"), event->crypto_receive_key_update.phase);
@@ -1061,6 +1074,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("crypto-receive-key-update-prepare"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->crypto_receive_key_update_prepare.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->crypto_receive_key_update_prepare.at);
     json_write_pair_c(out_, STR_LIT("phase"), event->crypto_receive_key_update_prepare.phase);
@@ -1073,6 +1087,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-sent"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_sent.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_sent.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_sent.pn);
@@ -1085,6 +1100,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-received"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_received.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_received.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_received.pn);
@@ -1099,6 +1115,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-prepare"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_prepare.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_prepare.at);
     json_write_pair_c(out_, STR_LIT("first-octet"), event->packet_prepare.first_octet);
@@ -1109,6 +1126,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-acked"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_acked.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_acked.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_acked.pn);
@@ -1119,6 +1137,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-lost"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_lost.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_lost.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_lost.pn);
@@ -1129,6 +1148,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("packet-decryption-failed"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->packet_decryption_failed.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->packet_decryption_failed.at);
     json_write_pair_c(out_, STR_LIT("pn"), event->packet_decryption_failed.pn);
@@ -1138,6 +1158,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("pto"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->pto.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->pto.at);
     json_write_pair_c(out_, STR_LIT("inflight"), event->pto.inflight);
@@ -1149,6 +1170,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("cc-ack-received"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->cc_ack_received.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->cc_ack_received.at);
     json_write_pair_c(out_, STR_LIT("largest-acked"), event->cc_ack_received.largest_acked);
@@ -1161,6 +1183,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("cc-congestion"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->cc_congestion.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->cc_congestion.at);
     json_write_pair_c(out_, STR_LIT("max-lost-pn"), event->cc_congestion.max_lost_pn);
@@ -1172,6 +1195,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-block-received"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->ack_block_received.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_block_received.at);
     json_write_pair_c(out_, STR_LIT("ack-block-begin"), event->ack_block_received.ack_block_begin);
@@ -1182,6 +1206,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-delay-received"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->ack_delay_received.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_delay_received.at);
     json_write_pair_c(out_, STR_LIT("ack-delay"), event->ack_delay_received.ack_delay);
@@ -1191,6 +1216,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->ack_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_send.at);
     json_write_pair_c(out_, STR_LIT("largest-acked"), event->ack_send.largest_acked);
@@ -1201,6 +1227,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ping-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->ping_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ping_send.at);
     break;
@@ -1209,6 +1236,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ping-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->ping_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ping_receive.at);
     break;
@@ -1217,6 +1245,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("transport-close-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->transport_close_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->transport_close_send.at);
     json_write_pair_c(out_, STR_LIT("error-code"), event->transport_close_send.error_code);
@@ -1228,6 +1257,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("transport-close-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->transport_close_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->transport_close_receive.at);
     json_write_pair_c(out_, STR_LIT("error-code"), event->transport_close_receive.error_code);
@@ -1239,6 +1269,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("application-close-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->application_close_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->application_close_send.at);
     json_write_pair_c(out_, STR_LIT("error-code"), event->application_close_send.error_code);
@@ -1249,6 +1280,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("application-close-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->application_close_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->application_close_receive.at);
     json_write_pair_c(out_, STR_LIT("error-code"), event->application_close_receive.error_code);
@@ -1259,6 +1291,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_send.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_send.stream_stream_id);
@@ -1271,6 +1304,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_receive.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_receive.stream_stream_id);
@@ -1282,6 +1316,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-acked"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_acked.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_acked.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_acked.stream_id);
@@ -1293,6 +1328,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-lost"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_lost.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_lost.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_lost.stream_id);
@@ -1304,6 +1340,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("reset-stream-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->reset_stream_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->reset_stream_send.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->reset_stream_send.stream_id);
@@ -1315,6 +1352,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("reset-stream-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->reset_stream_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->reset_stream_receive.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->reset_stream_receive.stream_id);
@@ -1326,6 +1364,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stop-sending-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stop_sending_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stop_sending_send.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stop_sending_send.stream_id);
@@ -1336,6 +1375,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stop-sending-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stop_sending_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stop_sending_receive.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stop_sending_receive.stream_id);
@@ -1346,6 +1386,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-data-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->max_data_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_data_send.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_data_send.maximum);
@@ -1355,6 +1396,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-data-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->max_data_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_data_receive.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_data_receive.maximum);
@@ -1364,6 +1406,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-streams-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->max_streams_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_streams_send.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_streams_send.maximum);
@@ -1374,6 +1417,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-streams-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->max_streams_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_streams_receive.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->max_streams_receive.maximum);
@@ -1384,6 +1428,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-stream-data-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->max_stream_data_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_stream_data_send.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->max_stream_data_send.stream_stream_id);
@@ -1394,6 +1439,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("max-stream-data-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->max_stream_data_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->max_stream_data_receive.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->max_stream_data_receive.stream_id);
@@ -1404,6 +1450,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->new_token_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_send.at);
     json_write_pair_c(out_, STR_LIT("token"), event->new_token_send.token, (event->new_token_send.token_len < STR_LEN ? event->new_token_send.token_len : STR_LEN));
@@ -1415,6 +1462,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-acked"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->new_token_acked.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_acked.at);
     json_write_pair_c(out_, STR_LIT("generation"), event->new_token_acked.generation);
@@ -1424,6 +1472,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-token-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->new_token_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_token_receive.at);
     json_write_pair_c(out_, STR_LIT("token"), event->new_token_receive.token, (event->new_token_receive.token_len < STR_LEN ? event->new_token_receive.token_len : STR_LEN));
@@ -1434,6 +1483,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("handshake-done-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->handshake_done_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->handshake_done_send.at);
     break;
@@ -1442,6 +1492,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("handshake-done-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->handshake_done_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->handshake_done_receive.at);
     break;
@@ -1450,6 +1501,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("streams-blocked-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->streams_blocked_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->streams_blocked_send.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->streams_blocked_send.maximum);
@@ -1460,6 +1512,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("streams-blocked-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->streams_blocked_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->streams_blocked_receive.at);
     json_write_pair_c(out_, STR_LIT("maximum"), event->streams_blocked_receive.maximum);
@@ -1470,6 +1523,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-connection-id-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->new_connection_id_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_connection_id_send.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->new_connection_id_send.sequence);
@@ -1482,6 +1536,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("new-connection-id-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->new_connection_id_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->new_connection_id_receive.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->new_connection_id_receive.sequence);
@@ -1494,6 +1549,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("retire-connection-id-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->retire_connection_id_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->retire_connection_id_send.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->retire_connection_id_send.sequence);
@@ -1503,6 +1559,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("retire-connection-id-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->retire_connection_id_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->retire_connection_id_receive.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->retire_connection_id_receive.sequence);
@@ -1512,6 +1569,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("data-blocked-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->data_blocked_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->data_blocked_send.at);
     json_write_pair_c(out_, STR_LIT("off"), event->data_blocked_send.off);
@@ -1521,6 +1579,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("data-blocked-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->data_blocked_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->data_blocked_receive.at);
     json_write_pair_c(out_, STR_LIT("off"), event->data_blocked_receive.off);
@@ -1530,6 +1589,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-data-blocked-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_data_blocked_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_data_blocked_send.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_data_blocked_send.stream_id);
@@ -1540,6 +1600,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-data-blocked-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_data_blocked_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_data_blocked_receive.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_data_blocked_receive.stream_id);
@@ -1550,6 +1611,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("datagram-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->datagram_send.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->datagram_send.at);
     if (include_appdata_) {
@@ -1562,6 +1624,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("datagram-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->datagram_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->datagram_receive.at);
     if (include_appdata_) {
@@ -1574,6 +1637,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ack-frequency-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->ack_frequency_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->ack_frequency_receive.at);
     json_write_pair_c(out_, STR_LIT("sequence"), event->ack_frequency_receive.sequence);
@@ -1586,6 +1650,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-send-stream"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_send_stream.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_send_stream.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->quictrace_send_stream.stream_stream_id);
@@ -1598,6 +1663,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-recv-stream"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_recv_stream.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_recv_stream.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->quictrace_recv_stream.stream_id);
@@ -1610,6 +1676,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-cc-ack"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_cc_ack.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_cc_ack.at);
     json_write_pair_c(out_, STR_LIT("min-rtt"), event->quictrace_cc_ack.rtt_minimum);
@@ -1624,6 +1691,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("quictrace-cc-lost"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->quictrace_cc_lost.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->quictrace_cc_lost.at);
     json_write_pair_c(out_, STR_LIT("min-rtt"), event->quictrace_cc_lost.rtt_minimum);
@@ -1638,6 +1706,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-open"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_open.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_open.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_open.stream_stream_id);
@@ -1647,6 +1716,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-destroy"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_destroy.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_destroy.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_destroy.stream_stream_id);
@@ -1657,6 +1727,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-shift"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_shift.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_shift.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_shift.stream_stream_id);
@@ -1667,6 +1738,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-emit"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_emit.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_emit.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_emit.stream_stream_id);
@@ -1678,6 +1750,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-send-stop"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_send_stop.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_send_stop.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_send_stop.stream_stream_id);
@@ -1688,6 +1761,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_receive.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_receive.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_receive.stream_stream_id);
@@ -1702,6 +1776,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("stream-on-receive-reset"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->stream_on_receive_reset.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->stream_on_receive_reset.at);
     json_write_pair_c(out_, STR_LIT("stream-id"), event->stream_on_receive_reset.stream_stream_id);
@@ -1712,6 +1787,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("conn-stats"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn"), event->conn_stats.conn_master_id);
     json_write_pair_c(out_, STR_LIT("time"), event->conn_stats.at);
     json_write_pair_c(out_, STR_LIT("stats"), event->conn_stats.stats);
@@ -1722,27 +1798,28 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("-private-socket-lookup-flags-sni"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tid"), event->_private_socket_lookup_flags_sni.tid);
     json_write_pair_c(out_, STR_LIT("original-flags"), event->_private_socket_lookup_flags_sni.original_flags);
     json_write_pair_c(out_, STR_LIT("server-name"), event->_private_socket_lookup_flags_sni.server_name, (event->_private_socket_lookup_flags_sni.server_name_len < STR_LEN ? event->_private_socket_lookup_flags_sni.server_name_len : STR_LEN));
     json_write_pair_c(out_, STR_LIT("server-name-len"), event->_private_socket_lookup_flags_sni.server_name_len);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST: { // h2o:receive_request
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("receive-request"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->receive_request.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->receive_request.req_id);
     json_write_pair_c(out_, STR_LIT("http-version"), event->receive_request.http_version);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_RECEIVE_REQUEST_HEADER: { // h2o:receive_request_header
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("receive-request-header"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->receive_request_header.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->receive_request_header.req_id);
     if (include_appdata_) {
@@ -1753,24 +1830,24 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
       json_write_pair_c(out_, STR_LIT("value"), event->receive_request_header.value, (event->receive_request_header.value_len < STR_LEN ? event->receive_request_header.value_len : STR_LEN));
     }
     json_write_pair_c(out_, STR_LIT("value-len"), event->receive_request_header.value_len);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_SEND_RESPONSE: { // h2o:send_response
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("send-response"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->send_response.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->send_response.req_id);
     json_write_pair_c(out_, STR_LIT("status"), event->send_response.status);
     json_write_pair_c(out_, STR_LIT("tunnel"), event->send_response.tunnel);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_SEND_RESPONSE_HEADER: { // h2o:send_response_header
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("send-response-header"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->send_response_header.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->send_response_header.req_id);
     if (include_appdata_) {
@@ -1781,200 +1858,199 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
       json_write_pair_c(out_, STR_LIT("value"), event->send_response_header.value, (event->send_response_header.value_len < STR_LEN ? event->send_response_header.value_len : STR_LEN));
     }
     json_write_pair_c(out_, STR_LIT("value-len"), event->send_response_header.value_len);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H1_ACCEPT: { // h2o:h1_accept
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h1-accept"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h1_accept.conn_id);
     json_write_pair_c(out_, STR_LIT("sock"), event->h1_accept.sock);
     json_write_pair_c(out_, STR_LIT("conn"), event->h1_accept.conn);
     json_write_pair_c(out_, STR_LIT("conn-uuid"), event->h1_accept.conn_uuid, strlen(event->h1_accept.conn_uuid));
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H1_CLOSE: { // h2o:h1_close
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h1-close"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h1_close.conn_id);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H2_UNKNOWN_FRAME_TYPE: { // h2o:h2_unknown_frame_type
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h2-unknown-frame-type"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h2_unknown_frame_type.conn_id);
     json_write_pair_c(out_, STR_LIT("frame-type"), event->h2_unknown_frame_type.frame_type);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3S_ACCEPT: { // h2o:h3s_accept
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3s-accept"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h3s_accept.conn_id);
     json_write_pair_c(out_, STR_LIT("conn"), event->h3s_accept.conn);
     json_write_pair_c(out_, STR_LIT("quic-master-id"), event->h3s_accept.quic_master_id);
     json_write_pair_c(out_, STR_LIT("conn-uuid"), event->h3s_accept.conn_uuid, strlen(event->h3s_accept.conn_uuid));
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3S_DESTROY: { // h2o:h3s_destroy
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3s-destroy"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h3s_destroy.conn_id);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3S_STREAM_SET_STATE: { // h2o:h3s_stream_set_state
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3s-stream-set-state"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("conn-id"), event->h3s_stream_set_state.conn_id);
     json_write_pair_c(out_, STR_LIT("req-id"), event->h3s_stream_set_state.req_id);
     json_write_pair_c(out_, STR_LIT("state"), event->h3s_stream_set_state.state);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3_FRAME_RECEIVE: { // h2o:h3_frame_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-frame-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("frame-type"), event->h3_frame_receive.frame_type);
     if (include_appdata_) {
       json_write_pair_c(out_, STR_LIT("bytes"), event->h3_frame_receive.bytes, (event->h3_frame_receive.bytes_len < STR_LEN ? event->h3_frame_receive.bytes_len : STR_LEN));
     }
     json_write_pair_c(out_, STR_LIT("bytes-len"), event->h3_frame_receive.bytes_len);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3_PACKET_RECEIVE: { // h2o:h3_packet_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-packet-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("dest"), event->h3_packet_receive.dest);
     json_write_pair_c(out_, STR_LIT("src"), event->h3_packet_receive.src);
     json_write_pair_c(out_, STR_LIT("bytes"), event->h3_packet_receive.bytes, (event->h3_packet_receive.bytes_len < STR_LEN ? event->h3_packet_receive.bytes_len : STR_LEN));
     json_write_pair_c(out_, STR_LIT("bytes-len"), event->h3_packet_receive.bytes_len);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3_PACKET_FORWARD: { // h2o:h3_packet_forward
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-packet-forward"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("dest"), event->h3_packet_forward.dest);
     json_write_pair_c(out_, STR_LIT("src"), event->h3_packet_forward.src);
     json_write_pair_c(out_, STR_LIT("num-packets"), event->h3_packet_forward.num_packets);
     json_write_pair_c(out_, STR_LIT("bytes-len"), event->h3_packet_forward.num_bytes);
     json_write_pair_c(out_, STR_LIT("fd"), event->h3_packet_forward.fd);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3_PACKET_FORWARD_TO_NODE_IGNORE: { // h2o:h3_packet_forward_to_node_ignore
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-packet-forward-to-node-ignore"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("node-id"), event->h3_packet_forward_to_node_ignore.node_id);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3_PACKET_FORWARD_TO_THREAD_IGNORE: { // h2o:h3_packet_forward_to_thread_ignore
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-packet-forward-to-thread-ignore"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("thread-id"), event->h3_packet_forward_to_thread_ignore.thread_id);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3_FORWARDED_PACKET_RECEIVE: { // h2o:h3_forwarded_packet_receive
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3-forwarded-packet-receive"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("dest"), event->h3_forwarded_packet_receive.dest);
     json_write_pair_c(out_, STR_LIT("src"), event->h3_forwarded_packet_receive.src);
     json_write_pair_c(out_, STR_LIT("bytes-len"), event->h3_forwarded_packet_receive.num_bytes);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_H3C_TUNNEL_CREATE: { // h2o:h3c_tunnel_create
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("h3c-tunnel-create"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tunnel"), event->h3c_tunnel_create.tunnel);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_ON_DESTROY: { // h2o:tunnel_on_destroy
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-on-destroy"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_on_destroy.tunnel);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_ON_READ: { // h2o:tunnel_on_read
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-on-read"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_on_read.tunnel);
     json_write_pair_c(out_, STR_LIT("err"), event->tunnel_on_read.err, strlen(event->tunnel_on_read.err));
     if (include_appdata_) {
       json_write_pair_c(out_, STR_LIT("bytes"), event->tunnel_on_read.bytes, (event->tunnel_on_read.bytes_len < STR_LEN ? event->tunnel_on_read.bytes_len : STR_LEN));
     }
     json_write_pair_c(out_, STR_LIT("bytes-len"), event->tunnel_on_read.bytes_len);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_PROCEED_READ: { // h2o:tunnel_proceed_read
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-proceed-read"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_proceed_read.tunnel);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_WRITE: { // h2o:tunnel_write
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-write"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_write.tunnel);
     if (include_appdata_) {
       json_write_pair_c(out_, STR_LIT("bytes"), event->tunnel_write.bytes, (event->tunnel_write.bytes_len < STR_LEN ? event->tunnel_write.bytes_len : STR_LEN));
     }
     json_write_pair_c(out_, STR_LIT("bytes-len"), event->tunnel_write.bytes_len);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_TUNNEL_ON_WRITE_COMPLETE: { // h2o:tunnel_on_write_complete
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("tunnel-on-write-complete"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tunnel"), event->tunnel_on_write_complete.tunnel);
     json_write_pair_c(out_, STR_LIT("err"), event->tunnel_on_write_complete.err, strlen(event->tunnel_on_write_complete.err));
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_CREATE: { // h2o:socket_tunnel_create
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("socket-tunnel-create"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tunnel"), event->socket_tunnel_create.tunnel);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
   case H2OLOG_EVENT_ID_H2O_SOCKET_TUNNEL_START: { // h2o:socket_tunnel_start
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("socket-tunnel-start"));
     json_write_pair_c(out_, STR_LIT("tid"), event->tid);
     json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());
     json_write_pair_c(out_, STR_LIT("tunnel"), event->socket_tunnel_start.tunnel);
     json_write_pair_c(out_, STR_LIT("bytes-to-consume"), event->socket_tunnel_start.bytes_to_consume);
-    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());
     break;
   }
 

--- a/src/h2olog/misc/gen_raw_tracer.py
+++ b/src/h2olog/misc/gen_raw_tracer.py
@@ -710,6 +710,7 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     handle_event_func += '    json_write_pair_n(out_, STR_LIT("type"), STR_LIT("%s"));\n' % probe_name.replace("_", "-")
     handle_event_func += '    json_write_pair_c(out_, STR_LIT("tid"), event->tid);\n'
     handle_event_func += '    json_write_pair_c(out_, STR_LIT("seq"), seq_);\n'
+    handle_event_func += '    json_write_pair_c(out_, STR_LIT("h2olog-time"), time_milliseconds());\n'
 
     for field_name, field_type in flat_args_map.items():
       stmts = ""
@@ -742,9 +743,6 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
         handle_event_func += "    }\n"
       else:
         handle_event_func += stmts
-
-    if metadata["provider"] == "h2o":
-      handle_event_func += '    json_write_pair_c(out_, STR_LIT("time"), time_milliseconds());\n'
 
     handle_event_func += "    break;\n"
     handle_event_func += "  }\n"


### PR DESCRIPTION
At the moment, `time` field means two things:
* for events generated by quicly, it represents the time value that quicly referred to, when generating an event
* for events generated by h2o, it represents the time value when h2olog received the event

This is very confusing, and it is easy to miss the fact that the latter cannot be used for tracking events related to time (because there could be significant delay from when h2o generates an event until when h2olog receives them).

This PR changes the name of the latter to `h2olog-time` to avoid the confusion, adding the field to all the events. As an alternative, we can just get rid of the field.

Thoughts? @gfx @janaiyengar 