### PR TITLE
prevent http1 completion timeout from mistakenly getting cleared

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -1158,7 +1158,9 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
     if (conn->_ostr_final.chunked_buf != NULL && chunked_suffix.len != 0)
         bufs[bufcnt++] = chunked_suffix;
 
-    set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, req_io_on_timeout);
+    if (bufcnt != 0)
+        set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, req_io_on_timeout);
+
     h2o_socket_write(conn->sock, bufs, bufcnt, h2o_send_state_is_in_progress(send_state) ? on_send_next : on_send_complete);
 }
 


### PR DESCRIPTION
http1 protocol handler tries to defer `on_send_complete`, but in request streaming mode
the client can continue to send the request body while that. If it happens `handle_one_body_fragment`
mistakenly clears that timeout, which can causes the connection never gets closed by both side,
i.e. connection stalling.
Thanks to https://github.com/h2o/h2o/pull/2786, we can call h2o_socket_write even if bufcnt == 0, so this PR fixes the issue by using unconditional h2o_socket_write to avoid timeout_entry reuse.