### PR TITLE
add current directory to @INC in upstream.psgi

### DIFF
--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -6,6 +6,7 @@ use Getopt::Long;
 use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use URI::Escape;
+use lib '.';
 use t::Util;
 
 my ($aggregated_mode, $h2o_keepalive, $starlet_keepalive, $starlet_force_chunked, $unix_socket);

--- a/t/assets/upstream.psgi
+++ b/t/assets/upstream.psgi
@@ -6,6 +6,7 @@ use Plack::Builder;
 use Plack::Request;
 use Plack::TempBuffer;
 use Time::HiRes qw(sleep);
+use lib '.';
 use t::Util;
 
 my $force_chunked = $ENV{FORCE_CHUNKED} || 0;


### PR DESCRIPTION
As of Perl 5.26 current directory is not included in `@INC`, so plackup with recent perl fails with `module t::Util not found` error