### PR TITLE
expose delivery rate to log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ SET(LIB_SOURCE_FILES
     deps/quicly/lib/loss.c
     deps/quicly/lib/quicly.c
     deps/quicly/lib/ranges.c
+    deps/quicly/lib/rate.c
     deps/quicly/lib/recvstate.c
     deps/quicly/lib/remote_cid.c
     deps/quicly/lib/retire_cid.c

--- a/deps/quicly/CMakeLists.txt
+++ b/deps/quicly/CMakeLists.txt
@@ -57,6 +57,7 @@ SET(QUICLY_LIBRARY_FILES
     lib/loss.c
     lib/quicly.c
     lib/ranges.c
+    lib/rate.c
     lib/recvstate.c
     lib/remote_cid.c
     lib/retire_cid.c
@@ -73,6 +74,7 @@ SET(UNITTEST_SOURCE_FILES
     t/lossy.c
     t/maxsender.c
     t/ranges.c
+    t/rate.c
     t/remote_cid.c
     t/retire_cid.c
     t/sentmap.c

--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -39,6 +39,7 @@ extern "C" {
 #include "quicly/linklist.h"
 #include "quicly/loss.h"
 #include "quicly/cc.h"
+#include "quicly/rate.h"
 #include "quicly/recvstate.h"
 #include "quicly/sendstate.h"
 #include "quicly/maxsender.h"
@@ -440,6 +441,10 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t lost;                                                                                                             \
         /**                                                                                                                        \
+         * Total number of bytes for which acknowledgements have been received.                                                    \
+         */                                                                                                                        \
+        uint64_t ack_received;                                                                                                     \
+        /**                                                                                                                        \
          * Total amount of stream-level payload being sent                                                                         \
          */                                                                                                                        \
         uint64_t stream_data_sent;                                                                                                 \
@@ -454,8 +459,8 @@ struct st_quicly_conn_streamgroup_state_t {
     struct {                                                                                                                       \
         uint64_t padding, ping, ack, reset_stream, stop_sending, crypto, new_token, stream, max_data, max_stream_data,             \
             max_streams_bidi, max_streams_uni, data_blocked, stream_data_blocked, streams_blocked, new_connection_id,              \
-            retire_connection_id, path_challenge, path_response, transport_close, application_close, handshake_done,               \
-            datagram, ack_frequency;                                                                                               \
+            retire_connection_id, path_challenge, path_response, transport_close, application_close, handshake_done, datagram,     \
+            ack_frequency;                                                                                                         \
     } num_frames_sent, num_frames_received;                                                                                        \
     /**                                                                                                                            \
      * Total number of PTOs observed during the connection.                                                                        \
@@ -475,6 +480,10 @@ typedef struct st_quicly_stats_t {
      * Congestion control stats (experimental; TODO cherry-pick what can be exposed as part of a stable API).
      */
     quicly_cc_t cc;
+    /**
+     * Estimated delivery rate, in bytes/second.
+     */
+    quicly_rate_t delivery_rate;
 } quicly_stats_t;
 
 /**
@@ -875,6 +884,10 @@ static struct sockaddr *quicly_get_peername(quicly_conn_t *conn);
  *
  */
 int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats);
+/**
+ *
+ */
+int quicly_get_delivery_rate(quicly_conn_t *conn, quicly_rate_t *delivery_rate);
 /**
  *
  */

--- a/deps/quicly/include/quicly/rate.h
+++ b/deps/quicly/include/quicly/rate.h
@@ -83,7 +83,7 @@ typedef struct st_quicly_ratemeter_t {
 typedef struct st_quicly_rate_t {
     uint64_t latest;
     uint64_t smoothed;
-    uint64_t variance;
+    uint64_t stdev;
 } quicly_rate_t;
 
 /**

--- a/deps/quicly/include/quicly/rate.h
+++ b/deps/quicly/include/quicly/rate.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021 Fastly, Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef quicly_rate_h
+#define quicly_rate_h
+
+#include <stdint.h>
+#include "quicly/ranges.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef QUICLY_DELIVERY_RATE_SAMPLE_PERIOD
+/**
+ * sampling period of delivery rate, in milliseconds
+ */
+#define QUICLY_DELIVERY_RATE_SAMPLE_PERIOD 50
+#endif
+
+#ifndef QUICLY_DELIVERY_RATE_SAMPLE_COUNT
+/**
+ * number of samples to retain (and to calculate average from)
+ */
+#define QUICLY_DELIVERY_RATE_SAMPLE_COUNT 10
+#endif
+
+struct st_quicly_rate_sample_t {
+    uint32_t elapsed;
+    uint32_t bytes_acked;
+};
+
+/**
+ * State used for estimating the delivery rate.
+ */
+typedef struct st_quicly_ratemeter_t {
+    /**
+     * ring buffer retaining the most recent samples
+     */
+    struct {
+        struct st_quicly_rate_sample_t entries[QUICLY_DELIVERY_RATE_SAMPLE_COUNT];
+        size_t latest;
+    } past_samples;
+    /**
+     * packet number range within which the flow has been CWND-limited
+     */
+    quicly_range_t pn_cwnd_limited;
+    /**
+     * Current sample being collected, if any. When running, `start.at` and `start.bytes_acked` retains the values at the start of
+     * the current sampling period. When not, `start.at` is set to INT64_MAX, and `sample` is zero-cleared.
+     */
+    struct {
+        struct {
+            int64_t at;
+            uint64_t bytes_acked;
+        } start;
+        struct st_quicly_rate_sample_t sample;
+    } current;
+} quicly_ratemeter_t;
+
+/**
+ * Estimated delivery rate, in bytes / second.
+ */
+typedef struct st_quicly_rate_t {
+    uint64_t latest;
+    uint64_t smoothed;
+    uint64_t variance;
+} quicly_rate_t;
+
+/**
+ *
+ */
+void quicly_ratemeter_init(quicly_ratemeter_t *meter);
+/**
+ * Notifies the estimator that the flow is CWND-limited at the point of sending packets *starting* from packet number `pn`.
+ */
+void quicly_ratemeter_in_cwnd_limited(quicly_ratemeter_t *meter, uint64_t pn);
+/**
+ * Notifies that the estimator that the flow is not CWND-limited when the packet number of the next packet will be `pn`.
+ */
+void quicly_ratemeter_not_cwnd_limited(quicly_ratemeter_t *meter, uint64_t pn);
+/**
+ * Given three values, update the estimation.
+ * @param bytes_acked  total number of bytes being acked from the beginning of the connection; i.e.,
+ *                     `quicly_stats_t::num_bytes.ack_received`
+ */
+void quicly_ratemeter_on_ack(quicly_ratemeter_t *meter, int64_t now, uint64_t bytes_acked, uint64_t pn);
+/**
+ * Returns the delivery rate estimate
+ */
+void quicly_ratemeter_report(quicly_ratemeter_t *meter, quicly_rate_t *rate);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/deps/quicly/include/quicly/sentmap.h
+++ b/deps/quicly/include/quicly/sentmap.h
@@ -91,12 +91,35 @@ typedef enum en_quicly_sentmap_event_t {
  */
 typedef int (*quicly_sent_acked_cb)(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *data);
 
+struct st_quicly_sent_ack_additional_t {
+    uint8_t gap;
+    uint8_t length;
+};
+
+/**
+ * Describes what is inside a packet or frame being sent. Within the sentmap, each packet-level entry (identified by .acked ==
+ * quicly_sentmap__type_packet) is followed by a number of frame-level entries. Size of `quicly_sent_t` is kept as 256 bits (64-bit
+ * * 4).
+ */
 struct st_quicly_sent_t {
     quicly_sent_acked_cb acked;
     union {
         quicly_sent_packet_t packet;
+        /**
+         * ACK frame. Represents up to 8 ack ranges. If not full, `additional` list is terminated by .gap = 0.
+         */
         struct {
-            quicly_range_t range;
+            uint64_t start;
+            union {
+                struct {
+                    uint64_t start_length;
+                    struct st_quicly_sent_ack_additional_t additional[4];
+                } ranges64;
+                struct {
+                    uint8_t start_length;
+                    struct st_quicly_sent_ack_additional_t additional[7];
+                } ranges8;
+            };
         } ack;
         struct {
             quicly_stream_id_t stream_id;

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -5020,7 +5020,7 @@ static int handle_max_stream_data_frame(quicly_conn_t *conn, struct st_quicly_ha
     if ((stream = quicly_get_stream(conn, frame.stream_id)) == NULL)
         return 0;
 
-    if (frame.max_stream_data < stream->_send_aux.max_stream_data)
+    if (frame.max_stream_data <= stream->_send_aux.max_stream_data)
         return 0;
     stream->_send_aux.max_stream_data = frame.max_stream_data;
     stream->_send_aux.blocked = QUICLY_SENDER_STATE_NONE;

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -349,6 +349,10 @@ struct st_quicly_conn_t {
             ptls_iovec_t payloads[10];
             size_t count;
         } datagram_frame_payloads;
+        /**
+         * delivery rate estimator
+         */
+        quicly_ratemeter_t ratemeter;
     } egress;
     /**
      * crypto data
@@ -1209,6 +1213,14 @@ int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
     /* set or generate the non-pre-built stats fields here */
     stats->rtt = conn->egress.loss.rtt;
     stats->cc = conn->egress.cc;
+    quicly_ratemeter_report(&conn->egress.ratemeter, &stats->delivery_rate);
+
+    return 0;
+}
+
+int quicly_get_delivery_rate(quicly_conn_t *conn, quicly_rate_t *delivery_rate)
+{
+    quicly_ratemeter_report(&conn->egress.ratemeter, delivery_rate);
     return 0;
 }
 
@@ -1269,12 +1281,27 @@ static int scheduler_can_send(quicly_conn_t *conn)
     return conn->super.ctx->stream_scheduler->can_send(conn->super.ctx->stream_scheduler, conn, conn_is_saturated);
 }
 
-static void update_loss_alarm(quicly_conn_t *conn, int is_after_send)
+static void update_send_alarm(quicly_conn_t *conn, int can_send_stream_data, int is_after_send)
 {
     int has_outstanding = conn->egress.loss.sentmap.bytes_in_flight != 0 || conn->super.remote.address_validation.send_probe,
         handshake_is_in_progress = conn->initial != NULL || conn->handshake != NULL;
     quicly_loss_update_alarm(&conn->egress.loss, conn->stash.now, conn->egress.last_retransmittable_sent_at, has_outstanding,
-                             scheduler_can_send(conn), handshake_is_in_progress, conn->egress.max_data.sent, is_after_send);
+                             can_send_stream_data, handshake_is_in_progress, conn->egress.max_data.sent, is_after_send);
+}
+
+/**
+ * Updates the send alarm and adjusts the delivery rate estimator. This function is called from the receive path. From the sendp
+ * path, `update_send_alarm` is called directly.
+ */
+static void setup_next_send(quicly_conn_t *conn)
+{
+    int can_send_stream_data = scheduler_can_send(conn);
+
+    update_send_alarm(conn, can_send_stream_data, 0);
+
+    /* When the flow becomes application-limited due to receiving some information, stop collecting delivery rate samples. */
+    if (!can_send_stream_data)
+        quicly_ratemeter_not_cwnd_limited(&conn->egress.ratemeter, conn->egress.packet_number);
 }
 
 static int create_handshake_flow(quicly_conn_t *conn, size_t epoch)
@@ -2108,6 +2135,7 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, uint32_t protocol
     quicly_linklist_init(&conn->egress.pending_streams.blocked.uni);
     quicly_linklist_init(&conn->egress.pending_streams.blocked.bidi);
     quicly_linklist_init(&conn->egress.pending_streams.control);
+    quicly_ratemeter_init(&conn->egress.ratemeter);
     conn->crypto.tls = tls;
     if (handshake_properties != NULL) {
         assert(handshake_properties->additional_extensions == NULL);
@@ -2530,43 +2558,70 @@ static int decrypt_packet(ptls_cipher_context_t *header_protection,
     return 0;
 }
 
-static int on_ack_ack(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *sent)
+static int do_on_ack_ack(quicly_conn_t *conn, const quicly_sent_packet_t *packet, uint64_t start, uint64_t start_length,
+                         struct st_quicly_sent_ack_additional_t *additional, size_t additional_capacity)
+{
+    /* find the pn space */
+    struct st_quicly_pn_space_t *space;
+    switch (packet->ack_epoch) {
+    case QUICLY_EPOCH_INITIAL:
+        space = &conn->initial->super;
+        break;
+    case QUICLY_EPOCH_HANDSHAKE:
+        space = &conn->handshake->super;
+        break;
+    case QUICLY_EPOCH_1RTT:
+        space = &conn->application->super;
+        break;
+    default:
+        assert(!"FIXME");
+        return QUICLY_TRANSPORT_ERROR_INTERNAL;
+    }
+
+    /* subtract given ACK ranges */
+    int ret;
+    uint64_t end = start + start_length;
+    if ((ret = quicly_ranges_subtract(&space->ack_queue, start, end)) != 0)
+        return ret;
+    for (size_t i = 0; i < additional_capacity && additional[i].gap != 0; ++i) {
+        start = end + additional[i].gap;
+        end = start + additional[i].length;
+        if ((ret = quicly_ranges_subtract(&space->ack_queue, start, end)) != 0)
+            return ret;
+    }
+
+    /* make adjustments */
+    if (space->ack_queue.num_ranges == 0) {
+        space->largest_pn_received_at = INT64_MAX;
+        space->unacked_count = 0;
+    } else if (space->ack_queue.num_ranges > QUICLY_MAX_ACK_BLOCKS) {
+        quicly_ranges_drop_by_range_indices(&space->ack_queue, space->ack_queue.num_ranges - QUICLY_MAX_ACK_BLOCKS,
+                                            space->ack_queue.num_ranges);
+    }
+
+    return 0;
+}
+
+static int on_ack_ack_ranges64(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *sent)
 {
     quicly_conn_t *conn = (quicly_conn_t *)((char *)map - offsetof(quicly_conn_t, egress.loss.sentmap));
 
     /* TODO log */
 
-    if (acked) {
-        /* find the pn space */
-        struct st_quicly_pn_space_t *space;
-        switch (packet->ack_epoch) {
-        case QUICLY_EPOCH_INITIAL:
-            space = &conn->initial->super;
-            break;
-        case QUICLY_EPOCH_HANDSHAKE:
-            space = &conn->handshake->super;
-            break;
-        case QUICLY_EPOCH_1RTT:
-            space = &conn->application->super;
-            break;
-        default:
-            assert(!"FIXME");
-            return QUICLY_TRANSPORT_ERROR_INTERNAL;
-        }
-        /* subtract given ACK range, then make adjustments */
-        int ret;
-        if ((ret = quicly_ranges_subtract(&space->ack_queue, sent->data.ack.range.start, sent->data.ack.range.end)) != 0)
-            return ret;
-        if (space->ack_queue.num_ranges == 0) {
-            space->largest_pn_received_at = INT64_MAX;
-            space->unacked_count = 0;
-        } else if (space->ack_queue.num_ranges > QUICLY_MAX_ACK_BLOCKS) {
-            quicly_ranges_drop_by_range_indices(&space->ack_queue, space->ack_queue.num_ranges - QUICLY_MAX_ACK_BLOCKS,
-                                                space->ack_queue.num_ranges);
-        }
-    }
+    return acked ? do_on_ack_ack(conn, packet, sent->data.ack.start, sent->data.ack.ranges64.start_length,
+                                 sent->data.ack.ranges64.additional, PTLS_ELEMENTSOF(sent->data.ack.ranges64.additional))
+                 : 0;
+}
 
-    return 0;
+static int on_ack_ack_ranges8(quicly_sentmap_t *map, const quicly_sent_packet_t *packet, int acked, quicly_sent_t *sent)
+{
+    quicly_conn_t *conn = (quicly_conn_t *)((char *)map - offsetof(quicly_conn_t, egress.loss.sentmap));
+
+    /* TODO log */
+
+    return acked ? do_on_ack_ack(conn, packet, sent->data.ack.start, sent->data.ack.ranges8.start_length,
+                                 sent->data.ack.ranges8.additional, PTLS_ELEMENTSOF(sent->data.ack.ranges8.additional))
+                 : 0;
 }
 
 static int on_ack_stream_ack_one(quicly_conn_t *conn, quicly_stream_id_t stream_id, quicly_sendstate_sent_t *sent)
@@ -3012,6 +3067,10 @@ struct st_quicly_send_context_t {
      * address at which payload starts
      */
     uint8_t *dst_payload_from;
+    /**
+     * first packet number to be used within the lifetime of this send context
+     */
+    uint64_t first_packet_number;
 };
 
 static int commit_send_packet(quicly_conn_t *conn, quicly_send_context_t *s, int coalesced)
@@ -3115,7 +3174,13 @@ static inline uint8_t *emit_cid(uint8_t *dst, const quicly_cid_t *cid)
     return dst;
 }
 
-static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, size_t min_space, int ack_eliciting)
+enum allocate_frame_type {
+    ALLOCATE_FRAME_TYPE_NON_ACK_ELICITING,
+    ALLOCATE_FRAME_TYPE_ACK_ELICITING,
+    ALLOCATE_FRAME_TYPE_ACK_ELICITING_NO_CC,
+};
+
+static int do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, size_t min_space, enum allocate_frame_type frame_type)
 {
     int coalescible, ret;
 
@@ -3166,7 +3231,7 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
         if (s->num_datagrams >= s->max_datagrams)
             return QUICLY_ERROR_SENDBUF_FULL;
         /* note: send_window (ssize_t) can become negative; see doc-comment */
-        if (ack_eliciting && s->send_window <= 0)
+        if (frame_type == ALLOCATE_FRAME_TYPE_ACK_ELICITING && s->send_window <= 0)
             return QUICLY_ERROR_SENDBUF_FULL;
         if (s->payload_buf.end - s->payload_buf.datagram < conn->egress.max_udp_payload_size)
             return QUICLY_ERROR_SENDBUF_FULL;
@@ -3236,16 +3301,11 @@ static int _do_allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, siz
     }
 
 TargetReady:
-    if (ack_eliciting) {
+    if (frame_type != ALLOCATE_FRAME_TYPE_NON_ACK_ELICITING) {
         s->target.ack_eliciting = 1;
         conn->egress.last_retransmittable_sent_at = conn->stash.now;
     }
     return 0;
-}
-
-static int allocate_frame(quicly_conn_t *conn, quicly_send_context_t *s, size_t min_space)
-{
-    return _do_allocate_frame(conn, s, min_space, 0);
 }
 
 static int allocate_ack_eliciting_frame(quicly_conn_t *conn, quicly_send_context_t *s, size_t min_space, quicly_sent_t **sent,
@@ -3253,7 +3313,7 @@ static int allocate_ack_eliciting_frame(quicly_conn_t *conn, quicly_send_context
 {
     int ret;
 
-    if ((ret = _do_allocate_frame(conn, s, min_space, 1)) != 0)
+    if ((ret = do_allocate_frame(conn, s, min_space, ALLOCATE_FRAME_TYPE_ACK_ELICITING)) != 0)
         return ret;
     if ((*sent = quicly_sentmap_allocate(&conn->egress.loss.sentmap, acked)) == NULL)
         return PTLS_ERROR_NO_MEMORY;
@@ -3279,7 +3339,7 @@ static int send_ack(quicly_conn_t *conn, struct st_quicly_pn_space_t *space, qui
     }
 
 Emit: /* emit an ACK frame */
-    if ((ret = allocate_frame(conn, s, QUICLY_ACK_FRAME_CAPACITY)) != 0)
+    if ((ret = do_allocate_frame(conn, s, QUICLY_ACK_FRAME_CAPACITY, ALLOCATE_FRAME_TYPE_NON_ACK_ELICITING)) != 0)
         return ret;
     uint8_t *dst = s->dst;
     dst = quicly_encode_ack_frame(dst, s->dst_end, &space->ack_queue, ack_delay);
@@ -3312,12 +3372,39 @@ Emit: /* emit an ACK frame */
     s->dst = dst;
 
     { /* save what's inflight */
-        size_t i;
-        for (i = 0; i != space->ack_queue.num_ranges; ++i) {
+        size_t range_index = 0;
+        while (range_index < space->ack_queue.num_ranges) {
             quicly_sent_t *sent;
-            if ((sent = quicly_sentmap_allocate(&conn->egress.loss.sentmap, on_ack_ack)) == NULL)
+            struct st_quicly_sent_ack_additional_t *additional, *additional_end;
+            /* allocate */
+            if ((sent = quicly_sentmap_allocate(&conn->egress.loss.sentmap, on_ack_ack_ranges8)) == NULL)
                 return PTLS_ERROR_NO_MEMORY;
-            sent->data.ack.range = space->ack_queue.ranges[i];
+            /* store the first range, as well as preparing references to the additional slots */
+            sent->data.ack.start = space->ack_queue.ranges[range_index].start;
+            uint64_t length = space->ack_queue.ranges[range_index].end - space->ack_queue.ranges[range_index].start;
+            if (length <= UINT8_MAX) {
+                sent->data.ack.ranges8.start_length = length;
+                additional = sent->data.ack.ranges8.additional;
+                additional_end = additional + PTLS_ELEMENTSOF(sent->data.ack.ranges8.additional);
+            } else {
+                sent->acked = on_ack_ack_ranges64;
+                sent->data.ack.ranges64.start_length = length;
+                additional = sent->data.ack.ranges64.additional;
+                additional_end = additional + PTLS_ELEMENTSOF(sent->data.ack.ranges64.additional);
+            }
+            /* store additional ranges, if possible */
+            for (++range_index; range_index < space->ack_queue.num_ranges && additional < additional_end;
+                 ++range_index, ++additional) {
+                uint64_t gap = space->ack_queue.ranges[range_index].start - space->ack_queue.ranges[range_index - 1].end;
+                uint64_t length = space->ack_queue.ranges[range_index].end - space->ack_queue.ranges[range_index].start;
+                if (gap > UINT8_MAX || length > UINT8_MAX)
+                    break;
+                additional->gap = gap;
+                additional->length = length;
+            }
+            /* additional list is zero-terminated, if not full */
+            if (additional < additional_end)
+                additional->gap = 0;
         }
     }
 
@@ -4034,7 +4121,7 @@ static int send_handshake_flow(quicly_conn_t *conn, size_t epoch, quicly_send_co
 
         /* send probe if requested */
         if (send_probe) {
-            if ((ret = _do_allocate_frame(conn, s, 1, 1)) != 0)
+            if ((ret = do_allocate_frame(conn, s, 1, ALLOCATE_FRAME_TYPE_ACK_ELICITING)) != 0)
                 goto Exit;
             *s->dst++ = QUICLY_FRAME_TYPE_PING;
             conn->egress.last_retransmittable_sent_at = conn->stash.now;
@@ -4073,7 +4160,8 @@ static int send_connection_close(quicly_conn_t *conn, size_t epoch, quicly_send_
     }
 
     /* write frame */
-    if ((ret = allocate_frame(conn, s, quicly_close_frame_capacity(error_code, offending_frame_type, reason_phrase))) != 0)
+    if ((ret = do_allocate_frame(conn, s, quicly_close_frame_capacity(error_code, offending_frame_type, reason_phrase),
+                                 ALLOCATE_FRAME_TYPE_NON_ACK_ELICITING)) != 0)
         return ret;
     s->dst = quicly_encode_close_frame(s->dst, error_code, offending_frame_type, reason_phrase);
 
@@ -4299,7 +4387,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
             for (size_t i = 0; i != conn->egress.datagram_frame_payloads.count; ++i) {
                 ptls_iovec_t *payload = conn->egress.datagram_frame_payloads.payloads + i;
                 size_t required_space = quicly_datagram_frame_capacity(*payload);
-                if ((ret = _do_allocate_frame(conn, s, required_space, 1)) != 0)
+                if ((ret = do_allocate_frame(conn, s, required_space, ALLOCATE_FRAME_TYPE_ACK_ELICITING_NO_CC)) != 0)
                     goto Exit;
                 if (s->dst_end - s->dst >= required_space) {
                     s->dst = quicly_encode_datagram_frame(s->dst, *payload);
@@ -4314,7 +4402,7 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
         if (!ack_only) {
             /* PTO or loss detection timeout, always send PING. This is the easiest thing to do in terms of timer control. */
             if (min_packets_to_send != 0) {
-                if ((ret = _do_allocate_frame(conn, s, 1, 1)) != 0)
+                if ((ret = do_allocate_frame(conn, s, 1, ALLOCATE_FRAME_TYPE_ACK_ELICITING)) != 0)
                     goto Exit;
                 *s->dst++ = QUICLY_FRAME_TYPE_PING;
                 ++conn->super.stats.num_frames_sent.ping;
@@ -4338,7 +4426,8 @@ static int do_send(quicly_conn_t *conn, quicly_send_context_t *s)
                 if (conn->egress.path_challenge.head != NULL) {
                     do {
                         struct st_quicly_pending_path_challenge_t *c = conn->egress.path_challenge.head;
-                        if ((ret = allocate_frame(conn, s, QUICLY_PATH_CHALLENGE_FRAME_CAPACITY)) != 0)
+                        if ((ret = do_allocate_frame(conn, s, QUICLY_PATH_CHALLENGE_FRAME_CAPACITY,
+                                                     ALLOCATE_FRAME_TYPE_NON_ACK_ELICITING)) != 0)
                             goto Exit;
                         s->dst = quicly_encode_path_challenge_frame(s->dst, c->is_response, c->data);
                         if (c->is_response) {
@@ -4430,9 +4519,18 @@ Exit:
         commit_send_packet(conn, s, 0);
     }
     if (ret == 0) {
+        /* update timers, start / stop delivery rate estimator */
         if (conn->application == NULL || conn->application->super.unacked_count == 0)
             conn->egress.send_ack_at = INT64_MAX; /* we have sent ACKs for every epoch (or before address validation) */
-        update_loss_alarm(conn, 1);
+        int can_send_stream_data = scheduler_can_send(conn);
+        update_send_alarm(conn, can_send_stream_data, 1);
+        if (can_send_stream_data &&
+            (s->num_datagrams == s->max_datagrams || conn->egress.loss.sentmap.bytes_in_flight >= conn->egress.cc.cwnd)) {
+            /* as the flow is CWND-limited, start delivery rate estimator */
+            quicly_ratemeter_in_cwnd_limited(&conn->egress.ratemeter, s->first_packet_number);
+        } else {
+            quicly_ratemeter_not_cwnd_limited(&conn->egress.ratemeter, conn->egress.packet_number);
+        }
         if (s->num_datagrams != 0)
             update_idle_timeout(conn, 0);
     }
@@ -4461,7 +4559,11 @@ int quicly_set_cc(quicly_conn_t *conn, quicly_cc_type_t *cc)
 int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams, size_t *num_datagrams,
                 void *buf, size_t bufsize)
 {
-    quicly_send_context_t s = {{NULL, -1}, {}, datagrams, *num_datagrams, 0, {buf, (uint8_t *)buf + bufsize}};
+    quicly_send_context_t s = {.current = {.first_byte = -1},
+                               .datagrams = datagrams,
+                               .max_datagrams = *num_datagrams,
+                               .payload_buf = {.datagram = buf, .end = (uint8_t *)buf + bufsize},
+                               .first_packet_number = conn->egress.packet_number};
     int ret;
 
     lock_now(conn, 0);
@@ -4627,7 +4729,7 @@ static int enter_close(quicly_conn_t *conn, int local_is_initiating, int wait_dr
         conn->egress.send_ack_at = wait_draining ? conn->stash.now + get_sentmap_expiration_time(conn) : 0;
     }
 
-    update_loss_alarm(conn, 0);
+    setup_next_send(conn);
 
     return 0;
 }
@@ -4847,6 +4949,7 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
             QUICLY_PROBE(PACKET_ACKED, conn, conn->stash.now, pn_acked, is_late_ack);
             if (sent->cc_bytes_in_flight != 0) {
                 bytes_acked += sent->cc_bytes_in_flight;
+                conn->super.stats.num_bytes.ack_received += sent->cc_bytes_in_flight;
             }
             if ((ret = quicly_sentmap_update(&conn->egress.loss.sentmap, &iter, QUICLY_SENTMAP_EVENT_ACKED)) != 0)
                 return ret;
@@ -4871,6 +4974,9 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
 
     QUICLY_PROBE(ACK_DELAY_RECEIVED, conn, conn->stash.now, frame.ack_delay);
 
+    quicly_ratemeter_on_ack(&conn->egress.ratemeter, conn->stash.now, conn->super.stats.num_bytes.ack_received,
+                            largest_newly_acked.pn);
+
     /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
      * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
     quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.pn, state->epoch, conn->stash.now,
@@ -4892,7 +4998,7 @@ static int handle_ack_frame(quicly_conn_t *conn, struct st_quicly_handle_payload
     if ((ret = quicly_loss_detect_loss(&conn->egress.loss, conn->stash.now, conn->super.remote.transport_params.max_ack_delay,
                                        conn->initial == NULL && conn->handshake == NULL, on_loss_detected)) != 0)
         return ret;
-    update_loss_alarm(conn, 0);
+    setup_next_send(conn);
 
     return 0;
 }
@@ -5374,7 +5480,7 @@ static int handle_handshake_done_frame(quicly_conn_t *conn, struct st_quicly_han
     conn->super.remote.address_validation.send_probe = 0;
     if ((ret = discard_handshake_context(conn, QUICLY_EPOCH_HANDSHAKE)) != 0)
         return ret;
-    update_loss_alarm(conn, 0);
+    setup_next_send(conn);
     return 0;
 }
 
@@ -5869,7 +5975,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
         if (conn->initial != NULL) {
             if ((ret = discard_handshake_context(conn, QUICLY_EPOCH_INITIAL)) != 0)
                 goto Exit;
-            update_loss_alarm(conn, 0);
+            setup_next_send(conn);
             conn->super.remote.address_validation.validated = 1;
         }
         break;
@@ -5892,7 +5998,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
         if (quicly_is_client(conn) && conn->handshake != NULL && conn->handshake->cipher.egress.aead != NULL) {
             if ((ret = discard_handshake_context(conn, QUICLY_EPOCH_INITIAL)) != 0)
                 goto Exit;
-            update_loss_alarm(conn, 0);
+            setup_next_send(conn);
         }
         break;
     case QUICLY_EPOCH_HANDSHAKE:
@@ -5910,7 +6016,7 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
                     goto Exit;
                 assert(conn->handshake == NULL);
                 conn->egress.pending_flows |= QUICLY_PENDING_FLOW_HANDSHAKE_DONE_BIT;
-                update_loss_alarm(conn, 0);
+                setup_next_send(conn);
             }
         }
         break;

--- a/deps/quicly/lib/rate.c
+++ b/deps/quicly/lib/rate.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2021 Fastly, Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "picotls.h"
+#include "quicly/rate.h"
+
+static void start_sampling(quicly_ratemeter_t *meter, int64_t now, uint64_t bytes_acked)
+{
+    meter->current.start.at = now;
+    meter->current.start.bytes_acked = bytes_acked;
+}
+
+static void commit_sample(quicly_ratemeter_t *meter)
+{
+    ++meter->past_samples.latest;
+    if (meter->past_samples.latest >= PTLS_ELEMENTSOF(meter->past_samples.entries))
+        meter->past_samples.latest = 0;
+    meter->past_samples.entries[meter->past_samples.latest] = meter->current.sample;
+
+    meter->current.start.at = INT64_MAX;
+    meter->current.sample = (struct st_quicly_rate_sample_t){};
+}
+
+void quicly_ratemeter_init(quicly_ratemeter_t *meter)
+{
+    *meter = (quicly_ratemeter_t){
+        .past_samples = {.latest = PTLS_ELEMENTSOF(meter->past_samples.entries) - 1},
+        .pn_cwnd_limited = {.start = UINT64_MAX, .end = UINT64_MAX},
+        .current = {.start = {.at = INT64_MAX}},
+    };
+}
+
+void quicly_ratemeter_in_cwnd_limited(quicly_ratemeter_t *meter, uint64_t pn)
+{
+    /* bail out if already in cwnd-limited phase */
+    if (meter->pn_cwnd_limited.start != UINT64_MAX && meter->pn_cwnd_limited.end == UINT64_MAX)
+        return;
+
+    /* if the estimator was waiting for the end of the previous phase, and if a valid partial sample exists, commit it now */
+    if (meter->pn_cwnd_limited.end != UINT64_MAX && meter->current.sample.elapsed != 0)
+        commit_sample(meter);
+
+    /* begin new cwnd-limited phase */
+    meter->pn_cwnd_limited = (quicly_range_t){.start = pn, .end = UINT64_MAX};
+}
+
+void quicly_ratemeter_not_cwnd_limited(quicly_ratemeter_t *meter, uint64_t pn)
+{
+    if (meter->pn_cwnd_limited.start != UINT64_MAX && meter->pn_cwnd_limited.end == UINT64_MAX)
+        meter->pn_cwnd_limited.end = pn;
+}
+
+void quicly_ratemeter_on_ack(quicly_ratemeter_t *meter, int64_t now, uint64_t bytes_acked, uint64_t pn)
+{
+    if (meter->pn_cwnd_limited.start <= pn && pn < meter->pn_cwnd_limited.end) {
+        /* At the moment, the flow is CWND-limited. Either start the timer or update. */
+        if (meter->current.start.at == INT64_MAX) {
+            start_sampling(meter, now, bytes_acked);
+        } else {
+            meter->current.sample = (struct st_quicly_rate_sample_t){
+                .elapsed = (uint32_t)(now - meter->current.start.at),
+                .bytes_acked = (uint32_t)(bytes_acked - meter->current.start.bytes_acked),
+            };
+            if (meter->current.sample.elapsed >= QUICLY_DELIVERY_RATE_SAMPLE_PERIOD) {
+                commit_sample(meter);
+                start_sampling(meter, now, bytes_acked);
+            }
+        }
+    } else if (meter->pn_cwnd_limited.end <= pn) {
+        /* We have exitted CWND-limited state. Save current value, if any. */
+        if (meter->current.start.at != INT64_MAX) {
+            if (meter->current.sample.elapsed != 0)
+                commit_sample(meter);
+            meter->pn_cwnd_limited = (quicly_range_t){.start = UINT64_MAX, .end = UINT64_MAX};
+            meter->current.start.at = INT64_MAX;
+        }
+    }
+}
+
+static uint64_t to_speed(uint64_t bytes_acked, uint32_t elapsed)
+{
+    return bytes_acked * 1000 / elapsed;
+}
+
+void quicly_ratemeter_report(quicly_ratemeter_t *meter, quicly_rate_t *rate)
+{
+    { /* Calculate latest, or return if there are no samples at all. `latest` being reported will be the most recent "full" sample
+       * if available, or else a partial sample. */
+        const struct st_quicly_rate_sample_t *latest_sample = &meter->past_samples.entries[meter->past_samples.latest];
+        if (latest_sample->elapsed == 0) {
+            latest_sample = &meter->current.sample;
+            if (latest_sample->elapsed == 0) {
+                rate->latest = rate->smoothed = rate->variance = 0;
+                return;
+            }
+        }
+        rate->latest = to_speed(latest_sample->bytes_acked, latest_sample->elapsed);
+    }
+
+#define FOREACH_SAMPLE(func)                                                                                                       \
+    do {                                                                                                                           \
+        const struct st_quicly_rate_sample_t *sample;                                                                              \
+        for (size_t i = 0; i < PTLS_ELEMENTSOF(meter->past_samples.entries); ++i) {                                                \
+            if ((sample = &meter->past_samples.entries[i])->elapsed != 0) {                                                        \
+                func                                                                                                               \
+            }                                                                                                                      \
+        }                                                                                                                          \
+        if ((sample = &meter->current.sample)->elapsed != 0) {                                                                     \
+            func                                                                                                                   \
+        }                                                                                                                          \
+    } while (0)
+
+    { /* calculate average */
+        uint64_t total_acked = 0;
+        uint32_t total_elapsed = 0;
+        FOREACH_SAMPLE({
+            total_acked += sample->bytes_acked;
+            total_elapsed += sample->elapsed;
+        });
+        rate->smoothed = to_speed(total_acked, total_elapsed);
+    }
+
+    { /* calculate variance */
+        uint64_t sum = 0;
+        size_t count = 0;
+        FOREACH_SAMPLE({
+            uint64_t sample_speed = to_speed(sample->bytes_acked, sample->elapsed);
+            sum += (sample_speed - rate->smoothed) * (sample_speed - rate->smoothed);
+            ++count;
+        });
+        rate->variance = sum / count;
+    }
+
+#undef FOREACH_SAMPLE
+}

--- a/deps/quicly/quicly.xcodeproj/project.pbxproj
+++ b/deps/quicly/quicly.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		082195082683498900E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 082195072683498900E3EFCF /* cc-pico.c */; };
 		082195092683498900E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 082195072683498900E3EFCF /* cc-pico.c */; };
 		0821950A2683498900E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 082195072683498900E3EFCF /* cc-pico.c */; };
+		0829878E26E03D4D0053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829878D26E03D4D0053638F /* rate.c */; };
+		0829878F26E03D4D0053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829878D26E03D4D0053638F /* rate.c */; };
+		0829879026E03D4D0053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829878D26E03D4D0053638F /* rate.c */; };
+		0829879226E0A9DF0053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829879126E0A9DF0053638F /* rate.c */; };
 		E904233D24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
 		E904233E24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
 		E904233F24AED0410072C5B7 /* loss.c in Sources */ = {isa = PBXBuildFile; fileRef = E904233C24AED0410072C5B7 /* loss.c */; };
@@ -145,6 +149,9 @@
 
 /* Begin PBXFileReference section */
 		082195072683498900E3EFCF /* cc-pico.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cc-pico.c"; sourceTree = "<group>"; };
+		0829878C26DF775B0053638F /* rate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rate.h; sourceTree = "<group>"; };
+		0829878D26E03D4D0053638F /* rate.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rate.c; sourceTree = "<group>"; };
+		0829879126E0A9DF0053638F /* rate.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rate.c; sourceTree = "<group>"; };
 		E904233C24AED0410072C5B7 /* loss.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loss.c; sourceTree = "<group>"; };
 		E904234024AEFB980072C5B7 /* loss.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loss.c; sourceTree = "<group>"; };
 		E9056C071F56965300E2B96C /* linklist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linklist.h; sourceTree = "<group>"; };
@@ -337,6 +344,7 @@
 				E904233C24AED0410072C5B7 /* loss.c */,
 				E98448411EA490A500390927 /* quicly.c */,
 				E9F6A41F1F3C0B6D0083F0B2 /* ranges.c */,
+				0829878D26E03D4D0053638F /* rate.c */,
 				E920D21D1F43E05000799777 /* recvstate.c */,
 				E9736528246FD3AC0039AA49 /* retire_cid.c */,
 				E9F6A42D1F41375B0083F0B2 /* sendstate.c */,
@@ -415,13 +423,14 @@
 			isa = PBXGroup;
 			children = (
 				E98884C221E3F23A0060F010 /* e2e.t */,
-				E9736534246FD3DA0039AA49 /* remote_cid.c */,
 				E99F8C281F4EAEF800C26B3D /* frame.c */,
 				E9736533246FD3DA0039AA49 /* local_cid.c */,
 				E904234024AEFB980072C5B7 /* loss.c */,
 				E920D22F1F49EE0B00799777 /* lossy.c */,
 				E99B75E61F5CF96900CF503E /* maxsender.c */,
 				E9F6A4291F3C3B7B0083F0B2 /* ranges.c */,
+				0829879126E0A9DF0053638F /* rate.c */,
+				E9736534246FD3DA0039AA49 /* remote_cid.c */,
 				E9736535246FD3DA0039AA49 /* retire_cid.c */,
 				E920D22D1F4981E500799777 /* sentmap.c */,
 				E920D2241F49412900799777 /* simple.c */,
@@ -456,6 +465,7 @@
 				E93E54BA1F69B750001C50FE /* loss.h */,
 				E920D2221F4536CB00799777 /* maxsender.h */,
 				E9F6A4261F3C3B050083F0B2 /* ranges.h */,
+				0829878C26DF775B0053638F /* rate.h */,
 				E920D21B1F43DE4100799777 /* recvstate.h */,
 				E9736522246FD3890039AA49 /* retire_cid.h */,
 				E92D43EC1F41DCF5002AC767 /* sendstate.h */,
@@ -711,6 +721,7 @@
 				E920D22B1F49533800799777 /* sentmap.c in Sources */,
 				E9D3CCCF21D22F4300516202 /* streambuf.c in Sources */,
 				E973652C246FD3AC0039AA49 /* local_cid.c in Sources */,
+				0829878E26E03D4D0053638F /* rate.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -733,6 +744,7 @@
 				E9B43E12246943D300824E51 /* fusion.c in Sources */,
 				E941428E23B0B845002D3CE0 /* defaults.c in Sources */,
 				E941429023B0B861002D3CE0 /* streambuf.c in Sources */,
+				0829878F26E03D4D0053638F /* rate.c in Sources */,
 				E93E546A1F663851001C50FE /* pembase64.c in Sources */,
 				E98042282239531A008B9745 /* cli.c in Sources */,
 				E941429223B0B870002D3CE0 /* sendstate.c in Sources */,
@@ -758,6 +770,7 @@
 				E9736537246FD3DA0039AA49 /* remote_cid.c in Sources */,
 				E99F8C291F4EAEF800C26B3D /* frame.c in Sources */,
 				E98041C722383C7A008B9745 /* cc-reno.c in Sources */,
+				0829879026E03D4D0053638F /* rate.c in Sources */,
 				E9D31DD1232DEDB400ACD5EC /* quicly-probes.d in Sources */,
 				E9736530246FD3B50039AA49 /* local_cid.c in Sources */,
 				E920D22C1F49533800799777 /* sentmap.c in Sources */,
@@ -786,6 +799,7 @@
 				E98042372244A5D7008B9745 /* defaults.c in Sources */,
 				E99F8C271F4E9F5D00C26B3D /* frame.c in Sources */,
 				E9736536246FD3DA0039AA49 /* local_cid.c in Sources */,
+				0829879226E0A9DF0053638F /* rate.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/deps/quicly/t/rate.c
+++ b/deps/quicly/t/rate.c
@@ -29,7 +29,7 @@
         quicly_ratemeter_report(&meter, &rate);                                                                                    \
         ok(rate.latest == el);                                                                                                     \
         ok(rate.smoothed == es);                                                                                                   \
-        ok(rate.variance == ev);                                                                                                   \
+        ok(rate.stdev == ev);                                                                                                      \
     } while (0)
 
 static void test_basic(void)

--- a/deps/quicly/t/rate.c
+++ b/deps/quicly/t/rate.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021 Fastly, Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "quicly/rate.h"
+#include "test.h"
+
+#define CHECK_REPORT(el, es, ev)                                                                                                   \
+    do {                                                                                                                           \
+        quicly_rate_t rate;                                                                                                        \
+        quicly_ratemeter_report(&meter, &rate);                                                                                    \
+        ok(rate.latest == el);                                                                                                     \
+        ok(rate.smoothed == es);                                                                                                   \
+        ok(rate.variance == ev);                                                                                                   \
+    } while (0)
+
+static void test_basic(void)
+{
+    quicly_ratemeter_t meter;
+
+    quicly_ratemeter_init(&meter);
+    CHECK_REPORT(0, 0, 0);
+
+    uint64_t pn = 0, bytes_acked = 0;
+    int64_t now = 1000;
+
+    /* send 1KB packet every 20ms, in CWND-limited state */
+    for (; pn < 100; ++pn) {
+        quicly_ratemeter_in_cwnd_limited(&meter, pn);
+        bytes_acked += 1000;
+        now += 20;
+        quicly_ratemeter_on_ack(&meter, now, bytes_acked, pn);
+    }
+    CHECK_REPORT(50000, 50000, 0);
+
+    /* send at a slow rate, in application-limited state */
+    for (; pn < 200; ++pn) {
+        quicly_ratemeter_not_cwnd_limited(&meter, pn);
+        bytes_acked += 10;
+        now += 20;
+        quicly_ratemeter_on_ack(&meter, now, bytes_acked, pn);
+    }
+    CHECK_REPORT(50000, 50000, 0);
+
+    /* send 2KB packet every 20ms, in CWND-limited state */
+    for (; pn < 300; ++pn) {
+        quicly_ratemeter_in_cwnd_limited(&meter, pn);
+        bytes_acked += 2000;
+        now += 20;
+        quicly_ratemeter_on_ack(&meter, now, bytes_acked, pn);
+    }
+    CHECK_REPORT(100000, 100000, 0);
+}
+
+static void test_burst(void)
+{
+    quicly_ratemeter_t meter;
+
+    quicly_ratemeter_init(&meter);
+    CHECK_REPORT(0, 0, 0);
+
+    /* send 10 packet burst (pn=1 to 10) */
+    quicly_ratemeter_in_cwnd_limited(&meter, 1);
+    quicly_ratemeter_not_cwnd_limited(&meter, 11);
+
+    /* ack every 2 packets up to pn=9, every 20ms */
+    uint64_t pn = 0, bytes_acked = 0;
+    int64_t now = 1000;
+    while (1) {
+        pn += 2;
+        bytes_acked += 2000;
+        now += 20;
+        quicly_ratemeter_on_ack(&meter, now, bytes_acked, pn);
+        if (pn == 10)
+            break;
+    }
+    CHECK_REPORT(100000, 100000, 0);
+
+    ok(meter.current.sample.elapsed != 0); /* we have an active sample ... */
+
+    pn += 1;
+    bytes_acked += 50;
+    now += 20;
+    quicly_ratemeter_on_ack(&meter, now, bytes_acked, pn);
+
+    ok(meter.current.sample.elapsed == 0); /* that gets committed by the next pn out of the window */
+
+    CHECK_REPORT(100000, 100000, 0);
+}
+
+void test_rate(void)
+{
+    subtest("basic", test_basic);
+    subtest("burst", test_burst);
+}

--- a/deps/quicly/t/test.c
+++ b/deps/quicly/t/test.c
@@ -628,6 +628,7 @@ int main(int argc, char **argv)
     subtest("next-packet-number", test_next_packet_number);
     subtest("address-token-codec", test_address_token_codec);
     subtest("ranges", test_ranges);
+    subtest("rate", test_rate);
     subtest("record-receipt", test_record_receipt);
     subtest("frame", test_frame);
     subtest("maxsender", test_maxsender);

--- a/deps/quicly/t/test.h
+++ b/deps/quicly/t/test.h
@@ -49,6 +49,7 @@ size_t transmit(quicly_conn_t *src, quicly_conn_t *dst);
 int max_data_is_equal(quicly_conn_t *client, quicly_conn_t *server);
 
 void test_ranges(void);
+void test_rate(void);
 void test_frame(void);
 void test_maxsender(void);
 void test_sentmap(void);

--- a/fuzz/quicly_mock.c
+++ b/fuzz/quicly_mock.c
@@ -331,6 +331,13 @@ uint32_t quicly_num_streams_by_group(quicly_conn_t *conn, int uni, int locally_i
     return 0;
 }
 
+int quicly_get_delivery_rate(quicly_conn_t *conn, quicly_rate_t *delivery_rate)
+{
+    /* Do nothing */
+    *delivery_rate = (quicly_rate_t){};
+    return 0;
+}
+
 int quicly_get_stats(quicly_conn_t *conn, quicly_stats_t *stats)
 {
     /* Do nothing */

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		082195102685262B00E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 0821950F2685262B00E3EFCF /* cc-pico.c */; };
 		082195112685262B00E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 0821950F2685262B00E3EFCF /* cc-pico.c */; };
 		082195122685262B00E3EFCF /* cc-pico.c in Sources */ = {isa = PBXBuildFile; fileRef = 0821950F2685262B00E3EFCF /* cc-pico.c */; };
+		0829879426E1F3530053638F /* rate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0829879326E1F3530053638F /* rate.h */; };
+		0829879626E1F3710053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829879526E1F3700053638F /* rate.c */; };
+		0829879726E1F3710053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829879526E1F3700053638F /* rate.c */; };
+		0829879826E1F3710053638F /* rate.c in Sources */ = {isa = PBXBuildFile; fileRef = 0829879526E1F3700053638F /* rate.c */; };
 		084FC7C11D54B90D00E89F66 /* http2_debug_state.c in Sources */ = {isa = PBXBuildFile; fileRef = 084FC7C01D54B90D00E89F66 /* http2_debug_state.c */; };
 		084FC7C51D54BB9200E89F66 /* http2_debug_state.c in Sources */ = {isa = PBXBuildFile; fileRef = 084FC7C31D54BB9200E89F66 /* http2_debug_state.c */; };
 		08790DDA1D80153600A04BC1 /* net.c in Sources */ = {isa = PBXBuildFile; fileRef = 08790DD91D80153600A04BC1 /* net.c */; };
@@ -680,6 +684,8 @@
 		0812AB291D7FD54700004F23 /* read.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = read.c; sourceTree = "<group>"; };
 		0812AB2A1D7FD54700004F23 /* read.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = read.h; sourceTree = "<group>"; };
 		0821950F2685262B00E3EFCF /* cc-pico.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cc-pico.c"; sourceTree = "<group>"; };
+		0829879326E1F3530053638F /* rate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rate.h; sourceTree = "<group>"; };
+		0829879526E1F3700053638F /* rate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rate.c; sourceTree = "<group>"; };
 		082E148C2692F51000603AED /* driver.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = driver.cc; sourceTree = "<group>"; };
 		082E1B402692F52100603AED /* driver_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = driver_common.h; sourceTree = "<group>"; };
 		082E1B412692F52100603AED /* quicly_mock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = quicly_mock.h; sourceTree = "<group>"; };
@@ -2440,6 +2446,7 @@
 				E9A8351424B1340C007D06C2 /* loss.c */,
 				E901C3F3213E1C4000D17C93 /* quicly.c */,
 				E901C3F2213E1C4000D17C93 /* ranges.c */,
+				0829879526E1F3700053638F /* rate.c */,
 				E98884CE21E7F3C80060F010 /* recvstate.c */,
 				E98403C72485172E00E3A6B1 /* remote_cid.c */,
 				E98403C82485172E00E3A6B1 /* retire_cid.c */,
@@ -2463,6 +2470,7 @@
 				E901C3DE213E1C3600D17C93 /* loss.h */,
 				E901C3DB213E1C3600D17C93 /* maxsender.h */,
 				E901C3DC213E1C3600D17C93 /* ranges.h */,
+				0829879326E1F3530053638F /* rate.h */,
 				E98884C321E7F3AE0060F010 /* recvstate.h */,
 				E98403D22485174A00E3A6B1 /* remote_cid.h */,
 				E98403D52485174B00E3A6B1 /* retire_cid.h */,
@@ -2846,6 +2854,7 @@
 				107923A719A3215F00C52AD6 /* token.h in Headers */,
 				E901C3E8213E1C3600D17C93 /* loss.h in Headers */,
 				107923A919A3215F00C52AD6 /* h2o.h in Headers */,
+				0829879426E1F3530053638F /* rate.h in Headers */,
 				E96A24CD23E673F400CA970A /* absprio.h in Headers */,
 				108867751AD9069900987967 /* defaults.c.h in Headers */,
 				1058C8881AA6DE4B008D6180 /* hostinfo.h in Headers */,
@@ -3265,6 +3274,7 @@
 				10AAAC651B6C9275004487C3 /* casper.c in Sources */,
 				E98403CF2485172E00E3A6B1 /* retire_cid.c in Sources */,
 				10AA2EC41AA0403A004322AC /* reproxy.c in Sources */,
+				0829879626E1F3710053638F /* rate.c in Sources */,
 				E96A24CF23E6743600CA970A /* absprio.c in Sources */,
 				10AA2EAC1A8DE0AE004322AC /* multithread.c in Sources */,
 				08790DDA1D80153600A04BC1 /* net.c in Sources */,
@@ -3423,6 +3433,7 @@
 				E96A24D323E6747A00CA970A /* absprio.c in Sources */,
 				7D937300202AC717005FE6AB /* server_timing.c in Sources */,
 				E9DF012924E4CDF60002EEC7 /* cc-cubic.c in Sources */,
+				0829879726E1F3710053638F /* rate.c in Sources */,
 				107D4D4C1B5880BC004A9B21 /* writer.c in Sources */,
 				E987E5EC1FD8C04D00DE4346 /* backward_references_hq.c in Sources */,
 				10E2995A1A68D03100701AA6 /* scheduler.c in Sources */,
@@ -3576,6 +3587,7 @@
 				E9708B451E52C7DF0029E0A5 /* file.c in Sources */,
 				E93BB59025DE3988009C24D8 /* pembase64.c in Sources */,
 				E9708B6C1E52C81D0029E0A5 /* compress.c in Sources */,
+				0829879826E1F3710053638F /* rate.c in Sources */,
 				E9708B1F1E49BAC60029E0A5 /* chash.c in Sources */,
 				E9708B821E52C84E0029E0A5 /* http1.c in Sources */,
 				E9708B7E1E52C8430029E0A5 /* events.c in Sources */,

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1005,8 +1005,9 @@ typedef struct st_h2o_conn_callbacks_t {
     union {
         struct {
             struct {
-                h2o_iovec_t (*name_)(h2o_req_t *req);
-            } congestion_control;
+                h2o_iovec_t (*cc_name)(h2o_req_t *req);
+                h2o_iovec_t (*delivery_rate)(h2o_req_t *req);
+            } transport;
             struct {
                 h2o_iovec_t (*protocol_version)(h2o_req_t *req);
                 h2o_iovec_t (*session_reused)(h2o_req_t *req);

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -277,6 +277,7 @@ ptls_t *h2o_socket_get_ptls(h2o_socket_t *sock);
  *
  */
 h2o_iovec_t h2o_socket_log_tcp_congestion_controller(h2o_socket_t *sock, h2o_mem_pool_t *pool);
+h2o_iovec_t h2o_socket_log_tcp_delivery_rate(h2o_socket_t *sock, h2o_mem_pool_t *pool);
 const char *h2o_socket_get_ssl_protocol_version(h2o_socket_t *sock);
 int h2o_socket_get_ssl_session_reused(h2o_socket_t *sock);
 const char *h2o_socket_get_ssl_cipher(h2o_socket_t *sock);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -873,6 +873,81 @@ h2o_iovec_t h2o_socket_log_tcp_congestion_controller(h2o_socket_t *sock, h2o_mem
     return h2o_iovec_init(NULL, 0);
 }
 
+h2o_iovec_t h2o_socket_log_tcp_delivery_rate(h2o_socket_t *sock, h2o_mem_pool_t *pool)
+{
+#if defined(__linux__) && defined(TCP_INFO)
+    int fd;
+    if ((fd = h2o_socket_get_fd(sock)) >= 0) {
+        /* A copy of `struct tcp_info` found in linux/tcp.h, up to `tcpi_delivery_rate`. Rest of the codebase uses netinet/tcp.h,
+         * which does not provide access to `tcpi_delivery_rate`. */
+        struct {
+            uint8_t tcpi_state;
+            uint8_t tcpi_ca_state;
+            uint8_t tcpi_retransmits;
+            uint8_t tcpi_probes;
+            uint8_t tcpi_backoff;
+            uint8_t tcpi_options;
+            uint8_t tcpi_snd_wscale : 4, tcpi_rcv_wscale : 4;
+            uint8_t tcpi_delivery_rate_app_limited : 1;
+
+            uint32_t tcpi_rto;
+            uint32_t tcpi_ato;
+            uint32_t tcpi_snd_mss;
+            uint32_t tcpi_rcv_mss;
+
+            uint32_t tcpi_unacked;
+            uint32_t tcpi_sacked;
+            uint32_t tcpi_lost;
+            uint32_t tcpi_retrans;
+            uint32_t tcpi_fackets;
+
+            /* Times. */
+            uint32_t tcpi_last_data_sent;
+            uint32_t tcpi_last_ack_sent; /* Not remembered, sorry. */
+            uint32_t tcpi_last_data_recv;
+            uint32_t tcpi_last_ack_recv;
+
+            /* Metrics. */
+            uint32_t tcpi_pmtu;
+            uint32_t tcpi_rcv_ssthresh;
+            uint32_t tcpi_rtt;
+            uint32_t tcpi_rttvar;
+            uint32_t tcpi_snd_ssthresh;
+            uint32_t tcpi_snd_cwnd;
+            uint32_t tcpi_advmss;
+            uint32_t tcpi_reordering;
+
+            uint32_t tcpi_rcv_rtt;
+            uint32_t tcpi_rcv_space;
+
+            uint32_t tcpi_total_retrans;
+
+            uint64_t tcpi_pacing_rate;
+            uint64_t tcpi_max_pacing_rate;
+            uint64_t tcpi_bytes_acked;    /* RFC4898 tcpEStatsAppHCThruOctetsAcked */
+            uint64_t tcpi_bytes_received; /* RFC4898 tcpEStatsAppHCThruOctetsReceived */
+            uint32_t tcpi_segs_out;       /* RFC4898 tcpEStatsPerfSegsOut */
+            uint32_t tcpi_segs_in;        /* RFC4898 tcpEStatsPerfSegsIn */
+
+            uint32_t tcpi_notsent_bytes;
+            uint32_t tcpi_min_rtt;
+            uint32_t tcpi_data_segs_in;  /* RFC4898 tcpEStatsDataSegsIn */
+            uint32_t tcpi_data_segs_out; /* RFC4898 tcpEStatsDataSegsOut */
+
+            uint64_t tcpi_delivery_rate;
+        } tcpi;
+        socklen_t tcpisz = sizeof(tcpi);
+        if (getsockopt(fd, IPPROTO_TCP, TCP_INFO, &tcpi, &tcpisz) == 0) {
+            char *buf = (char *)(pool != NULL ? h2o_mem_alloc_pool(pool, char, sizeof(H2O_UINT64_LONGEST_STR))
+                                              : h2o_mem_alloc(sizeof(H2O_UINT64_LONGEST_STR)));
+            size_t len = sprintf(buf, "%" PRIu64, (uint64_t)tcpi.tcpi_delivery_rate);
+            return h2o_iovec_init(buf, len);
+        }
+    }
+#endif
+    return h2o_iovec_init(NULL, 0);
+}
+
 h2o_iovec_t h2o_socket_log_ssl_session_id(h2o_socket_t *sock, h2o_mem_pool_t *pool)
 {
     h2o_iovec_t base64id, rawid = h2o_socket_get_ssl_session_id(sock);

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -292,7 +292,8 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_PROTO("http3.stream-id", http3.stream_id);
                     MAP_EXT_TO_PROTO("http3.quic-stats", http3.quic_stats);
                     MAP_EXT_TO_PROTO("http3.quic-version", http3.quic_version);
-                    MAP_EXT_TO_PROTO("cc.name", congestion_control.name_);
+                    MAP_EXT_TO_PROTO("cc.name", transport.cc_name);
+                    MAP_EXT_TO_PROTO("delivery-rate", transport.delivery_rate);
                     MAP_EXT_TO_PROTO("ssl.protocol-version", ssl.protocol_version);
                     MAP_EXT_TO_PROTO("ssl.session-reused", ssl.session_reused);
                     MAP_EXT_TO_PROTO("ssl.cipher", ssl.cipher);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -1261,6 +1261,7 @@ static int skip_tracing(h2o_conn_t *_conn)
     }
 
 DEFINE_LOGGER(tcp_congestion_controller)
+DEFINE_LOGGER(tcp_delivery_rate)
 DEFINE_LOGGER(ssl_protocol_version)
 DEFINE_LOGGER(ssl_session_reused)
 DEFINE_LOGGER(ssl_cipher)
@@ -1298,9 +1299,10 @@ static const h2o_conn_callbacks_t h1_callbacks = {
     .get_ptls = get_ptls,
     .skip_tracing = skip_tracing,
     .log_ = {{
-        .congestion_control =
+        .transport =
             {
-                .name_ = log_tcp_congestion_controller,
+                .cc_name = log_tcp_congestion_controller,
+                .delivery_rate = log_tcp_delivery_rate,
             },
         .ssl =
             {

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1492,6 +1492,7 @@ static int64_t get_rtt(h2o_conn_t *_conn)
         return h2o_socket_log_##name(conn->sock, &req->pool);                                                                      \
     }
 DEFINE_LOGGER(tcp_congestion_controller)
+DEFINE_LOGGER(tcp_delivery_rate)
 DEFINE_LOGGER(ssl_protocol_version)
 DEFINE_LOGGER(ssl_session_reused)
 DEFINE_LOGGER(ssl_cipher)
@@ -1589,9 +1590,10 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
         .get_debug_state = h2o_http2_get_debug_state,
         .get_rtt = get_rtt,
         .log_ = {{
-            .congestion_control =
+            .transport =
                 {
-                    .name_ = log_tcp_congestion_controller,
+                    .cc_name = log_tcp_congestion_controller,
+                    .delivery_rate = log_tcp_delivery_rate,
                 },
             .ssl =
                 {

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -615,15 +615,22 @@ static h2o_iovec_t log_quic_stats(h2o_req_t *req)
     size_t len, bufsize = 1400;
 Redo:
     buf = h2o_mem_alloc_pool(&req->pool, char, bufsize);
-    len = snprintf(buf, bufsize,
-                   "packets-received=%" PRIu64 ",packets-decryption-failed=%" PRIu64 ",packets-sent=%" PRIu64
-                   ",packets-lost=%" PRIu64 ",packets-ack-received=%" PRIu64 ",bytes-received=%" PRIu64 ",bytes-sent=%" PRIu64
-                   ",rtt-minimum=%" PRIu32 ",rtt-smoothed=%" PRIu32 ",rtt-variance=%" PRIu32 ",rtt-latest=%" PRIu32
-                   ",cwnd=%" PRIu32 APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, received) APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, sent),
-                   stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
-                   stats.num_packets.ack_received, stats.num_bytes.received, stats.num_bytes.sent, stats.rtt.minimum,
-                   stats.rtt.smoothed, stats.rtt.variance, stats.rtt.latest,
-                   stats.cc.cwnd APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, received) APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, sent));
+    len = snprintf(
+        buf, bufsize,
+        "packets-received=%" PRIu64 ",packets-decryption-failed=%" PRIu64 ",packets-sent=%" PRIu64 ",packets-lost=%" PRIu64
+        ",packets-lost-time-threshold=%" PRIu64 ",packets-ack-received=%" PRIu64 ",late-acked=%" PRIu64 ",bytes-received=%" PRIu64
+        ",bytes-sent=%" PRIu64 ",bytes-lost=%" PRIu64 ",bytes-ack-received=%" PRIu64 ",bytes-stream-data-sent=%" PRIu64
+        ",bytes-stream-data-resent=%" PRIu64 ",rtt-minimum=%" PRIu32 ",rtt-smoothed=%" PRIu32 ",rtt-variance=%" PRIu32
+        ",rtt-latest=%" PRIu32 ",cwnd=%" PRIu32 ",num-ptos=%" PRIu64 ",delivery-rate-latest=%" PRIu64
+        ",delivery-rate-smoothed=%" PRIu64 ",delivery-rate-variance=%" PRIu64 APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, received)
+            APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, sent),
+        stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
+        stats.num_packets.lost_time_threshold, stats.num_packets.ack_received, stats.num_packets.late_acked,
+        stats.num_bytes.received, stats.num_bytes.sent, stats.num_bytes.lost, stats.num_bytes.ack_received,
+        stats.num_bytes.stream_data_sent, stats.num_bytes.stream_data_resent, stats.rtt.minimum, stats.rtt.smoothed,
+        stats.rtt.variance, stats.rtt.latest, stats.cc.cwnd, stats.num_ptos, stats.delivery_rate.latest,
+        stats.delivery_rate.smoothed,
+        stats.delivery_rate.variance APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, received) APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, sent));
     if (len + 1 > bufsize) {
         bufsize = len + 1;
         goto Redo;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -622,7 +622,7 @@ Redo:
         ",bytes-sent=%" PRIu64 ",bytes-lost=%" PRIu64 ",bytes-ack-received=%" PRIu64 ",bytes-stream-data-sent=%" PRIu64
         ",bytes-stream-data-resent=%" PRIu64 ",rtt-minimum=%" PRIu32 ",rtt-smoothed=%" PRIu32 ",rtt-variance=%" PRIu32
         ",rtt-latest=%" PRIu32 ",cwnd=%" PRIu32 ",num-ptos=%" PRIu64 ",delivery-rate-latest=%" PRIu64
-        ",delivery-rate-smoothed=%" PRIu64 ",delivery-rate-variance=%" PRIu64 APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, received)
+        ",delivery-rate-smoothed=%" PRIu64 ",delivery-rate-stdev=%" PRIu64 APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, received)
             APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, sent),
         stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
         stats.num_packets.lost_time_threshold, stats.num_packets.ack_received, stats.num_packets.late_acked,
