### PR TITLE
Check Ruby version when WITH_MRUBY is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,17 @@ OPTION(BUILD_SHARED_LIBS "whether to build a shared library" OFF)
 FIND_PROGRAM(RUBY ruby)
 FIND_PROGRAM(BISON bison)
 IF (RUBY AND BISON)
-    SET(WITH_MRUBY_DEFAULT "ON")
+    # Bundled mruby cannot be built with Ruby 3.x
+    EXECUTE_PROCESS(
+        COMMAND "${RUBY}" -e "puts RUBY_VERSION"
+        OUTPUT_VARIABLE RUBY_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF ("${RUBY_VERSION}" VERSION_LESS "3.0.0")
+        SET(WITH_MRUBY_DEFAULT "ON")
+    ELSE ()
+        SET(WITH_MRUBY_DEFAULT "OFF")
+    ENDIF()
 ELSE ()
     SET(WITH_MRUBY_DEFAULT "OFF")
 ENDIF ()
@@ -724,16 +734,6 @@ SET(STANDALONE_SOURCE_FILES
     src/ssl.c)
 SET(STANDALONE_COMPILE_FLAGS "-DH2O_USE_LIBUV=0 -DH2O_USE_BROTLI=1 -DQUICLY_USE_TRACER=1")
 IF (WITH_MRUBY)
-    # Bundled mruby cannot be built with Ruby 3.x
-    EXECUTE_PROCESS(
-        COMMAND "${RUBY}" -e "puts RUBY_VERSION"
-        OUTPUT_VARIABLE RUBY_VERSION
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    IF (NOT ("${RUBY_VERSION}" VERSION_LESS "3.0.0"))
-        MESSAGE(FATAL_ERROR "Ruby 2.x needs for building mruby")
-    ENDIF()
-
     IF (${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
         SET(MRUBY_TOOLCHAIN "clang")
     ELSE ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -724,6 +724,16 @@ SET(STANDALONE_SOURCE_FILES
     src/ssl.c)
 SET(STANDALONE_COMPILE_FLAGS "-DH2O_USE_LIBUV=0 -DH2O_USE_BROTLI=1 -DQUICLY_USE_TRACER=1")
 IF (WITH_MRUBY)
+    # Bundled mruby cannot be built with Ruby 3.x
+    EXECUTE_PROCESS(
+        COMMAND "${RUBY}" -e "puts RUBY_VERSION"
+        OUTPUT_VARIABLE RUBY_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    IF (NOT ("${RUBY_VERSION}" VERSION_LESS "3.0.0"))
+        MESSAGE(FATAL_ERROR "Ruby 2.x needs for building mruby")
+    ENDIF()
+
     IF (${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
         SET(MRUBY_TOOLCHAIN "clang")
     ELSE ()


### PR DESCRIPTION
Bundled mruby cannot be built with Ruby 3.0.0 or higher versions by keyword argument problems. It's Rakefile is written in older Ruby syntax. And the error message is difficult to understand what is problem as below.

```
rake aborted!
wrong number of arguments (given 2, expected 1)
Rakefile:37:in `install_D'
make[2]: *** [CMakeFiles/mruby.dir/build.make:76: CMakeFiles/mruby] Error 1
make[1]: *** [CMakeFiles/Makefile2:816: CMakeFiles/mruby.dir/all] Error 2
```



Related issue #2789