### PR TITLE
[http3] Delay disposal of `h2o_req_t` even when `do_send` is called for the last time

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1319,7 +1319,7 @@ static void shutdown_by_generator(struct st_h2o_http3_server_stream_t *stream)
     if (stream->sendbuf.vecs.size == 0) {
         if (quicly_stream_has_receive_side(0, stream->quic->stream_id))
             quicly_request_stop(stream->quic, H2O_HTTP3_ERROR_EARLY_RESPONSE);
-        set_state(stream, H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT, 0);
+        set_state(stream, H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT, 1);
     }
 }
 


### PR DESCRIPTION
This is likely a regression in #2568, specifically cdc55bd.

`shutdown_by_generator` is called from `do_send` when the given send_state indicates that it is the last invocation. Prior to #2568, in `shutdown_by_generator`, we have been using `1` as the last argument (`in_generator`) of `set_state`. But in the aforementioned commit, value of the flag was changed to zero.

Now, `h2o_req_t` is disposed before `do_send` returns, and therefore, if the generator tries to use `h2o_req_t` or memory allocated from the memory pool of `h2o_req_t` _after_ calling `h2o_send`, that can to lead to use-after-free. Though I'm not sure if there's a path that would actually lead to such failure.

This PR addresses the concern by changing the value of the flag back to 1.