### PR TITLE
Fix output message which couldn't see occasionally.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3127,8 +3127,10 @@ static void *run_loop(void *_thread_index)
         h2o_set_signal_handler(SIGTERM, on_sigterm_set_flag_notify_threads);
         if (conf.shutdown_requested)
             exit(0);
-        fprintf(stderr, "h2o server (pid:%d) is ready to serve requests with %zu threads\n", (int)getpid(), conf.thread_map.size);
     }
+    if (thread_index == 0)
+        fprintf(stderr, "h2o server (pid:%d) is ready to serve requests with %zu threads\n", (int)getpid(), conf.thread_map.size);
+
     h2o_barrier_wait_post_sync_point(&conf.startup_sync_barrier);
 
     /* the main loop */


### PR DESCRIPTION
`h2o server (pid:%d) is ready to serve requests with %zu threads`  sometimes couldn't appear in several tests.

e.g. 
```
# t/40http3-corrupted-scid-initial.t --------------------------------
  0.179642 spawning ./build/h2o... [INFO] raised RLIMIT_NOFILE to 1048576
  0.197682 session ticket secrets have been (re)loaded
  0.214420 fetch-ocsp-response (using OpenSSL 1.1.1  11 Sep 2018)
  0.214623 fetch-ocsp-response (using OpenSSL 1.1.1  11 Sep 2018)
  0.217543 failed to extract ocsp URI from /tmp/fYIFLVkU_K/cert.crt
  0.233533 failed to extract ocsp URI from /tmp/bXNX_9ZVyb/cert.crt
  0.233549 [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
  0.236492 [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
  0.268511 done
  1.402670 ok 1 - server is alive after getting an Initial with corrupted SCID (1)
  2.412682 ok 2 - server is alive after getting an Initial with corrupted SCID (2)
  2.421758 ok 3 - Number of connections is two
  3.449471 ok 4 - server is alive after getting an Initial with zero-length SCID (1)
  4.459632 ok 5 - server is alive after getting an Initial with zero-length SCID (2)
  4.468501 ok 6 - Number of connections is still two
  4.468576 killing ./build/h2o... received SIGTERM, gracefully shutting down
 14.580324 failed, sending SIGKILL... killed (got 9)
 14.580709 1..6
 14.585674 0.30user 0.05system 0:14.58elapsed 2%CPU (0avgtext+0avgdata 32480maxresident)k
 14.585695 4160inputs+0outputs (4major+21931minor)pagefaults 0swaps
# t/40http3-corrupted-scid-initial.t succeeded
```
https://github.com/h2o/h2o/blob/a429117babff09542d3517c4fa36c1ef769889c1/src/main.c#L3126-L3131

in case of `h2o_barrier_wait_pre_sync_point` seems not to return 1, it couldn't be seen them.

https://github.com/h2o/h2o/blob/a429117babff09542d3517c4fa36c1ef769889c1/lib/common/multithread.c#L308-L316

And if `barrier->_count == 0`, `h2o_barrier_wait_pre_sync_point` returns 1. 

OTOH, h2o_barrier_wait(h2o_barrier_wait_pre_sync_point) is called several points around this source code, e.g, t/40http3-corrupted-scid-initial.t is called it in which registers the session ticket in register_session_tickets. 

https://github.com/h2o/h2o/blob/a429117babff09542d3517c4fa36c1ef769889c1/src/ssl.c#L449-L459

If `barrier->_count` became 0 by h2o_barrier_wait here,  `barrier->_count` could not be 0 by `h2o_barrier_wait_pre_sync_point` which is called from main loop at the start up. Thus I consider that it could not seen that message.