### PR TITLE
fix issues with SIGTERM handling and h2o_barrier_t

### DIFF
--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -184,7 +184,7 @@ void *writer_thread(void *arg)
         }
         close(wta->fd);
         h2o_barrier_wait(&wta->barrier);
-        h2o_barrier_destroy(&wta->barrier);
+        h2o_barrier_dispose(&wta->barrier);
         free(wta);
     }
 }

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -137,13 +137,13 @@ void h2o_sem_set_capacity(h2o_sem_t *sem, ssize_t new_capacity);
 
 void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
 /**
- * Wait for all threads to enter the barrier.
+ * Waits for all threads to enter the barrier.
  */
 void h2o_barrier_wait(h2o_barrier_t *barrier);
 /**
- * Wait for all threads to enter the barrier, then returns before the barriers are released. True is returned on the thread that
- * returns first, while on other threads false would be returned. In the first thread, it is possible to run any action that has to
- * be taken after all threads enter the barrier. All threads must call `h2o_barrier_wait_post_sync_point`.
+ * Waits for all threads to enter the barrier, then returns before the barriers are released. True is returned on one thread, while
+ * while false is returned on other threads. On the thread that returned true, it is possible to run any action that has to be taken
+ * while all threads are within the barrier. All threads then must call `h2o_barrier_wait_post_sync_point`.
  */
 int h2o_barrier_wait_pre_sync_point(h2o_barrier_t *barrier);
 void h2o_barrier_wait_post_sync_point(h2o_barrier_t *barrier);

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -140,7 +140,17 @@ void h2o_sem_set_capacity(h2o_sem_t *sem, ssize_t new_capacity);
         PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, count_                                                                \
     }
 void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
-int h2o_barrier_wait(h2o_barrier_t *barrier);
+/**
+ * Wait for all threads to enter the barrier.
+ */
+void h2o_barrier_wait(h2o_barrier_t *barrier);
+/**
+ * Wait for all threads to enter the barrier, then returns before the barriers are released. True is returned on the thread that
+ * returns first, while on other threads false would be returned. In the first thread, it is possible to run any action that has to
+ * be taken after all threads enter the barrier. All threads must call `h2o_barrier_wait_post_sync_point`.
+ */
+int h2o_barrier_wait_pre_sync_point(h2o_barrier_t *barrier);
+void h2o_barrier_wait_post_sync_point(h2o_barrier_t *barrier);
 int h2o_barrier_done(h2o_barrier_t *barrier);
 void h2o_barrier_add(h2o_barrier_t *barrier, size_t delta);
 void h2o_barrier_dispose(h2o_barrier_t *barrier);

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -143,7 +143,7 @@ void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
 int h2o_barrier_wait(h2o_barrier_t *barrier);
 int h2o_barrier_done(h2o_barrier_t *barrier);
 void h2o_barrier_add(h2o_barrier_t *barrier, size_t delta);
-void h2o_barrier_destroy(h2o_barrier_t *barrier);
+void h2o_barrier_dispose(h2o_barrier_t *barrier);
 
 void h2o_error_reporter__on_timeout(h2o_timer_t *timer);
 #define H2O_ERROR_REPORTER_INITIALIZER(s)                                                                                          \

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -135,10 +135,6 @@ void h2o_sem_wait(h2o_sem_t *sem);
 void h2o_sem_post(h2o_sem_t *sem);
 void h2o_sem_set_capacity(h2o_sem_t *sem, ssize_t new_capacity);
 
