### PR TITLE
avoid comparing an array to NULL pointer

### DIFF
--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -438,9 +438,12 @@ h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *_listener)
 
     /* cache the remote address, if we know that we are going to use the value (in h2o_socket_ebpf_lookup_flags) */
 #if H2O_USE_EBPF_MAP
-    struct sockaddr_storage _peeraddr;
-    struct sockaddr_storage *peeraddr = &_peeraddr;
-    socklen_t peeraddrlen[1] = {sizeof(peeraddr[0])};
+    struct {
+        struct sockaddr_storage storage;
+        socklen_t len;
+    } _peeraddr;
+    struct sockaddr_storage *peeraddr = &_peeraddr.storage;
+    socklen_t *peeraddrlen = &_peeraddr.len;
 #else
     struct sockaddr_storage *peeraddr = NULL;
     socklen_t *peeraddrlen = NULL;

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -438,7 +438,8 @@ h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *_listener)
 
     /* cache the remote address, if we know that we are going to use the value (in h2o_socket_ebpf_lookup_flags) */
 #if H2O_USE_EBPF_MAP
-    struct sockaddr_storage peeraddr[1];
+    struct sockaddr_storage _peeraddr;
+    struct sockaddr_storage *peeraddr = &_peeraddr;
     socklen_t peeraddrlen[1] = {sizeof(peeraddr[0])};
 #else
     struct sockaddr_storage *peeraddr = NULL;


### PR DESCRIPTION
Otherwise we see the warning below.
```
warning: comparison of array 'peeraddr' not equal to a null pointer is always true [-Wtautological-pointer-compare]
```