@@ -630,7 +630,7 @@ Redo:
         stats.num_bytes.stream_data_sent, stats.num_bytes.stream_data_resent, stats.rtt.minimum, stats.rtt.smoothed,
         stats.rtt.variance, stats.rtt.latest, stats.cc.cwnd, stats.num_ptos, stats.delivery_rate.latest,
         stats.delivery_rate.smoothed,
-        stats.delivery_rate.variance APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, received) APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, sent));
+        stats.delivery_rate.stdev APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, received) APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, sent));
     if (len + 1 > bufsize) {
         bufsize = len + 1;
         goto Redo;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1760,9 +1760,9 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
         .num_reqs_inflight = num_reqs_inflight,
         .get_tracer = get_tracer,
         .log_ = {{
-            .congestion_control =
+            .transport =
                 {
-                    .name_ = log_cc_name,
+                    .cc_name = log_cc_name,
                 },
             .ssl =
                 {


### PR DESCRIPTION
Introduces`%{delivery-rate}x` that maps to `tcp_info::tcpi_delivery_rate` when TCP is used, or to `quicly_delivery_rate_t::delivery_rate.latest` when QUIC is used.

Also adds missing / new fields `%{http3.stats}x` to, including `delivery-rate.latest`, `delivery-rate.smoothed`, `delivery-rate.variance`.

Incorporates https://github.com/h2o/quicly/pull/486