### PR TITLE
`misc/docker-ci/Dockerfile.ubuntu*`: Run `dumb-init` with `--rewrite 1:0` to ignore SIGHUP.

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu1604
+++ b/misc/docker-ci/Dockerfile.ubuntu1604
@@ -70,4 +70,4 @@ RUN echo 'ci ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 WORKDIR /home/ci
 USER ci
 
-ENTRYPOINT ["/usr/local/bin/dumb-init"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--rewrite", "1:0"]

--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -90,4 +90,4 @@ RUN echo 'ci ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 WORKDIR /home/ci
 USER ci
 
-ENTRYPOINT ["/usr/local/bin/dumb-init"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--rewrite", "1:0"]


### PR DESCRIPTION
Run `dumb-init` with `--rewrite 1:0` to ignore SIGHUP.

Otherwise the installation of `runit` in the container kills the container because the pre and post scripts in the package send SIGHUP to pid 1, presumably to tell a normal init to reload its configuration.