### PR TITLE
mark the conn as is_closing to prevent sending any more frames

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -339,6 +339,9 @@ void h2o_http2_conn_unregister_stream(h2o_http2_conn_t *conn, h2o_http2_stream_t
 
 void close_connection_now(h2o_http2_conn_t *conn)
 {
+    /* mark as is_closing here to prevent sending any more frames */
+    conn->state = H2O_HTTP2_CONN_STATE_IS_CLOSING;
+
     h2o_http2_stream_t *stream;
 
     assert(!h2o_timer_is_linked(&conn->_write.timeout_entry));


### PR DESCRIPTION
This `h2o_http2_stream_close` calls (https://github.com/h2o/h2o/blob/master/lib/http2/connection.c#L346) can cause `h2o_http2_conn_request_write` calls, which in turn links `conn->_write.timeout_entry`. It causes this assertion (https://github.com/h2o/h2o/blob/master/lib/http2/connection.c#L377) to be failed. This PR fixes the issue by forcing `conn->state == H2O_HTTP2_CONN_STATE_IS_CLOSING` before closing streams, so that this block (https://github.com/h2o/h2o/blob/94c7448b78bb840564b7a78b18e251237c8edd0b/lib/http2/connection.c#L334-L337) never gets executed.