### PR TITLE
[CI] install liburing to h2oserver/h2o-ci:ubuntu2004

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -84,6 +84,12 @@ RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/
 # komake
 RUN wget -O /usr/local/bin/komake https://raw.githubusercontent.com/kazuho/komake/main/komake && chmod +x /usr/local/bin/komake
 
+# liburing
+RUN git clone --depth=1 https://github.com/axboe/liburing.git && \
+	cd liburing && \
+	make install && \
+	make clean
+
 # create user
 RUN useradd --create-home ci
 RUN echo 'ci ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
While the current plan is to ditch #2976 in favor of #2993, we do plan to using io_uring for non-blocking disk reads in the file handler.

So let's have liburing installed now on CI.