### PR TITLE
connect handler: fix double close

### DIFF
--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -533,7 +533,7 @@ static void tcp_on_read(h2o_socket_t *_sock, const char *err)
         h2o_iovec_t vec = h2o_iovec_init(self->sock->input->bytes, self->sock->input->size);
         h2o_send(self->src_req, &vec, 1, H2O_SEND_STATE_IN_PROGRESS);
     } else {
-        if (self->read_closed) {
+        if (!self->read_closed) {
             /* unidirectional close is signalled using H2O_SEND_STATE_FINAL, but the write side remains open */
             self->read_closed = 1;
             h2o_send(self->src_req, NULL, 0, H2O_SEND_STATE_FINAL);


### PR DESCRIPTION
In some paths, nothing prevents the connect handler calling
`h2o_send(FINAL);` twice. skip calling `h2o_send` if the read side has
already been closed.