### PR TITLE
add 'h2o_socket_is_write_complete()

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -256,6 +256,11 @@ size_t h2o_socket_do_prepare_for_latency_optimized_write(h2o_socket_t *sock,
  */
 void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb);
 /**
+ * called after h2o_socket_write to check whether the write fully finish(written to kernel buffer) or not
+ * @param sock the socket
+ */
+int h2o_socket_is_write_complete(h2o_socket_t *sock);
+/**
  * starts polling on the socket (for read) and calls given callback when data arrives
  * @param sock the socket
  * @param cb callback to be called when data arrives

--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -726,9 +726,11 @@ static void start_request(struct st_h2o_http1client_t *client, h2o_iovec_t metho
     }
     client->super.bytes_written.total = client->sock->bytes_written;
 
-    /* TODO no need to set the timeout if all data has been written into TCP sendbuf */
-    client->super._timeout.cb = on_send_timeout;
-    h2o_timer_link(client->super.ctx->loop, client->super.ctx->io_timeout, &client->super._timeout);
+    /* no need to set the timeout if all data has been written into TCP sendbuf */
+    if (!h2o_socket_is_write_complete(client->sock)) {
+        client->super._timeout.cb = on_send_timeout;
+        h2o_timer_link(client->super.ctx->loop, client->super.ctx->io_timeout, &client->super._timeout);
+    }
 
     client->state.req = STREAM_STATE_BODY;
     client->super.timings.request_begin_at = h2o_gettimeofday(client->super.ctx->loop);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -136,6 +136,7 @@ static int has_pending_ssl_bytes(struct st_h2o_socket_ssl_t *ssl);
 static size_t generate_tls_records(h2o_socket_t *sock, h2o_iovec_t **bufs, size_t *bufcnt, size_t first_buf_written);
 static void do_dispose_socket(h2o_socket_t *sock);
 static void do_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb);
+static int is_write_complete(h2o_socket_t *sock);
 static void do_read_start(h2o_socket_t *sock);
 static void do_read_stop(h2o_socket_t *sock);
 static int do_export(h2o_socket_t *_sock, h2o_socket_export_t *info);
@@ -826,6 +827,11 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
     }
 
     do_write(sock, bufs, bufcnt, cb);
+}
+
+int h2o_socket_is_write_complete(h2o_socket_t *sock)
+{
+    return is_write_complete(sock);
 }
 
 void on_write_complete(h2o_socket_t *sock, const char *err)

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -315,6 +315,12 @@ void do_write(h2o_socket_t *_sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_
     link_to_statechanged(sock);
 }
 
+int is_write_complete(h2o_socket_t *_sock)
+{
+    struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;
+    return sock->_flags & H2O_SOCKET_FLAG_IS_WRITE_NOTIFY;
+}
+
 int h2o_socket_get_fd(h2o_socket_t *_sock)
 {
     struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -298,6 +298,13 @@ void do_write(h2o_socket_t *_sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_
     }
 }
 
+int is_write_complete(h2o_socket_t *_sock)
+{
+    struct st_h2o_uv_socket_t *sock = (struct st_h2o_uv_socket_t *)_sock;
+    /* TODO: how to judge? */
+    return 0;
+}
+
 void h2o_socket_notify_write(h2o_socket_t *_sock, h2o_socket_cb cb)
 {
     struct st_h2o_uv_socket_t *sock = (struct st_h2o_uv_socket_t *)_sock;


### PR DESCRIPTION
This PR add the **h2o_socket_is_write_complete()** API which can be 
called directly after **h2o_socket_write()** to check whether the write fully finished(written to kernel buffer) or not.
For libuv backend,  left unimplement.  
 