### PR TITLE
Ignore errors coming from SSL_write

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -758,7 +758,15 @@ static size_t generate_tls_records_from_one_vec(h2o_socket_t *sock, const void *
         assert(ret == 0);
     } else {
         int ret = SSL_write(sock->ssl->ossl, input, (int)tls_write_size);
-        assert(ret == tls_write_size);
+        /* The error happens if SSL_write is called after SSL_read returns a fatal error (e.g. due to corrupt TCP
+         * packet being received). We need to take care of this since some protocol implementations send data after
+         * the read-side of the connection gets closed (note that protocol implementations are (yet) incapable of
+         * distinguishing a normal shutdown and close due to an error using the `status` value of the read
+         * callback).
+         */
+        assert(ret <= 0 || ret == tls_write_size);
+        if (ret <= 0)
+            return 0;
     }
 
     SOCKET_PROBE(WRITE_TLS_RECORD, sock, tls_write_size, sock->ssl->output.buf.off);


### PR DESCRIPTION
This brings back the pre #2859 behavior where we ignore `SSL_write`
errors since they are due to a previous independent `SSL_read`.

Another possibility would be to only ignore `ret == -1` and `
SSL_get_error == SSL_ERROR_ZERO_RETURN`, but this fix is more
conservative by just reviving the old behavior.