### PR TITLE
When disposing of a request, always reset `stream->datagram_flow_id`

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -408,6 +408,7 @@ static void pre_dispose_request(struct st_h2o_http3_server_stream_t *stream)
         /* it's possible the tunnel wasn't established yet */
         if (iter != kh_end(conn->datagram_flows))
             kh_del(stream, conn->datagram_flows, iter);
+        stream->datagram_flow_id = UINT64_MAX;
     }
 
     if (stream->req.is_tunnel_req)


### PR DESCRIPTION
This is necessary in `pre_dispose_request`, because the following race
might happen otherwise:
- we receive a tunneling request in `handle_input_expect_headers_process_connect`, `stream->datagram_flow_id`
  is set to something else than `UINT64_MAX`, `write_` is set by the connect handler
- we need to do a DNS resolution, so `finalize_do_send_setup_udp_tunnel`
  isn't called immediatley. As a result, the stream isn't added to `conn->datagram_flows`.
- something causes the request to be destroyed, we call
  `pre_dispose_request`, the stream isn't in present in
  `conn->datagram_flows`, no action is taken.
- DNS resolution completes succesfully,
  `finalize_do_send_setup_udp_tunnel` is called, the stream is added to
  `conn->datagram_flows`, in spite of the request having been disposed of.
- A datagram comes in for that stream, we find it in
  `conn->datagram_flows`, and call the `write_` callback, which would
  cause a use after free.

By setting the `stream->datagram_flow_id` to `UINT64_MAX`, we avoid
adding the stream back to `conn->datagram_flows`, and in the last step,
we simply drop the datagram.