### PR TITLE
libh2o: remove macro 'H2O_USE_PICOTLS' judge

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -4628,7 +4628,6 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					"H2O_USE_PICOTLS=1",
 					"PICOTLS_USE_DTRACE=1",
 					"QUICLY_USE_DTRACE=1",
 					"QUICLY_USE_TRACER=1",
@@ -4673,7 +4672,6 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					"H2O_USE_PICOTLS=1",
 					"PICOTLS_USE_DTRACE=1",
 					"QUICLY_USE_DTRACE=1",
 					"QUICLY_USE_TRACER=1",

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -843,11 +843,9 @@ h2o_iovec_t h2o_socket_get_ssl_session_id(h2o_socket_t *sock)
 const char *h2o_socket_get_ssl_server_name(const h2o_socket_t *sock)
 {
     if (sock->ssl != NULL) {
-#if H2O_USE_PICOTLS
         if (sock->ssl->ptls != NULL) {
             return ptls_get_server_name(sock->ssl->ptls);
         } else
-#endif
             if (sock->ssl->ossl != NULL) {
             return SSL_get_servername(sock->ssl->ossl, TLSEXT_NAMETYPE_host_name);
         }


### PR DESCRIPTION
'H2O_USE_PICOTLS' removed in a42769ce4dceee6c57e9453e59af5e67ab9d267f