### PR TITLE
constants obsoleted in RFC 3493 may not be available

### DIFF
--- a/lib/common/hostinfo.c
+++ b/lib/common/hostinfo.c
@@ -73,14 +73,18 @@ static const char *hostinfo_error_from_gai_error(int ret)
     switch (ret) {
     case EAI_NONAME:
         return h2o_hostinfo_error_nxdomain;
+#ifdef EAI_NODATA /* obsoleted in RFC 3493 and not supported by FreeBSD */
     case EAI_NODATA:
         return h2o_hostinfo_error_nodata;
+#endif
     case EAI_FAIL:
         return h2o_hostinfo_error_refused;
     case EAI_AGAIN:
         return h2o_hostinfo_error_servfail;
+#ifdef EAI_ADDRFAMILY
     case EAI_ADDRFAMILY:
         return h2o_hostinfo_error_gai_addrfamily;
+#endif
     case EAI_BADFLAGS:
         return h2o_hostinfo_error_gai_badflags;
     case EAI_FAMILY:


### PR DESCRIPTION
In #2568, we switched from using `gai_strerror` to using our own function that converts error codes to strings, as `gai_strerror` is locale-dependent and therefore cannot be included in the `proxy-status` response header.

However, that has caused the FreeBSD to break, because it does not define EAI_NODATA, AI_ADDRFAMILY, constants that were obsoleted in RFC 3493.

Fixes #2944.