### PR TITLE
[test] [bug-fix] run_openssl_client() should ignore child's SIGPIPE on STDIN instead of EOF test

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -847,19 +847,20 @@ sub run_openssl_client {
     sleep $timeout;
     $chld_in->autoflush(1);
 
-    my $sig_pipe = $SIG{PIPE};
-    $SIG{PIPE} = 'IGNORE';
-    if ($request_default) {
-        print $chld_in <<"EOT";
+    {
+        local $SIG{PIPE} = 'IGNORE';
+
+        if ($request_default) {
+            print $chld_in <<"EOT";
 GET $path HTTP/1.1\r
 Host: $san:$port\r
 Connection: close\r
 \r
 EOT
-    } elsif (defined $request && $request ne '') {
-        print $chld_in "$request";
+        } elsif (defined $request && $request ne '') {
+            print $chld_in "$request";
+        }
     }
-    $SIG{PIPE} = $sig_pipe;
 
     while ($timeout > 0.0) {
         my $cpid_wait = waitpid($cpid, POSIX::WNOHANG);

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -847,16 +847,19 @@ sub run_openssl_client {
     sleep $timeout;
     $chld_in->autoflush(1);
 
+    my $sig_pipe = $SIG{PIPE};
+    $SIG{PIPE} = 'IGNORE';
     if ($request_default) {
-        $chld_in->eof() || print $chld_in <<"EOT";
+        print $chld_in <<"EOT";
 GET $path HTTP/1.1\r
 Host: $san:$port\r
 Connection: close\r
 \r
 EOT
     } elsif (defined $request && $request ne '') {
-        $chld_in->eof() || print $chld_in "$request";
+        print $chld_in "$request";
     }
+    $SIG{PIPE} = $sig_pipe;
 
     while ($timeout > 0.0) {
         my $cpid_wait = waitpid($cpid, POSIX::WNOHANG);


### PR DESCRIPTION
This amends https://github.com/h2o/h2o/pull/2947.

I discovered a minor issue that `eof()` could return `0` even when writing to the file handle would result in a `SIGPIPE` signal, and then the `print` fails and the script exits.  The more correct way to deal with the child's `STDIN` file is to handle the `SIGPIPE` signal by ignoring it while writing.
