### PR TITLE
[h2o_mem_recycle_t] improve memory locality and API

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -93,6 +93,7 @@ typedef struct st_h2o_iovec_t {
 } h2o_iovec_t;
 
 typedef struct st_h2o_mem_recycle_t {
+    const size_t *memsize;
     size_t max;
     size_t cnt;
     struct st_h2o_mem_recycle_chunk_t *_link;
@@ -207,7 +208,7 @@ static void *h2o_mem_realloc(void *oldp, size_t sz);
 /**
  * allocates memory using the reusing allocator
  */
-void *h2o_mem_alloc_recycle(h2o_mem_recycle_t *allocator, size_t sz);
+void *h2o_mem_alloc_recycle(h2o_mem_recycle_t *allocator);
 /**
  * returns the memory to the reusing allocator
  */

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -96,7 +96,7 @@ typedef struct st_h2o_mem_recycle_t {
     const size_t *memsize;
     size_t max;
     size_t cnt;
-    struct st_h2o_mem_recycle_chunk_t *_link;
+    void **chunks;
 } h2o_mem_recycle_t;
 
 struct st_h2o_mem_pool_shared_entry_t {

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -293,6 +293,10 @@ static h2o_mem_recycle_t *buffer_get_recycle(unsigned power, int only_if_exists)
             return NULL;
         buffer_recycle_bins.bins =
             h2o_mem_realloc(buffer_recycle_bins.bins, sizeof(*buffer_recycle_bins.bins) * (power - H2O_BUFFER_MIN_ALLOC_POWER + 1));
+        for (size_t p = H2O_BUFFER_MIN_ALLOC_POWER; p <= buffer_recycle_bins.largest_power; ++p) {
+            struct buffer_recycle_bin_t *bin = buffer_recycle_bins.bins + p - H2O_BUFFER_MIN_ALLOC_POWER;
+            bin->recycle.memsize = &bin->memsize;
+        }
         do {
             ++buffer_recycle_bins.largest_power;
             struct buffer_recycle_bin_t *newbin =

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -79,7 +79,8 @@ struct st_h2o_mem_pool_shared_ref_t {
 
 void *(*volatile h2o_mem__set_secure)(void *, int, size_t) = memset;
 
-__thread h2o_mem_recycle_t h2o_mem_pool_allocator = {16};
+static const size_t mem_pool_allocator_memsize = sizeof(union un_h2o_mem_pool_chunk_t);
+__thread h2o_mem_recycle_t h2o_mem_pool_allocator = {&mem_pool_allocator_memsize, 16};
 size_t h2o_mmap_errors = 0;
 
 void h2o__fatal(const char *file, int line, const char *msg, ...)
@@ -96,11 +97,11 @@ void h2o__fatal(const char *file, int line, const char *msg, ...)
     abort();
 }
 
-void *h2o_mem_alloc_recycle(h2o_mem_recycle_t *allocator, size_t sz)
+void *h2o_mem_alloc_recycle(h2o_mem_recycle_t *allocator)
 {
     struct st_h2o_mem_recycle_chunk_t *chunk;
     if (allocator->cnt == 0)
-        return h2o_mem_alloc(sz);
+        return h2o_mem_alloc(*allocator->memsize);
     /* detach and return the pooled pointer */
     chunk = allocator->_link;
     assert(chunk != NULL);
@@ -196,7 +197,7 @@ void *h2o_mem__do_alloc_pool_aligned(h2o_mem_pool_t *pool, size_t alignment, siz
     pool->chunk_offset = ALIGN_TO(pool->chunk_offset, alignment);
     if (sizeof(pool->chunks->bytes) - pool->chunk_offset < sz) {
         /* allocate new chunk */
-        union un_h2o_mem_pool_chunk_t *newp = h2o_mem_alloc_recycle(&h2o_mem_pool_allocator, sizeof(*newp));
+        union un_h2o_mem_pool_chunk_t *newp = h2o_mem_alloc_recycle(&h2o_mem_pool_allocator);
         newp->next = pool->chunks;
         pool->chunks = newp;
         pool->chunk_offset = ALIGN_TO(sizeof(newp->next), alignment);
@@ -243,6 +244,7 @@ static size_t topagesize(size_t capacity)
  */
 #define H2O_BUFFER_MIN_ALLOC_POWER 12
 
+static size_t buffer_recycle_bins_sizeof_zero_sized = sizeof(h2o_buffer_t);
 /**
  * Retains recycle bins for `h2o_buffer_t`.
  */
@@ -250,7 +252,10 @@ static __thread struct {
     /**
      * Holds recycle bins for `h2o_buffer_t`. Bin for capacity 2^x is located at x - H2O_BUFFER_MIN_ALLOC_POWER.
      */
-    h2o_mem_recycle_t *bins;
+    struct buffer_recycle_bin_t {
+        size_t memsize;
+        h2o_mem_recycle_t recycle;
+    } * bins;
     /**
      * Bins for capacicties no greater than this value exist.
      */
@@ -259,7 +264,7 @@ static __thread struct {
      * Bin containing chunks of sizeof(h2o_buffer_t). This is used by empties buffers to retain the previous capacity.
      */
     h2o_mem_recycle_t zero_sized;
-} buffer_recycle_bins = {NULL, H2O_BUFFER_MIN_ALLOC_POWER - 1, {100}};
+} buffer_recycle_bins = {NULL, H2O_BUFFER_MIN_ALLOC_POWER - 1, {&buffer_recycle_bins_sizeof_zero_sized, 100}};
 
 static unsigned buffer_size_to_power(size_t sz)
 {
@@ -277,7 +282,7 @@ static unsigned buffer_size_to_power(size_t sz)
 void h2o_buffer_clear_recycle(int full)
 {
     for (unsigned i = H2O_BUFFER_MIN_ALLOC_POWER; i <= buffer_recycle_bins.largest_power; ++i)
-        h2o_mem_clear_recycle(&buffer_recycle_bins.bins[i - H2O_BUFFER_MIN_ALLOC_POWER], full);
+        h2o_mem_clear_recycle(&buffer_recycle_bins.bins[i - H2O_BUFFER_MIN_ALLOC_POWER].recycle, full);
 
     if (full) {
         free(buffer_recycle_bins.bins);
@@ -297,11 +302,14 @@ static h2o_mem_recycle_t *buffer_get_recycle(unsigned power, int only_if_exists)
             h2o_mem_realloc(buffer_recycle_bins.bins, sizeof(*buffer_recycle_bins.bins) * (power - H2O_BUFFER_MIN_ALLOC_POWER + 1));
         do {
             ++buffer_recycle_bins.largest_power;
-            buffer_recycle_bins.bins[buffer_recycle_bins.largest_power - H2O_BUFFER_MIN_ALLOC_POWER] = (h2o_mem_recycle_t){16};
+            struct buffer_recycle_bin_t *newbin =
+                buffer_recycle_bins.bins + buffer_recycle_bins.largest_power - H2O_BUFFER_MIN_ALLOC_POWER;
+            newbin->memsize = (size_t)1 << power;
+            newbin->recycle = (h2o_mem_recycle_t){&newbin->memsize, 16};
         } while (buffer_recycle_bins.largest_power < power);
     }
 
-    return &buffer_recycle_bins.bins[power - H2O_BUFFER_MIN_ALLOC_POWER];
+    return &buffer_recycle_bins.bins[power - H2O_BUFFER_MIN_ALLOC_POWER].recycle;
 }
 
 static void buffer_init(h2o_buffer_t *buf, size_t size, char *bytes, size_t capacity, h2o_buffer_prototype_t *prototype, int fd)
@@ -359,13 +367,14 @@ static h2o_buffer_t *buffer_allocate(h2o_buffer_prototype_t *prototype, size_t m
     h2o_mem_recycle_t *allocator = buffer_get_recycle(alloc_power, 1);
     if (allocator == NULL || allocator->cnt == 0)
         goto AllocNormal;
-    newp = h2o_mem_alloc_recycle(allocator, (size_t)1 << alloc_power);
+    assert(*allocator->memsize == (size_t)1 << alloc_power);
+    newp = h2o_mem_alloc_recycle(allocator);
     goto AllocDone;
 
 AllocNormal:
     /* allocate using `min_capacity` */
     alloc_power = buffer_size_to_power(offsetof(h2o_buffer_t, _buf) + min_capacity);
-    newp = h2o_mem_alloc_recycle(buffer_get_recycle(alloc_power, 0), (size_t)1 << alloc_power);
+    newp = h2o_mem_alloc_recycle(buffer_get_recycle(alloc_power, 0));
 
 AllocDone:
     buffer_init(newp, 0, newp->_buf, ((size_t)1 << alloc_power) - offsetof(h2o_buffer_t, _buf), prototype, -1);
@@ -448,7 +457,7 @@ h2o_iovec_t h2o_buffer_try_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
             } else {
                 unsigned alloc_power = buffer_size_to_power(offsetof(h2o_buffer_t, _buf) + new_capacity);
                 new_capacity = ((size_t)1 << alloc_power) - offsetof(h2o_buffer_t, _buf);
-                h2o_buffer_t *newp = h2o_mem_alloc_recycle(buffer_get_recycle(alloc_power, 0), (size_t)1 << alloc_power);
+                h2o_buffer_t *newp = h2o_mem_alloc_recycle(buffer_get_recycle(alloc_power, 0));
                 buffer_init(newp, inbuf->size, newp->_buf, new_capacity, inbuf->_prototype, -1);
                 memcpy(newp->_buf, inbuf->bytes, inbuf->size);
                 h2o_buffer__do_free(inbuf);
@@ -486,7 +495,7 @@ void h2o_buffer_consume_all(h2o_buffer_t **inbuf, int record_capacity)
 {
     if ((*inbuf)->size != 0) {
         if (record_capacity) {
-            h2o_buffer_t *newp = h2o_mem_alloc_recycle(&buffer_recycle_bins.zero_sized, sizeof(*newp));
+            h2o_buffer_t *newp = h2o_mem_alloc_recycle(&buffer_recycle_bins.zero_sized);
             buffer_init(newp, 0, NULL, (*inbuf)->capacity, (*inbuf)->_prototype, -1);
             h2o_buffer__do_free(*inbuf);
             *inbuf = newp;

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -301,7 +301,7 @@ static h2o_mem_recycle_t *buffer_get_recycle(unsigned power, int only_if_exists)
             ++buffer_recycle_bins.largest_power;
             struct buffer_recycle_bin_t *newbin =
                 buffer_recycle_bins.bins + buffer_recycle_bins.largest_power - H2O_BUFFER_MIN_ALLOC_POWER;
-            newbin->memsize = (size_t)1 << power;
+            newbin->memsize = (size_t)1 << buffer_recycle_bins.largest_power;
             newbin->recycle = (h2o_mem_recycle_t){&newbin->memsize, 16};
         } while (buffer_recycle_bins.largest_power < power);
     }

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -162,7 +162,7 @@ h2o_buffer_prototype_t h2o_socket_buffer_prototype = {
     &h2o_socket_buffer_mmap_settings};
 
 size_t h2o_socket_ssl_buffer_size = H2O_SOCKET_DEFAULT_SSL_BUFFER_SIZE;
-__thread h2o_mem_recycle_t h2o_socket_ssl_buffer_allocator = {1024};
+__thread h2o_mem_recycle_t h2o_socket_ssl_buffer_allocator = {&h2o_socket_ssl_buffer_size, 1024};
 
 const char h2o_socket_error_out_of_memory[] = "out of memory";
 const char h2o_socket_error_io[] = "I/O error";
@@ -235,7 +235,7 @@ static void dispose_write_buf(h2o_socket_t *sock)
 static void init_ssl_output_buffer(struct st_h2o_socket_ssl_t *ssl)
 {
     ptls_buffer_init(&ssl->output.buf, h2o_mem_alloc_recycle(&h2o_socket_ssl_buffer_allocator),
-                     h2o_socket_ssl_buffer_allocator.memsize);
+                     *h2o_socket_ssl_buffer_allocator.memsize);
     ssl->output.buf.is_allocated = 1; /* set to true, so that the allocated memory is freed when the buffer is expanded */
     ssl->output.pending_off = 0;
 }

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -248,7 +248,7 @@ static void dispose_ssl_output_buffer(struct st_h2o_socket_ssl_t *ssl)
 
     assert(ssl->output.buf.is_allocated);
 
-    if (ssl->output.buf.capacity == h2o_socket_ssl_buffer_size) {
+    if (ssl->output.buf.capacity == *h2o_socket_ssl_buffer_allocator.memsize) {
         h2o_mem_free_recycle(&h2o_socket_ssl_buffer_allocator, ssl->output.buf.base);
     } else {
         free(ssl->output.buf.base);

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -234,8 +234,8 @@ static void dispose_write_buf(h2o_socket_t *sock)
 
 static void init_ssl_output_buffer(struct st_h2o_socket_ssl_t *ssl)
 {
-    ptls_buffer_init(&ssl->output.buf, h2o_mem_alloc_recycle(&h2o_socket_ssl_buffer_allocator, h2o_socket_ssl_buffer_size),
-                     h2o_socket_ssl_buffer_size);
+    ptls_buffer_init(&ssl->output.buf, h2o_mem_alloc_recycle(&h2o_socket_ssl_buffer_allocator),
+                     h2o_socket_ssl_buffer_allocator.memsize);
     ssl->output.buf.is_allocated = 1; /* set to true, so that the allocated memory is freed when the buffer is expanded */
     ssl->output.pending_off = 0;
 }


### PR DESCRIPTION
* Improves memory locality by retaining an array of pointers pointing to chunks being recycled. Previously, chunks were linked.
* Add `size_t *` to `h2o_mem_recycle_t` that contains the size of the chunks being recycled. This change makes `h2o_mem_recycle_t` more standalone. Previously, callers of `h2o_mem_alloc_recycle` had to specify the correct size that is retained somewhere else.