### PR TITLE
Defer connection close if data is in flight.

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1440,7 +1440,7 @@ void do_emit_writereq(h2o_http2_conn_t *conn)
         conn->state = H2O_HTTP2_CONN_STATE_IS_CLOSING;
     /* fall-thru */
     case H2O_HTTP2_CONN_STATE_IS_CLOSING:
-        close_connection_now(conn);
+        close_connection(conn);
         break;
     }
 }


### PR DESCRIPTION
h2o may have tried to send a GOAWAY, but it is possible that the socket was
not yet writable.

In this case, the connection close cannot happen now, it must be deferred and
closed in `on_write_complete`, instead.