-#define H2O_BARRIER_INITIALIZER(count_)                                                                                            \
-    {                                                                                                                              \
-        PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, count_                                                                \
-    }
 void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
 /**
  * Wait for all threads to enter the barrier.

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -294,7 +294,13 @@ void h2o_barrier_init(h2o_barrier_t *barrier, size_t count)
     barrier->_out_of_wait = count;
 }
 
-int h2o_barrier_wait(h2o_barrier_t *barrier)
+void h2o_barrier_wait(h2o_barrier_t *barrier)
+{
+    h2o_barrier_wait_pre_sync_point(barrier);
+    h2o_barrier_wait_post_sync_point(barrier);
+}
+
+int h2o_barrier_wait_pre_sync_point(h2o_barrier_t *barrier)
 {
     int ret;
     pthread_mutex_lock(&barrier->_mutex);
@@ -303,15 +309,19 @@ int h2o_barrier_wait(h2o_barrier_t *barrier)
         pthread_cond_broadcast(&barrier->_cond);
         ret = 1;
     } else {
-        while (barrier->_count)
+        while (barrier->_count != 0)
             pthread_cond_wait(&barrier->_cond, &barrier->_mutex);
         ret = 0;
     }
+    return ret;
+}
+
+void h2o_barrier_wait_post_sync_point(h2o_barrier_t *barrier)
+{
     pthread_mutex_unlock(&barrier->_mutex);
     /* This is needed to synchronize h2o_barrier_dispose with the exit of this function, so make sure that we can't destroy the
      * mutex or the condition before all threads have exited wait(). */
     __sync_sub_and_fetch(&barrier->_out_of_wait, 1);
-    return ret;
 }
 
 int h2o_barrier_done(h2o_barrier_t *barrier)

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -308,11 +308,8 @@ int h2o_barrier_wait(h2o_barrier_t *barrier)
         ret = 0;
     }
     pthread_mutex_unlock(&barrier->_mutex);
-    /*
-     * this is needed to synchronize h2o_barrier_destroy with the
-     * exit of this function, so make sure that we can't destroy the
-     * mutex or the condition before all threads have exited wait()
-     */
+    /* This is needed to synchronize h2o_barrier_dispose with the exit of this function, so make sure that we can't destroy the
+     * mutex or the condition before all threads have exited wait(). */
     __sync_sub_and_fetch(&barrier->_out_of_wait, 1);
     return ret;
 }
@@ -327,7 +324,7 @@ void h2o_barrier_add(h2o_barrier_t *barrier, size_t delta)
     __sync_add_and_fetch(&barrier->_count, delta);
 }
 
