### PR TITLE
Fix up Prometeus by removing the requests JSON object

### DIFF
--- a/share/h2o/mruby/prometheus.rb
+++ b/share/h2o/mruby/prometheus.rb
@@ -43,6 +43,7 @@ module H2O
       status, headers, body = @app.call(env)
       stats = JSON.parse(body.join)
       version = stats.delete('server-version') || ''
+      requests = stats.delete('requests') || ''
       stats = stats.select {|k, v| v.kind_of?(Numeric) || v.kind_of?(Array) }
       s = ""
       stats.each {|k, v|


### PR DESCRIPTION
remove the h2o_requests response in the prometheus scrape output as the JSON object that is returned causes a parsing error