### PR TITLE
Sort paths in the descending order of length at libh2o-level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/common/url.c
     t/00unit/lib/common/timerwheel.c
     t/00unit/lib/common/absprio.c
+    t/00unit/lib/core/config.c
     t/00unit/lib/core/headers.c
     t/00unit/lib/core/proxy.c
     t/00unit/lib/core/util.c

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		080B3CC327E1AF6C004AC8E6 /* config.c in Sources */ = {isa = PBXBuildFile; fileRef = 080B3CC227E1AF6C004AC8E6 /* config.c */; };
 		080D35EB1D5E060D0029B7E5 /* http2_debug_state.c in Sources */ = {isa = PBXBuildFile; fileRef = 080D35EA1D5E060D0029B7E5 /* http2_debug_state.c */; };
 		0812174E1E07B89600712F36 /* redis.c in Sources */ = {isa = PBXBuildFile; fileRef = 0812174C1E07B89600712F36 /* redis.c */; };
 		0812AB201D7FCFEB00004F23 /* async.c in Sources */ = {isa = PBXBuildFile; fileRef = 0812AB1C1D7FCFEB00004F23 /* async.c */; };
@@ -672,6 +673,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		080B3CC227E1AF6C004AC8E6 /* config.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = config.c; sourceTree = "<group>"; };
 		080D35EA1D5E060D0029B7E5 /* http2_debug_state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http2_debug_state.c; sourceTree = "<group>"; };
 		0812174C1E07B89600712F36 /* redis.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = redis.c; sourceTree = "<group>"; };
 		0812AB1C1D7FCFEB00004F23 /* async.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = async.c; sourceTree = "<group>"; };
@@ -1625,6 +1627,7 @@
 		104B9A4E1A5FAA91009EEE64 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				080B3CC227E1AF6C004AC8E6 /* config.c */,
 				104B9A471A5F9472009EEE64 /* headers.c */,
 				105534C81A3BB41C00627ECB /* proxy.c */,
 				1070E1621B4508B0001CCAFA /* util.c */,
@@ -3424,6 +3427,7 @@
 				105534C71A3BB29100627ECB /* string.c in Sources */,
 				E9316EE824417EAA00C9C127 /* decode.c in Sources */,
 				E98403CD2485172E00E3A6B1 /* remote_cid.c in Sources */,
+				080B3CC327E1AF6C004AC8E6 /* config.c in Sources */,
 				E987E5ED1FD8C04D00DE4346 /* backward_references.c in Sources */,
 				107D4D4B1B5880BC004A9B21 /* scanner.c in Sources */,
 				1079244E19A3266700C52AD6 /* request.c in Sources */,

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -221,8 +221,24 @@ h2o_pathconf_t *h2o_config_register_path(h2o_hostconf_t *hostconf, const char *p
     h2o_pathconf_t *pathconf = h2o_mem_alloc(sizeof(*pathconf));
     h2o_config_init_pathconf(pathconf, hostconf->global, path, hostconf->mimemap);
 
+    /* Find the slot to insert the new pathconf. Sort order is descending by the path length so that longer pathconfs overriding
+     * subdirectories of shorter ones would work, regardless of the regisration order. Pathconfs sharing the same length are sorted
+     * in the ascending order of memcmp / strcmp (as we have always done in the h2o standalone server). */
+    size_t slot;
+    for (slot = 0; slot < hostconf->paths.size; ++slot) {
+        if (pathconf->path.len > hostconf->paths.entries[slot]->path.len)
+            break;
+        if (pathconf->path.len == hostconf->paths.entries[slot]->path.len &&
+            memcmp(pathconf->path.base, hostconf->paths.entries[slot]->path.base, pathconf->path.len) < 0)
+            break;
+    }
+
     h2o_vector_reserve(NULL, &hostconf->paths, hostconf->paths.size + 1);
-    hostconf->paths.entries[hostconf->paths.size++] = pathconf;
+    if (slot < hostconf->paths.size)
+        memmove(hostconf->paths.entries + slot + 1, hostconf->paths.entries + slot,
+                (hostconf->paths.size - slot) * sizeof(hostconf->paths.entries[0]));
+    hostconf->paths.entries[slot] = pathconf;
+    ++hostconf->paths.size;
 
     return pathconf;
 }

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -241,17 +241,6 @@ Exit:
     return ret;
 }
 
