### PR TITLE
[FreeBSD] use pthread_setaffinity_np

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,27 +77,6 @@ __sync_add_and_fetch(&a, 1);
 return 0;
 }" ARCH_SUPPORTS_64BIT_ATOMICS)
 
-CMAKE_PUSH_CHECK_STATE()
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
-CHECK_C_SOURCE_COMPILES("
-#define _GNU_SOURCE
-#include <sched.h>
-#include <pthread.h>
-int main(void) {
-#ifndef __NetBSD__
-cpu_set_t s;
-CPU_ZERO(&s);
-pthread_setaffinity_np(0, sizeof(s), &s);
-#else
-cpuset_t *s = cpuset_create();
-cpuset_zero(s);
-pthread_setaffinity_np(0, cpuset_size(s), s);
-cpuset_destroy(s);
-#endif
-return 0;
-}" HAS_PTHREAD_SETAFFINITY_NP)
-CMAKE_POP_CHECK_STATE()
-
 # Find out if libc provices backtrace()
 CMAKE_PUSH_CHECK_STATE()
 FIND_LIBRARY(LIBC_BACKTRACE_LIB "execinfo")

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <netinet/udp.h>
 #include "h2o.h"
 #include "h2o/configurator.h"

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
+#include <sys/types.h>
 #include <netinet/udp.h>
 #include "h2o.h"
 #include "h2o/configurator.h"

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -23,12 +23,12 @@
 #define __APPLE_USE_RFC_3542 /* to use IPV6_PKTINFO */
 #endif
 #include <errno.h>
+#include <sys/types.h>
 #include <netinet/in.h>
 #include <netinet/udp.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <sys/socket.h>
-#include <sys/types.h>
 #include "picotls/openssl.h"
 #include "h2o/string_.h"
 #include "h2o/http3_common.h"


### PR DESCRIPTION
#2017 introduced use of `pthread_setaffinity_np` on linux, and #2574 extended that to NetBSD. So far, we have relied on `CHECK_C_SOURCE_COMPILES` to detect the availability of the feature.

However, that has led to issues on FreeBSD: see #2933 and #2934.

In reality, feature detection using duck-typing (compile some code, and if that succeeds, assume that the API can be used) works only if support for an API is provided in a consistent way between platforms that support that API.

This is not the case for `phread_setaffinity_np`. Linux uses `cpu_set_t`. FreeBSD uses `cpuset_t`. NetBSD uses `cpuset_t`, but requires applications to allocate the structure on heap using API.

Considering the fact that we have to have different code for each platform, it is simpler to just to `#if platform` in the source files directly.