### PR TITLE
localize $? by using wrapped guard function

### DIFF
--- a/t/40ssl-cipher-suite.t
+++ b/t/40ssl-cipher-suite.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use File::Temp qw(tempfile);
 use Net::EmptyPort qw(check_port empty_port);
-use Scope::Guard qw(scope_guard);
 use Test::More;
 use t::Util;
 

--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use File::Temp qw(tempdir);
 use Net::EmptyPort qw(check_port empty_port);
-use Scope::Guard qw(scope_guard);
 use Test::Requires qw(Plack::Runner Starlet);
 use Test::More;
 use Time::HiRes qw(sleep);
@@ -165,7 +164,7 @@ sub spawn_plack_server {
     while (!check_port($port)) {
         sleep 0.1;
     }
-    scope_guard(sub {
+    guard(sub {
         kill 'TERM', $upstream_pid;
         while (waitpid($upstream_pid, 0) != $upstream_pid) {}
     });

--- a/t/40tls13-early-data.t
+++ b/t/40tls13-early-data.t
@@ -164,7 +164,7 @@ sub spawn_plack_server {
     while (!check_port($port)) {
         sleep 0.1;
     }
-    guard(sub {
+    make_guard(sub {
         kill 'TERM', $upstream_pid;
         while (waitpid($upstream_pid, 0) != $upstream_pid) {}
     });

--- a/t/50mruby-error-log.t
+++ b/t/50mruby-error-log.t
@@ -3,7 +3,6 @@ use warnings;
 use Digest::MD5 qw(md5_hex);
 use File::Temp qw(tempdir);
 use Net::EmptyPort qw(empty_port check_port);
-use Scope::Guard qw(scope_guard);
 use Test::More;
 use Test::Exception;
 use Time::HiRes;
@@ -198,7 +197,7 @@ EOT
                 $client->close;
                 exit 0;
             };
-            my $upstream = scope_guard(sub {
+            my $upstream = guard(sub {
                 kill 'TERM', $upstream_pid;
                 while (waitpid($upstream_pid, 0) != $upstream_pid) {}
             });

--- a/t/50mruby-error-log.t
+++ b/t/50mruby-error-log.t
@@ -197,7 +197,7 @@ EOT
                 $client->close;
                 exit 0;
             };
-            my $upstream = guard(sub {
+            my $upstream = make_guard(sub {
                 kill 'TERM', $upstream_pid;
                 while (waitpid($upstream_pid, 0) != $upstream_pid) {}
             });

--- a/t/50mruby-redis.t
+++ b/t/50mruby-redis.t
@@ -3,7 +3,6 @@ use warnings;
 use IO::Socket::INET;
 use JSON;
 use Net::EmptyPort qw(check_port empty_port);
-use Scope::Guard qw/scope_guard/;
 use Time::HiRes;
 use Test::More;
 use t::Util;
@@ -491,7 +490,7 @@ sub spawn_command_timeout_mock {
         }
     }
 
-    my $guard = scope_guard(sub { kill 'KILL', $pid; });
+    my $guard = guard(sub { kill 'KILL', $pid; });
     return (+{ guard => $guard }, $port);
 }
 

--- a/t/50mruby-redis.t
+++ b/t/50mruby-redis.t
@@ -490,7 +490,7 @@ sub spawn_command_timeout_mock {
         }
     }
 
-    my $guard = guard(sub { kill 'KILL', $pid; });
+    my $guard = make_guard(sub { kill 'KILL', $pid; });
     return (+{ guard => $guard }, $port);
 }
 

--- a/t/50reverse-proxy-disconnected-keepalive.t
+++ b/t/50reverse-proxy-disconnected-keepalive.t
@@ -23,7 +23,7 @@ subtest "unix-socket" => sub {
 
     (undef, my $sockfn) = tempfile(UNLINK => 0);
     unlink $sockfn;
-    my $guard = Scope::Guard->new(sub {
+    my $guard = guard(sub {
         unlink $sockfn;
     });
 

--- a/t/50reverse-proxy-disconnected-keepalive.t
+++ b/t/50reverse-proxy-disconnected-keepalive.t
@@ -23,7 +23,7 @@ subtest "unix-socket" => sub {
 
     (undef, my $sockfn) = tempfile(UNLINK => 0);
     unlink $sockfn;
-    my $guard = guard(sub {
+    my $guard = make_guard(sub {
         unlink $sockfn;
     });
 

--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -3,7 +3,6 @@ use warnings;
 use feature qw/say/;
 BEGIN { $ENV{HTTP2_DEBUG} = 'debug' }
 use Net::EmptyPort qw(check_port empty_port);
-use Scope::Guard;
 use Test::More;
 use Time::HiRes qw(sleep);
 use IO::Socket::INET;
@@ -349,14 +348,12 @@ use IO::Select;
 use Socket;
 use Errno qw(EAGAIN EWOULDBLOCK);
 use Test::More;
-use Scope::Guard;
 
 sub new {
     my ($class, $server) = @_;
 
     my $self; $self = bless {
         sock => undef,
-        # guard => Scope::Guard->new(sub { diag 'GUARD HAPPEN'; $self->close }),
     }, $class;
 
     my $retry = 5;

--- a/t/50reverse-proxy-http2.t
+++ b/t/50reverse-proxy-http2.t
@@ -4,7 +4,6 @@ use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 BEGIN { $ENV{HTTP2_DEBUG} = 'debug' }
 use Protocol::HTTP2::Constants qw(:frame_types :errors :settings :flags :states :limits :endpoints);
-use Scope::Guard;
 use Time::HiRes;
 use t::Util;
 use JSON;

--- a/t/50reverse-proxy-proxy-protocol.t
+++ b/t/50reverse-proxy-proxy-protocol.t
@@ -30,7 +30,7 @@ print STDERR "**** yeoh";
             }
         }
     }
-    guard({
+    guard(sub {
         kill 'TERM', $pid;
     });
 };

--- a/t/50reverse-proxy-proxy-protocol.t
+++ b/t/50reverse-proxy-proxy-protocol.t
@@ -4,7 +4,6 @@ use IO::Socket::INET;
 use Test::TCP;
 use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
-use Scope::Guard qw(guard);
 use t::Util;
 
 my $upstream_port = empty_port();
@@ -31,9 +30,9 @@ print STDERR "**** yeoh";
             }
         }
     }
-    guard {
+    guard({
         kill 'TERM', $pid;
-    };
+    });
 };
 
 my $server = spawn_h2o(<< "EOT");

--- a/t/50reverse-proxy-proxy-protocol.t
+++ b/t/50reverse-proxy-proxy-protocol.t
@@ -30,7 +30,7 @@ print STDERR "**** yeoh";
             }
         }
     }
-    guard(sub {
+    make_guard(sub {
         kill 'TERM', $pid;
     });
 };

--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -46,7 +46,7 @@ my ($unix_socket_file, $unix_socket_guard) = do {
     unlink $fn;
     +(
         $fn,
-        guard(sub {
+        make_guard(sub {
             unlink $fn;
         }),
     );

--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -46,7 +46,7 @@ my ($unix_socket_file, $unix_socket_guard) = do {
     unlink $fn;
     +(
         $fn,
-        Scope::Guard->new(sub {
+        guard(sub {
             unlink $fn;
         }),
     );

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -486,7 +486,7 @@ sub wait_debugger {
 sub make_guard {
     my $code = shift;
     return Scope::Guard->new(sub {
-        # local $?;
+        local $?;
         $code->();
     });
 }
@@ -640,7 +640,7 @@ package H2ologTracer {
             return $bytes;
         };
 
-        my $guard = make_guard(sub {
+        my $guard = t::Util::make_guard(sub {
             if (waitpid($tracer_pid, WNOHANG) == 0) {
                 Test::More::diag "killing h2olog[$tracer_pid] with SIGTERM";
                 kill("TERM", $tracer_pid)

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -486,7 +486,7 @@ sub wait_debugger {
 sub make_guard {
     my $code = shift;
     return Scope::Guard->new(sub {
-        local $?;
+        # local $?;
         $code->();
     });
 }

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -15,7 +15,7 @@ use POSIX ":sys_wait_h";
 use Path::Tiny;
 use Protocol::HTTP2::Connection;
 use Protocol::HTTP2::Constants;
-use Scope::Guard qw(scope_guard);
+use Scope::Guard;
 use Test::More;
 use Time::HiRes qw(sleep gettimeofday tv_interval);
 use Carp;
@@ -193,7 +193,7 @@ sub spawn_server {
                 sleep 0.1;
             }
         }
-        my $guard = scope_guard(sub {
+        my $guard = guard(sub {
             return if $$ != $ppid;
             print STDERR "killing $args{argv}->[0]... ";
             my $sig = 'TERM';
@@ -453,7 +453,7 @@ sub one_shot_http_upstream {
     die "fork failed" unless defined $pid;
     if ($pid != 0) {
         close $listen;
-        my $guard = scope_guard(sub {
+        my $guard = guard(sub {
             kill 'KILL', $pid;
             while (waitpid($pid, WNOHANG) != $pid) {}
         });

--- a/t/run-tests
+++ b/t/run-tests
@@ -32,30 +32,16 @@ while (@scripts or %pids) {
         alarm(600);
         my $kid = eval { wait };
         alarm(0);
+        $kid;
     };
     if ($@) {
         for my $kid (keys %pids) {
             my $script = delete $pids{$kid};
-            print colorize("# $script --------------------------------\n", 'cyan');
-            print_log($script);
-            print colorize("# $script failed (timeout)\n", 'bright_red');
-            push @failures, $script;
+            commit_test($script, 0, 'timeout');
         }
-        next;
-    }
-    if ($pids{$kid}) {
+    } elsif ($pids{$kid}) {
         my $script = delete $pids{$kid};
-        print colorize("# $script --------------------------------\n", 'cyan');
-        print_log($script);
-
-        # add to the failed list, if necessary
-        if (WIFEXITED($?) and WEXITSTATUS($?) == 0) {
-            print colorize("# $script succeeded\n", 'bright_green');
-        } else {
-            print colorize("# $script failed\n", 'bright_red');
-            push @failures, $script;
-        }
-
+        commit_test($script, WIFEXITED($?) && (WEXITSTATUS($?) == 0));
     }
 }
 
@@ -102,14 +88,26 @@ sub get_logfn {
     "$tempdir/$script.out";
 }
 
-sub print_log {
-    my $script = shift;
+sub commit_test {
+    my ($script, $success, $extra_msg) = @_;
+    $extra_msg = $extra_msg ? " ($extra_msg)" : '';
+
+    print colorize("# $script --------------------------------\n", 'cyan');
+
     # print the output of the perl script being run
     my $logfn = get_logfn($script);
     open my $logfh, "<", $logfn
         or die "failed to open script:$logfn:$!";
     unlink $logfn;
     print do { local $/; <$logfh> };
+
+    # add to the failed list, if necessary
+    if ($success) {
+        print colorize("# $script succeeded$extra_msg\n", 'bright_green');
+    } else {
+        print colorize("# $script failed$extra_msg\n", 'bright_red');
+        push @failures, $script;
+    }
 }
 
 sub colorize {

--- a/t/run-tests
+++ b/t/run-tests
@@ -27,17 +27,26 @@ while (@scripts or %pids) {
     }
 
     # wait for tasks to exit
-    my $kid = wait;
+    my $kid = do {
+        local $SIG{ALRM} = sub { die };
+        alarm(600);
+        my $kid = eval { wait };
+        alarm(0);
+    };
+    if ($@) {
+        for my $kid (keys %pids) {
+            my $script = delete $pids{$kid};
+            print colorize("# $script --------------------------------\n", 'cyan');
+            print_log($script);
+            print colorize("# $script failed (timeout)\n", 'bright_red');
+            push @failures, $script;
+        }
+        next;
+    }
     if ($pids{$kid}) {
         my $script = delete $pids{$kid};
         print colorize("# $script --------------------------------\n", 'cyan');
-
-        # print the output of the perl script being run
-        my $logfn = get_logfn($script);
-        open my $logfh, "<", $logfn
-            or die "failed to open script:$logfn:$!";
-        unlink $logfn;
-        print do { local $/; <$logfh> };
+        print_log($script);
 
         # add to the failed list, if necessary
         if (WIFEXITED($?) and WEXITSTATUS($?) == 0) {
@@ -91,6 +100,16 @@ sub get_logfn {
     my $script = shift;
     $script =~ s{/}{__}g;
     "$tempdir/$script.out";
+}
+
+sub print_log {
+    my $script = shift;
+    # print the output of the perl script being run
+    my $logfn = get_logfn($script);
+    open my $logfh, "<", $logfn
+        or die "failed to open script:$logfn:$!";
+    unlink $logfn;
+    print do { local $/; <$logfh> };
 }
 
 sub colorize {


### PR DESCRIPTION
I saw some mysterious ci log in which there were several `not ok` but the test was regarded as `success` by `t/run-tests`.
It should be due to `$?` being overwrote in object destructor within Scope::Guard - one possible solution is localizing `$?` before calling destructor function.