### PR TITLE
Fix crash inside `RAND_bytes` while h2o is shuting down

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3974,5 +3974,8 @@ int main(int argc, char **argv)
     if (conf.pid_file != NULL)
         unlink(conf.pid_file);
 
-    return 0;
+    /* Use `_exit` to prevent functions registered via `atexit` from being invoked, otherwise we might see some threads die while
+     * trying to use whatever state that are cleaned up. Specifically, we see the ticket updater thread dying inside RAND_bytes,
+     * while or after `OpenSSL_cleanup` is invoked as an atexit callback. */
+    _exit(0);
 }


### PR DESCRIPTION
Recently, we are seeing multiple crashes like below.

Apparently, h2o is "gracefully shutting down," and the ticket updater thread is having trouble using an rwlock. The cause is likely a race condition between [`OpenSSL_cleanup` run as an atexit (3) callback](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/init.c#L140) and the ticket updater thread trying to generate random bytes.

This PR addresses the problem by preventing the invocation of `atexit` handlers. This looks like a regression introduced by #2460, which changed the shutdown method from `_exit` to returning from `main`.

With this PR, we would be having two ways of destroying threads: we will be joining worker threads that handle requests, but we will be letting `_exit` kill other threads abruptly.

That is unfortunate. Probably we should have changed #2460 in a way such that the worker threads would never refer to a stack-based value of the main thread.

But for the time being, maybe we can live with what we have now in this PR, until we have new information.

```
2022-04-22T03:14:10.1878077Z   5.601488     # Subtest: json
2022-04-22T03:14:10.1878374Z   5.680325 spawning /home/ci/h2o... [INFO] raised RLIMIT_NOFILE to 1024
2022-04-22T03:14:10.1878640Z   5.703791 done
2022-04-22T03:14:10.1879009Z   5.712407 fetch-ocsp-response (using OpenSSL 1.1.1f  31 Mar 2020)
2022-04-22T03:14:10.1879355Z   5.723220 failed to extract ocsp URI from /tmp/ZfnVqv41nw/cert.crt
2022-04-22T03:14:10.1879726Z   5.743738 [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2022-04-22T03:14:10.1880098Z   5.747287 h2o server (pid:13310) is ready to serve requests with 1 threads
2022-04-22T03:14:10.1880467Z   5.748414 killing /home/ci/h2o... received SIGTERM, gracefully shutting down
2022-04-22T03:14:10.1880768Z   5.749298 received fatal signal 11
2022-04-22T03:14:10.1881080Z   5.823642 [13310] /home/ci/h2o(backtrace+0x5b)[0x478cbb] backtrace at ??:?
2022-04-22T03:14:10.1881419Z   5.903347 [13310] /home/ci/h2o[0x882959] on_sigfatal at /h2o/src/main.c:2611
2022-04-22T03:14:10.1881932Z   5.911320 [13310] /lib/x86_64-linux-gnu/libpthread.so.0(+0x143c0)[0x7f6b758213c0] __restore_rt at ??:?
2022-04-22T03:14:10.1882545Z   5.916922 [13310] /lib/x86_64-linux-gnu/libpthread.so.0(pthread_rwlock_wrlock+0x16)[0x7f6b7581ad46] ?? ??:0
2022-04-22T03:14:10.1883113Z   5.922454 [13310] /lib/x86_64-linux-gnu/libcrypto.so.1.1(CRYPTO_THREAD_write_lock+0xd)[0x7f6b75b8ea2d] ?? ??:0
2022-04-22T03:14:10.1883592Z   5.927705 fetch-ocsp-response (using OpenSSL 1.1.1f  31 Mar 2020)
2022-04-22T03:14:10.1884021Z   5.928115 fetch-ocsp-response (using OpenSSL 1.1.1f  31 Mar 2020)
2022-04-22T03:14:10.1884545Z   5.932831 [13310] /lib/x86_64-linux-gnu/libcrypto.so.1.1(RAND_get_rand_method+0x3b)[0x7f6b75b4f36b] ?? ??:0
2022-04-22T03:14:10.1884935Z   5.939701 failed to extract ocsp URI from /tmp/Z9u4mqWEm_/cert.crt
2022-04-22T03:14:10.1885434Z   5.940673 [13310] /lib/x86_64-linux-gnu/libcrypto.so.1.1(RAND_bytes+0x16)[0x7f6b75b4f676] ?? ??:0
2022-04-22T03:14:10.1885808Z   5.959075 failed to extract ocsp URI from /tmp/Hs7za9n_H8/cert.crt
2022-04-22T03:14:10.1886234Z   5.979583 [13310] /home/ci/h2o(ptls_openssl_random_bytes+0x6)[0x57da46] ptls_openssl_random_bytes at /h2o/deps/picotls/lib/openssl.c:173
2022-04-22T03:14:10.1886665Z   5.992071 [13310] /home/ci/h2o(h2o_rand+0x26)[0x624f36] h2o_rand at /h2o/lib/common/rand.c:39
2022-04-22T03:14:10.1887035Z   6.005462 [13310] /home/ci/h2o[0x8883cc] ticket_internal_updater at /h2o/src/ssl.c:482
2022-04-22T03:14:10.1887542Z   6.007073 [13310] /lib/x86_64-linux-gnu/libpthread.so.0(+0x8609)[0x7f6b75815609] start_thread at ??:?
2022-04-22T03:14:10.1888028Z   6.010742 [13310] /lib/x86_64-linux-gnu/libc.so.6(clone+0x43)[0x7f6b75715163] ?? ??:0
2022-04-22T03:14:10.1888821Z   6.077476         not ok 1 - server die with signal 139
2022-04-22T03:14:10.1889306Z   6.079917         #   Failed test 'server die with signal 139'
2022-04-22T03:14:10.1889690Z   6.079935         #   at t/Util.pm line 211.
2022-04-22T03:14:10.1889942Z   6.079939 killed (got 139)
2022-04-22T03:14:10.1890157Z   6.079941         ok 2
2022-04-22T03:14:10.1890371Z   6.079944         1..2
2022-04-22T03:14:10.1890630Z   6.079946         # Looks like you failed 1 test of 2.
2022-04-22T03:14:10.1890960Z   6.079948     not ok 3 - json
2022-04-22T03:14:10.1891266Z   6.079950     #   Failed test 'json'
2022-04-22T03:14:10.1891594Z   6.079953     #   at t/50access-log.t line 317.
2022-04-22T03:14:10.1891839Z   6.079955     1..3
2022-04-22T03:14:10.1892363Z   6.079957     # Looks like you failed 1 test of 3.
2022-04-22T03:14:10.1892724Z   6.079959 not ok 12 - escape
2022-04-22T03:14:10.1893181Z   6.079961 #   Failed test 'escape'
2022-04-22T03:14:10.1893503Z   6.079964 #   at t/50access-log.t line 319.
2022-04-22T03:14:10.1893817Z   6.080892 # Subtest: json-null
```