### PR TITLE
add overflow checks to ensure that 0 <= ctx->base_index <= INT64_MAX

### DIFF
--- a/deps/picotls/include/picotls.h
+++ b/deps/picotls/include/picotls.h
@@ -168,6 +168,7 @@ extern "C" {
 #define PTLS_ALERT_CERTIFICATE_UNKNOWN 46
 #define PTLS_ALERT_ILLEGAL_PARAMETER 47
 #define PTLS_ALERT_UNKNOWN_CA 48
+#define PTLS_ALERT_ACCESS_DENIED 49
 #define PTLS_ALERT_DECODE_ERROR 50
 #define PTLS_ALERT_DECRYPT_ERROR 51
 #define PTLS_ALERT_PROTOCOL_VERSION 70
@@ -945,6 +946,9 @@ int ptls_buffer_push_asn1_ubigint(ptls_buffer_t *buf, const void *bignum, size_t
  */
 static uint8_t *ptls_encode_quicint(uint8_t *p, uint64_t v);
 #define PTLS_ENCODE_QUICINT_CAPACITY 8
+
+#define PTLS_QUICINT_MAX 4611686018427387903 // (1 << 62) - 1
+#define PTLS_QUICINT_LONGEST_STR "4611686018427387903"
 
 #define ptls_buffer_pushv(buf, src, len)                                                                                           \
     do {                                                                                                                           \

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -556,7 +556,6 @@ static struct st_h2o_qpack_header_t *resolve_dynamic(struct st_h2o_qpack_header_
                                                      const uint8_t **src, const uint8_t *src_end, unsigned prefix_bits,
                                                      const char **err_desc)
 {
-    assert(base_index >= 0);
     int64_t off;
 
     if (decode_int(&off, src, src_end, prefix_bits) != 0 || off >= base_index) {
@@ -570,7 +569,6 @@ static struct st_h2o_qpack_header_t *resolve_dynamic_postbase(struct st_h2o_qpac
                                                               const uint8_t **src, const uint8_t *src_end, unsigned prefix_bits,
                                                               const char **err_desc)
 {
-    assert(base_index >= 0);
     int64_t off;
 
     if (decode_int(&off, src, src_end, prefix_bits) != 0 || off > INT64_MAX - (base_index + 1)) {

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -787,7 +787,7 @@ static int parse_decode_context(h2o_qpack_decoder_t *qpack, struct st_h2o_qpack_
         return H2O_HTTP3_ERROR_QPACK_DECOMPRESSION_FAILED;
     }
 
-    /* sign and delta base */
+    /* sign and base index */
     if (*src >= src_end)
         return H2O_HTTP3_ERROR_QPACK_DECOMPRESSION_FAILED;
     int sign = (**src & 0x80) != 0;


### PR DESCRIPTION
According to the current implementation (and what the QPACK spec suggests), `ctx->base_index` can be negative, but it's not sure that such situation actually exists and it can cause int64_t overflows in `resolve_dynamic_postbase` function. This PR tries to make our decoder require that base index not to be negative, i.e. ensures `0 <= ctx->base_index <= INT64_MAX`.
See also: https://github.com/quicwg/base-drafts/issues/4938