### PR TITLE
[H2] close stream on both BODY_NONE or BODY_CLOSE_DELIVERED

### DIFF
--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -427,7 +427,7 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
 void h2o_http2_stream_proceed(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
 {
     if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM) {
-        if (stream->req_body.state == H2O_HTTP2_REQ_BODY_CLOSE_DELIVERED)
+        if (stream->req_body.state == H2O_HTTP2_REQ_BODY_NONE || stream->req_body.state == H2O_HTTP2_REQ_BODY_CLOSE_DELIVERED)
             h2o_http2_stream_close(conn, stream);
     } else {
         if (!stream->blocked_by_server)


### PR DESCRIPTION
After https://github.com/h2o/h2o/commit/b345dee5fb, there are streams that get stuck in:
  - `H2O_HTTP2_CONN_STATE_OPEN`
  - `H2O_HTTP2_STREAM_STATE_END_STREAM`
  - `H2O_HTTP2_REQ_BODY_NONE`

The memory is still attached to the connection, but the requests aren't disposed of as the stream finishes. So what we're seeing is the effect of long lived connections in which we accumulate requests that don't get freed.

This PR changes `h2o_http2_stream_proceed` to close the stream on both `H2O_HTTP2_REQ_BODY_CLOSE_DELIVERED` and `H2O_HTTP2_REQ_BODY_NONE`

