### PR TITLE
Fix bugs in the error handling path of pull vectors

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 		08CEA9DA267B0E3B00B4BB6B /* self_trace.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = self_trace.c; sourceTree = "<group>"; };
 		08E9CC4D1E41F6660049DD26 /* embedded.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedded.c.h; sourceTree = "<group>"; };
 		08EFC4DF27FE9F96004C532C /* throttle_resp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = throttle_resp.c; sourceTree = "<group>"; };
+		08EFC4CF27FD8FAA004C532C /* 50file-shrink.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50file-shrink.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		100A550C1C22857B00C4E3E0 /* 50mruby-htpasswd.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50mruby-htpasswd.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		100A550E1C2BB15100C4E3E0 /* http_request.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http_request.c; sourceTree = "<group>"; };
 		100A55131C2E5FAC00C4E3E0 /* 50mruby-http-request.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50mruby-http-request.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -2255,6 +2256,7 @@
 				E9AFBF12212A9801000F5DB8 /* 50file-custom-handler.t */,
 				107E34231C86801E00AEF5F8 /* 50file-file.t */,
 				100AE41A1B27D74800CE18BB /* 50file-range.t */,
+				08EFC4CF27FD8FAA004C532C /* 50file-shrink.t */,
 				E9AFBF13212A9801000F5DB8 /* 50graceful-shutdown.t */,
 				1058C87F1AA42568008D6180 /* 50headers.t */,
 				E9D49A5125FB562800F4A80D /* 50http1-proxy-full-uri.t */,

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -139,7 +139,7 @@ static int do_pread(h2o_sendvec_t *src, h2o_req_t *req, h2o_iovec_t dst, size_t 
                    -1 &&
                errno == EINTR)
             ;
-        if (rret == -1)
+        if (rret <= 0)
             return 0;
         bytes_read += rret;
     }

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -823,9 +823,14 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
 {
     struct st_h2o_http1_conn_t *conn = sock->data;
 
-    assert(conn->req._ostr_top == &conn->_ostr_final.super);
-
-    conn->req.timestamps.response_end_at = h2o_gettimeofday(conn->super.ctx->loop);
+    if (err == NULL) {
+        if (conn->req._ostr_top != &conn->_ostr_final.super) {
+            err = "pull error";
+        } else {
+            /* success */
+            conn->req.timestamps.response_end_at = h2o_gettimeofday(conn->super.ctx->loop);
+        }
+    }
 
     if (err != NULL)
         conn->req.http1_is_persistent = 0;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -161,8 +161,10 @@ static h2o_sendvec_t *send_data(h2o_http2_conn_t *conn, h2o_http2_stream_t *stre
     }
     while (bufcnt != 0) {
         size_t fill_size = sz_min(dst.len, bufs->len - *off_within_buf);
-        if (!(*bufs->callbacks->flatten)(bufs, &stream->req, h2o_iovec_init(dst.base, fill_size), *off_within_buf))
+        if (!(*bufs->callbacks->flatten)(bufs, &stream->req, h2o_iovec_init(dst.base, fill_size), *off_within_buf)) {
+            h2o_http2_encode_rst_stream_frame(&conn->_write.buf, stream->stream_id, -H2O_HTTP2_ERROR_INTERNAL);
             return NULL;
+        }
         dst.base += fill_size;
         dst.len -= fill_size;
         *off_within_buf += fill_size;

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -404,7 +404,6 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
     if (h2o_http2_window_get_avail(&stream->output_window) <= 0)
         return;
 
-    h2o_send_state_t send_state = stream->send_state;
     h2o_sendvec_t *nextbuf =
         send_data(conn, stream, stream->_data.entries, stream->_data.size, &stream->_data_off, stream->send_state);
     if (nextbuf == NULL) {
@@ -424,9 +423,9 @@ void h2o_http2_stream_send_pending_data(h2o_http2_conn_t *conn, h2o_http2_stream
         stream->_data.size = newsize;
     }
 
-    if (send_state == H2O_SEND_STATE_ERROR) {
-        stream->req.send_server_timing = 0; /* suppress sending trailers */
-    }
+    /* if the stream entered error state, suppress sending trailers */
+    if (stream->send_state == H2O_SEND_STATE_ERROR)
+        stream->req.send_server_timing = 0;
 }
 
 void h2o_http2_stream_proceed(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)

--- a/t/50file-shrink.t
+++ b/t/50file-shrink.t
@@ -1,0 +1,91 @@
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use File::Temp qw(tempdir);
+use IO::Handle;
+use Net::EmptyPort qw(empty_port wait_port);
+use Test::More;
+use t::Util;
+
+my $tempdir = tempdir(CLEANUP => 1);
+my $testdata = "hello world\n" x 100_000;
+
+# spawn server
+my $quic_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
+my $server = spawn_h2o(<< "EOT");
+listen:
+  type: quic
+  host: 127.0.0.1
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: $tempdir
+        header.add: "X-Traffic: 200000" # takes about 5 seconds
+throttle-response: ON
+EOT
+wait_port({port => $quic_port, proto => "udp"});
+
+my $doit = sub {
+    my $fetch = shift;
+
+    # write file
+    open my $fh, ">", "$tempdir/index.txt"
+        or die "failed to create file $tempdir/index.txt:$!";
+    print $fh $testdata;
+    $fh->flush;
+
+    subtest "normal" => sub {
+        my $resp = $fetch->("index.txt");
+        is $?, 0, "exit status";
+        is md5_hex($resp), md5_hex($testdata), "data";
+    };
+    subtest "shrink" => sub {
+        # spawn child prcoess that truncates the file after 2 seconds
+        my $pid = fork;
+        die "fork failed:$!"
+            unless defined $pid;
+        if ($pid == 0) {
+            sleep 2;
+            truncate($fh, 800000)
+                or die "truncate failed:$!";
+            exit 0;
+        }
+        # fetch file (which would return a partial result)
+        my $resp = $fetch->("index.txt");
+        isnt $?, 0, "exit status";
+        cmp_ok length($resp), "<", length($testdata), "length";
+        is md5_hex($resp), md5_hex(substr($testdata, 0, length($resp))), "data";
+        # reap pid
+        while (waitpid($pid, 0) != $pid) {}
+    };
+};
+
+# run test with each protocol
+run_with_curl($server, sub {
+    my ($proto, $port, $curl) = @_;
+    $doit->(sub {
+        my $fn = shift;
+        `$curl --silent --dump-header /dev/null '$proto://127.0.0.1:$port/$fn'`;
+    });
+});
+subtest 'http/3' => sub {
+    my $h3client = bindir() . "/h2o-httpclient";
+    plan skip_all => "$h3client not found"
+        unless -e $h3client;
+    $doit->(sub {
+        my $fn = shift;
+        `$h3client -3 100 https://127.0.0.1:$quic_port/$fn 2> /dev/null`;
+    });
+};
+
+undef $server;
+
+done_testing;


### PR DESCRIPTION
When pull vectors are used, we might encounter an error while trying to read from those vectors. The most prominent case is a file getting truncated while being served by h2o.

This PR adds a test that replicates that behavior, as well as fixing issues being found by that test.