### PR TITLE
Fix crash on bad request with error-doc

### DIFF
--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -347,7 +347,7 @@ void h2o_url_resolve_path(h2o_iovec_t *base, h2o_iovec_t *relative)
 {
     size_t base_path_len = base->len, rel_path_offset = 0;
 
-    if (relative->len != 0 && relative->base[0] == '/') {
+    if (base->base == NULL || (relative->len != 0 && relative->base[0] == '/')) {
         base_path_len = 0;
     } else {
         /* relative path */

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -525,6 +525,7 @@ static int contains_crlf_only(const char *s, size_t len)
 
 static void send_bad_request(struct st_h2o_http1_conn_t *conn, const char *body)
 {
+    conn->req.input.scheme = conn->sock->ssl != NULL ? &H2O_URL_SCHEME_HTTPS : &H2O_URL_SCHEME_HTTP;
     h2o_socket_read_stop(conn->sock);
     h2o_send_error_400(&conn->req, "Bad Request", body, H2O_SEND_ERROR_HTTP1_CLOSE_CONNECTION);
 }

--- a/t/50errordoc.t
+++ b/t/50errordoc.t
@@ -176,4 +176,22 @@ EOT
     }, qr/server failed to start/, 'duplicated statuses';
 };
 
+subtest 'issue/2753' => sub {
+   my ($port) = empty_ports(1, { host => "0.0.0.0" });
+   my $server = spawn_h2o_raw(<<"EOT", [$port]);
+hosts:
+  default:
+    listen:
+      port: $port
+    paths:
+      /:
+        file.dir: @{[DOC_ROOT]}
+error-doc:
+  - status: 400
+    url: 400.html
+EOT
+
+   my $resp = `curl --silent --dump-header /dev/stderr https://127.0.0.1:$port/nonexist 2>&1 > /dev/null`;
+   is $resp, "";
+};
 done_testing;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -200,6 +200,7 @@ sub spawn_server {
                 my $i = 0;
                 while (1) {
                     if (waitpid($pid, WNOHANG) == $pid) {
+                        Test::More::fail "segmentation fault" if $? == 11;
                         print STDERR "killed (got $?)\n";
                         last;
                     }


### PR DESCRIPTION
Fixes #2753 

* Fix h2o_url_resolve_path to prevent crash when base->base == NULL.
* Fix send_bad_request on http1.c when req.input->scheme == NULL.
* Cover with this scenario in t/50errordoc.t and catch a fail in test when spawn server causes segmentation fault.