### PR TITLE
add mock dns server to test suite

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu1604
+++ b/misc/docker-ci/Dockerfile.ubuntu1604
@@ -8,7 +8,7 @@ RUN apt-get install --yes php-cgi
 
 # tools for building and testing
 RUN apt-get install --yes apache2-utils cmake cmake-data git memcached netcat-openbsd nghttp2-client redis-server wget sudo
-RUN apt-get install --yes libev-dev libc-ares-dev libnghttp2-dev libssl-dev libuv1-dev zlib1g-dev libbrotli-dev
+RUN apt-get install --yes libev-dev libc-ares-dev libnghttp2-dev libssl-dev libuv1-dev zlib1g-dev libbrotli-dev dnsutils
 
 # clang-4.0 for fuzzing
 RUN apt-get install -y clang-4.0
@@ -42,6 +42,7 @@ RUN apt-get install --yes cpanminus
 RUN apt-get install --yes libfcgi-perl libfcgi-procmanager-perl libipc-signal-perl libjson-perl liblist-moreutils-perl libplack-perl libscope-guard-perl libtest-exception-perl libwww-perl libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
 RUN sudo cpanm --notest Starlet Protocol::HTTP2
+RUN sudo cpanm --notest Net::DNS::Nameserver
 
 # Test-TCP 2.21
 RUN sudo cpanm --notest https://github.com/tokuhirom/Test-TCP.git@2.21

--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -10,6 +10,7 @@ RUN apt-get install --yes \
 	cmake \
 	cmake-data \
 	curl \
+	dnsutils \
 	flex \
 	git \
 	libbrotli-dev \
@@ -60,6 +61,7 @@ RUN apt-get install --yes \
 	libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
 RUN sudo cpanm --notest Starlet Protocol::HTTP2
+RUN sudo cpanm --notest Net::DNS::Nameserver
 RUN sudo cpanm --notest https://github.com/tokuhirom/Test-TCP.git@2.21
 
 # h2spec

--- a/t/50dnsresolver.t
+++ b/t/50dnsresolver.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(empty_port wait_port);
+use Test::More;
+use t::Util;
+
+my $dns_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
+
+my $zone_rrs = [
+    'bar.example.com. 60 IN AAAA 2001:db8::1',
+    'foo.example.com. 60 IN AAAA 2001:db8::2',
+    'foo.example.com. 60 IN AAAA 2001:db8::3',
+    'bar.example.com. 60 IN A 127.0.0.2',
+    'foo.example.com. 60 IN A 127.0.0.3'
+    ];
+
+my $delays = {'A' => 2, 'AAAA' => 1};
+
+my $mock_dns = spawn_dns_server($dns_port, $zone_rrs, $delays);
+
+subtest "dns_resp" => sub {
+    my $resp;
+    my $before = time();
+    $resp = `dig +short \@127.0.0.1 -p $dns_port a foo.example.com`;
+    my $after = time();
+    like $resp, qr{^127.0.0.3};
+    $resp = `dig +short \@127.0.0.1 -p $dns_port aaaa foo.example.com`;
+    like $resp, qr{^2001:db8};
+    ok(($after - $before) >= 2);
+};
+
+done_testing;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -763,7 +763,7 @@ sub spawn_dns_server {
                         sleep($delays->{$qtype});
                     }
                     @ans = shuffle(@ans);
-                    return ( $rcode, \@ans, \@auth, \@add, $headermask, $optionmask );
+                    return ($rcode, \@ans, \@auth, \@add, $headermask, $optionmask);
                 },
                 Verbose      => 0
             ) || die "couldn't create nameserver object\n";

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -7,7 +7,9 @@ use File::Temp qw(tempfile tempdir);
 use IO::Socket::INET;
 use IO::Socket::SSL;
 use IO::Poll qw(POLLIN POLLOUT POLLHUP POLLERR);
+use List::Util qw(shuffle);
 use Net::EmptyPort qw(check_port empty_port);
+use Net::DNS::Nameserver;
 use POSIX ":sys_wait_h";
 use Path::Tiny;
 use Protocol::HTTP2::Connection;
@@ -48,6 +50,7 @@ our @EXPORT = qw(
     get_tracer
     check_dtrace_availability
     run_picotls_client
+    spawn_dns_server
 );
 
 use constant ASSETS_DIR => 't/assets';
@@ -729,6 +732,44 @@ EOT
         or die "failed to open file:$tempdir/resp.txt:$!";
     my $resp = do { local $/; <$fh> };
     return $resp;
+}
+
+sub spawn_dns_server {
+    my ($dns_port, $zone_rrs, $delays) = @_;
+
+    my $server = spawn_forked(sub {
+            my $ns = Net::DNS::Nameserver->new(
+                LocalPort    => $dns_port,
+                ReplyHandler => sub {
+                    my ( $qname, $qclass, $qtype, $peerhost, $query, $conn ) = @_;
+                    my ( $rcode, @ans, @auth, @add);
+
+                    foreach (@$zone_rrs) {
+                        my $rr = Net::DNS::RR->new($_);
+                        if ($rr->owner eq $qname && $rr->class eq $qclass && $rr->type eq $qtype) {
+                            push @ans, $rr;
+                        }
+                    }
+
+                    if (!@ans) {
+                        $rcode = "NXDOMAIN";
+                    } else {
+                        $rcode = "NOERROR";
+                    }
+                    # mark the answer as authoritative (by setting the 'aa' flag)
+                    my $headermask = {aa => 1};
+                    my $optionmask = {};
+                    if ($delays && $delays->{$qtype} > 0) {
+                        sleep($delays->{$qtype});
+                    }
+                    @ans = shuffle(@ans);
+                    return ( $rcode, \@ans, \@auth, \@add, $headermask, $optionmask );
+                },
+                Verbose      => 0
+            ) || die "couldn't create nameserver object\n";
+            $ns->main_loop;
+        });
+    return $server;
 }
 
 1;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -741,8 +741,8 @@ sub spawn_dns_server {
             my $ns = Net::DNS::Nameserver->new(
                 LocalPort    => $dns_port,
                 ReplyHandler => sub {
-                    my ( $qname, $qclass, $qtype, $peerhost, $query, $conn ) = @_;
-                    my ( $rcode, @ans, @auth, @add);
+                    my ($qname, $qclass, $qtype, $peerhost, $query, $conn) = @_;
+                    my ($rcode, @ans, @auth, @add);
 
                     foreach (@$zone_rrs) {
                         my $rr = Net::DNS::RR->new($_);


### PR DESCRIPTION
This PR integrates the `Net::DNS::Nameserver` module to implement a mock dns server that can be used by the test suite.

A sample test is included which tests:
  1. That each query type responds to the correct address family
  2. That configurable delays per query type work