### PR TITLE
Respond to SETTINGS_HEADER_TABLE_SIZE

### DIFF
--- a/include/h2o/http2_common.h
+++ b/include/h2o/http2_common.h
@@ -101,18 +101,18 @@ typedef struct st_h2o_hpack_header_table_entry_t {
 void h2o_hpack_dispose_header_table(h2o_hpack_header_table_t *header_table);
 
 size_t h2o_hpack_encode_string(uint8_t *dst, const char *s, size_t len);
-void h2o_hpack_flatten_push_promise(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                                    size_t max_frame_size, const h2o_url_scheme_t *scheme, h2o_iovec_t authority,
-                                    h2o_iovec_t method, h2o_iovec_t path, const h2o_header_t *headers, size_t num_headers,
-                                    uint32_t parent_stream_id);
-void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                                size_t max_frame_size, int status, const h2o_header_t *headers, size_t num_headers,
-                                const h2o_iovec_t *server_name, size_t content_length);
-void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                               size_t max_frame_size, h2o_iovec_t method, h2o_url_t *url, const h2o_header_t *headers,
-                               size_t num_headers, int is_end_stream);
-void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                                size_t max_frame_size, const h2o_header_t *headers, size_t num_headers);
+void h2o_hpack_flatten_push_promise(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                                    uint32_t stream_id, size_t max_frame_size, const h2o_url_scheme_t *scheme,
+                                    h2o_iovec_t authority, h2o_iovec_t method, h2o_iovec_t path, const h2o_header_t *headers,
+                                    size_t num_headers, uint32_t parent_stream_id);
+void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                                uint32_t stream_id, size_t max_frame_size, int status, const h2o_header_t *headers,
+                                size_t num_headers, const h2o_iovec_t *server_name, size_t content_length);
+void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                               uint32_t stream_id, size_t max_frame_size, h2o_iovec_t method, h2o_url_t *url,
+                               const h2o_header_t *headers, size_t num_headers, int is_end_stream);
+void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                                uint32_t stream_id, size_t max_frame_size, const h2o_header_t *headers, size_t num_headers);
 
 extern h2o_buffer_prototype_t h2o_http2_wbuf_buffer_prototype;
 

--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -392,10 +392,10 @@ inline int h2o_http2_stream_has_pending_data(h2o_http2_stream_t *stream)
 inline void h2o_http2_stream_send_push_promise(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
 {
     assert(!stream->push.promise_sent);
-    h2o_hpack_flatten_push_promise(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
-                                   conn->peer_settings.max_frame_size, stream->req.input.scheme, stream->req.input.authority,
-                                   stream->req.input.method, stream->req.input.path, stream->req.headers.entries,
-                                   stream->req.headers.size, stream->push.parent_stream_id);
+    h2o_hpack_flatten_push_promise(&conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size,
+                                   stream->stream_id, conn->peer_settings.max_frame_size, stream->req.input.scheme,
+                                   stream->req.input.authority, stream->req.input.method, stream->req.input.path,
+                                   stream->req.headers.entries, stream->req.headers.size, stream->push.parent_stream_id);
     stream->push.promise_sent = 1;
 }
 

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -966,8 +966,9 @@ static void on_connection_ready(struct st_h2o_http2client_stream_t *stream, stru
     }
 
     /* send headers */
-    h2o_hpack_flatten_request(&conn->output.buf, &conn->output.header_table, stream->stream_id, conn->peer_settings.max_frame_size,
-                              method, &url, headers, num_headers, body.base == NULL);
+    h2o_hpack_flatten_request(&conn->output.buf, &conn->output.header_table, conn->peer_settings.header_table_size,
+                              stream->stream_id, conn->peer_settings.max_frame_size, method, &url, headers, num_headers,
+                              body.base == NULL);
 
     if (body.base != NULL) {
         h2o_buffer_init(&stream->output.buf, &h2o_socket_buffer_prototype);

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -595,7 +595,6 @@ static int handle_settings_frame(struct st_h2o_http2client_conn_t *conn, h2o_htt
         }
     } else {
         uint32_t prev_initial_window_size = conn->peer_settings.initial_window_size;
-        /* FIXME handle SETTINGS_HEADER_TABLE_SIZE */
         int ret = h2o_http2_update_peer_settings(&conn->peer_settings, frame->payload, frame->length, err_desc);
         if (ret != 0)
             return ret;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1004,7 +1004,6 @@ static int handle_settings_frame(h2o_http2_conn_t *conn, h2o_http2_frame_t *fram
         }
     } else {
         uint32_t prev_initial_window_size = conn->peer_settings.initial_window_size;
-        /* FIXME handle SETTINGS_HEADER_TABLE_SIZE */
         int ret = h2o_http2_update_peer_settings(&conn->peer_settings, frame->payload, frame->length, err_desc);
         if (ret != 0)
             return ret;
@@ -1403,8 +1402,8 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
                 static const h2o_iovec_t name = {H2O_STRLIT("server-timing")};
                 trailers[num_trailers++] = (h2o_header_t){(h2o_iovec_t *)&name, NULL, server_timing};
             }
-            h2o_hpack_flatten_trailers(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
-                                       conn->peer_settings.max_frame_size, trailers, num_trailers);
+            h2o_hpack_flatten_trailers(&conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size,
+                                       stream->stream_id, conn->peer_settings.max_frame_size, trailers, num_trailers);
         }
         h2o_linklist_insert(&conn->_write.streams_to_proceed, &stream->_link);
     }

