### PR TITLE
don't apply filters when request is broken

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1769,7 +1769,11 @@ enum {
     /**
      * if set, does not flush the registered response headers
      */
-    H2O_SEND_ERROR_KEEP_HEADERS = 0x2
+    H2O_SEND_ERROR_KEEP_HEADERS = 0x2,
+    /**
+     * indicates a broken or incomplete HTTP request, and that some fields of `h2o_req_t` e.g., `input` might be NULL
+     */
+    H2O_SEND_ERROR_BROKEN_REQUEST = 0x04
 };
 
 /**

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -660,6 +660,11 @@ void h2o_send_error_generic(h2o_req_t *req, int status, const char *reason, cons
         h2o_req_bind_conf(req, hostconf, &hostconf->fallback_path);
     }
 
+    /* If the request is broken or incomplete, do not apply filters, as it would be dangerous to do so. Legitimate clients would not
+     * send broken requests, so we do not need to decorate error responses using errordoc handler or anything else. */
+    if ((flags & H2O_SEND_ERROR_BROKEN_REQUEST) != 0)
+        req->_next_filter_index = SIZE_MAX;
+
     if ((flags & H2O_SEND_ERROR_HTTP1_CLOSE_CONNECTION) != 0)
         req->http1_is_persistent = 0;
 

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -526,7 +526,7 @@ static int contains_crlf_only(const char *s, size_t len)
 static void send_bad_request(struct st_h2o_http1_conn_t *conn, const char *body)
 {
     h2o_socket_read_stop(conn->sock);
-    h2o_send_error_400(&conn->req, "Bad Request", body, H2O_SEND_ERROR_HTTP1_CLOSE_CONNECTION);
+    h2o_send_error_400(&conn->req, "Bad Request", body, H2O_SEND_ERROR_BROKEN_REQUEST | H2O_SEND_ERROR_HTTP1_CLOSE_CONNECTION);
 }
 
 static void proceed_request(h2o_req_t *req, size_t written, h2o_send_state_t send_state)

--- a/t/50errordoc.t
+++ b/t/50errordoc.t
@@ -176,4 +176,21 @@ EOT
     }, qr/server failed to start/, 'duplicated statuses';
 };
 
+subtest "bad request" => sub {
+    plan skip_all => "nc not found"
+        unless prog_exists("nc");
+    my $server = spawn_h2o(<<"EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: @{[DOC_ROOT]}
+error-doc:
+  - status: 400
+    url: /index.txt
+EOT
+    my $resp = `(echo badrequest/1.0; echo) | nc 127.0.0.1 $server->{port}`;
+    like $resp, qr{^HTTP/1.1 400 .*bad request$}is;
+};
+
 done_testing;

--- a/t/50errordoc.t
+++ b/t/50errordoc.t
@@ -190,7 +190,10 @@ error-doc:
     url: /index.txt
 EOT
     my $resp = `(echo badrequest/1.0; echo) | nc 127.0.0.1 $server->{port}`;
-    like $resp, qr{^HTTP/1.1 400 .*bad request$}is;
+    like $resp, qr{^HTTP/1.1 400 .*\nbad request$}is, "broken request headers -> undecorated 400";
+
+    my $resp = `(echo POST / HTTP/1.1; echo Transfer-Encoding: chunked; echo; echo hello world; echo; echo) | nc 127.0.0.1 $server->{port}`;
+    like $resp, qr{^HTTP/1.1 400 .*\nhello\n$}is, "valid request headers but broken entity -> decorated 400";
 };
 
 done_testing;


### PR DESCRIPTION
At the moment, doing so leads to a crash, as reported in #2900.

The excuse for skipping filters (e.g., error-doc) when receiving a broken request is that there is no point in trying to return something fancy in such case, because legitimate clients would never send broken requests.