-static int sort_from_longer_paths(const yoml_mapping_element_t *x, const yoml_mapping_element_t *y)
-{
-    size_t xlen = strlen(x->key->data.scalar), ylen = strlen(y->key->data.scalar);
-    if (xlen < ylen)
-        return 1;
-    else if (xlen > ylen)
-        return -1;
-    /* apply strcmp for stable sort */
-    return strcmp(x->key->data.scalar, y->key->data.scalar);
-}
-
 static yoml_t *convert_path_config_node(h2o_configurator_command_t *cmd, yoml_t *node)
 {
     size_t i, j;
@@ -329,8 +318,6 @@ static int on_config_paths(h2o_configurator_command_t *cmd, h2o_configurator_con
             return -1;
         }
     }
-    qsort(node->data.mapping.elements, node->data.mapping.size, sizeof(node->data.mapping.elements[0]),
-          (int (*)(const void *, const void *))sort_from_longer_paths);
 
     for (i = 0; i != node->data.mapping.size; ++i) {
         yoml_t *key = node->data.mapping.elements[i].key, *value;

--- a/t/00unit/lib/core/config.c
+++ b/t/00unit/lib/core/config.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Fastly, Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <string.h>
+#include "../../test.h"
+
+static void test_register_path(void)
+{
+    h2o_globalconf_t global;
+    h2o_config_init(&global);
+    h2o_hostconf_t *host = h2o_config_register_host(&global, h2o_iovec_init(H2O_STRLIT("www.example.com")), 8080);
+
+    h2o_config_register_path(host, "/", 0);
+    h2o_config_register_path(host, "/a", 0);
+    h2o_config_register_path(host, "/c", 0);
+    h2o_config_register_path(host, "/a/1", 0);
+    h2o_config_register_path(host, "/b", 0);
+
+#define CHECK(index, literal)                                                                                                      \
+    do {                                                                                                                           \
+        h2o_pathconf_t *p = host->paths.entries[index];                                                                            \
+        ok(h2o_memis(p->path.base, p->path.len, H2O_STRLIT(literal)));                                                             \
+    } while (0)
+    CHECK(0, "/a/1");
+    CHECK(1, "/a");
+    CHECK(2, "/b");
+    CHECK(3, "/c");
+    CHECK(4, "/");
+#undef CHECK
+}
+
+void test_lib__core_config_c(void)
+{
+    subtest("register-path", test_register_path);
+}

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -168,6 +168,7 @@ int main(int argc, char **argv)
         subtest("lib/common/time.c", test_lib__common__time_c);
         subtest("lib/common/timerwheel.c", test_lib__common__timerwheel_c);
         subtest("lib/common/absprio.c", test_lib__common__absprio_c);
+        subtest("lib/core/config.c", test_lib__core_config_c);
         subtest("lib/core/headers.c", test_lib__core__headers_c);
         subtest("lib/core/proxy.c", test_lib__core__proxy_c);
         subtest("lib/core/util.c", test_lib__core__util_c);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -62,6 +62,7 @@ void test_lib__common__time_c(void);
 void test_lib__common__timerwheel_c(void);
 void test_lib__common__url_c(void);
 void test_lib__common__absprio_c(void);
+void test_lib__core_config_c(void);
 void test_lib__core__headers_c(void);
 void test_lib__core__proxy_c(void);
 void test_lib__core__util_c(void);


### PR DESCRIPTION
We've always done this when the configurator is being used, but not when `h2o_config_register_path` is being called. I tend to believe that it is a bug to _not_ do that inside `h2o_config_register_path`, therefore changing the logic there.

Closes #2956.