### PR TITLE
fix: remove unused quic stats field

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -744,11 +744,6 @@ struct st_h2o_context_t {
     } ssl;
 
     /**
-     * aggregated quicly stats
-     */
-    struct st_h2o_quic_aggregated_stats_t quic;
-
-    /**
      * aggregated quic stats
      */
     h2o_quic_stats_t quic_stats;


### PR DESCRIPTION
Remove unused quic stats field

Fix missed from: https://github.com/h2o/h2o/pull/2923