### PR TITLE
send TLS alert before closing the socket, when OpenSSL is used and certificate verification fails

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -467,8 +467,7 @@ static void shutdown_ssl(h2o_socket_t *sock, const char *err)
         ret = 1; /* close the socket after sending close_notify */
     } else if (sock->ssl->ossl != NULL) {
         ERR_clear_error();
-        if ((ret = SSL_shutdown(sock->ssl->ossl)) == -1)
-            goto Close;
+        ret = SSL_shutdown(sock->ssl->ossl);
     } else {
         goto Close;
     }


### PR DESCRIPTION
As stated in the old comment being removed in this PR, OpenSSL as of 1.1.0 emits TLS alert inside `SSL_accept` when handshake the handshake fails, and `SSL_shutdown` returns an error when being called afterwards.

Our fix (#1872) to this change of behavior has been to check if there's anything in the output buffer, when `SSL_accept` or `SSL_connect` returns an error. If there's something, we'd delay the invocation of `on_handshake_complete` until the output is written to the socket.

However, the fix did not cover the case when `verify_result` is not `X509_V_OK`. Hence the problem as stated in the title of this PR.

Whatever the fix is, it should use one approach for handling all handshake errors.