### PR TITLE
FIX: handle null authority for reverse proxy

### DIFF
--- a/include/h2o/url.h
+++ b/include/h2o/url.h
@@ -115,11 +115,14 @@ extern const char h2o_url_host_to_sun_err_is_not_unix_socket[];
 
 inline int h2o_url_init(h2o_url_t *url, const h2o_url_scheme_t *scheme, h2o_iovec_t authority, h2o_iovec_t path)
 {
-    if (h2o_url_parse_hostport(authority.base, authority.len, &url->host, &url->_port) != authority.base + authority.len)
-        return -1;
+    /* core/proxy.c does not check the result and generates upstream request
+       We init url with given arguments and this approach is cleaner than handle
+       the corner case from core/proxy.c */
     url->scheme = scheme;
     url->authority = authority;
     url->path = path;
+    if (h2o_url_parse_hostport(authority.base, authority.len, &url->host, &url->_port) != authority.base + authority.len)
+        return -1;
     return 0;
 }
 

--- a/t/50reverse-proxy-null-host-header.t
+++ b/t/50reverse-proxy-null-host-header.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $upstream_port = empty_port();
+
+my $upstream = spawn_server(
+    argv     => [ qw(plackup -s Starlet --max-keepalive-reqs 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+    is_ready =>  sub {
+        check_port($upstream_port);
+    },
+);
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+        proxy.preserve-host: ON
+EOT
+
+my $url = "http://127.0.0.1:$server->{port}/index.txt";
+my $resp = `curl -s --http1.1 --dump-header /dev/stdout $url -H "Host;"`;
+like $resp, qr{HTTP/[^ ]+ 200\s}m;
+
+done_testing();
+


### PR DESCRIPTION
Hi, it's been a long time.

`core/proxy.c` does not check the result of `h2o_url_init()` and generates upstream request.
When given authority has zero value, and this can happen if `proxy.preserve-host` is set, it causes h2o crash.

We init url with given arguments regardless of parse result from `h2o_url_init()`.
I think this approach is cleaner than handling the corner case from core/proxy.c.

Test script is included. Thank you.
