### PR TITLE
simplify barrier

### DIFF
--- a/include/h2o/multithread.h
+++ b/include/h2o/multithread.h
@@ -140,13 +140,6 @@ void h2o_barrier_init(h2o_barrier_t *barrier, size_t count);
  * Waits for all threads to enter the barrier.
  */
 void h2o_barrier_wait(h2o_barrier_t *barrier);
-/**
- * Waits for all threads to enter the barrier, then returns before the barriers are released. True is returned on one thread, while
- * while false is returned on other threads. On the thread that returned true, it is possible to run any action that has to be taken
- * while all threads are within the barrier. All threads then must call `h2o_barrier_wait_post_sync_point`.
- */
-int h2o_barrier_wait_pre_sync_point(h2o_barrier_t *barrier);
-void h2o_barrier_wait_post_sync_point(h2o_barrier_t *barrier);
 int h2o_barrier_done(h2o_barrier_t *barrier);
 void h2o_barrier_add(h2o_barrier_t *barrier, size_t delta);
 void h2o_barrier_dispose(h2o_barrier_t *barrier);

--- a/lib/common/multithread.c
+++ b/lib/common/multithread.c
@@ -296,28 +296,14 @@ void h2o_barrier_init(h2o_barrier_t *barrier, size_t count)
 
 void h2o_barrier_wait(h2o_barrier_t *barrier)
 {
-    h2o_barrier_wait_pre_sync_point(barrier);
-    h2o_barrier_wait_post_sync_point(barrier);
-}
-
-int h2o_barrier_wait_pre_sync_point(h2o_barrier_t *barrier)
-{
-    int ret;
     pthread_mutex_lock(&barrier->_mutex);
     barrier->_count--;
     if (barrier->_count == 0) {
         pthread_cond_broadcast(&barrier->_cond);
-        ret = 1;
     } else {
         while (barrier->_count != 0)
             pthread_cond_wait(&barrier->_cond, &barrier->_mutex);
-        ret = 0;
     }
-    return ret;
-}
-
-void h2o_barrier_wait_post_sync_point(h2o_barrier_t *barrier)
-{
     pthread_mutex_unlock(&barrier->_mutex);
     /* This is needed to synchronize h2o_barrier_dispose with the exit of this function, so make sure that we can't destroy the
      * mutex or the condition before all threads have exited wait(). */

--- a/src/main.c
+++ b/src/main.c
@@ -3177,14 +3177,13 @@ static void *run_loop(void *_thread_index)
 
     /* Wait for all threads to become ready but before letting any of them serve connections, swap the signal handler for graceful
      * shutdown, check (and exit) if SIGTERM has been received already. */
-    if (h2o_barrier_wait_pre_sync_point(&conf.startup_sync_barrier_init)) {
+    h2o_barrier_wait(&conf.startup_sync_barrier_init);
+    if (thread_index == 0) {
         h2o_set_signal_handler(SIGTERM, on_sigterm_set_flag_notify_threads);
         if (conf.shutdown_requested)
             exit(0);
         fprintf(stderr, "h2o server (pid:%d) is ready to serve requests with %zu threads\n", (int)getpid(), conf.thread_map.size);
     }
-    h2o_barrier_wait_post_sync_point(&conf.startup_sync_barrier_init);
-
     h2o_barrier_wait(&conf.startup_sync_barrier_post);
 
     /* the main loop */


### PR DESCRIPTION
In #2915, we introduced the capability to run code immediately before a barrier opens. That has caused issues that led to #2949, #2951, #2998.

When I was reviewing #2949, #2951 seemed the right solution, based on my understanding that we need to have the capability of running some code from the barrier, as the barrier opens.

But #2998 made me realize that we can use two barriers for the same purpose. So, how about exercising that option to revert the complexity introduced by #2915? If we use two barriers, we do not need the two-phased barrier thing that allows the user to run code immediately before the barrier opens.

Builds on top of #2998. Essentially reverts #2915.