### PR TITLE
[http2] fix state inconsistency when a request is replayed internally

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1322,6 +1322,8 @@ static void on_read(h2o_socket_t *sock, const char *err)
                 h2o_http2_stream_t *stream =
                     H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _link, conn->early_data.blocked_streams.next);
                 h2o_linklist_unlink(&stream->_link);
+                if (!stream->blocked_by_server)
+                    h2o_http2_stream_set_blocked_by_server(conn, stream, 1);
                 h2o_replay_request(&stream->req);
             }
         }

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -335,14 +335,15 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *bufs,
     assert(h2o_send_state_is_in_progress(stream->send_state));
     assert(stream->_data.size == 0);
 
+    if (stream->blocked_by_server)
+        h2o_http2_stream_set_blocked_by_server(conn, stream, 0);
+
     if (stream->req.res.status == 425 && stream->req.reprocess_if_too_early) {
         assert(stream->state <= H2O_HTTP2_STREAM_STATE_SEND_HEADERS);
         h2o_http2_conn_register_for_replay(conn, stream);
         return;
     }
 
-    if (stream->blocked_by_server)
-        h2o_http2_stream_set_blocked_by_server(conn, stream, 0);
 
     stream->send_state = state;
 

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -337,6 +337,7 @@ void finalostream_send(h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *bufs,
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _ostr_final, self);
     h2o_http2_conn_t *conn = (h2o_http2_conn_t *)req->conn;
 
+    assert(h2o_send_state_is_in_progress(stream->send_state));
     assert(stream->_data.size == 0);
 
     if (stream->blocked_by_server)


### PR DESCRIPTION
Our HTTP/2 implementation is capable of internally replaying an HTTP request that is received too early (i.e., carried by TLS/1.3 early data).

When the HTTP/2 implementation takes that path, the stream state should be kept unmodified, as the request is "replayed" and a new HTTP response would be delivered. However, as being detected by the assertion added in #2953, we seem to be making unnecessary changes.

This PR address the issue, subsuming #2953.