### PR TITLE
close h2client stream on goaway

### DIFF
--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -655,6 +655,7 @@ static int handle_goaway_frame(struct st_h2o_http2client_conn_t *conn, h2o_http2
     kh_foreach_value(conn->streams, stream, {
         if (stream->stream_id > payload.last_stream_id) {
             call_callback_with_error(stream, h2o_httpclient_error_refused_stream);
+            close_stream(stream);
         }
     });
 


### PR DESCRIPTION
I don't see any reasons not to close the connection which hash bigger stream_id than last_stream_id. Maybe just a bug?