### PR TITLE
[http3] Enable UDP GSO based on configuration directive 

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -444,7 +444,7 @@ struct st_h2o_globalconf_t {
          */
         uint8_t use_delayed_ack : 1;
         /**
-         * a boolean indicating if UDP GSO should be used
+         * a boolean indicating if UDP GSO should be used when possible
          */
         uint8_t use_gso : 1;
         /**

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -450,7 +450,7 @@ struct st_h2o_globalconf_t {
         /**
          * a boolean indicating if UDP GSO should be used
          */
-        uint8_t use_udp_gso;
+        uint8_t use_gso;
     } http3;
 
     struct {

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -442,15 +442,15 @@ struct st_h2o_globalconf_t {
         /**
          * a boolean indicating if the delayed ack extension should be used (default true)
          */
-        uint8_t use_delayed_ack;
+        uint8_t use_delayed_ack : 1;
+        /**
+         * a boolean indicating if UDP GSO should be used
+         */
+        uint8_t use_gso : 1;
         /**
          * the callbacks
          */
         h2o_protocol_callbacks_t callbacks;
-        /**
-         * a boolean indicating if UDP GSO should be used
-         */
-        uint8_t use_gso;
     } http3;
 
     struct {

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -447,6 +447,10 @@ struct st_h2o_globalconf_t {
          * the callbacks
          */
         h2o_protocol_callbacks_t callbacks;
+        /**
+         * a boolean indicating if UDP GSO should be used
+         */
+        uint8_t use_udp_gso;
     } http3;
 
     struct {

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -202,7 +202,7 @@ struct st_h2o_quic_ctx_t {
     /**
      * boolean to indicate whether to use UDP GSO
      */
-    uint8_t use_udp_gso;
+    uint8_t use_gso;
     /**
      * preprocessor that rewrites a forwarded datagram (optional)
      */
@@ -332,8 +332,7 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
  * initializes the context
  */
 void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
-                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update,
-                           uint8_t use_udp_gso);
+                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update, uint8_t use_gso);
 /**
  *
  */

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -188,7 +188,7 @@ struct st_h2o_quic_ctx_t {
      */
     h2o_quic_accept_cb acceptor;
     /**
-     * 0 to disable load distribution of accepting connections by h2o (i.e. relies on the kernel's disbirution based on 4-tuple)
+     * 0 to disable load distribution of accepting connections by h2o (i.e. relies on the kernel's distribution based on 4-tuple)
      */
     uint32_t accept_thread_divisor;
     /**

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -200,6 +200,10 @@ struct st_h2o_quic_ctx_t {
      */
     uint8_t default_ttl;
     /**
+     * boolean to indicate whether to use UDP GSO
+     */
+    uint8_t use_udp_gso;
+    /**
      * preprocessor that rewrites a forwarded datagram (optional)
      */
     h2o_quic_preprocess_packet_cb preprocess_packet;
@@ -328,7 +332,8 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
  * initializes the context
  */
 void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
-                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update);
+                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update,
+                           uint8_t use_udp_gso);
 /**
  *
  */

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -202,7 +202,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http3.active_stream_window_size = H2O_DEFAULT_HTTP3_ACTIVE_STREAM_WINDOW_SIZE;
     config->http3.use_delayed_ack = 1;
 #ifdef UDP_SEGMENT
-    config->http3.use_udp_gso = 1;
+    config->http3.use_gso = 1;
 #endif
     config->http3.callbacks = H2O_HTTP3_SERVER_CALLBACKS;
     config->send_informational_mode = H2O_SEND_INFORMATIONAL_MODE_EXCEPT_H1;

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <netinet/udp.h>
 #include "h2o.h"
 #include "h2o/configurator.h"
 #include "h2o/http1.h"
@@ -200,6 +201,9 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http3.idle_timeout = quicly_spec_context.transport_params.max_idle_timeout;
     config->http3.active_stream_window_size = H2O_DEFAULT_HTTP3_ACTIVE_STREAM_WINDOW_SIZE;
     config->http3.use_delayed_ack = 1;
+#ifdef UDP_SEGMENT
+    config->http3.use_udp_gso = 1;
+#endif
     config->http3.callbacks = H2O_HTTP3_SERVER_CALLBACKS;
     config->send_informational_mode = H2O_SEND_INFORMATIONAL_MODE_EXCEPT_H1;
     config->mimemap = h2o_mimemap_create();

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -201,9 +201,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http3.idle_timeout = quicly_spec_context.transport_params.max_idle_timeout;
     config->http3.active_stream_window_size = H2O_DEFAULT_HTTP3_ACTIVE_STREAM_WINDOW_SIZE;
     config->http3.use_delayed_ack = 1;
-#ifdef UDP_SEGMENT
     config->http3.use_gso = 1;
-#endif
     config->http3.callbacks = H2O_HTTP3_SERVER_CALLBACKS;
     config->send_informational_mode = H2O_SEND_INFORMATIONAL_MODE_EXCEPT_H1;
     config->mimemap = h2o_mimemap_create();

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -628,7 +628,7 @@ static int on_config_http3_udp_gso(h2o_configurator_command_t *cmd, h2o_configur
         return -1;
     }
 #endif
-    ctx->globalconf->http3.use_udp_gso = (uint8_t)on;
+    ctx->globalconf->http3.use_gso = (uint8_t)on;
     return 0;
 }
 
