### PR TITLE
Fix timing errors in t/50config.t

### DIFF
--- a/t/50config.t
+++ b/t/50config.t
@@ -125,17 +125,10 @@ EOT
         subtest 'nonexist' => sub {
             local $@;
             delete local $ENV{FOO};
-            my $server;
             eval {
-                $server = $spawn->();
+                $spawn->();
             };
-            if ($@) {
-                pass("failed to start");
-            } else {
-                sleep 1;
-                my ($stderr, $stdout) = run_prog("curl --silent --dump-header /dev/stdout http://127.0.0.1:$server->{port}/");
-                is $stdout, "", "server should be down due to misconfiguration";
-            }
+            ok $@;
         };
     };
 };

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -249,6 +249,7 @@ sub spawn_h2o {
 
     # decide the port numbers
     my ($port, $tls_port) = empty_ports(2, { host => "0.0.0.0" });
+    my @all_ports = ($port, $tls_port);
 
     # setup the configuration file
     $conf = $conf->($port, $tls_port)
@@ -259,6 +260,7 @@ sub spawn_h2o {
             if $conf->{opts};
         $max_ssl_version = $conf->{max_ssl_version} || undef;
         $user = $conf->{user} if exists $conf->{user};
+        push @all_ports, $conf->{extra_ports} if exists $conf->{extra_ports};
         $conf = $conf->{conf};
     }
     $conf = <<"EOT";
@@ -276,7 +278,7 @@ listen:
 @{[$user ? "user: $user" : ""]}
 EOT
 
-    my $ret = spawn_h2o_raw($conf, [$port, $tls_port], \@opts);
+    my $ret = spawn_h2o_raw($conf, \@all_ports, \@opts);
     return {
         %$ret,
         port => $port,

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -186,16 +186,15 @@ sub spawn_server {
     if ($pid != 0) {
         print STDERR "spawning $args{argv}->[0]... ";
         if ($args{is_ready}) {
-            while (1) {
-                if ($args{is_ready}->()) {
-                    print STDERR "done\n";
-                    last;
-                }
+            for (my $i = 0; !$args{is_ready}->(); ++$i) {
                 if (waitpid($pid, WNOHANG) == $pid) {
                     die "server failed to start (got $?)\n";
                 }
+                die "server failed to boot in 10 seconds\n"
+                    if $i > 100;
                 sleep 0.1;
             }
+            print STDERR "done\n";
         }
         my $guard = make_guard(sub {
             return if $$ != $ppid;


### PR DESCRIPTION
This PR is an attempt to fix a regression in #2909, that causes occasional errors in tag/env/nonexist subtest of t/50config.t, i.e.,
```
2022-02-23T23:24:08.5063454Z   2.451822         # Subtest: nonexist
2022-02-23T23:24:08.5063714Z   2.556424 spawning /home/ci/h2o... done
2022-02-23T23:24:08.5064072Z   2.557273 [/tmp/26wzLxCoij:6] in command header.add, failed to parse the value; should be in form of `name: value`
2022-02-23T23:24:08.5064587Z   3.564353             ok 1 - server should be down due to misconfiguration
2022-02-23T23:24:08.5066054Z   3.564763 killing /home/ci/h2o...             not ok 2 - server die with signal 19968
2022-02-23T23:24:08.5066545Z   3.565127             #   Failed test 'server die with signal 19968'
2022-02-23T23:24:08.5067107Z   3.565130             #   at t/Util.pm line 212.
2022-02-23T23:24:08.5074657Z   3.565171 killed (got 19968)
2022-02-23T23:24:08.5074919Z   3.565536             1..2
2022-02-23T23:24:08.5075573Z   3.565665             # Looks like you failed 1 test of 2.
2022-02-23T23:24:08.5076066Z   3.565900         not ok 2 - nonexist
2022-02-23T23:24:08.5076422Z   3.566160         #   Failed test 'nonexist'
2022-02-23T23:24:08.5076689Z   3.566168         #   at t/50config.t line 139.
2022-02-23T23:24:08.5076937Z   3.566479         1..2
2022-02-23T23:24:08.5077184Z   3.566568         # Looks like you failed 1 test of 2.
2022-02-23T23:24:08.5077518Z   3.566964     not ok 5 - env
2022-02-23T23:24:08.5077820Z   3.567383     #   Failed test 'env'
2022-02-23T23:24:08.5078134Z   3.567386     #   at t/50config.t line 140.
2022-02-23T23:24:08.5078380Z   3.567658     1..5
2022-02-23T23:24:08.5078626Z   3.569963     # Looks like you failed 1 test of 5.
2022-02-23T23:24:08.5078950Z   3.569977 not ok 1 - tag
2022-02-23T23:24:08.5079240Z   3.569979 #   Failed test 'tag'
2022-02-23T23:24:08.5079606Z   3.569982 #   at t/50config.t line 141.
```

Since #2909 has been merged, a test failure is reported (by invoking `Test::More::fail`) when the server exits with an exit status other than 0 (success), SIGTERM, SIGKILL.

This has caused flakiness in the aforementioned subtest, as it uses a configuration file that first specifies the listen port then an erroneous line that leads to a configuration failure. The test case tries to check that the server has failed to boot. However, when `spawn_h2o` and underlying functions detect that the ports have become ready before `h2o` error-exits, the control is returned to the test-case, and then, when the guard object returned by `spawn_h2o` is discarded, test failure is reported as the exit code of the server is `EX_CONFIG`.

This PR address this problem by passing a dummy port to `spawn_h2o`, to prevent it from ever returning due to the ports becoming ready.