### PR TITLE
[server] [bug-fix] Crash in h2o_multithread_send_message() when on_sigterm() is called twice

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2492,12 +2492,14 @@ static void dispose_resolve_tag_arg(resolve_tag_arg_t *arg)
 
 static void on_sigterm(int signo)
 {
-    conf.shutdown_requested = 1;
-    if (!h2o_barrier_done(&conf.startup_sync_barrier)) {
-        /* initialization hasn't completed yet, exit right away */
-        exit(0);
+    if (conf.shutdown_requested == 0) {
+        conf.shutdown_requested = 1;
+        if (!h2o_barrier_done(&conf.startup_sync_barrier)) {
+            /* initialization hasn't completed yet, exit right away */
+            exit(0);
+        }
+        notify_all_threads();
     }
-    notify_all_threads();
 }
 
 #ifdef LIBC_HAS_BACKTRACE


### PR DESCRIPTION
While running `t/50graceful-shutdown.t`, I saw a crash in `on_sigterm() --> notify_all_threads() --> h2o_multithread_send_message()`.  This happens because `SIGTERM` is sent twice.  I'm not exactly sure why, but I suspect it's because `h2o` is running as a child processed forked by perl.
