### PR TITLE
Allow connecting to HTTP/2 servers over unix sockets

### DIFF
--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -279,7 +279,6 @@ struct st_h2o_httpclient_t {
         h2o_httpclient_head_cb on_head;
         h2o_httpclient_body_cb on_body;
     } _cb;
-    size_t _protocol_selector;
 };
 
 /**

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -133,6 +133,7 @@ typedef struct st_h2o_httpclient_ctx_t {
     uint64_t keepalive_timeout; /* only used for http2 for now */
     size_t max_buffer_size;
     unsigned tunnel_enabled : 1;
+    unsigned force_cleartext_http2 : 1;
 
     struct st_h2o_httpclient_protocol_selector_t {
         h2o_httpclient_protocol_ratio_t ratio;

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -279,6 +279,7 @@ struct st_h2o_httpclient_t {
         h2o_httpclient_head_cb on_head;
         h2o_httpclient_body_cb on_body;
     } _cb;
+    size_t _protocol_selector;
 };
 
 /**

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -123,9 +123,13 @@ static void on_pool_connect(h2o_socket_t *sock, const char *errstr, void *data, 
 
     h2o_iovec_t alpn_proto;
     if (sock->ssl == NULL || (alpn_proto = h2o_socket_ssl_get_selected_protocol(sock)).len == 0) {
+        /* 100% means prior knowledge connect, force h2 */
+        if (client->ctx->protocol_selector.ratio.http2 == 100)
+            goto ForceH2;
         h2o_httpclient__h1_on_connect(client, sock, origin);
     } else {
         if (h2o_memis(alpn_proto.base, alpn_proto.len, H2O_STRLIT("h2"))) {
+        ForceH2:
             /* detach this socket from the socketpool to count the number of h1 connections correctly */
             h2o_socketpool_detach(client->connpool->socketpool, sock);
             h2o_httpclient__h2_on_connect(client, sock, origin);

--- a/lib/common/httpclient.c
+++ b/lib/common/httpclient.c
@@ -107,6 +107,36 @@ static h2o_httpclient_t *create_client(h2o_httpclient_t **_client, h2o_mem_pool_
     return client;
 }
 
+static void on_pool_connect(h2o_socket_t *sock, const char *errstr, void *data, h2o_url_t *origin)
+{
+    h2o_httpclient_t *client = data;
+
+    h2o_timer_unlink(&client->_timeout);
+
+    client->_connect_req = NULL;
+
+    if (sock == NULL) {
+        assert(errstr != NULL);
+        on_connect_error(client, errstr);
+        return;
+    }
+
+    h2o_iovec_t alpn_proto;
+    if (sock->ssl == NULL || (alpn_proto = h2o_socket_ssl_get_selected_protocol(sock)).len == 0) {
+        h2o_httpclient__h1_on_connect(client, sock, origin);
+    } else {
+        if (h2o_memis(alpn_proto.base, alpn_proto.len, H2O_STRLIT("h2"))) {
+            /* detach this socket from the socketpool to count the number of h1 connections correctly */
+            h2o_socketpool_detach(client->connpool->socketpool, sock);
+            h2o_httpclient__h2_on_connect(client, sock, origin);
+        } else if (memcmp(alpn_proto.base, "http/1.1", alpn_proto.len) == 0) {
+            h2o_httpclient__h1_on_connect(client, sock, origin);
+        } else {
+            on_connect_error(client, h2o_httpclient_error_unknown_alpn_protocol);
+        }
+    }
+}
+
 enum {
     /**
      * indicates that H1 should be chosen
@@ -129,40 +159,6 @@ enum {
      */
     PROTOCOL_SELECTOR_COUNT
 };
-
-static void on_pool_connect(h2o_socket_t *sock, const char *errstr, void *data, h2o_url_t *origin)
-{
-    h2o_httpclient_t *client = data;
-
-    h2o_timer_unlink(&client->_timeout);
-
-    client->_connect_req = NULL;
-
-    if (sock == NULL) {
-        assert(errstr != NULL);
-        on_connect_error(client, errstr);
-        return;
-    }
-
-    h2o_iovec_t alpn_proto;
-    if (sock->ssl == NULL || (alpn_proto = h2o_socket_ssl_get_selected_protocol(sock)).len == 0) {
-        if (client->_protocol_selector == PROTOCOL_SELECTOR_H2) {
-            goto Force_H2;
-        }
-        h2o_httpclient__h1_on_connect(client, sock, origin);
-    } else {
-        if (h2o_memis(alpn_proto.base, alpn_proto.len, H2O_STRLIT("h2"))) {
-        Force_H2:
-            /* detach this socket from the socketpool to count the number of h1 connections correctly */
-            h2o_socketpool_detach(client->connpool->socketpool, sock);
-            h2o_httpclient__h2_on_connect(client, sock, origin);
-        } else if (memcmp(alpn_proto.base, "http/1.1", alpn_proto.len) == 0) {
-            h2o_httpclient__h1_on_connect(client, sock, origin);
-        } else {
-            on_connect_error(client, h2o_httpclient_error_unknown_alpn_protocol);
-        }
-    }
-}
 
 static size_t select_protocol(struct st_h2o_httpclient_protocol_selector_t *selector)
 {
@@ -210,10 +206,9 @@ static struct st_h2o_httpclient__h2_conn_t *find_h2conn(h2o_httpclient_connectio
 
 static void connect_using_socket_pool(h2o_httpclient_t **_client, h2o_mem_pool_t *pool, void *data, h2o_httpclient_ctx_t *ctx,
                                       h2o_httpclient_connection_pool_t *connpool, h2o_url_t *origin, const char *upgrade_to,
-                                      h2o_httpclient_connect_cb on_connect, h2o_iovec_t alpn_protos, size_t selected_protocol)
+                                      h2o_httpclient_connect_cb on_connect, h2o_iovec_t alpn_protos)
 {
     h2o_httpclient_t *client = create_client(_client, pool, data, ctx, connpool, upgrade_to, on_connect);
-    client->_protocol_selector = selected_protocol;
     h2o_timer_link(client->ctx->loop, client->ctx->connect_timeout, &client->_timeout);
     h2o_socketpool_connect(&client->_connect_req, connpool->socketpool, origin, ctx->loop, ctx->getaddr_receiver, alpn_protos,
                            on_pool_connect, client);
@@ -254,7 +249,7 @@ void h2o_httpclient_connect(h2o_httpclient_t **_client, h2o_mem_pool_t *pool, vo
     switch (selected_protocol) {
     case PROTOCOL_SELECTOR_H1:
         /* H1: use the socket pool to obtain a connection, without any ALPN */
-        connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, no_protos, selected_protocol);
+        connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, no_protos);
         break;
     case PROTOCOL_SELECTOR_H2: {
         /* H2: use existing H2 connection (if any) or create a new connection offering both H1 and H2 */
@@ -262,8 +257,7 @@ void h2o_httpclient_connect(h2o_httpclient_t **_client, h2o_mem_pool_t *pool, vo
         if (h2conn != NULL) {
             connect_using_h2conn(_client, pool, data, h2conn, connpool, upgrade_to, on_connect);
         } else {
-            connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, both_protos,
-                                      selected_protocol);
+            connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, both_protos);
         }
     } break;
     case PROTOCOL_SELECTOR_H3:
@@ -280,20 +274,17 @@ void h2o_httpclient_connect(h2o_httpclient_t **_client, h2o_mem_pool_t *pool, vo
             if (http2_ratio <= http1_ratio) {
                 connect_using_h2conn(_client, pool, data, h2conn, connpool, upgrade_to, on_connect);
             } else {
-                connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, no_protos,
-                                          selected_protocol);
+                connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, no_protos);
             }
         } else if (h2conn != NULL) {
             /* h2 connection exists */
             connect_using_h2conn(_client, pool, data, h2conn, connpool, upgrade_to, on_connect);
         } else if (connpool->socketpool->_shared.pooled_count != 0) {
             /* h1 connection exists */
-            connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, no_protos,
-                                      selected_protocol);
+            connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, no_protos);
         } else {
             /* no connections, connect using ALPN */
-            connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, both_protos,
-                                      selected_protocol);
+            connect_using_socket_pool(_client, pool, data, ctx, connpool, origin, upgrade_to, on_connect, both_protos);
         }
     } break;
     }

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -652,7 +652,10 @@ int main(int argc, char **argv)
             ssl_verify_none = 1;
             break;
         case '2':
-            if (sscanf(optarg, "%" SCNd8, &ctx.protocol_selector.ratio.http2) != 1 ||
+            if (!strcasecmp(optarg, "f")) {
+                ctx.protocol_selector.ratio.http2 = 100;
+                ctx.force_cleartext_http2 = 1;
+            } else if (sscanf(optarg, "%" SCNd8, &ctx.protocol_selector.ratio.http2) != 1 ||
                 !(0 <= ctx.protocol_selector.ratio.http2 && ctx.protocol_selector.ratio.http2 <= 100)) {
                 fprintf(stderr, "failed to parse HTTP/2 ratio (-2)\n");
                 exit(EXIT_FAILURE);


### PR DESCRIPTION
I'm not sure this even makes sense, but the idea is that the client has previous knowledge of a server listening on a socket and expecting HTTP/2 (there's no SSL, so it's clear text HTTP/2, but not h2c).