### PR TITLE
set num-threads to 2 to prevent tests running out of file descriptors

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -178,6 +178,7 @@ sub spawn_server {
     die "fork failed:$!"
         unless defined $pid;
     if ($pid != 0) {
+        system("sudo prlimit --nofile=1048576:1048576 --pid $pid");
         print STDERR "spawning $args{argv}->[0]... ";
         if ($args{is_ready}) {
             while (1) {


### PR DESCRIPTION
Depending on the system configuration, `h2o` could run out of file descriptors on start up while running tests in docker on a machine with a large number of cores.