### PR TITLE
fix a UB in http1client.c

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -660,9 +660,10 @@ static h2o_iovec_t build_request(struct st_h2o_http1client_t *client, h2o_iovec_
         APPEND_HEADER(&h);
     }
 
-    h2o_header_t *h, *h_end;
-    for (h = (h2o_header_t *)headers, h_end = h + num_headers; h != h_end; ++h)
-        APPEND_HEADER(h);
+    if (num_headers != 0) {
+        for (const h2o_header_t *h = headers, *h_end = h + num_headers; h != h_end; ++h)
+            APPEND_HEADER(h);
+    }
 
     APPEND_STRLIT("\r\n");
 


### PR DESCRIPTION
Fixing UB warnings in `h2o-httpclient` to make its output be machine-readable. This is the easiest one:

> lib/common/http1client.c:664:49: runtime error: applying zero offset to null pointer


