### PR TITLE
Etag alternative representation for compress #2896

### DIFF
--- a/lib/handler/compress.c
+++ b/lib/handler/compress.c
@@ -98,13 +98,15 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     if (compressible_types == 0)
         goto Next;
 
-    /* skip if content-encoding header is being set (as well as obtain the location of accept-ranges) */
-    size_t content_encoding_header_index = -1, accept_ranges_header_index = -1;
+    /* skip if content-encoding header is being set (as well as obtain the location of accept-ranges moreover identify index of etag to modified weaken) */
+    size_t content_encoding_header_index = -1, accept_ranges_header_index = -1, etag_header_index = -1;
     for (i = 0; i != req->res.headers.size; ++i) {
         if (req->res.headers.entries[i].name == &H2O_TOKEN_CONTENT_ENCODING->buf)
             content_encoding_header_index = i;
         else if (req->res.headers.entries[i].name == &H2O_TOKEN_ACCEPT_RANGES->buf)
             accept_ranges_header_index = i;
+        else if (req->res.headers.entries[i].name == &H2O_TOKEN_ETAG->buf)
+            etag_header_index = i;
         else
             continue;
     }
@@ -130,6 +132,9 @@ static void on_setup_ostream(h2o_filter_t *_self, h2o_req_t *req, h2o_ostream_t 
     req->res.content_length = SIZE_MAX;
     h2o_add_header(&req->pool, &req->res.headers, H2O_TOKEN_CONTENT_ENCODING, NULL, compressor->name.base, compressor->name.len);
     h2o_set_header_token(&req->pool, &req->res.headers, H2O_TOKEN_VARY, H2O_STRLIT("accept-encoding"));
+    if (etag_header_index != -1) {
+        req->res.headers.entries[etag_header_index].value = h2o_concat(&req->pool, h2o_iovec_init(H2O_STRLIT("W/")), req->res.headers.entries[etag_header_index].value);
+    }
     if (accept_ranges_header_index != -1) {
         req->res.headers.entries[accept_ranges_header_index].value = h2o_iovec_init(H2O_STRLIT("none"));
     } else {

--- a/t/50compress.t
+++ b/t/50compress.t
@@ -3,6 +3,7 @@ use warnings;
 use Digest::MD5 qw(md5_hex);
 use Test::More;
 use t::Util;
+use File::Temp qw(tempfile);
 
 plan skip_all => 'curl not found'
     unless prog_exists('curl');
@@ -38,33 +39,45 @@ run_with_curl($server, sub {
         if $curl =~ /--http2/;
     my $fetch_orig = sub {
         my ($path, $opts) = @_;
-        run_prog("$curl --silent $opts $proto://127.0.0.1:$port$path/alice.txt");
+        run_prog("$curl --silent --dump-header /dev/stderr $opts $proto://127.0.0.1:$port$path/alice.txt");
     };
     my $fetch_gunzip = sub {
         my ($path, $opts) = @_;
-        run_prog("$curl --silent $opts $proto://127.0.0.1:$port$path/alice.txt | gzip -cd");
+        my ($tempfh, $tempfn) = tempfile(UNLINK => 1);
+        my $headers = `$curl --silent --dump-header /dev/stderr $opts $proto://127.0.0.1:$port$path/alice.txt 2>&1 > $tempfn`;
+        my $body = `cat $tempfn | gzip -cd`;
+        close $tempfh;
+        ($headers, $body);
     };
+
     my $expected = md5_file("@{[DOC_ROOT]}/alice.txt");
+    my $expected_etag = etag_file("@{[DOC_ROOT]}/alice.txt");
+    my ($headers, $body) = $fetch_orig->("/off", "");
+    is md5_hex($body), $expected, "off wo. accept-encoding";
+    like $headers, qr{^etag: $expected_etag\r$}im, "it has an etag";
+    ($headers, $body) = $fetch_orig->("/on", "");
+    is md5_hex($body), $expected, "on wo. accept-encoding";
+    like $headers, qr{^etag: $expected_etag\r$}im, "it has an etag";
+    ($headers, $body) = $fetch_orig->("/off", "-H accept-encoding:gzip");
+    is md5_hex($body), $expected, "off with accept-encoding";
+    like $headers, qr{^etag: $expected_etag\r$}im, "it has an etag";
+    ($headers, $body) = $fetch_gunzip->("/on", "-H accept-encoding:gzip");
+    is md5_hex($body), $expected, "on with accept-encoding";
+    like $headers, qr{^etag: W/$expected_etag\r$}im, "it has a weak etag";
+    ($headers, $body) = $fetch_gunzip->("/on", "-H 'accept-encoding:gzip, deflate'");
+    is md5_hex($body), $expected, "on with accept-encoding: gzip, deflate";
+    like $headers, qr{^etag: W/$expected_etag\r$}im, "it has a weak etag";
+    ($headers, $body) = $fetch_gunzip->("/on", "-H 'accept-encoding:deflate, gzip'");
+    is md5_hex($body), $expected, "on with accept-encoding: deflate, gzip";
+    like $headers, qr{^etag: W/$expected_etag\r$}im, "it has a weak etag";
+    ($headers, $body) = $fetch_orig->("/on", "-H accept-encoding:deflate");
+    is md5_hex($body), $expected, "on with accept-encoding, deflate only";
+    like $headers, qr{^etag: $expected_etag\r$}im, "it has an etag";
 
-    my $resp = $fetch_orig->("/off", "");
-    is md5_hex($resp), $expected, "off wo. accept-encoding";
-    $resp = $fetch_orig->("/on", "");
-    is md5_hex($resp), $expected, "on wo. accept-encoding";
-    $resp = $fetch_orig->("/off", "-H accept-encoding:gzip");
-    is md5_hex($resp), $expected, "off with accept-encoding";
-    $resp = $fetch_gunzip->("/on", "-H accept-encoding:gzip");
-    is md5_hex($resp), $expected, "on with accept-encoding";
-    $resp = $fetch_gunzip->("/on", "-H 'accept-encoding:gzip, deflate'");
-    is md5_hex($resp), $expected, "on with accept-encoding: gzip, deflate";
-    $resp = $fetch_gunzip->("/on", "-H 'accept-encoding:deflate, gzip'");
-    is md5_hex($resp), $expected, "on with accept-encoding: deflate, gzip";
-    $resp = $fetch_orig->("/on", "-H accept-encoding:deflate");
-    is md5_hex($resp), $expected, "on with accept-encoding, deflate only";
+    ($headers, $body) = $fetch_orig->("/off-by-mime", "-H accept-encoding:gzip");
+    is md5_hex($body), $expected, "off due to is_compressible:NO";
 
-    $resp = $fetch_orig->("/off-by-mime", "-H accept-encoding:gzip");
-    is md5_hex($resp), $expected, "off due to is_compressible:NO";
-
-    $resp = run_prog("$curl --silent -H accept-encoding:gzip $proto://127.0.0.1:$port/on/index.txt");
+    my $resp = run_prog("$curl --silent -H accept-encoding:gzip $proto://127.0.0.1:$port/on/index.txt");
     is md5_hex($resp), md5_file("@{[DOC_ROOT]}/index.txt"), "tiny file not compressed";
 
     $resp = run_prog("$curl --silent -H accept-encoding:gzip $proto://127.0.0.1:$port/on/halfdome.jpg");

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
     empty_ports
     create_data_file
     md5_file
+    etag_file
     prog_exists
     run_prog
     openssl_can_negotiate
@@ -333,6 +334,13 @@ sub md5_file {
         or die "failed to open file:$fn:$!";
     local $/;
     return md5_hex(join '', <$fh>);
+}
+
+sub etag_file {
+    my $fn = shift;
+    my @st = stat $fn
+        or die "failed to stat file:$fn:$!";
+    return sprintf("\"%08x-%zx\"", $st[9], $st[7]);
 }
 
 sub prog_exists {


### PR DESCRIPTION
Fixes: #2896 

in #2896, @Jxck proposed the etag adding W/ for alternative representation (e.g. gzip, br, zstd). I implemented this.