### PR TITLE
[throttle-response] fix crash when either generator or client is slow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,7 @@ SET(UNIT_TEST_SOURCE_FILES
     t/00unit/lib/handler/headers.c
     t/00unit/lib/handler/mimemap.c
     t/00unit/lib/handler/redirect.c
+    t/00unit/lib/handler/throttle_resp.c
     t/00unit/lib/http2/cache_digests.c
     t/00unit/lib/http2/casper.c
     t/00unit/lib/http2/hpack.c
@@ -542,6 +543,7 @@ LIST(REMOVE_ITEM UNIT_TEST_SOURCE_FILES
     lib/handler/headers.c
     lib/handler/mimemap.c
     lib/handler/redirect.c
+    lib/handler/throttle_resp.c
     lib/http2/cache_digests.c
     lib/http2/casper.c
     lib/http2/hpack.c

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		08CEA9DC267B0E3B00B4BB6B /* self_trace.c in Sources */ = {isa = PBXBuildFile; fileRef = 08CEA9DA267B0E3B00B4BB6B /* self_trace.c */; };
 		08CEA9DD267B0E3B00B4BB6B /* self_trace.c in Sources */ = {isa = PBXBuildFile; fileRef = 08CEA9DA267B0E3B00B4BB6B /* self_trace.c */; };
 		08E9CC4E1E41F6660049DD26 /* embedded.c.h in Headers */ = {isa = PBXBuildFile; fileRef = 08E9CC4D1E41F6660049DD26 /* embedded.c.h */; };
+		08EFC4E027FE9F96004C532C /* throttle_resp.c in Sources */ = {isa = PBXBuildFile; fileRef = 08EFC4DF27FE9F96004C532C /* throttle_resp.c */; };
 		08F320DD1E7A9CA60038FA5A /* redis.c in Sources */ = {isa = PBXBuildFile; fileRef = 08790DE31D8276EA00A04BC1 /* redis.c */; };
 		08F320DE1E7A9CB80038FA5A /* async.c in Sources */ = {isa = PBXBuildFile; fileRef = 0812AB1C1D7FCFEB00004F23 /* async.c */; settings = {COMPILER_FLAGS = "-Wno-conversion"; }; };
 		08F320DF1E7A9CBB0038FA5A /* hiredis.c in Sources */ = {isa = PBXBuildFile; fileRef = 0812AB1E1D7FCFEB00004F23 /* hiredis.c */; settings = {COMPILER_FLAGS = "-Wno-conversion"; }; };
@@ -732,6 +733,7 @@
 		08CEA9D6267AF0EB00B4BB6B /* self_trace.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = self_trace.c; sourceTree = "<group>"; };
 		08CEA9DA267B0E3B00B4BB6B /* self_trace.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = self_trace.c; sourceTree = "<group>"; };
 		08E9CC4D1E41F6660049DD26 /* embedded.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedded.c.h; sourceTree = "<group>"; };
+		08EFC4DF27FE9F96004C532C /* throttle_resp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = throttle_resp.c; sourceTree = "<group>"; };
 		100A550C1C22857B00C4E3E0 /* 50mruby-htpasswd.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50mruby-htpasswd.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		100A550E1C2BB15100C4E3E0 /* http_request.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http_request.c; sourceTree = "<group>"; };
 		100A55131C2E5FAC00C4E3E0 /* 50mruby-http-request.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50mruby-http-request.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -1642,6 +1644,7 @@
 				105534C21A3B917000627ECB /* mimemap.c */,
 				1058C87C1AA41789008D6180 /* headers.c */,
 				10F9F2641AF4795D0056F26B /* redirect.c */,
+				08EFC4DF27FE9F96004C532C /* throttle_resp.c */,
 			);
 			path = handler;
 			sourceTree = "<group>";
@@ -3480,6 +3483,7 @@
 				E96A24D323E6747A00CA970A /* absprio.c in Sources */,
 				7D937300202AC717005FE6AB /* server_timing.c in Sources */,
 				E9DF012924E4CDF60002EEC7 /* cc-cubic.c in Sources */,
+				08EFC4E027FE9F96004C532C /* throttle_resp.c in Sources */,
 				0829879726E1F3710053638F /* rate.c in Sources */,
 				107D4D4C1B5880BC004A9B21 /* writer.c in Sources */,
 				E987E5EC1FD8C04D00DE4346 /* backward_references_hq.c in Sources */,

--- a/lib/handler/throttle_resp.c
+++ b/lib/handler/throttle_resp.c
@@ -22,73 +22,79 @@
 #include <stdlib.h>
 #include "h2o.h"
 
-#ifndef HUNDRED_MS
-#define HUNDRED_MS 100
-#endif
-
-#ifndef ONE_SECOND
-#define ONE_SECOND 1000
-#endif
-
 typedef struct st_throttle_resp_t {
     h2o_ostream_t super;
     h2o_timer_t timeout_entry;
-    int64_t tokens;
-    size_t token_inc;
+    struct {
+        uint64_t at;
+        ssize_t bytes_left;
+    } window;
     h2o_req_t *req;
+    size_t bytes_per_sec;
     struct {
         H2O_VECTOR(h2o_sendvec_t) bufs;
         h2o_send_state_t stream_state;
     } state;
 } throttle_resp_t;
 
-static void real_send(throttle_resp_t *self)
+/**
+ * Given current deficit (`bytes_left` which would be negative) and bytes_per_sec, returns when the deficit would become
+ * non-negative.
+ */
+static uint64_t calc_delay(ssize_t bytes_left, size_t bytes_per_sec)
 {
-    /* a really simple token bucket implementation */
-    assert(self->tokens > 0);
-    size_t i, token_consume;
-
-    token_consume = 0;
-
-    for (i = 0; i < self->state.bufs.size; i++) {
-        token_consume += self->state.bufs.entries[i].len;
-    }
-
-    self->tokens -= token_consume;
-
-    h2o_ostream_send_next(&self->super, self->req, self->state.bufs.entries, self->state.bufs.size, self->state.stream_state);
-    if (!h2o_send_state_is_in_progress(self->state.stream_state))
-        h2o_timer_unlink(&self->timeout_entry);
+    return (-bytes_left * (uint64_t)1000 + bytes_per_sec - 1) / bytes_per_sec;
 }
 
-static void add_token(h2o_timer_t *entry)
+static void real_send(throttle_resp_t *self)
+{
+    uint64_t now = h2o_now(self->req->conn->ctx->loop);
+
+    /* if time has changed since previous invocation, update window */
+    if (self->window.at < now) {
+        /* burst rate (after upstream remains silent) is limited to 1-second worth of data */
+        uint64_t addition = (self->bytes_per_sec * (now - self->window.at)) / 1000;
+        if (addition > self->bytes_per_sec)
+            addition = self->bytes_per_sec;
+        self->window.bytes_left += addition;
+        self->window.at = now;
+    }
+
+    /* schedule the timer for delayed invocation, if window is negative at this moment */
+    if (self->window.bytes_left < 0) {
+        uint64_t delay = calc_delay(self->window.bytes_left, self->bytes_per_sec);
+        assert(delay > 0);
+        h2o_timer_link(self->req->conn->ctx->loop, delay, &self->timeout_entry);
+        return;
+    }
+
+    /* adjust window and send */
+    for (size_t i = 0; i < self->state.bufs.size; i++)
+        self->window.bytes_left -= self->state.bufs.entries[i].len;
+    h2o_ostream_send_next(&self->super, self->req, self->state.bufs.entries, self->state.bufs.size, self->state.stream_state);
+}
+
+static void on_timer(h2o_timer_t *entry)
 {
     throttle_resp_t *self = H2O_STRUCT_FROM_MEMBER(throttle_resp_t, timeout_entry, entry);
-
-    h2o_timer_link(self->req->conn->ctx->loop, 100, &self->timeout_entry);
-    self->tokens += self->token_inc;
-
-    if (self->tokens > 0)
-        real_send(self);
+    real_send(self);
 }
 
 static void on_send(h2o_ostream_t *_self, h2o_req_t *req, h2o_sendvec_t *inbufs, size_t inbufcnt, h2o_send_state_t state)
 {
     throttle_resp_t *self = (void *)_self;
-    size_t i;
 
-    /* I don't know if this is a proper way. */
+    assert(!h2o_timer_is_linked(&self->timeout_entry));
+
+    /* save state */
     h2o_vector_reserve(&req->pool, &self->state.bufs, inbufcnt);
-    /* start to save state */
-    for (i = 0; i < inbufcnt; ++i) {
+    for (size_t i = 0; i < inbufcnt; ++i) {
         self->state.bufs.entries[i] = inbufs[i];
     }
     self->state.bufs.size = inbufcnt;
     self->state.stream_state = state;
 
-    /* if there's token, we try to send */
-    if (self->tokens > 0)
-        real_send(self);
+    real_send(self);
 }
 
 static void on_stop(h2o_ostream_t *_self, h2o_req_t *req)
@@ -101,47 +107,45 @@ static void on_stop(h2o_ostream_t *_self, h2o_req_t *req)
 static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t **slot)
 {
     throttle_resp_t *throttle;
-    h2o_iovec_t traffic_header_value;
-    size_t traffic_limit;
+    size_t bytes_per_sec;
 
+    /* only handle 200 OK with content */
     if (req->res.status != 200)
         goto Next;
     if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("HEAD")))
         goto Next;
 
