### PR TITLE
`rand` might not be MT-safe, use `rand_r` instead

### DIFF
--- a/include/h2o/rand.h
+++ b/include/h2o/rand.h
@@ -25,12 +25,18 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+/**
+ * srand is a no-op
+ */
 #define h2o_srand()
+/**
+ * Wrapper of rand (3) or arc4random (3). Guaranteed to be multi-thread safe.
+ */
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #define h2o_rand() arc4random()
 #else
-#define h2o_srand() srand(time(NULL) ^ getpid())
-#define h2o_rand() rand()
+#define H2O_DEFINE_RAND 1
+int h2o_rand(void);
 #endif
 
 /*

--- a/lib/common/rand.c
+++ b/lib/common/rand.c
@@ -26,6 +26,23 @@
 #include "h2o/string_.h"
 #include "picotls/openssl.h"
 
+#if H2O_DEFINE_RAND
+int h2o_rand(void)
+{
+    static __thread struct {
+        unsigned seed;
+        unsigned initialized;
+    } state;
+
+    if (!state.initialized) {
+        ptls_openssl_random_bytes(&state.seed, sizeof(state.seed));
+        state.initialized = 1;
+    }
+
+    return rand_r(&state.seed);
+}
+#endif
+
 static void format_uuid_rfc4122(char *dst, uint8_t *octets, uint8_t version)
 {
     // Variant:


### PR DESCRIPTION
Inspired by #2863.