### PR TITLE
[connect-udp] add mock definitions

### DIFF
--- a/fuzz/quicly_mock.c
+++ b/fuzz/quicly_mock.c
@@ -453,5 +453,17 @@ int quicly_foreach_stream(quicly_conn_t *conn, void *thunk, int (*cb)(void *thun
     return 0;
 }
 
+quicly_stream_t *quicly_get_stream(quicly_conn_t *conn, quicly_stream_id_t stream_id)
+{
+    assert(0 && "unimplemented");
+    NULL;
+}
+
+void quicly_send_datagram_frames(quicly_conn_t *conn, ptls_iovec_t *datagrams, size_t num_datagrams)
+{
+    assert(0 && "unimplemented");
+    NULL;
+}
+
 const uint32_t quicly_supported_versions[] = {QUICLY_PROTOCOL_VERSION_1, QUICLY_PROTOCOL_VERSION_DRAFT29,
                                               QUICLY_PROTOCOL_VERSION_DRAFT27, 0};

--- a/fuzz/quicly_mock.c
+++ b/fuzz/quicly_mock.c
@@ -456,13 +456,12 @@ int quicly_foreach_stream(quicly_conn_t *conn, void *thunk, int (*cb)(void *thun
 quicly_stream_t *quicly_get_stream(quicly_conn_t *conn, quicly_stream_id_t stream_id)
 {
     assert(0 && "unimplemented");
-    NULL;
+    return NULL;
 }
 
 void quicly_send_datagram_frames(quicly_conn_t *conn, ptls_iovec_t *datagrams, size_t num_datagrams)
 {
     assert(0 && "unimplemented");
-    NULL;
 }
 
 const uint32_t quicly_supported_versions[] = {QUICLY_PROTOCOL_VERSION_1, QUICLY_PROTOCOL_VERSION_DRAFT29,

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1721,6 +1721,7 @@ static void on_h3_destroy(h2o_quic_conn_t *h3_)
     if (h2o_timer_is_linked(&conn->timeout))
         h2o_timer_unlink(&conn->timeout);
     h2o_http3_dispose_conn(&conn->h3);
+    kh_destroy(stream, conn->datagram_flows);
 
     /* check consistency post-disposal */
     assert(conn->num_streams.recv_headers == 0);
@@ -1809,6 +1810,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
         if (accept_ret == QUICLY_ERROR_DECRYPTION_FAILED)
             ret = (h2o_http3_conn_t *)H2O_QUIC_ACCEPT_CONN_DECRYPTION_FAILED;
         h2o_http3_dispose_conn(&conn->h3);
+        kh_destroy(stream, conn->datagram_flows);
         free(conn);
         return ret;
     }


### PR DESCRIPTION
kazuho/connect-udp (#2568) branch started using two new quicly functions. Hence add corresponding entries to the mock.