### PR TITLE
add missing initialization of newly added flag

### DIFF
--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -148,13 +148,15 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
         .keepalive_timeout = self->config.keepalive_timeout,
         .max_buffer_size = self->config.max_buffer_size,
         .tunnel_enabled = self->config.tunnel_enabled,
-        .protocol_selector = (struct st_h2o_httpclient_protocol_selector_t){
-            .ratio = self->config.protocol_ratio,
-        },
-        .http2 = {
-            .latency_optimization = ctx->globalconf->http2.latency_optimization, /* TODO provide config knob, or disable? */
-            .max_concurrent_streams = self->config.http2.max_concurrent_streams,
-        },
+        .protocol_selector =
+            (struct st_h2o_httpclient_protocol_selector_t){
+                .ratio = self->config.protocol_ratio,
+            },
+        .http2 =
+            {
+                .latency_optimization = ctx->globalconf->http2.latency_optimization, /* TODO provide config knob, or disable? */
+                .max_concurrent_streams = self->config.http2.max_concurrent_streams,
+            },
         .http3 = self->config.protocol_ratio.http3 != 0 ? create_http3_context(ctx->loop, ctx->globalconf->http3.use_gso) : NULL,
     };
 

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -155,7 +155,7 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
             .latency_optimization = ctx->globalconf->http2.latency_optimization, /* TODO provide config knob, or disable? */
             .max_concurrent_streams = self->config.http2.max_concurrent_streams,
         },
-        .http3 = client_ctx->protocol_selector.ratio.http3 != 0 ? create_http3_context(ctx->loop, ctx->globalconf->http3.use_gso) : NULL,
+        .http3 = self->config.protocol_ratio.http3 != 0 ? create_http3_context(ctx->loop, ctx->globalconf->http3.use_gso) : NULL,
     };
 
     handler_ctx->client_ctx = client_ctx;

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -148,10 +148,7 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
         .keepalive_timeout = self->config.keepalive_timeout,
         .max_buffer_size = self->config.max_buffer_size,
         .tunnel_enabled = self->config.tunnel_enabled,
-        .protocol_selector =
-            (struct st_h2o_httpclient_protocol_selector_t){
-                .ratio = self->config.protocol_ratio,
-            },
+        .protocol_selector = {.ratio = self->config.protocol_ratio},
         .http2 =
             {
                 .latency_optimization = ctx->globalconf->http2.latency_optimization, /* TODO provide config knob, or disable? */

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -139,24 +139,24 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
         return;
 
     h2o_httpclient_ctx_t *client_ctx = h2o_mem_alloc(sizeof(*ctx));
-    client_ctx->loop = ctx->loop;
-    client_ctx->getaddr_receiver = &ctx->receivers.hostinfo_getaddr;
-    client_ctx->io_timeout = self->config.io_timeout;
-    client_ctx->connect_timeout = self->config.connect_timeout;
-    client_ctx->first_byte_timeout = self->config.first_byte_timeout;
-    client_ctx->keepalive_timeout = self->config.keepalive_timeout;
-    client_ctx->tunnel_enabled = self->config.tunnel_enabled;
-    client_ctx->force_cleartext_http2 = 1;
-
-    client_ctx->max_buffer_size = self->config.max_buffer_size;
-    client_ctx->protocol_selector = (struct st_h2o_httpclient_protocol_selector_t){.ratio = self->config.protocol_ratio};
-
-    client_ctx->http2.latency_optimization =
-        ctx->globalconf->http2.latency_optimization; /* TODO provide config knob, or disable? */
-    client_ctx->http2.max_concurrent_streams = self->config.http2.max_concurrent_streams;
-
-    client_ctx->http3 =
-        client_ctx->protocol_selector.ratio.http3 != 0 ? create_http3_context(ctx->loop, ctx->globalconf->http3.use_gso) : NULL;
+    *client_ctx = (h2o_httpclient_ctx_t){
+        .loop = ctx->loop,
+        .getaddr_receiver = &ctx->receivers.hostinfo_getaddr,
+        .io_timeout = self->config.io_timeout,
+        .connect_timeout = self->config.connect_timeout,
+        .first_byte_timeout = self->config.first_byte_timeout,
+        .keepalive_timeout = self->config.keepalive_timeout,
+        .max_buffer_size = self->config.max_buffer_size,
+        .tunnel_enabled = self->config.tunnel_enabled,
+        .protocol_selector = (struct st_h2o_httpclient_protocol_selector_t){
+            .ratio = self->config.protocol_ratio,
+        },
+        .http2 = {
+            .latency_optimization = ctx->globalconf->http2.latency_optimization, /* TODO provide config knob, or disable? */
+            .max_concurrent_streams = self->config.http2.max_concurrent_streams,
+        },
+        .http3 = client_ctx->protocol_selector.ratio.http3 != 0 ? create_http3_context(ctx->loop, ctx->globalconf->http3.use_gso) : NULL,
+    };
 
     handler_ctx->client_ctx = client_ctx;
 }

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -146,6 +146,7 @@ static void on_context_init(h2o_handler_t *_self, h2o_context_t *ctx)
     client_ctx->first_byte_timeout = self->config.first_byte_timeout;
     client_ctx->keepalive_timeout = self->config.keepalive_timeout;
     client_ctx->tunnel_enabled = self->config.tunnel_enabled;
+    client_ctx->force_cleartext_http2 = 1;
 
     client_ctx->max_buffer_size = self->config.max_buffer_size;
     client_ctx->protocol_selector = (struct st_h2o_httpclient_protocol_selector_t){.ratio = self->config.protocol_ratio};


### PR DESCRIPTION
The problem only appears when we set H2 ratio 100: h2o may ignore ALPN even if that flag isn't set
https://github.com/h2o/h2o/blob/master/lib/common/httpclient.c#L125-L130