### PR TITLE
http3 fuzzer fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,6 +940,7 @@ IF (BUILD_FUZZER)
     TARGET_LINK_LIBRARIES(h2o-fuzzer-http2 libh2o-evloop ${EXTRA_LIBS} ${LIB_FUZZER})
     # h3 fuzzer does not use libh2o so it can replace quicly with quicly_mock
     TARGET_LINK_LIBRARIES(h2o-fuzzer-http3 ${EXTRA_LIBS} ${LIB_FUZZER} ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS})
+    TARGET_INCLUDE_DIRECTORIES(h2o-fuzzer-http3 PUBLIC ${OPENSSL_INCLUDE_DIR})
     TARGET_LINK_LIBRARIES(h2o-fuzzer-url libh2o-evloop ${EXTRA_LIBS} ${LIB_FUZZER})
     TARGET_LINK_LIBRARIES(h3-header-generator libh2o-evloop ${EXTRA_LIBS})
 

--- a/fuzz/quicly_mock.c
+++ b/fuzz/quicly_mock.c
@@ -21,7 +21,6 @@
  */
 
 #include <assert.h>
-#include <malloc.h>
 #include "khash.h"
 #include "quicly.h"
 #include "quicly/sendstate.h"


### PR DESCRIPTION
This fixes 2 minor issues of h2o-fuzzer-http3 which I faced on macOS.

- `malloc.h` is Linux specific and we even don't use malloc and others in this program
- Couldn't find `<openssl/openssl.h>` without adding $OPENSSL_INCLUDE_DIR as include directory