### PR TITLE
[http3] safer handling of CMSG (in terms of type aliasing)

### DIFF
--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -86,32 +86,41 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
             0
 #endif
         ];
-    } cmsgbuf = {.buf = {}};
-    struct cmsghdr *cmsg = &cmsgbuf.hdr;
+    } cmsgbuf;
+    struct msghdr mess = {
+        .msg_name = &dest->sa,
+        .msg_namelen = quicly_get_socklen(&dest->sa),
+        .msg_control = cmsgbuf.buf,
+        .msg_controllen = sizeof(cmsgbuf.buf),
+    };
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&mess);
+    int ret;
+
+#define PUSH_CMSG(level, type, value)                                                                                              \
+    do {                                                                                                                           \
+        cmsg->cmsg_level = (level);                                                                                                \
+        cmsg->cmsg_type = (type);                                                                                                  \
+        cmsg->cmsg_len = CMSG_LEN(sizeof(value));                                                                                  \
+        memcpy(CMSG_DATA(cmsg), &value, sizeof(value));                                                                            \
+        cmsg = CMSG_NXTHDR(&mess, cmsg);                                                                                           \
+    } while (0)
 
     /* first CMSG is the source address */
     if (src->sa.sa_family != AF_UNSPEC) {
-        size_t cmsg_bodylen = 0;
         switch (src->sa.sa_family) {
         case AF_INET: {
 #if defined(IP_PKTINFO)
             if (*ctx->sock.port != src->sin.sin_port)
                 return 0;
-            cmsg->cmsg_level = IPPROTO_IP;
-            cmsg->cmsg_type = IP_PKTINFO;
-            cmsg_bodylen = sizeof(struct in_pktinfo);
-            memcpy(&((struct in_pktinfo *)CMSG_DATA(cmsg))->ipi_spec_dst, &src->sin.sin_addr, sizeof(struct in_addr));
+            struct in_pktinfo info = {.ipi_spec_dst = src->sin.sin_addr};
+            PUSH_CMSG(IPPROTO_IP, IP_PKTINFO, info);
 #elif defined(IP_SENDSRCADDR)
             if (*ctx->sock.port != src->sin.sin_port)
                 return 0;
             struct sockaddr_in *fdaddr = (struct sockaddr_in *)&ctx->sock.addr;
             assert(fdaddr->sin_family == AF_INET);
-            if (fdaddr->sin_addr.s_addr == INADDR_ANY) {
-                cmsg->cmsg_level = IPPROTO_IP;
-                cmsg->cmsg_type = IP_SENDSRCADDR;
-                cmsg_bodylen = sizeof(struct in_addr);
-                memcpy(CMSG_DATA(cmsg), &src->sin.sin_addr, sizeof(struct in_addr));
-            }
+            if (fdaddr->sin_addr.s_addr == INADDR_ANY)
+                PUSH_CMSG(IPPROTO_IP, IP_SENDSRCADDR, src->sin.sin_addr);
 #else
             h2o_fatal("IP_PKTINFO not available");
 #endif
@@ -120,10 +129,8 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
 #ifdef IPV6_PKTINFO
             if (*ctx->sock.port != src->sin6.sin6_port)
                 return 0;
-            cmsg->cmsg_level = IPPROTO_IPV6;
-            cmsg->cmsg_type = IPV6_PKTINFO;
-            cmsg_bodylen = sizeof(struct in6_pktinfo);
-            memcpy(&((struct in6_pktinfo *)CMSG_DATA(cmsg))->ipi6_addr, &src->sin6.sin6_addr, sizeof(struct in6_addr));
+            struct in6_pktinfo info = {.ipi6_addr = src->sin6.sin6_addr};
+            PUSH_CMSG(IPPROTO_IPV6, IPV6_PKTINFO, info);
 #else
             h2o_fatal("IPV6_PKTINFO not available");
 #endif
@@ -132,8 +139,6 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
             h2o_fatal("unexpected address family");
             break;
         }
-        cmsg->cmsg_len = (socklen_t)CMSG_LEN(cmsg_bodylen);
-        cmsg = (struct cmsghdr *)((char *)cmsg + CMSG_SPACE(cmsg_bodylen));
     }
 
     /* next CMSG is UDP_SEGMENT size (for GSO) */
@@ -143,26 +148,15 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
         for (size_t i = 1; i < num_datagrams - 1; ++i)
             assert(datagrams[i].iov_len == datagrams[0].iov_len);
         uint16_t segsize = (uint16_t)datagrams[0].iov_len;
-        cmsg->cmsg_level = SOL_UDP;
-        cmsg->cmsg_type = UDP_SEGMENT;
-        cmsg->cmsg_len = CMSG_LEN(sizeof(segsize));
-        memcpy(CMSG_DATA(cmsg), &segsize, sizeof(segsize));
-        cmsg = (struct cmsghdr *)((char *)cmsg + CMSG_SPACE(sizeof(segsize)));
+        PUSH_CMSG(SOL_UDP, UDP_SEGMENT, segsize);
         using_gso = 1;
     }
 #endif
 