-void h2o_barrier_destroy(h2o_barrier_t *barrier)
+void h2o_barrier_dispose(h2o_barrier_t *barrier)
 {
     while (__sync_add_and_fetch(&barrier->_out_of_wait, 0) != 0) {
         sched_yield();

--- a/src/main.c
+++ b/src/main.c
@@ -2492,12 +2492,14 @@ static void dispose_resolve_tag_arg(resolve_tag_arg_t *arg)
 
 static void on_sigterm(int signo)
 {
-    conf.shutdown_requested = 1;
-    if (!h2o_barrier_done(&conf.startup_sync_barrier)) {
-        /* initialization hasn't completed yet, exit right away */
-        exit(0);
+    if (conf.shutdown_requested == 0) {
+        conf.shutdown_requested = 1;
+        if (!h2o_barrier_done(&conf.startup_sync_barrier)) {
+            /* initialization hasn't completed yet, exit right away */
+            exit(0);
+        }
+        notify_all_threads();
     }
-    notify_all_threads();
 }
 
 #ifdef LIBC_HAS_BACKTRACE

--- a/src/main.c
+++ b/src/main.c
@@ -2490,16 +2490,22 @@ static void dispose_resolve_tag_arg(resolve_tag_arg_t *arg)
     free(arg->node_cache.entries);
 }
 
-static void on_sigterm(int signo)
+static void on_sigterm(int notify_threads)
 {
-    if (conf.shutdown_requested == 0) {
-        conf.shutdown_requested = 1;
-        if (!h2o_barrier_done(&conf.startup_sync_barrier)) {
-            /* initialization hasn't completed yet, exit right away */
-            exit(0);
-        }
+    conf.shutdown_requested = 1;
+    if (notify_threads)
         notify_all_threads();
-    }
+    h2o_set_signal_handler(SIGTERM, SIG_IGN);
+}
+
+static void on_sigterm_set_flag_only(int signo)
+{
+    on_sigterm(0);
+}
+
+static void on_sigterm_set_flag_notify_threads(int signo)
+{
+    on_sigterm(1);
 }
 
 #ifdef LIBC_HAS_BACKTRACE
@@ -2560,7 +2566,7 @@ static void on_sigfatal(int signo)
 
 static void setup_signal_handlers(void)
 {
-    h2o_set_signal_handler(SIGTERM, on_sigterm);
+    h2o_set_signal_handler(SIGTERM, on_sigterm_set_flag_only);
     h2o_set_signal_handler(SIGPIPE, SIG_IGN);
 #ifdef LIBC_HAS_BACKTRACE
     if ((crash_handler_fd = popen_crash_handler()) == -1)
@@ -3102,11 +3108,15 @@ static void *run_loop(void *_thread_index)
     /* and start listening */
     update_listener_state(listeners);
 
-    /* make sure all threads are initialized before starting to serve requests */
-    h2o_barrier_wait(&conf.startup_sync_barrier);
-
-    if (thread_index == 0)
+    /* Wait for all threads to become ready but before letting any of them serve connections, swap the signal handler for graceful
+     * shutdown, check (and exit) if SIGTERM has been received already. */
+    if (h2o_barrier_wait_pre_sync_point(&conf.startup_sync_barrier)) {
+        h2o_set_signal_handler(SIGTERM, on_sigterm_set_flag_notify_threads);
+        if (conf.shutdown_requested)
+            exit(0);
         fprintf(stderr, "h2o server (pid:%d) is ready to serve requests with %zu threads\n", (int)getpid(), conf.thread_map.size);
+    }
+    h2o_barrier_wait_post_sync_point(&conf.startup_sync_barrier);
 
     /* the main loop */
     uint64_t last_buffer_gc_at = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -309,7 +309,6 @@ static struct {
     .launch_time = 0,                /* initialized in main() */
     .threads = NULL,
     .shutdown_requested = 0,
-    .startup_sync_barrier = H2O_BARRIER_INITIALIZER(SIZE_MAX),
     .state = {{0}},
     .crash_handler = "share/h2o/annotate-backtrace-symbols",
     .crash_handler_wait_pipe_close = 0,


### PR DESCRIPTION
Subsumes #2913.

Fixed issues are:
* barrier:
  * [x] H2O_BARRIER_INITIALIZER fails to set `_out_of_wait`, therefore would not work correctly. The macro has been removed in 455f709, as it is impossible with standard C to use given argument twice. We can reintroduce the macro if necessary, by refactoring the structure or by using GNU extension.
  * [x] Rename `h2o_barrier_destroy` to `_dispose`, as the function does not `free` the provided address (c223ef3).
  * [x] Introduce "wait_pre_sync_point" and -post_sync_point functions so that action can be defined that is to be taken while all threads are within the barrier. Changes the return type of `h2o_barrier_wait` from int to void, as it the return value cannot be used for this purpose (or any other) (d1fa557).
* SIGTERM:
  * [x] Race condition when signal handler is invoked while `h2o_barrier_init` is called. As of 7b5dad5, SIGTERM handler no longer refers to `conf.startup_sync_barrier`.
  * [x] Race condition / deadlock in `h2o_multithread_send_message`, due to the possibility of both the application logic (of the worker thread) and the signal handler trying to acquire mutex. This issue has been fixed by receiving SIGTERM no more than once (11b882a, 7b5dad5). Assuming that `epoll` / `poll` / `kqueue` do not misfire for a pipe that's left open for the entire lifetime of the event loop, there is guarantee that the signal handler will release mutex before the application logic acquires that.
  * [x] `on_sigterm` invoking `exit` which is not async-signal safe. 7b5dad5 eliminates such use. Now, if SIGTERM is received before h2o starts serving connections, it would exit after all worker threads are set up but before connections are being served. This is better than status quo, as any error that happens during start up would be reported rather than exitting with 0, when SIGTERM is received during startup.
  * [x] Potential invalid pointer access (reported by ASAN as stack underflow) when SIGTERM is delivered more than once. Initially fixed in 11b882a by consulting flag. As of 7b5dad5, the state is being represented by the address being registered as the SIGTERM handler.