### PR TITLE
Dockerfile cleanup: unpin Test::TCP

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu1604
+++ b/misc/docker-ci/Dockerfile.ubuntu1604
@@ -42,11 +42,8 @@ RUN (cd openssl-${OPENSSL_VERSION} && \
 RUN apt-get install --yes cpanminus
 RUN apt-get install --yes libfcgi-perl libfcgi-procmanager-perl libipc-signal-perl libjson-perl liblist-moreutils-perl libplack-perl libscope-guard-perl libtest-exception-perl libwww-perl libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN sudo cpanm --notest Test::More Starlet Protocol::HTTP2
-RUN sudo cpanm --notest Net::DNS::Nameserver
+RUN sudo cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
 
-# Test-TCP 2.21
-RUN sudo cpanm --notest https://github.com/tokuhirom/Test-TCP.git@2.21
 # h2spec
 RUN curl -Ls https://github.com/i110/h2spec/releases/download/v2.2.0-4e8cc7e/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin
 

--- a/misc/docker-ci/Dockerfile.ubuntu1604
+++ b/misc/docker-ci/Dockerfile.ubuntu1604
@@ -17,7 +17,7 @@ ENV PATH=/usr/lib/llvm-4.0/bin:$PATH
 
 # curl with http2 support
 RUN wget --no-verbose -O - https://curl.haxx.se/download/curl-7.57.0.tar.gz | tar xzf -
-RUN (cd curl-7.57.0 && ./configure --prefix=/usr/local --without-brotli --with-nghttp2 --disable-shared && make && sudo make install)
+RUN (cd curl-7.57.0 && ./configure --prefix=/usr/local --without-brotli --with-nghttp2 --disable-shared && make && make install)
 
 ARG OPENSSL_URL="https://www.openssl.org/source/"
 # openssl 1.1.0
@@ -42,7 +42,7 @@ RUN (cd openssl-${OPENSSL_VERSION} && \
 RUN apt-get install --yes cpanminus
 RUN apt-get install --yes libfcgi-perl libfcgi-procmanager-perl libipc-signal-perl libjson-perl liblist-moreutils-perl libplack-perl libscope-guard-perl libtest-exception-perl libwww-perl libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN sudo cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
+RUN cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
 
 # h2spec
 RUN curl -Ls https://github.com/i110/h2spec/releases/download/v2.2.0-4e8cc7e/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin

--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -45,7 +45,7 @@ RUN apt-get install --yes \
 # install curl 7.57.0 because t/50fastcgi.t depends on it.
 RUN apt-get install --yes libnghttp2-dev \
 	&& wget --no-verbose -O - https://curl.haxx.se/download/curl-7.57.0.tar.gz | tar xzf - \
-	&& (cd curl-7.57.0 && ./configure --prefix=/usr/local --without-brotli --with-nghttp2 --disable-shared && make && sudo make install)
+	&& (cd curl-7.57.0 && ./configure --prefix=/usr/local --without-brotli --with-nghttp2 --disable-shared && make && make install)
 
 # perl
 RUN apt-get install --yes \
@@ -61,7 +61,7 @@ RUN apt-get install --yes \
 	libwww-perl \
 	libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN sudo cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
+RUN cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
 
 # h2spec
 RUN curl -Ls https://github.com/i110/h2spec/releases/download/v2.2.0-4e8cc7e/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin

--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -61,9 +61,7 @@ RUN apt-get install --yes \
 	libwww-perl \
 	libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN sudo cpanm --notest Test::More Starlet Protocol::HTTP2
-RUN sudo cpanm --notest Net::DNS::Nameserver
-RUN sudo cpanm --notest https://github.com/tokuhirom/Test-TCP.git@2.21
+RUN sudo cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
 
 # h2spec
 RUN curl -Ls https://github.com/i110/h2spec/releases/download/v2.2.0-4e8cc7e/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin


### PR DESCRIPTION
Test::TCP 2.21 has been widely available on CPAN and there shouldn't be a need to pin to a specific version on Git.