### PR TITLE
lib/http2/connection.c::proceed_request reset streams on error

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -737,10 +737,10 @@ static void proceed_request(h2o_req_t *req, size_t written, h2o_send_state_t sen
 
     if (send_state == H2O_SEND_STATE_ERROR) {
         finish_body_streaming(stream);
-        if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING)
+        if (conn->state < H2O_HTTP2_CONN_STATE_IS_CLOSING) {
             stream_send_error(conn, stream->stream_id, H2O_HTTP2_ERROR_STREAM_CLOSED);
-        if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM)
-            h2o_http2_stream_close(conn, stream);
+            h2o_http2_stream_reset(conn, stream);
+        }
         return;
     }
 


### PR DESCRIPTION
(backport of #2819)

Before this PR, we could call `stream_send_error` possibly without closing the stream and definitely without reseting it.
This is problematic, because its possible that `stream_send_error` queues a write, without setting the stream state to `H2O_HTTP2_STREAM_STATE_END_STREAM`, allowing a subsequent write to happen and eventually assert.