### PR TITLE
socketpool: unix socket optimization

### DIFF
--- a/lib/common/socketpool.c
+++ b/lib/common/socketpool.c
@@ -417,6 +417,13 @@ static void start_connect(h2o_socketpool_connect_request_t *req, struct sockaddr
     req->sock->data = req;
     req->sock->on_close.cb = on_close;
     req->sock->on_close.data = close_data;
+#if defined(__linux__)
+    /* This is a unix socket, it will be ready to be written to
+     * immediately, or fail immediately: either with ECONNREFUSED if the
+     * socket isn't present or EAGAIN if the listen queue is full */
+    if (addr->sa_family == AF_UNIX)
+        on_connect(req->sock, NULL);
+#endif
 }
 
 static void on_getaddr(h2o_hostinfo_getaddr_req_t *getaddr_req, const char *errstr, struct addrinfo *res, void *_req)


### PR DESCRIPTION
In practice, on linux, unix sockets are either immediately directly
connected or fail immediately [1]. Use this as a small optimization to avoid
a round trip to epoll.

This shouldn't make the caller more complex because it should already
have to deal with synchronous failures.

[1] https://github.com/torvalds/linux/blob/ce4c854ee8681bc66c1c369518b6594e93b11ee5/net/unix/af_unix.c#L1468-L1486