@@ -1084,8 +1084,7 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(&c->super, "http3-delayed-ack",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http3_delayed_ack);
-        h2o_configurator_define_command(&c->super, "http3-udp-gso",
-                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+        h2o_configurator_define_command(&c->super, "http3-gso", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http3_udp_gso);
         h2o_configurator_define_command(&c->super, "file.mime.settypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
+#include <netinet/udp.h>
 #include "h2o.h"
 #include "h2o/configurator.h"
 
@@ -615,6 +616,22 @@ static int on_config_http3_delayed_ack(h2o_configurator_command_t *cmd, h2o_conf
     return 0;
 }
 
+static int on_config_http3_udp_gso(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    ssize_t on;
+
+    if ((on = h2o_configurator_get_one_of(cmd, node, "OFF,ON")) == -1)
+        return -1;
+#if !defined(UDP_SEGMENT)
+    if (on) {
+        h2o_configurator_errprintf(cmd, node, "this build does not support UDP GSO");
+        return -1;
+    }
+#endif
+    ctx->globalconf->http3.use_udp_gso = (uint8_t)on;
+    return 0;
+}
+
 static int assert_is_mimetype(h2o_configurator_command_t *cmd, yoml_t *node)
 {
     if (node->type != YOML_TYPE_SCALAR) {
@@ -1067,6 +1084,9 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
         h2o_configurator_define_command(&c->super, "http3-delayed-ack",
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http3_delayed_ack);
+        h2o_configurator_define_command(&c->super, "http3-udp-gso",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http3_udp_gso);
         h2o_configurator_define_command(&c->super, "file.mime.settypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -616,7 +616,7 @@ static int on_config_http3_delayed_ack(h2o_configurator_command_t *cmd, h2o_conf
     return 0;
 }
 
-static int on_config_http3_udp_gso(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+static int on_config_http3_gso(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     ssize_t on;
 
@@ -1085,7 +1085,7 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
                                         H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_http3_delayed_ack);
         h2o_configurator_define_command(&c->super, "http3-gso", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
-                                        on_config_http3_udp_gso);
+                                        on_config_http3_gso);
         h2o_configurator_define_command(&c->super, "file.mime.settypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -101,7 +101,8 @@ static h2o_http3client_ctx_t *create_http3_context(h2o_loop_t *loop)
         abort();
     }
     h2o_socket_t *sock = h2o_evloop_socket_create(loop, sockfd, H2O_SOCKET_FLAG_DONT_READ);
-    h2o_quic_init_context(&h3ctx->h3, loop, sock, &h3ctx->quic, NULL, h2o_httpclient_http3_notify_connection_update);
+    h2o_quic_init_context(&h3ctx->h3, loop, sock, &h3ctx->quic, NULL, h2o_httpclient_http3_notify_connection_update,
+                          0 /* no gso */);
 
     h3ctx->load_session = NULL; /* TODO reuse session? */
 

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -137,6 +137,7 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
     }
 
     /* next CMSG is UDP_SEGMENT size (for GSO) */
+    int using_gso = 0;
 #ifdef UDP_SEGMENT
     if (num_datagrams > 1 && ctx->use_gso) {
         for (size_t i = 1; i < num_datagrams - 1; ++i)
@@ -147,6 +148,7 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
         cmsg->cmsg_len = CMSG_LEN(sizeof(segsize));
         memcpy(CMSG_DATA(cmsg), &segsize, sizeof(segsize));
         cmsg = (struct cmsghdr *)((char *)cmsg + CMSG_SPACE(sizeof(segsize)));
+        using_gso = 1;
     }
 #endif
 
@@ -161,30 +163,23 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
     }
     int ret;
 
-#ifdef UDP_SEGMENT
-    /* a user of libh2o might accidentally set use_gso even if the libh2o build does not support GSO.
-     * the ifdef guard above is to safeguard such a case */
-    if (ctx->use_gso) {
+    if (using_gso) {
         mess.msg_iov = datagrams;
-        mess.msg_iovlen = num_datagrams;
+        mess.msg_iovlen = (int)num_datagrams;
         while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
             ;
         if (ret == -1)
             goto SendmsgError;
-        goto GsoSendDone;
+    } else {
+        for (size_t i = 0; i < num_datagrams; ++i) {
+            mess.msg_iov = datagrams + i;
+            mess.msg_iovlen = 1;
+            while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
+                ;
+            if (ret == -1)
+                goto SendmsgError;
+        }
     }
-#endif
-    for (size_t i = 0; i < num_datagrams; ++i) {
-        mess.msg_iov = datagrams + i;
-        mess.msg_iovlen = 1;
-        while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
-            ;
-        if (ret == -1)
-            goto SendmsgError;
-    }
-#ifdef UDP_SEGMENT
-GsoSendDone:
-#endif
 
     h2o_error_reporter_record_success(&track_sendmsg);
 

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -138,7 +138,7 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
 
     /* next CMSG is UDP_SEGMENT size (for GSO) */
 #ifdef UDP_SEGMENT
-    if (num_datagrams > 1) {
+    if (num_datagrams > 1 && ctx->use_udp_gso) {
         for (size_t i = 1; i < num_datagrams - 1; ++i)
             assert(datagrams[i].iov_len == datagrams[0].iov_len);
         uint16_t segsize = (uint16_t)datagrams[0].iov_len;
@@ -160,23 +160,24 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
         mess.msg_controllen = (socklen_t)((char *)cmsg - cmsgbuf.buf);
     }
     int ret;
-#ifdef UDP_SEGMENT
-    mess.msg_iov = datagrams;
-    mess.msg_iovlen = num_datagrams;
-    while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
-        ;
-    if (ret == -1)
-        goto SendmsgError;
-#else
-    for (size_t i = 0; i < num_datagrams; ++i) {
-        mess.msg_iov = datagrams + i;
-        mess.msg_iovlen = 1;
+
+    if (ctx->use_udp_gso) {
+        mess.msg_iov = datagrams;
+        mess.msg_iovlen = num_datagrams;
         while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
             ;
         if (ret == -1)
             goto SendmsgError;
+    } else {
+        for (size_t i = 0; i < num_datagrams; ++i) {
+            mess.msg_iov = datagrams + i;
+            mess.msg_iovlen = 1;
+            while ((ret = (int)sendmsg(h2o_socket_get_fd(ctx->sock.sock), &mess, 0)) == -1 && errno == EINTR)
+                ;
+            if (ret == -1)
+                goto SendmsgError;
+        }
     }
-#endif
 
     h2o_error_reporter_record_success(&track_sendmsg);
 
@@ -974,7 +975,8 @@ Validation_Success:;
 }
 
 void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
-                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update)
+                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update,
+                           uint8_t use_udp_gso)
 {
     assert(quic->stream_open != NULL);
 
@@ -987,6 +989,7 @@ void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *
                             notify_conn_update};
     ctx->sock.sock->data = ctx;
     ctx->sock.addrlen = h2o_socket_getsockname(ctx->sock.sock, (void *)&ctx->sock.addr);
+    ctx->use_udp_gso = use_udp_gso;
     assert(ctx->sock.addrlen != 0);
     switch (ctx->sock.addr.ss_family) {
     case AF_INET:

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -568,7 +568,7 @@ int main(int argc, char **argv)
         }
         h2o_socket_t *sock = h2o_evloop_socket_create(ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
         h2o_quic_init_context(&h3ctx.h3, ctx.loop, sock, &h3ctx.quic, NULL, h2o_httpclient_http3_notify_connection_update,
-                              0 /* no gso */);
+                              1 /* use_gso */);
     }
 #endif
 

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -567,7 +567,8 @@ int main(int argc, char **argv)
             exit(EXIT_FAILURE);
         }
         h2o_socket_t *sock = h2o_evloop_socket_create(ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
-        h2o_quic_init_context(&h3ctx.h3, ctx.loop, sock, &h3ctx.quic, NULL, h2o_httpclient_http3_notify_connection_update);
+        h2o_quic_init_context(&h3ctx.h3, ctx.loop, sock, &h3ctx.quic, NULL, h2o_httpclient_http3_notify_connection_update,
+                              0 /* no gso */);
     }
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -2953,7 +2953,7 @@ static void *run_loop(void *_thread_index)
         /* setup quic context and the unix socket to receive forwarded packets */
         if (thread_index < conf.quic.num_threads && listener_config->quic.ctx != NULL) {
             h2o_quic_init_context(&listeners[i].http3.ctx.super, conf.threads[thread_index].ctx.loop, listeners[i].sock,
-                                  listener_config->quic.ctx, on_http3_accept, NULL, conf.globalconf.http3.use_udp_gso);
+                                  listener_config->quic.ctx, on_http3_accept, NULL, conf.globalconf.http3.use_gso);
             h2o_quic_set_context_identifier(&listeners[i].http3.ctx.super, 0, (uint32_t)thread_index, conf.quic.node_id, 4,
                                             forward_quic_packets, rewrite_forwarded_quic_datagram);
             listeners[i].http3.ctx.accept_ctx = &listeners[i].accept_ctx;

--- a/src/main.c
+++ b/src/main.c
@@ -2953,7 +2953,7 @@ static void *run_loop(void *_thread_index)
         /* setup quic context and the unix socket to receive forwarded packets */
         if (thread_index < conf.quic.num_threads && listener_config->quic.ctx != NULL) {
             h2o_quic_init_context(&listeners[i].http3.ctx.super, conf.threads[thread_index].ctx.loop, listeners[i].sock,
-                                  listener_config->quic.ctx, on_http3_accept, NULL);
+                                  listener_config->quic.ctx, on_http3_accept, NULL, conf.globalconf.http3.use_udp_gso);
             h2o_quic_set_context_identifier(&listeners[i].http3.ctx.super, 0, (uint32_t)thread_index, conf.quic.node_id, 4,
                                             forward_quic_packets, rewrite_forwarded_quic_datagram);
             listeners[i].http3.ctx.accept_ctx = &listeners[i].accept_ctx;


### PR DESCRIPTION
This commit introduces `http3-udp-gso` directive, which controls
whether UDP GSO is used.

Default is on if UDP_SEGMENT is defined. This is the same behavior
as the current code.