-    /* send datagrams */
-    struct msghdr mess = {
-        .msg_name = &dest->sa,
-        .msg_namelen = quicly_get_socklen(&dest->sa),
-    };
-    if (cmsg != &cmsgbuf.hdr) {
-        mess.msg_control = &cmsgbuf.buf;
-        mess.msg_controllen = (socklen_t)((char *)cmsg - cmsgbuf.buf);
-    }
-    int ret;
+    /* commit CMSG length */
+    mess.msg_controllen = (socklen_t)((char *)cmsg - (char *)cmsgbuf.buf);
 
+    /* send datagrams */
     if (using_gso) {
         mess.msg_iov = datagrams;
         mess.msg_iovlen = (int)num_datagrams;
@@ -198,6 +192,8 @@ SendmsgError:
     h2o_error_reporter_record_error(ctx->loop, &track_sendmsg, 60000, errno);
 
     return 1;
+
+#undef PUSH_CMSG
 }
 
 static inline const h2o_http3_conn_callbacks_t *get_callbacks(h2o_http3_conn_t *conn)

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -84,7 +84,7 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
 #endif
             + CMSG_SPACE(1) /* this sentry makes sure that CMSG_NXTHDR succeeds; also for calculating msg_controllen at the end */
         ];
-    } cmsgbuf;
+    } cmsgbuf = {};
     struct msghdr mess = {
         .msg_name = &dest->sa,
         .msg_namelen = quicly_get_socklen(&dest->sa),

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -82,9 +82,9 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
 #ifdef UDP_SEGMENT
             + CMSG_SPACE(sizeof(uint16_t))
 #endif
-            + CMSG_SPACE(1) /* this sentry makes sure that CMSG_NXTHDR succeeds; also for calculating msg_controllen at the end */
+            + CMSG_SPACE(1) /* sentry */
         ];
-    } cmsgbuf = {};
+    } cmsgbuf = {.buf = {} /* zero-cleared so that CMSG_NXTHDR can be used for locating the *next* cmsghdr */ };
     struct msghdr mess = {
         .msg_name = &dest->sa,
         .msg_namelen = quicly_get_socklen(&dest->sa),

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -772,7 +772,8 @@ void h2o_quic_read_socket(h2o_quic_ctx_t *ctx, h2o_socket_t *sock)
 #ifdef IP_PKTINFO
                 if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_PKTINFO) {
                     dgrams[dgram_index].destaddr.sin.sin_family = AF_INET;
-                    dgrams[dgram_index].destaddr.sin.sin_addr = ((struct in_pktinfo *)CMSG_DATA(cmsg))->ipi_addr;
+                    memcpy(&dgrams[dgram_index].destaddr.sin.sin_addr, CMSG_DATA(cmsg) + offsetof(struct in_pktinfo, ipi_addr),
+                           sizeof(struct in_addr));
                     dgrams[dgram_index].destaddr.sin.sin_port = *ctx->sock.port;
                     goto DestAddrFound;
                 }
