### PR TITLE
when falling back to OpenSSL, do not apply per-SNI config to picotls

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -460,6 +460,12 @@ struct st_on_client_hello_ptls_t {
 
 static int on_client_hello_ptls(ptls_on_client_hello_t *_self, ptls_t *tls, ptls_on_client_hello_parameters_t *params)
 {
+    /* `on_client_hello_ptls` can be called even when OpenSSL is going to be used, due to client supporting only TLS/1.2 (see
+     * https://github.com/h2o/picotls/pull/311). If that is the case, there is nothing to do here, as everything will be done in
+     * `on_sni_callback`. */
+    if (params->incompatible_version)
+        return 0;
+
     struct st_on_client_hello_ptls_t *self = (struct st_on_client_hello_ptls_t *)_self;
     void *conn = *ptls_get_data_ptr(tls);
     struct listener_ssl_config_t *ssl_config;


### PR DESCRIPTION
As of https://github.com/h2o/picotls/pull/311, picotls invokes the client hello callback even when the handshake is to be delegated to OpenSSL. However, when incorporating that pull request to h2o in #2335, we made no change to h2o.

Now, when receiving a TLS 1.2 handshake, all the per-SNI setup is done in `on_client_hello_ptls`, then OpenSSL calls `on_sni_callback`, at which point we once more do the per-SNI setup.

This might be considered no more than waste of some CPU cycles, but it becomes an actual issue when there are setup procedures that cannot be run more than once. #3007 attempts to introduce `h2o_socket_use_zerocopy`, which can be called only once. If we call this function in `on_client_hello_ptls`, then in `on_sni_callback`, an assertion failure is raised.

This PR addresses the issue by skipping any setup logic inside `on_client_hello_ptls`, when the TLS handshake is about to be delegated to OpenSSL.