### PR TITLE
h2olog: add -D<name> to enable BCC debug flags

### DIFF
--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -64,7 +64,7 @@ Optional arguments:
   -a                Include application data which are omitted by default.
   -r                Run without dropping root privilege.
   -w <path>         Path to write the output (default: stdout).
-  -f <flag>         Enables a BCC debug flag (supported flag: DEBUG_LLVM_IR,
+  -f <flag>         Turn on a BCC debug flag (supported flag: DEBUG_LLVM_IR,
                     DEBUG_BPF, DEBUG_PREPROCESSOR, DEBUG_SOURCE,
                     DEBUG_BPF_REGISTER_STATE, DEBUG_BTF)
 

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -64,7 +64,7 @@ Optional arguments:
   -a                Include application data which are omitted by default.
   -r                Run without dropping root privilege.
   -w <path>         Path to write the output (default: stdout).
-  -D <flag>         Enables a BCC debug flag (supported flag: DEBUG_LLVM_IR,
+  -f <flag>         Enables a BCC debug flag (supported flag: DEBUG_LLVM_IR,
                     DEBUG_BPF, DEBUG_PREPROCESSOR, DEBUG_SOURCE,
                     DEBUG_BPF_REGISTER_STATE, DEBUG_BTF)
 
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
     double sampling_rate = 1.0;
     std::vector<std::pair<std::vector<uint8_t> /* address */, unsigned /* netmask */>> sampling_addresses;
     std::vector<std::string> sampling_snis;
-    while ((c = getopt(argc, argv, "hHdrlap:t:s:w:S:A:N:D:")) != -1) {
+    while ((c = getopt(argc, argv, "hHdrlap:t:s:w:S:A:N:f:")) != -1) {
         switch (c) {
         case 'H':
             tracer.reset(create_http_tracer());
@@ -339,7 +339,7 @@ int main(int argc, char **argv)
         case 'd':
             debug++;
             break;
-        case 'D':
+        case 'f':
 #define BCC_FLAG(var, flag)                                                                                                        \
     if (strcmp(optarg, #flag) == 0) {                                                                                              \
         var |= ebpf::flag;                                                                                                         \
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
             BCC_FLAG(bcc_flags, DEBUG_BTF)
             // else
             {
-                fprintf(stderr, "Error: unknown name for -D: %s\n", optarg);
+                fprintf(stderr, "Error: unknown name for -f: %s\n", optarg);
                 exit(EXIT_FAILURE);
             }
 #undef BCC_FLAG

--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <bcc/BPF.h>
 #include <bcc/libbpf.h>
+#include <bcc/bpf_module.h>
 
 extern "C" {
 #include <unistd.h>
@@ -63,6 +64,9 @@ Optional arguments:
   -a                Include application data which are omitted by default.
   -r                Run without dropping root privilege.
   -w <path>         Path to write the output (default: stdout).
+  -D <flag>         Enables a BCC debug flag (supported flag: DEBUG_LLVM_IR,
+                    DEBUG_BPF, DEBUG_PREPROCESSOR, DEBUG_SOURCE,
+                    DEBUG_BPF_REGISTER_STATE, DEBUG_BTF)
 
 Examples:
   h2olog -p $(pgrep -o h2o) -H
@@ -261,6 +265,7 @@ int main(int argc, char **argv)
     std::unique_ptr<h2o_tracer> tracer(create_raw_tracer());
 
     int debug = 0;
+    unsigned int bcc_flags = 0;
     bool preserve_root = false;
     bool list_usdts = false;
     bool include_appdata = false;
@@ -271,7 +276,7 @@ int main(int argc, char **argv)
     double sampling_rate = 1.0;
     std::vector<std::pair<std::vector<uint8_t> /* address */, unsigned /* netmask */>> sampling_addresses;
     std::vector<std::string> sampling_snis;
-    while ((c = getopt(argc, argv, "hHdrlap:t:s:w:S:A:N:")) != -1) {
+    while ((c = getopt(argc, argv, "hHdrlap:t:s:w:S:A:N:D:")) != -1) {
         switch (c) {
         case 'H':
             tracer.reset(create_http_tracer());
@@ -334,6 +339,24 @@ int main(int argc, char **argv)
         case 'd':
             debug++;
             break;
+        case 'D':
+#define BCC_FLAG(var, flag)                                                                                                        \
+    if (strcmp(optarg, #flag) == 0) {                                                                                              \
+        var |= ebpf::flag;                                                                                                         \
+    } else
+            BCC_FLAG(bcc_flags, DEBUG_LLVM_IR)
+            BCC_FLAG(bcc_flags, DEBUG_BPF)
+            BCC_FLAG(bcc_flags, DEBUG_PREPROCESSOR)
+            BCC_FLAG(bcc_flags, DEBUG_SOURCE)
+            BCC_FLAG(bcc_flags, DEBUG_BPF_REGISTER_STATE)
+            BCC_FLAG(bcc_flags, DEBUG_BTF)
+            // else
+            {
+                fprintf(stderr, "Error: unknown name for -D: %s\n", optarg);
+                exit(EXIT_FAILURE);
+            }
+#undef BCC_FLAG
+            break;
         case 'l':
             list_usdts = true;
             break;
@@ -394,7 +417,7 @@ int main(int argc, char **argv)
         cflags.push_back(generate_header_filter_cflag(response_header_filters));
     }
 
-    ebpf::BPF bpf;
+    ebpf::BPF bpf(bcc_flags);
     std::vector<ebpf::USDT> probes;
 
     bool selective_tracing = false;


### PR DESCRIPTION
As h2olog becomes complex, we need to debug its internals by investigating LLVM IR and BPF bytecode.  This PR adds a flag `-D` to enable implementation-defined debug flags.