### PR TITLE
Fix test quic port in test

### DIFF
--- a/t/40http3-invalid-token.t
+++ b/t/40http3-invalid-token.t
@@ -9,8 +9,10 @@ my $client_prog = bindir() . "/h2o-httpclient";
 plan skip_all => "$client_prog not found"
     unless -e $client_prog;
 
-my $port = empty_port();
-my $quic_port = empty_port();
+my $quic_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
 
 my $server = spawn_h2o(<< "EOT");
 listen:


### PR DESCRIPTION
During fixing #2931, I found the weird port using in `t/40http3-invalid-token.t`.
It may use the port as quic protocol,  nevertheless it seems to bind the tcp protocol port.

https://metacpan.org/pod/Net::EmptyPort#proto1
Net::EmptyPort spec says that `Default is tcp. You can find an empty UDP port by specifying udp.`

I'm not completely sure whether this test uses tcp port intentionally or not, if it's true we should write some comments.

And moreover `$port` is used anywhere in this test.