### PR TITLE
simplify `shutdown_ssl`

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -475,7 +475,7 @@ static void shutdown_ssl(h2o_socket_t *sock, const char *err)
 
     if (has_pending_ssl_bytes(sock->ssl)) {
         h2o_socket_read_stop(sock);
-        flush_pending_ssl(sock, ret == 1 ? dispose_socket : shutdown_ssl);
+        flush_pending_ssl(sock, dispose_socket);
     } else {
         goto Close;
     }

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -476,8 +476,6 @@ static void shutdown_ssl(h2o_socket_t *sock, const char *err)
     if (has_pending_ssl_bytes(sock->ssl)) {
         h2o_socket_read_stop(sock);
         flush_pending_ssl(sock, ret == 1 ? dispose_socket : shutdown_ssl);
-    } else if (ret == 2 && SSL_get_error(sock->ssl->ossl, ret) == SSL_ERROR_WANT_READ) {
-        h2o_socket_read_start(sock, shutdown_ssl);
     } else {
         goto Close;
     }

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -473,11 +473,9 @@ static void shutdown_ssl(h2o_socket_t *sock, const char *err)
     if (has_pending_ssl_bytes(sock->ssl)) {
         h2o_socket_read_stop(sock);
         flush_pending_ssl(sock, dispose_socket);
-    } else {
-        goto Close;
+        return;
     }
 
-    return;
 Close:
     dispose_socket(sock, err);
 }

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -444,8 +444,6 @@ static void dispose_socket(h2o_socket_t *sock, const char *err)
 
 static void shutdown_ssl(h2o_socket_t *sock, const char *err)
 {
-    int ret;
-
     if (err != NULL)
         goto Close;
 
@@ -460,14 +458,13 @@ static void shutdown_ssl(h2o_socket_t *sock, const char *err)
         ptls_buffer_t wbuf;
         uint8_t wbuf_small[32];
         ptls_buffer_init(&wbuf, wbuf_small, sizeof(wbuf_small));
-        if ((ret = ptls_send_alert(sock->ssl->ptls, &wbuf, PTLS_ALERT_LEVEL_WARNING, PTLS_ALERT_CLOSE_NOTIFY)) != 0)
+        if (ptls_send_alert(sock->ssl->ptls, &wbuf, PTLS_ALERT_LEVEL_WARNING, PTLS_ALERT_CLOSE_NOTIFY) != 0)
             goto Close;
         write_ssl_bytes(sock, wbuf.base, wbuf.off);
         ptls_buffer_dispose(&wbuf);
-        ret = 1; /* close the socket after sending close_notify */
     } else if (sock->ssl->ossl != NULL) {
         ERR_clear_error();
-        if ((ret = SSL_shutdown(sock->ssl->ossl)) == -1)
+        if (SSL_shutdown(sock->ssl->ossl) == -1)
             goto Close;
     } else {
         goto Close;


### PR DESCRIPTION
`shutdown_ssl` seems unnecessarily complicated. This refactors the code for simplicity.

Some of the complexity stems from the attempt to support clean bidirectional shutdown, waiting for the receipt of an TLS alert after sending one. While such shutdown is necessary for application protocols that rely on TLS alert to identify message identity to prevent truncation attack, it is unnecessary for most application protocols including HTTP. HTTP has its own mechanism of indicating message boundary, or truncation is considered a known issue when using HTTP/1 with connection close being end of the message.

Anyways, `shutdown_ssl` has never closed the connection in such a clean manner, and we can simplify the code.

The other issue related to closing the socket immediately after sending a TLS alert is that when the TCP/IP stack receives some data from the cilent while FIN sent to the peer is in flight, the stack might send a RESET, and that might cause some messages sent by the endpoint to be discarded. However, this issue should be fixed by implementing lingering close at the socket layer rather than at the TLS layer, as the issue exists with cleartext HTTP as well.