### PR TITLE
treat zero-length authority the same way as no host header

### DIFF
--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -134,14 +134,13 @@ h2o_hostconf_t *h2o_req_setup(h2o_req_t *req)
 
     req->processed_at = h2o_get_timestamp(ctx, &req->pool);
 
-    /* find the host context */
-    if (req->input.authority.base != NULL) {
+    /* find the host context (or use the default if authority is missing or is of zero-length) */
+    if (req->input.authority.len != 0) {
         if (req->conn->hosts[1] == NULL ||
             (hostconf = find_hostconf(req->conn->hosts, req->input.authority, req->input.scheme->default_port,
                                       &req->authority_wildcard_match)) == NULL)
             hostconf = find_default_hostconf(req->conn->hosts);
     } else {
-        /* set the authority name to the default one */
         hostconf = find_default_hostconf(req->conn->hosts);
         req->input.authority = hostconf->authority.hostport;
     }

--- a/t/50reverse-proxy-null-host-header.t
+++ b/t/50reverse-proxy-null-host-header.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port empty_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $upstream_port = empty_port();
+
+my $upstream = spawn_server(
+    argv     => [ qw(plackup -s Starlet --max-keepalive-reqs 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+    is_ready =>  sub {
+        check_port($upstream_port);
+    },
+);
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+        proxy.preserve-host: ON
+EOT
+
+my $url = "http://127.0.0.1:$server->{port}/index.txt";
+my $resp = `curl -s --http1.1 --dump-header /dev/stdout $url -H "Host;"`;
+like $resp, qr{HTTP/[^ ]+ 200\s}m;
+
+done_testing();
+


### PR DESCRIPTION
As pointed out by @cwyang in #2955, reverse proxy handler crashes when receiving a request carrying a zero-length authority.

This PR addresses the problem in a different way than #2955. We already have the path to handle the case where the Host header field is missing - in which case we pretend as if we received the "default" hostname. This PR adjusts the condition check so that the same path would be taken when the given authority is zero-length.

Closes #2955.