### PR TITLE
[test] [bug-fix] Many openssl s_client tests fail occasionally due to timing issues

### DIFF
--- a/t/40memcached-session-resumption.t
+++ b/t/40memcached-session-resumption.t
@@ -48,7 +48,7 @@ hosts:
         file.dir: @{[ DOC_ROOT ]}
 EOT
             sleep 1; # wait for h2o to connect to memcached
-            my $lines = run_openssl_client_joined({ host => "127.0.0.1", port => $server->{tls_port}, opts => "-no_ticket $opts" });
+            my $lines = run_openssl_client({ host => "127.0.0.1", port => $server->{tls_port}, opts => "-no_ticket $opts" });
             $lines =~ m{---\n(New|Reused),}s
                 or die "failed to parse the output of s_client:{{{$lines}}}";
             is $1, $expected;

--- a/t/40memcached-session-resumption.t
+++ b/t/40memcached-session-resumption.t
@@ -48,12 +48,7 @@ hosts:
         file.dir: @{[ DOC_ROOT ]}
 EOT
             sleep 1; # wait for h2o to connect to memcached
-            my $lines = do {
-                open my $fh, "-|", "openssl s_client -no_ticket $opts -connect 127.0.0.1:$server->{tls_port} 2>&1 < /dev/null"
-                    or die "failed to open pipe:$!";
-                local $/;
-                <$fh>;
-            };
+            my $lines = run_openssl_client_joined({ host => "127.0.0.1", port => $server->{tls_port}, opts => "-no_ticket $opts" });
             $lines =~ m{---\n(New|Reused),}s
                 or die "failed to parse the output of s_client:{{{$lines}}}";
             is $1, $expected;

