### PR TITLE
fix h3 leak and update fuzz/quicly_mock.c to fix h2o-fuzzer-http3 build

### DIFF
--- a/fuzz/quicly_mock.c
+++ b/fuzz/quicly_mock.c
@@ -101,6 +101,14 @@ int quicly_stream_can_send(quicly_stream_t *stream, int at_stream_level)
     return 1;
 }
 
+quicly_stream_t *quicly_get_stream(quicly_conn_t *conn, quicly_stream_id_t stream_id)
+{
+     khiter_t iter = kh_get(quicly_stream_t, conn->streams, stream_id);
+     if (iter != kh_end(conn->streams))
+         return kh_val(conn->streams, iter);
+     return NULL;
+}
+
 ptls_t *quicly_get_tls(quicly_conn_t *conn)
 {
     /* TODO: is this okay */
@@ -446,6 +454,12 @@ Exit:
     *num_datagrams = 0;
     return ret;
 }
+
+void quicly_send_datagram_frames(quicly_conn_t *conn, ptls_iovec_t *datagrams, size_t num_datagrams)
+{
+    quicly_send(conn, NULL, NULL, (struct iovec *) datagrams, &num_datagrams, NULL, 0);
+}
+
 
 int quicly_foreach_stream(quicly_conn_t *conn, void *thunk, int (*cb)(void *thunk, quicly_stream_t *stream))
 {

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1721,6 +1721,7 @@ static void on_h3_destroy(h2o_quic_conn_t *h3_)
     if (h2o_timer_is_linked(&conn->timeout))
         h2o_timer_unlink(&conn->timeout);
     h2o_http3_dispose_conn(&conn->h3);
+    kh_destroy(stream, conn->datagram_flows);
 
     /* check consistency post-disposal */
     assert(conn->num_streams.recv_headers == 0);
@@ -1809,6 +1810,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
         if (accept_ret == QUICLY_ERROR_DECRYPTION_FAILED)
             ret = (h2o_http3_conn_t *)H2O_QUIC_ACCEPT_CONN_DECRYPTION_FAILED;
         h2o_http3_dispose_conn(&conn->h3);
+        kh_destroy(stream, conn->datagram_flows);
         free(conn);
         return ret;
     }


### PR DESCRIPTION
The build for `h2o-fuzzer-http3` is failing in the `connect-udp` branch due to the quicly mock being out of date, aa32c8442db481a7b66c17b37e7a16d1128ad3e3 should address it. Let me know if this is not the correct branch to fix this in and I'll retarget and if `quicly_send_datagram_frames` should be more than just a stub.

The h3 fuzzer is still failing however due to a leak of the `datagram_flows` table in `lib/http3/server.c`, this is addresed in a9c4a2505421b14ab87933f69e23ba16746aca59