--- a/lib/http2/frame.c
+++ b/lib/http2/frame.c
@@ -62,11 +62,6 @@ int h2o_http2_update_peer_settings(h2o_http2_settings_t *settings, const uint8_t
 
     if (len != 0)
         return H2O_HTTP2_ERROR_FRAME_SIZE;
-
-    /* cap dynamic table size to default (i.e., 4096 bytes) */
-    if (settings->header_table_size > H2O_HTTP2_SETTINGS_DEFAULT.header_table_size)
-        settings->header_table_size = H2O_HTTP2_SETTINGS_DEFAULT.header_table_size;
-
     return 0;
 }
 

--- a/lib/http2/frame.c
+++ b/lib/http2/frame.c
@@ -62,6 +62,11 @@ int h2o_http2_update_peer_settings(h2o_http2_settings_t *settings, const uint8_t
 
     if (len != 0)
         return H2O_HTTP2_ERROR_FRAME_SIZE;
+
+    /* cap dynamic table size to default (i.e., 4096 bytes) */
+    if (settings->header_table_size > H2O_HTTP2_SETTINGS_DEFAULT.header_table_size)
+        settings->header_table_size = H2O_HTTP2_SETTINGS_DEFAULT.header_table_size;
+
     return 0;
 }
 

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -28,6 +28,7 @@
 
 #define HEADER_TABLE_OFFSET 62
 #define HEADER_TABLE_ENTRY_SIZE_OFFSET 32
+#define DYNAMIC_TABLE_SIZE_UPDATE_MAX_SIZE 5
 #define STATUS_HEADER_MAX_SIZE 5
 #define CONTENT_LENGTH_HEADER_MAX_SIZE                                                                                             \
     (3 + sizeof(H2O_SIZE_T_LONGEST_STR) - 1) /* uses Literal Header Field without Indexing (RFC7541 6.2.2) */
@@ -728,6 +729,24 @@ size_t h2o_hpack_encode_string(uint8_t *dst, const char *s, size_t len)
     return encode_as_is(dst, s, len);
 }
 
+static uint8_t *header_table_adjust_size(h2o_hpack_header_table_t *table, uint32_t new_capacity, uint8_t *dst)
+{
+    /* do nothing if the table size is smaller than current size */
+    if (new_capacity >= table->hpack_capacity)
+        return dst;
+
+    /* update state */
+    table->hpack_capacity = new_capacity;
+    while (table->num_entries != 0 && table->hpack_size > table->hpack_capacity)
+        header_table_evict_one(table);
+
+    /* encode Dynamic Table Size Update */
+    *dst = 0x20;
+    dst = h2o_hpack_encode_int(dst, table->hpack_capacity, 3);
+
+    return dst;
+}
+
 static uint8_t *do_encode_header(h2o_hpack_header_table_t *header_table, uint8_t *dst, const h2o_iovec_t *name,
                                  const h2o_iovec_t *value, int dont_compress)
 {
@@ -914,12 +933,13 @@ static void fixup_frame_headers(h2o_buffer_t **buf, size_t start_at, uint8_t typ
     }
 }
 
