### PR TITLE
fix perl warnings in tests

### DIFF
--- a/t/50errordoc.t
+++ b/t/50errordoc.t
@@ -192,7 +192,7 @@ EOT
     my $resp = `(echo badrequest/1.0; echo) | nc 127.0.0.1 $server->{port}`;
     like $resp, qr{^HTTP/1.1 400 .*\nbad request$}is, "broken request headers -> undecorated 400";
 
-    my $resp = `(echo POST / HTTP/1.1; echo Transfer-Encoding: chunked; echo; echo hello world; echo; echo) | nc 127.0.0.1 $server->{port}`;
+    $resp = `(echo POST / HTTP/1.1; echo Transfer-Encoding: chunked; echo; echo hello world; echo; echo) | nc 127.0.0.1 $server->{port}`;
     like $resp, qr{^HTTP/1.1 400 .*\nhello\n$}is, "valid request headers but broken entity -> decorated 400";
 };
 


### PR DESCRIPTION
Fix a perl warning `"my" variable $resp masks earlier declaration in same scope at t/50errordoc.t line 195.`