--- a/t/40redis-session-resumption.t
+++ b/t/40redis-session-resumption.t
@@ -33,7 +33,7 @@ sub test {
     my ($server, $client_opts, $expected) = @_;
     $expected = [ $expected ] unless ref $expected eq 'ARRAY';
     for my $exp (@$expected) {
-        my $lines = run_openssl_client_joined({ host => "127.0.0.1", port => $server->{tls_port}, opts => "-no_ticket $client_opts" });
+        my $lines = run_openssl_client({ host => "127.0.0.1", port => $server->{tls_port}, opts => "-no_ticket $client_opts" });
         if (ok $lines !~ qr/ssl handshake failure/, 'ssl handshake failure') {
             $lines =~ m{---\n(New|Reused),}s
                 or die "failed to parse the output of s_client:{{{$lines}}}";

--- a/t/40redis-session-resumption.t
+++ b/t/40redis-session-resumption.t
@@ -33,12 +33,7 @@ sub test {
     my ($server, $client_opts, $expected) = @_;
     $expected = [ $expected ] unless ref $expected eq 'ARRAY';
     for my $exp (@$expected) {
-        my $lines = do {
-            open my $fh, "-|", "openssl s_client -no_ticket $client_opts -connect 127.0.0.1:$server->{tls_port} 2>&1 < /dev/null"
-                or die "failed to open pipe:$!";
-            local $/;
-            <$fh>;
-        };
+        my $lines = run_openssl_client_joined({ host => "127.0.0.1", port => $server->{tls_port}, opts => "-no_ticket $client_opts" });
         if (ok $lines !~ qr/ssl handshake failure/, 'ssl handshake failure') {
             $lines =~ m{---\n(New|Reused),}s
                 or die "failed to parse the output of s_client:{{{$lines}}}";

--- a/t/40session-ticket.t
+++ b/t/40session-ticket.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use File::Temp qw(tempdir);
-use IPC::Open2;
 use Net::EmptyPort qw(check_port empty_port);
 use Test::More;
 use Time::HiRes qw(sleep);
@@ -130,13 +129,8 @@ EOT
 }
 
 sub test {
-    my $lines = do {
-        my $cmd_opts = (-e "$tempdir/session" ? "-sess_in $tempdir/session" : "") . " -sess_out $tempdir/session";
-        open2(my $outfh, my $infh, "timeout 1 openssl s_client $cmd_opts -connect 127.0.0.1:$server->{tls_port} 2>&1")
-            or die "failed to open pipe:$!";
-        local $/;
-        <$outfh>;
-    };
+    my $cmd_opts = (-e "$tempdir/session" ? "-sess_in $tempdir/session" : "") . " -sess_out $tempdir/session";
+    my $lines = run_openssl_client_joined({ host => "127.0.0.1", port => $server->{tls_port}, opts => "$cmd_opts" });
     $lines =~ m{---\n(New|Reused),}s
         or die "failed to parse the output of s_client:{{{$lines}}}";
     $1;

--- a/t/40session-ticket.t
+++ b/t/40session-ticket.t
@@ -130,7 +130,7 @@ EOT
 
 sub test {
     my $cmd_opts = (-e "$tempdir/session" ? "-sess_in $tempdir/session" : "") . " -sess_out $tempdir/session";
-    my $lines = run_openssl_client_joined({ host => "127.0.0.1", port => $server->{tls_port}, opts => "$cmd_opts" });
+    my $lines = run_openssl_client({ host => "127.0.0.1", port => $server->{tls_port}, opts => "$cmd_opts" });
     $lines =~ m{---\n(New|Reused),}s
         or die "failed to parse the output of s_client:{{{$lines}}}";
     $1;

--- a/t/40ssl-cipher-suite.t
+++ b/t/40ssl-cipher-suite.t
@@ -39,11 +39,11 @@ my ($guard, $pid) = spawn_server(
 
 subtest "tls1.2" => sub {
     # connect to the server with AES256-SHA as the first choice, and check that AES128-SHA was selected
-    my $log = run_openssl_client_joined({ host => "127.0.0.1", port => $port, opts => "-tls1_2 -cipher AES256-SHA:AES128-SHA" });
+    my $log = run_openssl_client({ host => "127.0.0.1", port => $port, opts => "-tls1_2 -cipher AES256-SHA:AES128-SHA" });
     like $log, qr/^\s*Cipher\s*:\s*AES128-SHA\s*$/m;
 
     # connect to the server with AES256-SHA as the only choice, and check that handshake failure is returned
-    $log = run_openssl_client_joined({ host => "127.0.0.1", port => $port, opts => "-tls1_2 -cipher AES256-SHA" });
+    $log = run_openssl_client({ host => "127.0.0.1", port => $port, opts => "-tls1_2 -cipher AES256-SHA" });
     like $log, qr/alert handshake failure/m; # "handshake failure" the official name for TLS alert 40
 };
 
@@ -51,10 +51,10 @@ subtest "tls1.3" => sub {
     plan skip_all => "openssl does not support tls 1.3"
         unless `openssl s_client -help 2>&1` =~ /^\s*-tls1_3\s+/m;
     # TLS 1.3 test
-    my $log = run_openssl_client_joined({ host => "127.0.0.1", port => $port, opts => "-tls1_3 -ciphersuites TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256" });
+    my $log = run_openssl_client({ host => "127.0.0.1", port => $port, opts => "-tls1_3 -ciphersuites TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256" });
     like $log, qr/^\s*Cipher\s*:\s*TLS_CHACHA20_POLY1305_SHA256\s*$/m;
 
-    $log = run_openssl_client_joined({ host => "127.0.0.1", port => $port, opts => "-tls1_3 -ciphersuites TLS_AES_256_GCM_SHA384" });
+    $log = run_openssl_client({ host => "127.0.0.1", port => $port, opts => "-tls1_3 -ciphersuites TLS_AES_256_GCM_SHA384" });
     unlike $log, qr/TLS_AES_256_GCM_SHA384/m;
 };
 

--- a/t/40ssl-cipher-suite.t
+++ b/t/40ssl-cipher-suite.t
@@ -39,11 +39,11 @@ my ($guard, $pid) = spawn_server(
 
 subtest "tls1.2" => sub {
     # connect to the server with AES256-SHA as the first choice, and check that AES128-SHA was selected
-    my $log = `openssl s_client -tls1_2 -cipher AES256-SHA:AES128-SHA -host 127.0.0.1 -port $port < /dev/null 2>&1`;
+    my $log = run_openssl_client_joined({ host => "127.0.0.1", port => $port, opts => "-tls1_2 -cipher AES256-SHA:AES128-SHA" });
     like $log, qr/^\s*Cipher\s*:\s*AES128-SHA\s*$/m;
 
     # connect to the server with AES256-SHA as the only choice, and check that handshake failure is returned
-    $log = `openssl s_client -tls1_2 -cipher AES256-SHA -host 127.0.0.1 -port $port < /dev/null 2>&1`;
+    $log = run_openssl_client_joined({ host => "127.0.0.1", port => $port, opts => "-tls1_2 -cipher AES256-SHA" });
     like $log, qr/alert handshake failure/m; # "handshake failure" the official name for TLS alert 40
 };
 
@@ -51,10 +51,10 @@ subtest "tls1.3" => sub {
     plan skip_all => "openssl does not support tls 1.3"
         unless `openssl s_client -help 2>&1` =~ /^\s*-tls1_3\s+/m;
     # TLS 1.3 test
-    my $log = `openssl s_client -tls1_3 -ciphersuites TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256 -host 127.0.0.1 -port $port < /dev/null 2>&1`;
+    my $log = run_openssl_client_joined({ host => "127.0.0.1", port => $port, opts => "-tls1_3 -ciphersuites TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256" });
     like $log, qr/^\s*Cipher\s*:\s*TLS_CHACHA20_POLY1305_SHA256\s*$/m;
 
-    $log = `openssl s_client -tls1_3 -ciphersuites TLS_AES_256_GCM_SHA384 -host 127.0.0.1 -port $port < /dev/null 2>&1`;
+    $log = run_openssl_client_joined({ host => "127.0.0.1", port => $port, opts => "-tls1_3 -ciphersuites TLS_AES_256_GCM_SHA384" });
     unlike $log, qr/TLS_AES_256_GCM_SHA384/m;
 };
 

--- a/t/40tls-multiple-certs.t
+++ b/t/40tls-multiple-certs.t
@@ -8,7 +8,7 @@ use t::Util;
 my $tls_port = empty_port();
 
 plan skip_all => 'openssl s_client does not support TLS 1.3 + ECDSA' unless do {
-    my $resp = run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-tls1_3 -sigalgs ECDSA+SHA256" });
+    my $resp = run_openssl_client({ host => "127.0.0.1", port => $tls_port, opts => "-tls1_3 -sigalgs ECDSA+SHA256" });
     $resp =~ /^connect:errno=/m;
 };
 
@@ -36,7 +36,7 @@ EOT
 
 sub doit {
     my ($algs, $expected) = @_;
-    my $resp = run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-sigalgs $algs" });
+    my $resp = run_openssl_client({ host => "127.0.0.1", port => $tls_port, opts => "-sigalgs $algs" });
     like $resp, qr/\nPeer signature type: $expected\n.*\nDONE/s, "$algs -> $expected";
 }
 

--- a/t/40tls-multiple-certs.t
+++ b/t/40tls-multiple-certs.t
@@ -8,7 +8,7 @@ use t::Util;
 my $tls_port = empty_port();
 
 plan skip_all => 'openssl s_client does not support TLS 1.3 + ECDSA' unless do {
-    my $resp = `openssl s_client -tls1_3 -sigalgs ECDSA+SHA256 -connect 127.0.0.1:$tls_port < /dev/null 2>&1`;
+    my $resp = run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-tls1_3 -sigalgs ECDSA+SHA256" });
     $resp =~ /^connect:errno=/m;
 };
 
@@ -36,7 +36,7 @@ EOT
 
 sub doit {
     my ($algs, $expected) = @_;
-    my $resp = `openssl s_client -sigalgs $algs -connect 127.0.0.1:$tls_port < /dev/null 2>&1`;
+    my $resp = run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-sigalgs $algs" });
     like $resp, qr/\nPeer signature type: $expected\n.*\nDONE/s, "$algs -> $expected";
 }
 

--- a/t/50status.t
+++ b/t/50status.t
@@ -123,7 +123,8 @@ EOT
 
         my $build_req = sub {
             my ($tlsver, $alpn) = @_;
-            "(echo GET / HTTP/1.0; echo) | openssl s_client -$tlsver -alpn $alpn -connect 127.0.0.1:$tls_port > /dev/null";
+            my $req = "GET / HTTP/1.0\r\r";
+            run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-$tlsver -alpn $alpn", request => $req });
         };
 
         # error by TLS minimum version
@@ -147,9 +148,9 @@ EOT
         my ($server, $port, $tls_port) = $setup->();
 
         # full handshake
-        `openssl s_client -no_ticket -sess_out $tempdir/session -connect 127.0.0.1:$tls_port < /dev/null`;
+        run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-no_ticket -sess_out $tempdir/session" });
         # resume handshake
-        `openssl s_client -no_ticket -sess_in $tempdir/session  -connect 127.0.0.1:$tls_port < /dev/null`;
+        run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-no_ticket -sess_in $tempdir/session" });
 
         my $resp = `curl --silent -o /dev/stderr http://127.0.0.1:$port/s/json?show=ssl 2>&1 > /dev/null`;
         my $jresp = decode_json($resp);

--- a/t/50status.t
+++ b/t/50status.t
@@ -124,7 +124,7 @@ EOT
         my $build_req = sub {
             my ($tlsver, $alpn) = @_;
             my $req = "GET / HTTP/1.0\r\r";
-            run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-$tlsver -alpn $alpn", request => $req });
+            run_openssl_client({ host => "127.0.0.1", port => $tls_port, opts => "-$tlsver -alpn $alpn", request => $req });
         };
 
         # error by TLS minimum version
@@ -148,9 +148,9 @@ EOT
         my ($server, $port, $tls_port) = $setup->();
 
         # full handshake
-        run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-no_ticket -sess_out $tempdir/session" });
+        run_openssl_client({ host => "127.0.0.1", port => $tls_port, opts => "-no_ticket -sess_out $tempdir/session" });
         # resume handshake
-        run_openssl_client_joined({ host => "127.0.0.1", port => $tls_port, opts => "-no_ticket -sess_in $tempdir/session" });
+        run_openssl_client({ host => "127.0.0.1", port => $tls_port, opts => "-no_ticket -sess_in $tempdir/session" });
 
         my $resp = `curl --silent -o /dev/stderr http://127.0.0.1:$port/s/json?show=ssl 2>&1 > /dev/null`;
         my $jresp = decode_json($resp);

--- a/t/90live-fetch-ocsp-response.t
+++ b/t/90live-fetch-ocsp-response.t
@@ -26,7 +26,7 @@ done_testing;
 
 sub doit {
     my $host = shift;
-    my $input = run_openssl_client_joined({ host => $host, port => 443, opts => "-showcerts -CAfile /dev/null" });
+    my $input = run_openssl_client({ host => $host, port => 443, opts => "-showcerts -CAfile /dev/null" });
     my @certs;
     while ($input =~ /(-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----)/sg) {
         push @certs, $1;

--- a/t/90live-fetch-ocsp-response.t
+++ b/t/90live-fetch-ocsp-response.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use File::Temp qw(tempfile);
 use Test::More;
+use t::Util;
 
 plan skip_all => "skipping live tests (setenv LIVE_TESTS=1 to run them)"
     unless $ENV{LIVE_TESTS};
@@ -25,12 +26,7 @@ done_testing;
 
 sub doit {
     my $host = shift;
-    my $input = do {
-        open my $fh, "-|", "openssl s_client -showcerts -host $host -port 443 -CAfile /dev/null < /dev/null 2>&1"
-            or die "failed to invoke openssl:$!";
-        local $/;
-        <$fh>;
-    };
+    my $input = run_openssl_client_joined({ host => $host, port => 443, opts => "-showcerts -CAfile /dev/null" });
     my @certs;
     while ($input =~ /(-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----)/sg) {
         push @certs, $1;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -836,7 +836,6 @@ sub run_openssl_client {
     my $ossl_opts = $opts->{opts} // '';
     my $ossl_cmd = $opts->{ossl_cmd} // 'openssl';
 
-    my $tempdir = tempdir();
     my $cmd = "$ossl_cmd s_client $ossl_opts -connect $host:$port";
     if (defined $san && $san ne '') {
         $cmd = $cmd." -servername $san";

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -845,8 +845,6 @@ sub run_openssl_client {
     my $cpid = open3(my $chld_in, my $chld_out, my $chld_err = gensym, $cmd);
     sleep $timeout;
     $chld_in->autoflush(1);
-    $chld_out->autoflush(1);
-    $chld_err->autoflush(1);
     if ($request_default) {
         $chld_in->eof() || print $chld_in <<"EOT";
 GET $path HTTP/1.1\r

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -843,7 +843,7 @@ sub run_openssl_client {
     }
     diag("run_openssl_client: $cmd");
     my $cpid = open3(my $chld_in, my $chld_out, my $chld_err = gensym, $cmd);
-    sleep ${timeout};
+    sleep $timeout;
     $chld_in->autoflush(1);
     $chld_out->autoflush(1);
     $chld_err->autoflush(1);

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -832,7 +832,7 @@ sub run_openssl_client {
     my $path = $opts->{path} // '/';
     my $timeout = $opts->{timeout} // 2.0;
     my $request = $opts->{request};
-    my $request_default = $opts->{request_default} // 0;
+    my $request_default = $opts->{request_default} // undef;
     my $ossl_opts = $opts->{opts} // '';
     my $ossl_cmd = $opts->{ossl_cmd} // 'openssl';
 


### PR DESCRIPTION
## Overview
There are many tests that utilize `openssl s_client` which are flaky.  They sometimes fail randomly with an error that includes the tool’s output.  The failures are usually timing issues which are not predictable and subsequent attempts to run the tests often succeed.

This patch unifies the way that the tool is called across all unit tests using the `run_openssl_client()` method to get a more consistent behavior.  The method has been enhanced to use `open3()`, then `waitpid()` until the process ends with a configurable timeout, optionally insert data using `stdin`, and capture `stdout`  and `stderr` separately.