-void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                               size_t max_frame_size, h2o_iovec_t method, h2o_url_t *url, const h2o_header_t *headers,
-                               size_t num_headers, int is_end_stream)
+void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                               uint32_t stream_id, size_t max_frame_size, h2o_iovec_t method, h2o_url_t *url,
+                               const h2o_header_t *headers, size_t num_headers, int is_end_stream)
 {
     size_t capacity = calc_headers_capacity(headers, num_headers);
     capacity += H2O_HTTP2_FRAME_HEADER_SIZE;
+    capacity += DYNAMIC_TABLE_SIZE_UPDATE_MAX_SIZE;
     capacity += calc_capacity(H2O_TOKEN_METHOD->buf.len, method.len);
     capacity += calc_capacity(H2O_TOKEN_SCHEME->buf.len, url->scheme->name.len);
     capacity += calc_capacity(H2O_TOKEN_AUTHORITY->buf.len, url->authority.len);
@@ -929,12 +949,12 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
     uint8_t *dst = (void *)(h2o_buffer_reserve(buf, capacity).base + H2O_HTTP2_FRAME_HEADER_SIZE);
 
     /* encode */
+    dst = header_table_adjust_size(header_table, hpack_capacity, dst);
     dst = encode_method(header_table, dst, method);
     dst = encode_scheme(header_table, dst, url->scheme);
     dst = encode_header_token(header_table, dst, H2O_TOKEN_AUTHORITY, &url->authority);
     dst = encode_path(header_table, dst, url->path);
-    size_t i;
-    for (i = 0; i != num_headers; ++i) {
+    for (size_t i = 0; i != num_headers; ++i) {
         const h2o_header_t *header = headers + i;
         if (header->name == &H2O_TOKEN_ACCEPT_ENCODING->buf &&
             h2o_memis(header->value.base, header->value.len, H2O_STRLIT("gzip, deflate"))) {
@@ -950,14 +970,15 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
                         is_end_stream ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0);
 }
 
-void h2o_hpack_flatten_push_promise(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                                    size_t max_frame_size, const h2o_url_scheme_t *scheme, h2o_iovec_t authority,
-                                    h2o_iovec_t method, h2o_iovec_t path, const h2o_header_t *headers, size_t num_headers,
-                                    uint32_t parent_stream_id)
+void h2o_hpack_flatten_push_promise(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                                    uint32_t stream_id, size_t max_frame_size, const h2o_url_scheme_t *scheme,
+                                    h2o_iovec_t authority, h2o_iovec_t method, h2o_iovec_t path, const h2o_header_t *headers,
+                                    size_t num_headers, uint32_t parent_stream_id)
 {
     size_t capacity = calc_headers_capacity(headers, num_headers);
     capacity += H2O_HTTP2_FRAME_HEADER_SIZE /* first frame header */
                 + 4;                        /* promised stream id */
+    capacity += DYNAMIC_TABLE_SIZE_UPDATE_MAX_SIZE;
     capacity += calc_capacity(H2O_TOKEN_METHOD->buf.len, method.len);
     capacity += calc_capacity(H2O_TOKEN_SCHEME->buf.len, scheme->name.len);
     capacity += calc_capacity(H2O_TOKEN_AUTHORITY->buf.len, authority.len);
@@ -968,12 +989,12 @@ void h2o_hpack_flatten_push_promise(h2o_buffer_t **buf, h2o_hpack_header_table_t
 
     /* encode */
     dst = h2o_http2_encode32u(dst, stream_id);
+    dst = header_table_adjust_size(header_table, hpack_capacity, dst);
     dst = encode_method(header_table, dst, method);
     dst = encode_scheme(header_table, dst, scheme);
     dst = encode_header_token(header_table, dst, H2O_TOKEN_AUTHORITY, &authority);
     dst = encode_path(header_table, dst, path);
-    size_t i;
-    for (i = 0; i != num_headers; ++i) {
+    for (size_t i = 0; i != num_headers; ++i) {
         const h2o_header_t *header = headers + i;
         if (header->name == &H2O_TOKEN_ACCEPT_ENCODING->buf &&
             h2o_memis(header->value.base, header->value.len, H2O_STRLIT("gzip, deflate"))) {
@@ -988,13 +1009,14 @@ void h2o_hpack_flatten_push_promise(h2o_buffer_t **buf, h2o_hpack_header_table_t
     fixup_frame_headers(buf, start_at, H2O_HTTP2_FRAME_TYPE_PUSH_PROMISE, parent_stream_id, max_frame_size, 0);
 }
 
-void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                                size_t max_frame_size, int status, const h2o_header_t *headers, size_t num_headers,
-                                const h2o_iovec_t *server_name, size_t content_length)
+void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                                uint32_t stream_id, size_t max_frame_size, int status, const h2o_header_t *headers,
+                                size_t num_headers, const h2o_iovec_t *server_name, size_t content_length)
 {
     size_t capacity = calc_headers_capacity(headers, num_headers);
     capacity += H2O_HTTP2_FRAME_HEADER_SIZE; /* for the first header */
-    capacity += STATUS_HEADER_MAX_SIZE;      /* for :status: */
+    capacity += DYNAMIC_TABLE_SIZE_UPDATE_MAX_SIZE;
+    capacity += STATUS_HEADER_MAX_SIZE; /* for :status: */
 #ifndef H2O_UNITTEST
     if (server_name != NULL && server_name->len) {
         capacity += 5 + server_name->len; /* for Server: */
@@ -1007,6 +1029,7 @@ void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *he
     uint8_t *dst = (void *)(h2o_buffer_reserve(buf, capacity).base + H2O_HTTP2_FRAME_HEADER_SIZE); /* skip frame header */
 
     /* encode */
+    dst = header_table_adjust_size(header_table, hpack_capacity, dst);
     dst = encode_status(dst, status);
 #ifndef H2O_UNITTEST
     /* TODO keep some kind of reference to the indexed Server header, and reuse it */
@@ -1014,8 +1037,7 @@ void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *he
         dst = encode_header_token(header_table, dst, H2O_TOKEN_SERVER, server_name);
     }
 #endif
-    size_t i;
-    for (i = 0; i != num_headers; ++i)
+    for (size_t i = 0; i != num_headers; ++i)
         dst = encode_header(header_table, dst, headers + i);
     if (content_length != SIZE_MAX)
         dst = encode_content_length(dst, content_length);
@@ -1025,17 +1047,18 @@ void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *he
     fixup_frame_headers(buf, start_at, H2O_HTTP2_FRAME_TYPE_HEADERS, stream_id, max_frame_size, 0);
 }
 
-void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t stream_id,
-                                size_t max_frame_size, const h2o_header_t *headers, size_t num_headers)
+void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                                uint32_t stream_id, size_t max_frame_size, const h2o_header_t *headers, size_t num_headers)
 {
     size_t capacity = calc_headers_capacity(headers, num_headers);
     capacity += H2O_HTTP2_FRAME_HEADER_SIZE;
+    capacity += DYNAMIC_TABLE_SIZE_UPDATE_MAX_SIZE;
 
     size_t start_at = (*buf)->size;
     uint8_t *dst = (void *)(h2o_buffer_reserve(buf, capacity).base + H2O_HTTP2_FRAME_HEADER_SIZE); /* skip frame header */
 
-    size_t i;
-    for (i = 0; i != num_headers; ++i)
+    dst = header_table_adjust_size(header_table, hpack_capacity, dst);
+    for (size_t i = 0; i != num_headers; ++i)
         dst = encode_header(header_table, dst, headers + i);
     (*buf)->size = (char *)dst - (*buf)->bytes;
 

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -743,7 +743,7 @@ static uint8_t *header_table_adjust_size(h2o_hpack_header_table_t *table, uint32
 
     /* encode Dynamic Table Size Update */
     *dst = 0x20;
-    dst = h2o_hpack_encode_int(dst, table->hpack_capacity, 3);
+    dst = h2o_hpack_encode_int(dst, table->hpack_capacity, 5);
 
     return dst;
 }

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -731,7 +731,8 @@ size_t h2o_hpack_encode_string(uint8_t *dst, const char *s, size_t len)
 
 static uint8_t *header_table_adjust_size(h2o_hpack_header_table_t *table, uint32_t new_capacity, uint8_t *dst)
 {
-    /* do nothing if the table size is smaller than current size */
+    /* Do nothing if user-supplied value is greater than the current value. Because we never allow the peer to increase the table
+     * size here, there is no need to worry about using excess memory. */
     if (new_capacity >= table->hpack_capacity)
         return dst;
 

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -311,10 +311,10 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
                               H2O_STRLIT("pushed"));
     if (stream->req.send_server_timing)
         h2o_add_server_timing_header(&stream->req, 1);
-    h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
-                               conn->peer_settings.max_frame_size, stream->req.res.status, stream->req.res.headers.entries,
-                               stream->req.res.headers.size, &conn->super.ctx->globalconf->server_name,
-                               stream->req.res.content_length);
+    h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size,
+                               stream->stream_id, conn->peer_settings.max_frame_size, stream->req.res.status,
+                               stream->req.res.headers.entries, stream->req.res.headers.size,
+                               &conn->super.ctx->globalconf->server_name, stream->req.res.content_length);
     h2o_http2_conn_request_write(conn);
     h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY);
 
@@ -388,9 +388,9 @@ static void finalostream_send_informational(h2o_ostream_t *self, h2o_req_t *req)
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _ostr_final, self);
     h2o_http2_conn_t *conn = (h2o_http2_conn_t *)req->conn;
 
