### PR TITLE
[t/40server-push.t] use mruby handler to avoid timing issues between h2o and upstream

### DIFF
--- a/t/40server-push.t
+++ b/t/40server-push.t
@@ -37,6 +37,11 @@ hosts:
             [399, { "link" => "</index.txt.gz>; rel=preload" }, [] ]
           end
         proxy.reverse.url: http://127.0.0.1:$upstream_port
+      /push-unprioritized:
+        mruby.handler: |
+          Proc.new do |env|
+            [200, { "link" => "</assets/index.txt>; rel=preload" }, [ File.read("@{[DOC_ROOT]}/halfdome.jpg") ] ]
+          end
       /mruby-critical:
         mruby.handler: |
           Proc.new do |env|
@@ -55,8 +60,8 @@ EOT
         };
         subtest 'push-unprioritized' => sub {
             # index.txt is smaller than index.txt.gz, hence receiving the former always completes first
-            my $resp = `nghttp $opts -n --stat -w 10 '$proto://127.0.0.1:$port/halfdome.jpg?resp:link=</halfdome.jpg?pushed>\%3b\%20rel=preload'`;
-            like $resp, qr{\nid\s*responseEnd\s.*\s/halfdome\.jpg\?resp.*\s/halfdome\.jpg\?pushed}is;
+            my $resp = `nghttp $opts -n --stat -W 20 -w 20 '$proto://127.0.0.1:$port/push-unprioritized'`;
+            like $resp, qr{\nid\s*responseEnd\s.*\s/push-unprioritized.*\s/assets/index\.txt}is;
         };
         subtest "push-1xx" => sub {
             my $out = `nghttp $opts -n --stat '$proto://127.0.0.1:$port/1xx-push/'`;


### PR DESCRIPTION
Until now, "push-unpriotized" has assumed that using a small stream-level window leads to more predictable scheduling between requests.

That is an incorrect assumption. When the stream-level window is small, every stream will make equal amount of progress (as indicated by the window size) every round-trip. To paraphrase, use of a small window preserves the timing differences between the TTFB of the responses.

This PR changes the handler that generates the responses for this test from a upstream.psgi to a mruby handler. Doing that prevents the timing issues caused by IPC between h2o and upstream.psgi.