### PR TITLE
Do not try to connect to the same address repeatedly in the connect handler.

### DIFF
--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -443,9 +443,11 @@ static struct st_server_address_t *pick_and_swap(struct st_connect_generator_t *
 
 static void try_connect(struct st_connect_generator_t *self)
 {
-    struct st_server_address_t *server_address = NULL;
+    struct st_server_address_t *server_address;
 
     do {
+        server_address = NULL;
+
         /* Fetch the next address from the list of resolved addresses. */
         for (size_t i = self->server_addresses.used; i < self->server_addresses.size; i++) {
             if (self->pick_v4 && self->server_addresses.list[i].sa->sa_family == AF_INET)

--- a/t/50connect.t
+++ b/t/50connect.t
@@ -38,6 +38,7 @@ hosts:
         proxy.connect:
           - "+127.0.0.1:$origin_port"
           - "+127.0.0.1:$one_shot_upstream"
+          - "+255.255.255.255:$origin_port"
         proxy.timeout.io: 2000
 EOT
 
@@ -101,6 +102,10 @@ subtest "curl-h1" => sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error https://8.8.8.8/ 2>&1 2>&1`;
         like $content, qr{Received HTTP code 403 from proxy after CONNECT};
         unlike $content, qr{proxy-status:}i;
+    };
+    subtest "immediate connect failure" => sub {
+        my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://255.255.255.255:$origin_port/ 2>&1 2>&1`;
+        like $content, qr{Received HTTP code 502 from proxy after CONNECT};
     };
 };
 


### PR DESCRIPTION
When the connect function returns with an error immediately, do not carry over the already tried server_address into the next connect attempt, because that can cause an infinite loop.

The test case demonstrates the problem using `255.255.255.255`. A non-blocking connect to this address fails immediately on the operating systems that I have access to (Linux, MacOS and OpenBSD), albeit with a different errno on each (ENETUNREACH, EAFNOSUPPORT and EINVAL respectively).