-    h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, stream->stream_id,
-                               conn->peer_settings.max_frame_size, req->res.status, req->res.headers.entries, req->res.headers.size,
-                               NULL, SIZE_MAX);
+    h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size,
+                               stream->stream_id, conn->peer_settings.max_frame_size, req->res.status, req->res.headers.entries,
+                               req->res.headers.size, NULL, SIZE_MAX);
     h2o_http2_conn_request_write(conn);
 }
 

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -102,8 +102,9 @@ static void check_flatten(h2o_hpack_header_table_t *header_table, h2o_res_t *res
     const char *err_desc;
 
     h2o_buffer_init(&buf, &h2o_socket_buffer_prototype);
-    h2o_hpack_flatten_response(&buf, header_table, 1, H2O_HTTP2_SETTINGS_DEFAULT.max_frame_size, res->status, res->headers.entries,
-                               res->headers.size, NULL, SIZE_MAX);
+    h2o_hpack_flatten_response(&buf, header_table, H2O_HTTP2_SETTINGS_DEFAULT.header_table_size, 1,
+                               H2O_HTTP2_SETTINGS_DEFAULT.max_frame_size, res->status, res->headers.entries, res->headers.size,
+                               NULL, SIZE_MAX);
 
     ok(h2o_http2_decode_frame(&frame, (uint8_t *)buf->bytes, buf->size, H2O_HTTP2_SETTINGS_DEFAULT.max_frame_size, &err_desc) > 0);
     ok(h2o_memis(frame.payload, frame.length, expected, expected_len));
@@ -402,8 +403,8 @@ static void test_hpack_push(void)
     h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_ACCEPT_ENCODING, NULL, accept_encoding.base, accept_encoding.len);
 
     /* serialize, deserialize, and compare */
