### PR TITLE
Fix set sigterm handler when the last thread enters barrier

### DIFF
--- a/fuzz/driver.cc
+++ b/fuzz/driver.cc
@@ -205,7 +205,7 @@ static int feeder(int sfd, char *buf, size_t len, h2o_barrier_t **barrier)
     wta->fd = pair[0];
     wta->buf = buf;
     wta->len = len;
-    h2o_barrier_init(&wta->barrier, 2);
+    h2o_barrier_init(&wta->barrier, 2, barrier_last_passed_cb);
     *barrier = &wta->barrier;
 
     write_fully(sfd, (char *)&wta, sizeof(wta), 1);
@@ -271,7 +271,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         static char tmpname[] = "/tmp/h2o-fuzz-XXXXXX";
         char *dirname;
 
-        h2o_barrier_init(&init_barrier, 2);
+        h2o_barrier_init(&init_barrier, 2, barrier_last_passed_cb);
         signal(SIGPIPE, SIG_IGN);
 
         dirname = mkdtemp(tmpname);

--- a/fuzz/driver_common.cc
+++ b/fuzz/driver_common.cc
@@ -122,3 +122,7 @@ void register_proxy(h2o_hostconf_t *hostconf, const char *unix_path, h2o_access_
     if (logfh != NULL)
         h2o_access_log_register(pathconf, logfh);
 }
+
+void barrier_last_passed_cb(void)
+{
+}

--- a/fuzz/driver_common.h
+++ b/fuzz/driver_common.h
@@ -32,5 +32,6 @@ h2o_pathconf_t *register_handler(h2o_hostconf_t *hostconf, const char *path, int
 void write_fully(int fd, char *buf, size_t len, int abort_on_err);
 void *upstream_thread(void *arg);
 void register_proxy(h2o_hostconf_t *hostconf, const char *unix_path, h2o_access_log_filehandle_t *logfh);
+void barrier_last_passed_cb(void);
 
 #endif

--- a/fuzz/driver_h3.cc
+++ b/fuzz/driver_h3.cc
@@ -109,7 +109,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         pthread_t tupstream;
         const char *client_timeout_ms_str, *log_access_str;
 
-        h2o_barrier_init(&init_barrier, 2);
+        h2o_barrier_init(&init_barrier, 2, barrier_last_passed_cb);
         signal(SIGPIPE, SIG_IGN);
 
         dirname = mkdtemp(tmpname);

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -54,6 +54,7 @@ typedef struct st_h2o_barrier_t {
     pthread_cond_t _cond;
     size_t _count;
     size_t _out_of_wait;
+    void (*_last_pass_cb)(void);
 } h2o_barrier_t;
 
 /**
@@ -135,11 +136,11 @@ void h2o_sem_wait(h2o_sem_t *sem);
 void h2o_sem_post(h2o_sem_t *sem);
 void h2o_sem_set_capacity(h2o_sem_t *sem, ssize_t new_capacity);
 
-void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
+void h2o_barrier_init(h2o_barrier_t *barrier, size_t count, void (*cb)(void));
 /**
  * Waits for all threads to enter the barrier.
  */
-int h2o_barrier_wait(h2o_barrier_t *barrier);
+void h2o_barrier_wait(h2o_barrier_t *barrier);
 int h2o_barrier_done(h2o_barrier_t *barrier);
 void h2o_barrier_add(h2o_barrier_t *barrier, size_t delta);
 void h2o_barrier_dispose(h2o_barrier_t *barrier);

--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -139,14 +139,7 @@ void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
 /**
  * Waits for all threads to enter the barrier.
  */
-void h2o_barrier_wait(h2o_barrier_t *barrier);
-/**
- * Waits for all threads to enter the barrier, then returns before the barriers are released. True is returned on one thread, while
- * while false is returned on other threads. On the thread that returned true, it is possible to run any action that has to be taken
- * while all threads are within the barrier. All threads then must call `h2o_barrier_wait_post_sync_point`.
- */
-int h2o_barrier_wait_pre_sync_point(h2o_barrier_t *barrier);
-void h2o_barrier_wait_post_sync_point(h2o_barrier_t *barrier);
+int h2o_barrier_wait(h2o_barrier_t *barrier);
 int h2o_barrier_done(h2o_barrier_t *barrier);
 void h2o_barrier_add(h2o_barrier_t *barrier, size_t delta);
 void h2o_barrier_dispose(h2o_barrier_t *barrier);

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -294,13 +294,7 @@ void h2o_barrier_init(h2o_barrier_t *barrier, size_t count)
     barrier->_out_of_wait = count;
 }
 
-void h2o_barrier_wait(h2o_barrier_t *barrier)
-{
-    h2o_barrier_wait_pre_sync_point(barrier);
-    h2o_barrier_wait_post_sync_point(barrier);
-}
-
-int h2o_barrier_wait_pre_sync_point(h2o_barrier_t *barrier)
+int h2o_barrier_wait(h2o_barrier_t *barrier)
 {
     int ret;
     pthread_mutex_lock(&barrier->_mutex);
@@ -309,19 +303,15 @@ int h2o_barrier_wait_pre_sync_point(h2o_barrier_t *barrier)
         pthread_cond_broadcast(&barrier->_cond);
         ret = 1;
     } else {
-        while (barrier->_count != 0)
+        while (barrier->_count)
             pthread_cond_wait(&barrier->_cond, &barrier->_mutex);
         ret = 0;
     }
-    return ret;
-}
-
-void h2o_barrier_wait_post_sync_point(h2o_barrier_t *barrier)
-{
     pthread_mutex_unlock(&barrier->_mutex);
     /* This is needed to synchronize h2o_barrier_dispose with the exit of this function, so make sure that we can't destroy the
      * mutex or the condition before all threads have exited wait(). */
     __sync_sub_and_fetch(&barrier->_out_of_wait, 1);
+    return ret;
 }
 
 int h2o_barrier_done(h2o_barrier_t *barrier)


### PR DESCRIPTION
To reconsider #2949 
I fixes message emitting and sigterm handler registration when session ticket thread passes the barrier_wait at last as well.
h2o_barrier_init registers the callback func which sets h2o_set_sigterm and emits server spawning message.
When the last thread coming h2o_barrier_wait, its callback fires.
I'm not sure clearly what should I do about fuzzing of h2o_barrier_init.