### PR TITLE
Fix connection remain in CLOSE_WAIT.

### DIFF
--- a/include/h2o/socketpool.h
+++ b/include/h2o/socketpool.h
@@ -102,6 +102,7 @@ typedef struct st_h2o_socketpool_t {
     uint64_t timeout; /* in milliseconds */
     struct {
         h2o_loop_t *loop;
+        h2o_loop_t *sock_loop;
         h2o_timer_t timeout;
     } _interval_cb;
     SSL_CTX *_ssl_ctx;


### PR DESCRIPTION
* Fixes #2816
* Use the loop that which socket generating thread has for the timer.
`pool-> _interval_cb.loop` is not necessarily equal to the loop which belongs to the socket.

In the first place, when it is not to equal `pool-> _interval_cb.loop`  and socket's loop(`this_loop`), it could not be set on_timeout timer like that.

https://github.com/h2o/h2o/blob/98c7c889d553b06bb9a0c98533f16c0d7cb0e3ee/lib/common/socketpool.c#L107-L114

https://github.com/h2o/h2o/blob/98c7c889d553b06bb9a0c98533f16c0d7cb0e3ee/lib/common/socketpool.c#L606

In my observation, #2816 has occurred when it called `check_pool_expired_locked` in case of `pool-> _interval_cb.loop` is different from socket's loop.

Moreover, `entry->added_at` has obtained from the socket's loop, OTOH `now_ms` in `destroy_expired_locked` has got from  `pool-> _interval_cb.loop`. it would be miscalculate expire, if `pool-> _interval_cb.loop` doesn't equal to the socket's loop.

https://github.com/h2o/h2o/blob/98c7c889d553b06bb9a0c98533f16c0d7cb0e3ee/lib/common/socketpool.c#L598

https://github.com/h2o/h2o/blob/98c7c889d553b06bb9a0c98533f16c0d7cb0e3ee/lib/common/socketpool.c#L91-L96