-    h2o_hpack_flatten_push_promise(&buf, &encode_table, 0, 16384, req.input.scheme, req.input.authority, req.input.method,
-                                   req.input.path, req.headers.entries, req.headers.size, 0);
+    h2o_hpack_flatten_push_promise(&buf, &encode_table, H2O_HTTP2_SETTINGS_DEFAULT.header_table_size, 0, 16384, req.input.scheme,
+                                   req.input.authority, req.input.method, req.input.path, req.headers.entries, req.headers.size, 0);
     parse_and_compare_request(&decode_table, buf->bytes, buf->size, method, &H2O_URL_SCHEME_HTTPS, authority,
                               h2o_iovec_init(H2O_STRLIT("/")), H2O_TOKEN_USER_AGENT->buf, user_agent, H2O_TOKEN_ACCEPT->buf,
                               accept_root, H2O_TOKEN_ACCEPT_LANGUAGE->buf, accept_language, H2O_TOKEN_ACCEPT_ENCODING->buf,
@@ -420,8 +421,8 @@ static void test_hpack_push(void)
     h2o_add_header(&req.pool, &req.headers, H2O_TOKEN_REFERER, NULL, referer.base, referer.len);
 
     /* serialize, deserialize, and compare */
-    h2o_hpack_flatten_push_promise(&buf, &encode_table, 0, 16384, req.input.scheme, req.input.authority, req.input.method,
-                                   req.input.path, req.headers.entries, req.headers.size, 0);
+    h2o_hpack_flatten_push_promise(&buf, &encode_table, H2O_HTTP2_SETTINGS_DEFAULT.header_table_size, 0, 16384, req.input.scheme,
+                                   req.input.authority, req.input.method, req.input.path, req.headers.entries, req.headers.size, 0);
     parse_and_compare_request(
         &decode_table, buf->bytes, buf->size, method, &H2O_URL_SCHEME_HTTPS, authority, h2o_iovec_init(H2O_STRLIT("/banner.jpg")),
         H2O_TOKEN_USER_AGENT->buf, user_agent, H2O_TOKEN_ACCEPT->buf, accept_images, H2O_TOKEN_ACCEPT_LANGUAGE->buf,
@@ -432,8 +433,8 @@ static void test_hpack_push(void)
     req.input.path = h2o_iovec_init(H2O_STRLIT("/icon.png"));
 
     /* serialize, deserialize, and compare */
-    h2o_hpack_flatten_push_promise(&buf, &encode_table, 0, 16384, req.input.scheme, req.input.authority, req.input.method,
-                                   req.input.path, req.headers.entries, req.headers.size, 0);
+    h2o_hpack_flatten_push_promise(&buf, &encode_table, H2O_HTTP2_SETTINGS_DEFAULT.header_table_size, 0, 16384, req.input.scheme,
+                                   req.input.authority, req.input.method, req.input.path, req.headers.entries, req.headers.size, 0);
     parse_and_compare_request(&decode_table, buf->bytes, buf->size, method, &H2O_URL_SCHEME_HTTPS, authority,
                               h2o_iovec_init(H2O_STRLIT("/icon.png")), H2O_TOKEN_USER_AGENT->buf, user_agent, H2O_TOKEN_ACCEPT->buf,
                               accept_images, H2O_TOKEN_ACCEPT_LANGUAGE->buf, accept_language, H2O_TOKEN_ACCEPT_ENCODING->buf,
@@ -499,8 +500,9 @@ static void test_token_wo_hpack_id(void)
     res.reason = "OK";
     h2o_add_header(&pool, &res.headers, H2O_TOKEN_TE, NULL, H2O_STRLIT("test"));
 
-    h2o_hpack_flatten_response(&buf, &table, 1, H2O_HTTP2_SETTINGS_DEFAULT.max_frame_size, res.status, res.headers.entries,
-                               res.headers.size, NULL, SIZE_MAX);
+    h2o_hpack_flatten_response(&buf, &table, H2O_HTTP2_SETTINGS_DEFAULT.header_table_size, 1,
+                               H2O_HTTP2_SETTINGS_DEFAULT.max_frame_size, res.status, res.headers.entries, res.headers.size, NULL,
+                               SIZE_MAX);
     ok(h2o_memis(buf->bytes + 9, buf->size - 9,
                  H2O_STRLIT("\x88"     /* :status:200 */
                             "\x40\x02" /* literal header w. incremental indexing, raw, TE */
@@ -508,8 +510,9 @@ static void test_token_wo_hpack_id(void)
                             "\x83" /* header value, huffman */
                             "IP\x9f" /* test */)));
     h2o_buffer_consume(&buf, buf->size);
-    h2o_hpack_flatten_response(&buf, &table, 1, H2O_HTTP2_SETTINGS_DEFAULT.max_frame_size, res.status, res.headers.entries,
-                               res.headers.size, NULL, SIZE_MAX);
+    h2o_hpack_flatten_response(&buf, &table, H2O_HTTP2_SETTINGS_DEFAULT.header_table_size, 1,
+                               H2O_HTTP2_SETTINGS_DEFAULT.max_frame_size, res.status, res.headers.entries, res.headers.size, NULL,
+                               SIZE_MAX);
     ok(h2o_memis(buf->bytes + 9, buf->size - 9,
                  H2O_STRLIT("\x88" /* :status:200 */
                             "\xbe" /* te: test, indexed */)));

--- a/t/40protocol.t
+++ b/t/40protocol.t
@@ -51,6 +51,14 @@ subtest 'nghttp' => sub {
             unless openssl_can_negotiate();
         $doit->('https', $tls_port);
     };
+    subtest 'dtsu' => sub {
+        plan skip_all => 'OpenSSL does not support protocol negotiation; it is too old'
+            unless openssl_can_negotiate();
+        for my $table_size (0, 1024) {
+            my $content = `nghttp --header-table-size=$table_size https://127.0.0.1:$tls_port/index.txt`;
+            is $content, "hello\n";
+        }
+    };
 };
 
 subtest 'ab' => sub {


### PR DESCRIPTION
Handle SETTINGS_HEADER_TABLE_SIZE.

As discussed in HTTPWG, we can ignore if the value is no less than default (4096), but should handle it when given value is less than 4096, by evicting items from the table and sending a Dynamic Table Size Update instruction.

ToDo:
* [x] add tests