### PR TITLE
[quic] [stats] Implement quic.num-bytes.lost, quic.num-bytes.stream-data-sent, quic.num-bytes.stream-data-resent statistics

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -622,8 +622,8 @@ struct st_h2o_quic_aggregated_stats_t {
     func(num_bytes.received, "num-bytes.received") \
     func(num_bytes.sent, "num-bytes.sent") \
     func(num_bytes.lost, "num-bytes.lost") \
-    func(num_bytes.stream_data_sent, "num-bytes.stream_data_sent") \
-    func(num_bytes.stream_data_resent, "num-bytes.stream_data_resent") \
+    func(num_bytes.stream_data_sent, "num-bytes.stream-data-sent") \
+    func(num_bytes.stream_data_resent, "num-bytes.stream-data-resent") \
     func(num_frames_sent.padding, "num-frames-sent.padding") \
     func(num_frames_sent.ping, "num-frames-sent.ping") \
     func(num_frames_sent.ack, "num-frames-sent.ack") \

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -621,6 +621,8 @@ struct st_h2o_quic_aggregated_stats_t {
     func(num_packets.late_acked, "num-packets.late-acked") \
     func(num_bytes.received, "num-bytes.received") \
     func(num_bytes.sent, "num-bytes.sent") \
+    func(num_bytes.lost, "num-bytes.lost") \
+    func(num_bytes.resent, "num-bytes.resent") \
     func(num_frames_sent.padding, "num-frames-sent.padding") \
     func(num_frames_sent.ping, "num-frames-sent.ping") \
     func(num_frames_sent.ack, "num-frames-sent.ack") \

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -622,7 +622,8 @@ struct st_h2o_quic_aggregated_stats_t {
     func(num_bytes.received, "num-bytes.received") \
     func(num_bytes.sent, "num-bytes.sent") \
     func(num_bytes.lost, "num-bytes.lost") \
-    func(num_bytes.resent, "num-bytes.resent") \
+    func(num_bytes.stream_data_sent, "num-bytes.stream_data_sent") \
+    func(num_bytes.stream_data_resent, "num-bytes.stream_data_resent") \
     func(num_frames_sent.padding, "num-frames-sent.padding") \
     func(num_frames_sent.ping, "num-frames-sent.ping") \
     func(num_frames_sent.ack, "num-frames-sent.ack") \


### PR DESCRIPTION
## Overview
There is a pending update to QUIC in https://github.com/h2o/quicly/pull/482 that implements a counter for lost and resent Bytes.  This change implements the output of those statistics.

**DO NOT MERGE** until https://github.com/h2o/quicly/pull/482 has been merged and the corresponding commit imported to [h2o/h2o](https://github.com/h2o/h2o).

## Test
```
$ ./h2o-httpclient -k -3 100 -C 10 -t 100 -H "user-agent: nalramli/1.0" -b 2800 -c 1400 https://127.0.0.2:1443/1GB.dat 1>/dev/null 2>&1

$ ./h2o-httpclient -k -H "user-agent: nalramli/1.0" http://127.0.0.1:1444/server-status/json 2>/dev/null | grep "quic.num-bytes."
 "quic.num-bytes.received": 61253512,
 "quic.num-bytes.sent": 102950747761,
 "quic.num-bytes.lost": 212945920,
 "quic.num-bytes.stream-data-sent": 100214927406,
 "quic.num-bytes.stream-data-resent": 207284349,
```