@@ -780,7 +781,7 @@ void h2o_quic_read_socket(h2o_quic_ctx_t *ctx, h2o_socket_t *sock)
 #ifdef IP_RECVDSTADDR
                 if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_RECVDSTADDR) {
                     dgrams[dgram_index].destaddr.sin.sin_family = AF_INET;
-                    dgrams[dgram_index].destaddr.sin.sin_addr = *(struct in_addr *)CMSG_DATA(cmsg);
+                    memcpy(&dgrams[dgram_index].destaddr.sin.sin_addr, CMSG_DATA(cmsg), sizeof(struct in_addr));
                     dgrams[dgram_index].destaddr.sin.sin_port = *ctx->sock.port;
                     goto DestAddrFound;
                 }
@@ -788,7 +789,8 @@ void h2o_quic_read_socket(h2o_quic_ctx_t *ctx, h2o_socket_t *sock)
 #ifdef IPV6_PKTINFO
                 if (cmsg->cmsg_level == IPPROTO_IPV6 && cmsg->cmsg_type == IPV6_PKTINFO) {
                     dgrams[dgram_index].destaddr.sin6.sin6_family = AF_INET6;
-                    dgrams[dgram_index].destaddr.sin6.sin6_addr = ((struct in6_pktinfo *)CMSG_DATA(cmsg))->ipi6_addr;
+                    memcpy(&dgrams[dgram_index].destaddr.sin6.sin6_addr, CMSG_DATA(cmsg) + offsetof(struct in6_pktinfo, ipi6_addr),
+                           sizeof(struct in6_addr));
                     dgrams[dgram_index].destaddr.sin6.sin6_port = *ctx->sock.port;
                     goto DestAddrFound;
                 }

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -79,12 +79,10 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
 #else
             CMSG_SPACE(1)
 #endif
-            +
 #ifdef UDP_SEGMENT
-            CMSG_SPACE(sizeof(uint16_t))
-#else
-            0
+            + CMSG_SPACE(sizeof(uint16_t))
 #endif
+            + CMSG_SPACE(1) /* this sentry makes sure that CMSG_NXTHDR succeeds; also for calculating msg_controllen at the end */
         ];
     } cmsgbuf;
     struct msghdr mess = {
@@ -93,16 +91,16 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
         .msg_control = cmsgbuf.buf,
         .msg_controllen = sizeof(cmsgbuf.buf),
     };
-    struct cmsghdr *cmsg = NULL;
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&mess);
     int ret;
 
 #define PUSH_CMSG(level, type, value)                                                                                              \
     do {                                                                                                                           \
-        cmsg = cmsg == NULL ? CMSG_FIRSTHDR(&mess) : CMSG_NXTHDR(&mess, cmsg);                                                     \
         cmsg->cmsg_level = (level);                                                                                                \
         cmsg->cmsg_type = (type);                                                                                                  \
         cmsg->cmsg_len = CMSG_LEN(sizeof(value));                                                                                  \
         memcpy(CMSG_DATA(cmsg), &value, sizeof(value));                                                                            \
+        cmsg = CMSG_NXTHDR(&mess, cmsg);                                                                                           \
     } while (0)
 
     /* first CMSG is the source address */
@@ -154,12 +152,8 @@ int h2o_quic_send_datagrams(h2o_quic_ctx_t *ctx, quicly_address_t *dest, quicly_
 #endif
 
     /* commit CMSG length */
-    if (cmsg != NULL) {
-        mess.msg_controllen = (socklen_t)((char *)cmsg - (char *)cmsgbuf.buf) + cmsg->cmsg_len;
-    } else {
+    if ((mess.msg_controllen = (socklen_t)((char *)cmsg - (char *)cmsgbuf.buf)) == 0)
         mess.msg_control = NULL;
-        mess.msg_controllen = 0;
-    }
 
     /* send datagrams */
     if (using_gso) {


### PR DESCRIPTION
When gcc 5.4.0 that comes with ubuntu16.04 is being used, we see type aliasing warnings. We do not see them when gcc 9.4.0 (ubuntu20.04) is used. Also, it is somewhat questionable if all the warnings are legit.

However, the send-side is at least hard to understand. Also, there is theoretical concern that copies involved might generate bus error due to unaligned access; there is no guarantee that `CMSG_DATA()` returns addresses that we can read and write using `=` (assignment operators) for all the types that we use.

Closes #2963.