### PR TITLE
TCP: hardcode the accepts to 10 per loop.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2687,9 +2687,7 @@ static void on_socketclose(void *data)
 static void on_accept(h2o_socket_t *listener, const char *err)
 {
     struct listener_ctx_t *ctx = listener->data;
-    size_t num_accepts = conf.max_connections / 16 / conf.thread_map.size;
-    if (num_accepts < 8)
-        num_accepts = 8;
+    size_t num_accepts = 10;
 
     if (err != NULL) {
         return;

--- a/src/main.c
+++ b/src/main.c
@@ -2687,6 +2687,10 @@ static void on_socketclose(void *data)
 static void on_accept(h2o_socket_t *listener, const char *err)
 {
     struct listener_ctx_t *ctx = listener->data;
+    /*
+     * TLS Handshakes take about 1ms, this effectively limits the latency
+     * induced by TLS handshakes to 10ms per event loop.
+     */
     size_t num_accepts = 10;
 
     if (err != NULL) {


### PR DESCRIPTION
TLS Handshakes take about 1ms, this effectively limits the latency
induced by TLS handshakes to 10ms per event loop.

QUIC doesn't suffer from this problem since we're limiting the packets handled to 10 at a time.