-    ssize_t xt_index;
-    if ((xt_index = h2o_find_header(&req->res.headers, H2O_TOKEN_X_TRAFFIC, -1)) == -1)
-        goto Next;
-
-    traffic_header_value = req->res.headers.entries[xt_index].value;
-    char *buf = traffic_header_value.base;
-
-    if (H2O_UNLIKELY((traffic_limit = h2o_strtosizefwd(&buf, traffic_header_value.len)) == SIZE_MAX))
-        goto Next;
-
-    throttle = (void *)h2o_add_ostream(req, H2O_ALIGNOF(*throttle), sizeof(*throttle), slot);
-
-    /* calculate the token increment per 100ms */
-    throttle->token_inc = traffic_limit * HUNDRED_MS / ONE_SECOND;
-    if (req->preferred_chunk_size > throttle->token_inc) {
-        req->preferred_chunk_size = throttle->token_inc;
-        if (req->preferred_chunk_size < 4096)
-            req->preferred_chunk_size = 4096;
+    { /* obtain the rate from X-Traffic header field and delete the header field, or skip */
+        ssize_t xt_index;
+        if ((xt_index = h2o_find_header(&req->res.headers, H2O_TOKEN_X_TRAFFIC, -1)) == -1)
+            goto Next;
+        char *buf = req->res.headers.entries[xt_index].value.base;
+        if (H2O_UNLIKELY((bytes_per_sec = h2o_strtosizefwd(&buf, req->res.headers.entries[xt_index].value.len)) == SIZE_MAX))
+            goto Next;
+        h2o_delete_header(&req->res.headers, xt_index);
     }
 
-    h2o_delete_header(&req->res.headers, xt_index);
-
+    /* instantiate the ostream filter */
+    throttle = (void *)h2o_add_ostream(req, H2O_ALIGNOF(*throttle), sizeof(*throttle), slot);
     throttle->super.do_send = on_send;
     throttle->super.stop = on_stop;
+    h2o_timer_init(&throttle->timeout_entry, on_timer);
+    throttle->window.at = h2o_now(req->conn->ctx->loop);
+    throttle->window.bytes_left = 0;
     throttle->req = req;
+    throttle->bytes_per_sec = bytes_per_sec;
     memset(&throttle->state.bufs, 0, sizeof(throttle->state.bufs));
     throttle->state.stream_state = H2O_SEND_STATE_IN_PROGRESS;
 
-    throttle->tokens = throttle->token_inc;
-    slot = &throttle->super.next;
+    { /* reduce `preferred_chunk_size` so that we'd be sending one chunk every 100ms */
+        size_t chunk_size = bytes_per_sec / 10;
+        if (chunk_size < 4096)
+            chunk_size = 4096;
+        if (req->preferred_chunk_size > chunk_size)
+            req->preferred_chunk_size = chunk_size;
+    }
 
-    h2o_timer_init(&throttle->timeout_entry, add_token);
-    h2o_timer_link(throttle->req->conn->ctx->loop, 100, &throttle->timeout_entry);
+    slot = &throttle->super.next;
 
 Next:
     h2o_setup_next_ostream(req, slot);

--- a/lib/handler/throttle_resp.c
+++ b/lib/handler/throttle_resp.c
@@ -134,8 +134,8 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
     throttle->super.do_send = on_send;
     throttle->super.stop = on_stop;
     throttle->req = req;
-    throttle->state.bufs.capacity = 0;
-    throttle->state.bufs.size = 0;
+    memset(&throttle->state.bufs, 0, sizeof(throttle->state.bufs));
+    throttle->state.stream_state = H2O_SEND_STATE_IN_PROGRESS;
 
     throttle->tokens = throttle->token_inc;
     slot = &throttle->super.next;

--- a/lib/handler/throttle_resp.c
+++ b/lib/handler/throttle_resp.c
@@ -123,8 +123,11 @@ static void on_setup_ostream(h2o_filter_t *self, h2o_req_t *req, h2o_ostream_t *
 
     /* calculate the token increment per 100ms */
     throttle->token_inc = traffic_limit * HUNDRED_MS / ONE_SECOND;
-    if (req->preferred_chunk_size > throttle->token_inc)
+    if (req->preferred_chunk_size > throttle->token_inc) {
         req->preferred_chunk_size = throttle->token_inc;
+        if (req->preferred_chunk_size < 4096)
+            req->preferred_chunk_size = 4096;
+    }
 
     h2o_delete_header(&req->res.headers, xt_index);
 

--- a/t/00unit/lib/handler/throttle_resp.c
+++ b/t/00unit/lib/handler/throttle_resp.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Fastly, Kazuho Oku
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "../../test.h"
+#include "../../../../lib/handler/throttle_resp.c"
+
+void test_lib__handler__throttle_resp_c(void)
+{
+    ok(calc_delay(-1, 1) == 1000);
+    ok(calc_delay(-1, 1000) == 1);
+    ok(calc_delay(-1, 100000) == 1);
+
+    ok(calc_delay(-1000, 500) == 2000);
+    ok(calc_delay(-1000, 1000) == 1000);
+    ok(calc_delay(-1000, 100000) == 10);
+}

--- a/t/00unit/test.c
+++ b/t/00unit/test.c
@@ -174,6 +174,7 @@ int main(int argc, char **argv)
         subtest("lib/handler/connect.c", test_lib__handler__connect_c);
         subtest("lib/handler/headers.c", test_lib__handler__headers_c);
         subtest("lib/handler/mimemap.c", test_lib__handler__mimemap_c);
+        subtest("lib/handler/throttle_resp.c", test_lib__handler__throttle_resp_c);
         subtest("lib/http2/hpack.c", test_lib__http2__hpack);
         subtest("lib/http2/scheduler.c", test_lib__http2__scheduler);
         subtest("lib/http2/casper.c", test_lib__http2__casper);

--- a/t/00unit/test.h
+++ b/t/00unit/test.h
@@ -72,6 +72,7 @@ void test_lib__handler__gzip_c(void);
 void test_lib__handler__headers_c(void);
 void test_lib__handler__mimemap_c(void);
 void test_lib__handler__redirect_c(void);
+void test_lib__handler__throttle_resp_c(void);
 void test_lib__http2__hpack(void);
 void test_lib__http2__scheduler(void);
 void test_lib__http2__casper(void);

--- a/t/50throttle-response.t
+++ b/t/50throttle-response.t
@@ -14,7 +14,8 @@ my $all_data = do {
     <$fh>;
 };
 
-my $server = spawn_h2o(<< "EOT");
+subtest "file" => sub {
+    my $server = spawn_h2o(<< "EOT");
 throttle-response: ON
 hosts:
   default:
@@ -24,19 +25,58 @@ hosts:
         header.add: "X-Traffic: 100000"
 EOT
 
-run_with_curl($server, sub {
-    my ($proto, $port, $curl_cmd) = @_;
-    $curl_cmd .= " --silent --show-error";
-    my $url = "$proto://127.0.0.1:$port/halfdome.jpg";
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl_cmd) = @_;
+        $curl_cmd .= " --silent --show-error";
+        my $url = "$proto://127.0.0.1:$port/halfdome.jpg";
 
-    subtest "throttle-to-low-speed" => sub {
+        subtest "throttle-to-low-speed" => sub {
+            my $start_time = time;
+            my $resp = `$curl_cmd $url`;
+            my $end_time = time;
+            is $resp, $all_data;
+            my $speed = length($resp) / ($end_time - $start_time);
+            cmp_ok($speed, '<=', 100000 * 1.1); # the implementation may cause response speed is a bit larger than the limitation, especially when file is not big enough.
+        };
+    });
+};
+
+subtest "delayed" => sub {
+    plan skip_all => 'mruby support is off'
+        unless server_features()->{mruby};
+
+    my $server = spawn_h2o(<< "EOT");
+throttle-response: ON
+hosts:
+  default:
+    paths:
+      "/":
+        mruby.handler: |
+          Proc.new do |env|
+            [
+              200,
+              { "X-Traffic" => "100000" },
+              Class.new do
+                def each
+                  yield "hello "
+                  sleep 1
+                  yield "world"
+                end
+              end.new,
+            ]
+          end
+EOT
+
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl_cmd) = @_;
         my $start_time = time;
-        my $resp = `$curl_cmd $url`;
-        my $end_time = time;
-        is $resp, $all_data;
-        my $speed = length($resp) / ($end_time - $start_time);
-        cmp_ok($speed, '<=', 100000 * 1.1); # the implementation may cause response speed is a bit larger than the limitation, especially when file is not big enough.
-    };
-});
+        my $resp = `$curl_cmd --silent --show-error $proto://127.0.0.1:$port/`;
+        is $?, 0, "exit status";
+        is $resp, "hello world";
+        my $elapsed = time - $start_time;
+        cmp_ok $elapsed, '>', 0.9;
+        cmp_ok $elapsed, '<', 1.1;
+    });
+};
 
 done_testing();

--- a/t/50throttle-response.t
+++ b/t/50throttle-response.t
@@ -10,7 +10,7 @@ plan skip_all => 'curl not found'
 my $all_data = do {
     open my $fh, "<", "@{[DOC_ROOT]}/halfdome.jpg"
         or die "failed to open file:@{[DOC_ROOT]}/halfdome.jpg:$!";
-    undef $/;
+    local $/;
     <$fh>;
 };
 


### PR DESCRIPTION
At the moment, throttle response handler invokes `h2o_ostream_send_next` every 100ms. This would violate the contract (call `h2o_ostream_send_next` exactly once per invocation of `do_send`) when the generator is slow in calling `do_send`, either due to the generator itself being slow or the connection being slow (that delays the invocation of `h2o_proceed_request`).

This PR refactors the design of the throttle response handler so that the timer would be set only when `do_send` is called with an accurate timeout value.