### PR TITLE
check if available bytes is 0 before cleaning up

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -970,7 +970,8 @@ static void proceed_request_streaming(h2o_req_t *_req, const char *errstr)
     assert(!h2o_linklist_is_linked(&stream->link));
     assert(conn->num_streams_req_streaming != 0 || stream->req.is_tunnel_req);
 
-    if (errstr != NULL || quicly_recvstate_transfer_complete(&stream->quic->recvstate)) {
+    if (errstr != NULL || (quicly_recvstate_bytes_available(&stream->quic->recvstate) == 0 &&
+                           quicly_recvstate_transfer_complete(&stream->quic->recvstate))) {
         /* tidy up the request streaming */
         stream->req.write_req.cb = NULL;
         stream->req.write_req.ctx = NULL;


### PR DESCRIPTION
There is a case where we have started streaming, received all data from the stream, but have not processed it all before cleaning up, resulting in truncation and the client waiting for more data.