### PR TITLE
Fix fetch-ocsp-response_test to pass

### DIFF
--- a/t/90live-fetch-ocsp-response.t
+++ b/t/90live-fetch-ocsp-response.t
@@ -26,7 +26,7 @@ done_testing;
 
 sub doit {
     my $host = shift;
-    my $input = run_openssl_client({ host => $host, port => 443, opts => "-showcerts -CAfile /dev/null" });
+    my $input = run_openssl_client({ host => $host, port => 443, opts => "-showcerts" });
     my @certs;
     while ($input =~ /(-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----)/sg) {
         push @certs, $1;


### PR DESCRIPTION
I fixed the fetch-ocsp-response tests on ubuntu 20.04 (openssl1.1.1).
As you can see, 90live-fetch-ocsp-response.to had failed for `openssl s_client -showcerts` command error.

```
ci@51de20a1a5b5:/h2o.ro$ LIVE_TESTS=1 H2O_ROOT=. BINARY_DIR=/home/ci/ prove -I. -v t/90live-fetch-ocsp-response.t
t/90live-fetch-ocsp-response.t ..
# Subtest: www.verisign.com
    # run_openssl_client: openssl s_client -showcerts -CAfile /dev/null -connect www.verisign.com:443
    not ok 1 - chain has more than 2 certificates

    #   Failed test 'chain has more than 2 certificates'
    #   at t/90live-fetch-ocsp-response.t line 34.
fetch-ocsp-response (using OpenSSL 1.1.1f  31 Mar 2020)
unable to load certificate
140287124342080:error:0909006C:PEM routines:get_name:no start line:../crypto/pem/pem_lib.c:745:Expecting: TRUSTED CERTIFICATE
OpenSSL exitted abnormally: openssl x509 -in /tmp/raHXDk_ETX -noout -ocsp_uri: at share/h2o/fetch-ocsp-response line 143.
    not ok 2 - fetch-ocsp-response exitted with status:256

    #   Failed test 'fetch-ocsp-response exitted with status:256'
    #   at t/90live-fetch-ocsp-response.t line 44.
    1..2
    # Looks like you failed 2 tests of 2.
not ok 1 - www.verisign.com
...
fetch-ocsp-response (using OpenSSL 1.1.1f  31 Mar 2020)
unable to load certificate
140279418836288:error:0909006C:PEM routines:get_name:no start line:../crypto/pem/pem_lib.c:745:Expecting: TRUSTED CERTIFICATE
OpenSSL exitted abnormally: openssl x509 -in /tmp/D4VHByOK6V -noout -ocsp_uri: at share/h2o/fetch-ocsp-response line 143.
    not ok 2 - fetch-ocsp-response exitted with status:256
    1..2
not ok 6 - www.startssl.com
1..6

    #   Failed test 'fetch-ocsp-response exitted with status:256'
    #   at t/90live-fetch-ocsp-response.t line 44.
    # Looks like you failed 2 tests of 2.

#   Failed test 'www.startssl.com'
#   at t/90live-fetch-ocsp-response.t line 22.
# Looks like you failed 6 tests of 6.
Dubious, test returned 6 (wstat 1536, 0x600)
Failed 6/6 subtests

Test Summary Report
-------------------
t/90live-fetch-ocsp-response.t (Wstat: 1536 Tests: 6 Failed: 6)
  Failed tests:  1-6
  Non-zero exit status: 6
Files=1, Tests=6, 12 wallclock secs ( 0.03 usr  0.00 sys +  0.35 cusr  0.10 csys =  0.48 CPU)
Result: FAIL
```

So, I just removed the `-CAfile /dev/null` options. Then it worked fine. And also I tried to check ubuntu 16.04(OpenSSL 1.0.2), and it passed.

```
ci@51de20a1a5b5:/h2o.ro$ LIVE_TESTS=1 H2O_ROOT=. BINARY_DIR=/home/ci/ prove -I. -v t/90live-fetch-ocsp-response.t
t/90live-fetch-ocsp-response.t ..
# Subtest: www.verisign.com
    # run_openssl_client: openssl s_client -showcerts -connect www.verisign.com:443
    ok 1 - chain has more than 2 certificates
fetch-ocsp-response (using OpenSSL 1.1.1f  31 Mar 2020)
sending OCSP request to http://ocsp.digicert.com
/tmp/t42lxJCp74: good
        This Update: Apr 21 08:03:01 2022 GMT
        Next Update: Apr 28 07:18:01 2022 GMT
verifying the response signature
verify OK (used: -VAfile /tmp/D3XmD8gZHB/issuer.crt)
    ok 2 - successfully fetched and verified OCSP response
    1..2
ok 1 - www.verisign.com
...
ok 5 - www.godaddy.com
# Subtest: www.startssl.com
    # run_openssl_client: openssl s_client -showcerts -connect www.startssl.com:443
    ok 1 - chain has more than 2 certificates
fetch-ocsp-response (using OpenSSL 1.1.1f  31 Mar 2020)
sending OCSP request to http://ocsp.crlocsp.cn
/tmp/xS8ZJQIX6B: good
        This Update: Apr 19 16:42:26 2022 GMT
        Next Update: Apr 26 16:42:26 2022 GMT
verifying the response signature
verify OK (used: -VAfile /tmp/APd3QN6RBx/issuer.crt)
    ok 2 - successfully fetched and verified OCSP response
    1..2
ok 6 - www.startssl.com
1..6
ok
All tests successful.
Files=1, Tests=6, 28 wallclock secs ( 0.02 usr  0.00 sys +  0.43 cusr  0.07 csys =  0.52 CPU)
Result: PASS
```
Note: It cannot reproduce for this CI because this test has been skipped as LIVE_TESTS and it has occurred only for ubuntu20 images. Thus, We could not have a chance to notice it until now.
BTW, When will your docker file which is based on ubuntu 16.04 keeps?
It seems that Ubuntu 22.04 was released today.