### PR TITLE
libh2o: add macro 'H2O_EVLOOP_USE_CLOCK'

### DIFF
--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -44,7 +44,11 @@ typedef struct st_h2o_evloop_t {
     } _statechanged;
     uint64_t _now_millisec;
     uint64_t _now_nanosec;
+#ifdef H2O_EVLOOP_USE_CLOCK
+    struct timespec _ts_at;
+#else
     struct timeval _tv_at;
+#endif
     h2o_timerwheel_t *_timeouts;
     h2o_sliding_counter_t exec_time_nanosec_counter;
 } h2o_evloop_t;
@@ -79,7 +83,14 @@ static void h2o_timer_link(h2o_evloop_t *loop, uint64_t delay_ticks, h2o_timer_t
 
 static inline struct timeval h2o_gettimeofday(h2o_evloop_t *loop)
 {
+#ifdef H2O_EVLOOP_USE_CLOCK
+    struct timeval _tv;
+    _tv.tv_sec = loop->_ts_at.tv_sec;
+    _tv.tv_usec = loop->_ts_at.tv_nsec / 1000;
+    return _tv;
+#else
     return loop->_tv_at;
+#endif
 }
 
 static inline uint64_t h2o_now(h2o_evloop_t *loop)

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -507,8 +507,13 @@ h2o_evloop_t *create_evloop(size_t sz)
 
 void update_now(h2o_evloop_t *loop)
 {
+#ifdef H2O_EVLOOP_USE_CLOCK
+    clock_gettime(H2O_EVLOOP_USE_CLOCK, &loop->_ts_at);
+    loop->_now_nanosec = (uint64_t)loop->_ts_at.tv_sec * 1000000000 + loop->_ts_at.tv_nsec;
+#else
     gettimeofday(&loop->_tv_at, NULL);
     loop->_now_nanosec = ((uint64_t)loop->_tv_at.tv_sec * 1000000 + loop->_tv_at.tv_usec) * 1000;
+#endif
     loop->_now_millisec = loop->_now_nanosec / 1000000;
 }
 


### PR DESCRIPTION
thus makes it possible to use clock_gettime(2) instead of gettimeofday(2) for evloop.
potential usecase is to define as eg 'CLOCK_MONOTONIC' to
avoid wall-time discontinuous jumps.

Issues #2321