### PR TITLE
auto-tuning of memory recycler

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -225,6 +225,10 @@ void h2o_mem_free_recycle(h2o_mem_recycle_t *allocator, void *p);
  * release all the memory chunks cached in input allocator to system
  */
 void h2o_mem_clear_recycle(h2o_mem_recycle_t *allocator, int full);
+/**
+ *
+ */
+static int h2o_mem_recycle_is_empty(h2o_mem_recycle_t *allocator);
 
 /**
  * initializes the memory pool.
@@ -269,6 +273,10 @@ static int h2o_mem_release_shared(void *p);
  * frees unused memory being pooled for recycling
  */
 void h2o_buffer_clear_recycle(int full);
+/**
+ *
+ */
+int h2o_buffer_recycle_is_empty(void);
 /**
  * initialize the buffer using given prototype.
  */
@@ -412,6 +420,11 @@ inline void *h2o_memcpy(void *dst, const void *src, size_t n)
     else if (n != 0)
         h2o_fatal("null pointer passed to memcpy");
     return dst;
+}
+
+inline int h2o_mem_recycle_is_empty(h2o_mem_recycle_t *allocator)
+{
+    return allocator->chunks.size == 0;
 }
 
 inline h2o_iovec_t h2o_iovec_init(const void *base, size_t len)

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -92,16 +92,26 @@ typedef struct st_h2o_iovec_t {
     size_t len;
 } h2o_iovec_t;
 
+#define H2O_VECTOR(type)                                                                                                           \
+    struct {                                                                                                                       \
+        type *entries;                                                                                                             \
+        size_t size;                                                                                                               \
+        size_t capacity;                                                                                                           \
+    }
+
+typedef H2O_VECTOR(void) h2o_vector_t;
+typedef H2O_VECTOR(uint8_t) h2o_byte_vector_t;
+typedef H2O_VECTOR(h2o_iovec_t) h2o_iovec_vector_t;
+
 typedef struct st_h2o_mem_recycle_conf_t {
     size_t memsize;
-    size_t max_cnt;
     size_t alignment;
 } h2o_mem_recycle_conf_t;
 
 typedef struct st_h2o_mem_recycle_t {
     const h2o_mem_recycle_conf_t *conf;
-    void **chunks;
-    size_t cnt;
+    H2O_VECTOR(void *) chunks;
+    size_t low_watermark;
 } h2o_mem_recycle_t;
 
 struct st_h2o_mem_pool_shared_entry_t {
@@ -168,17 +178,6 @@ typedef struct st_h2o_doublebuffer_t {
     unsigned char inflight : 1;
     size_t _bytes_inflight;
 } h2o_doublebuffer_t;
-
-#define H2O_VECTOR(type)                                                                                                           \
-    struct {                                                                                                                       \
-        type *entries;                                                                                                             \
-        size_t size;                                                                                                               \
-        size_t capacity;                                                                                                           \
-    }
-
-typedef H2O_VECTOR(void) h2o_vector_t;
-typedef H2O_VECTOR(uint8_t) h2o_byte_vector_t;
-typedef H2O_VECTOR(h2o_iovec_t) h2o_iovec_vector_t;
 
 extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -236,7 +236,7 @@ extern h2o_buffer_prototype_t h2o_socket_buffer_prototype;
 /**
  * see H2O_SOCKET_DEFAULT_SSL_BUFFER_SIZE
  */
-extern size_t h2o_socket_ssl_buffer_size;
+extern h2o_mem_recycle_conf_t h2o_socket_ssl_buffer_conf;
 extern __thread h2o_mem_recycle_t h2o_socket_ssl_buffer_allocator;
 
 /**

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -138,7 +138,6 @@ void h2o_mem_clear_recycle(h2o_mem_recycle_t *allocator, int full)
         size_t delta = (allocator->low_watermark + 1) / 2;
         assert(allocator->chunks.size >= delta);
         allocator->low_watermark = allocator->chunks.size - delta;
-        allocator->low_watermark = allocator->chunks.size;
     }
 
     while (allocator->chunks.size > allocator->low_watermark)

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -304,6 +304,17 @@ void h2o_buffer_clear_recycle(int full)
     h2o_mem_clear_recycle(&buffer_recycle_bins.zero_sized, full);
 }
 
+int h2o_buffer_recycle_is_empty(void)
+{
+    for (unsigned i = H2O_BUFFER_MIN_ALLOC_POWER; i <= buffer_recycle_bins.largest_power; ++i) {
+        if (!h2o_mem_recycle_is_empty(&buffer_recycle_bins.bins[i - H2O_BUFFER_MIN_ALLOC_POWER].recycle))
+            return 0;
+    }
+    if (!h2o_mem_recycle_is_empty(&buffer_recycle_bins.zero_sized))
+        return 0;
+    return 1;
+}
+
 static h2o_mem_recycle_t *buffer_get_recycle(unsigned power, int only_if_exists)
 {
     if (power > buffer_recycle_bins.largest_power) {

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -129,12 +129,19 @@ void h2o_mem_clear_recycle(h2o_mem_recycle_t *allocator, int full)
     if (allocator->chunks.capacity == 0)
         return;
 
-    /* Set new watermark to (current-size + watermark) / 2 and clear if we have more entries than that. The intent of this design
-     * are:
+    /* Update waterwark. New watermark is set to max(low_watermark,current) / 2, in order to:
      * - under stable condition, reduce exponentially the number of buffers being kept
-     * - adopt to the increase of the buffers being kept
-     */
-    allocator->low_watermark = full ? 0 : (allocator->chunks.size + allocator->low_watermark) / 2;
+     * - adopt to the increase of the buffers being kept */
+    size_t new_watermark;
+    if (full) {
+        new_watermark = 0;
+    } else {
+        new_watermark = allocator->low_watermark;
+        if (new_watermark < allocator->chunks.size)
+            new_watermark = allocator->chunks.size;
+        new_watermark /= 2;
+    }
+    allocator->low_watermark = new_watermark;
 
     while (allocator->chunks.size > allocator->low_watermark)
         free(allocator->chunks.entries[--allocator->chunks.size]);

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -79,8 +79,8 @@ struct st_h2o_mem_pool_shared_ref_t {
 
 void *(*volatile h2o_mem__set_secure)(void *, int, size_t) = memset;
 
-static const size_t mem_pool_allocator_memsize = sizeof(union un_h2o_mem_pool_chunk_t);
-__thread h2o_mem_recycle_t h2o_mem_pool_allocator = {&mem_pool_allocator_memsize, 16};
+static const h2o_mem_recycle_conf_t mem_pool_allocator_conf = {.memsize = sizeof(union un_h2o_mem_pool_chunk_t), .max_cnt = 16};
+__thread h2o_mem_recycle_t h2o_mem_pool_allocator = {&mem_pool_allocator_conf};
 size_t h2o_mmap_errors = 0;
 
 void h2o__fatal(const char *file, int line, const char *msg, ...)
@@ -100,7 +100,7 @@ void h2o__fatal(const char *file, int line, const char *msg, ...)
 void *h2o_mem_alloc_recycle(h2o_mem_recycle_t *allocator)
 {
     if (allocator->cnt == 0)
-        return h2o_mem_alloc(*allocator->memsize);
+        return h2o_mem_aligned_alloc(allocator->conf->alignment, allocator->conf->memsize);
     /* detach and return the pooled pointer */
     return allocator->chunks[--allocator->cnt];
 }
@@ -109,9 +109,9 @@ void h2o_mem_free_recycle(h2o_mem_recycle_t *allocator, void *p)
 {
 #if !ASAN_IN_USE
     /* register the pointer to the pool and return unless the pool is full */
-    if (allocator->cnt < allocator->max) {
+    if (allocator->cnt < allocator->conf->max_cnt) {
         if (allocator->chunks == NULL)
-            allocator->chunks = h2o_mem_alloc(sizeof(*allocator->chunks) * allocator->max);
+            allocator->chunks = h2o_mem_alloc(sizeof(*allocator->chunks) * allocator->conf->max_cnt);
         allocator->chunks[allocator->cnt++] = p;
         return;
     }
@@ -237,7 +237,7 @@ static size_t topagesize(size_t capacity)
  */
 #define H2O_BUFFER_MIN_ALLOC_POWER 12
 
-static size_t buffer_recycle_bins_sizeof_zero_sized = sizeof(h2o_buffer_t);
+static const h2o_mem_recycle_conf_t buffer_recycle_bins_zero_sized_conf = {.memsize = sizeof(h2o_buffer_t), .max_cnt = 100};
 /**
  * Retains recycle bins for `h2o_buffer_t`.
  */
@@ -246,7 +246,7 @@ static __thread struct {
      * Holds recycle bins for `h2o_buffer_t`. Bin for capacity 2^x is located at x - H2O_BUFFER_MIN_ALLOC_POWER.
      */
     struct buffer_recycle_bin_t {
-        size_t memsize;
+        h2o_mem_recycle_conf_t conf;
         h2o_mem_recycle_t recycle;
     } * bins;
     /**
@@ -257,7 +257,7 @@ static __thread struct {
      * Bin containing chunks of sizeof(h2o_buffer_t). This is used by empties buffers to retain the previous capacity.
      */
     h2o_mem_recycle_t zero_sized;
-} buffer_recycle_bins = {NULL, H2O_BUFFER_MIN_ALLOC_POWER - 1, {&buffer_recycle_bins_sizeof_zero_sized, 100}};
+} buffer_recycle_bins = {NULL, H2O_BUFFER_MIN_ALLOC_POWER - 1, {&buffer_recycle_bins_zero_sized_conf}};
 
 static unsigned buffer_size_to_power(size_t sz)
 {
@@ -295,14 +295,14 @@ static h2o_mem_recycle_t *buffer_get_recycle(unsigned power, int only_if_exists)
             h2o_mem_realloc(buffer_recycle_bins.bins, sizeof(*buffer_recycle_bins.bins) * (power - H2O_BUFFER_MIN_ALLOC_POWER + 1));
         for (size_t p = H2O_BUFFER_MIN_ALLOC_POWER; p <= buffer_recycle_bins.largest_power; ++p) {
             struct buffer_recycle_bin_t *bin = buffer_recycle_bins.bins + p - H2O_BUFFER_MIN_ALLOC_POWER;
-            bin->recycle.memsize = &bin->memsize;
+            bin->recycle.conf = &bin->conf;
         }
         do {
             ++buffer_recycle_bins.largest_power;
             struct buffer_recycle_bin_t *newbin =
                 buffer_recycle_bins.bins + buffer_recycle_bins.largest_power - H2O_BUFFER_MIN_ALLOC_POWER;
-            newbin->memsize = (size_t)1 << buffer_recycle_bins.largest_power;
-            newbin->recycle = (h2o_mem_recycle_t){&newbin->memsize, 16};
+            newbin->conf = (h2o_mem_recycle_conf_t){.memsize = (size_t)1 << buffer_recycle_bins.largest_power, .max_cnt = 16};
+            newbin->recycle = (h2o_mem_recycle_t){&newbin->conf};
         } while (buffer_recycle_bins.largest_power < power);
     }
 
@@ -364,7 +364,7 @@ static h2o_buffer_t *buffer_allocate(h2o_buffer_prototype_t *prototype, size_t m
     h2o_mem_recycle_t *allocator = buffer_get_recycle(alloc_power, 1);
     if (allocator == NULL || allocator->cnt == 0)
         goto AllocNormal;
-    assert(*allocator->memsize == (size_t)1 << alloc_power);
+    assert(allocator->conf->memsize == (size_t)1 << alloc_power);
     newp = h2o_mem_alloc_recycle(allocator);
     goto AllocDone;
 

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -167,7 +167,7 @@ h2o_buffer_prototype_t h2o_socket_buffer_prototype = {
     {H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE}, /* minimum initial capacity; actual initial size is ~8KB, see h2o_buffer_reserve */
     &h2o_socket_buffer_mmap_settings};
 
-h2o_mem_recycle_conf_t h2o_socket_ssl_buffer_conf = {.memsize = H2O_SOCKET_DEFAULT_SSL_BUFFER_SIZE, .max_cnt = 1024};
+h2o_mem_recycle_conf_t h2o_socket_ssl_buffer_conf = {.memsize = H2O_SOCKET_DEFAULT_SSL_BUFFER_SIZE};
 __thread h2o_mem_recycle_t h2o_socket_ssl_buffer_allocator = {&h2o_socket_ssl_buffer_conf};
 
 int h2o_socket_use_ktls = 0;

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -167,8 +167,8 @@ h2o_buffer_prototype_t h2o_socket_buffer_prototype = {
     {H2O_SOCKET_INITIAL_INPUT_BUFFER_SIZE}, /* minimum initial capacity; actual initial size is ~8KB, see h2o_buffer_reserve */
     &h2o_socket_buffer_mmap_settings};
 
-size_t h2o_socket_ssl_buffer_size = H2O_SOCKET_DEFAULT_SSL_BUFFER_SIZE;
-__thread h2o_mem_recycle_t h2o_socket_ssl_buffer_allocator = {&h2o_socket_ssl_buffer_size, 1024};
+h2o_mem_recycle_conf_t h2o_socket_ssl_buffer_conf = {.memsize = H2O_SOCKET_DEFAULT_SSL_BUFFER_SIZE, .max_cnt = 1024};
+__thread h2o_mem_recycle_t h2o_socket_ssl_buffer_allocator = {&h2o_socket_ssl_buffer_conf};
 
 int h2o_socket_use_ktls = 0;
 
@@ -248,7 +248,7 @@ static void dispose_write_buf(h2o_socket_t *sock)
 static void init_ssl_output_buffer(struct st_h2o_socket_ssl_t *ssl)
 {
     ptls_buffer_init(&ssl->output.buf, h2o_mem_alloc_recycle(&h2o_socket_ssl_buffer_allocator),
-                     *h2o_socket_ssl_buffer_allocator.memsize);
+                     h2o_socket_ssl_buffer_allocator.conf->memsize);
     ssl->output.buf.is_allocated = 1; /* set to true, so that the allocated memory is freed when the buffer is expanded */
     ssl->output.pending_off = 0;
 }
@@ -261,7 +261,7 @@ static void dispose_ssl_output_buffer(struct st_h2o_socket_ssl_t *ssl)
 
     assert(ssl->output.buf.is_allocated);
 
-    if (ssl->output.buf.capacity == *h2o_socket_ssl_buffer_allocator.memsize) {
+    if (ssl->output.buf.capacity == h2o_socket_ssl_buffer_allocator.conf->memsize) {
         h2o_mem_free_recycle(&h2o_socket_ssl_buffer_allocator, ssl->output.buf.base);
     } else {
         free(ssl->output.buf.base);
@@ -868,7 +868,7 @@ void h2o_socket_sendvec(h2o_socket_t *sock, h2o_sendvec_t *vecs, size_t cnt, h2o
             return;
 #endif
         /* Load the vector onto memory now. */
-        assert(h2o_socket_ssl_buffer_size >= H2O_PULL_SENDVEC_MAX_SIZE);
+        assert(h2o_socket_ssl_buffer_allocator.conf->memsize >= H2O_PULL_SENDVEC_MAX_SIZE);
         sock->_write_buf.flattened = h2o_mem_alloc_recycle(&h2o_socket_ssl_buffer_allocator);
         bufs[pull_index] = h2o_iovec_init(sock->_write_buf.flattened, vecs[pull_index].len);
         if (!vecs[pull_index].callbacks->read_(vecs + pull_index, bufs[pull_index].base, bufs[pull_index].len)) {

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -253,7 +253,7 @@ static const h2o_sendvec_callbacks_t self_allocated_vec_callbacks = {h2o_sendvec
 
 static int sendvec_size_is_for_recycle(size_t size)
 {
-    if (*h2o_socket_ssl_buffer_allocator.memsize / 2 <= size && size <= *h2o_socket_ssl_buffer_allocator.memsize)
+    if (h2o_socket_ssl_buffer_allocator.conf->memsize / 2 <= size && size <= h2o_socket_ssl_buffer_allocator.conf->memsize)
         return 1;
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -3212,19 +3212,23 @@ static void *run_loop(void *_thread_index)
     h2o_barrier_wait(&conf.startup_sync_barrier_post);
 
     /* the main loop */
-    uint64_t last_buffer_gc_at = 0;
+    uint64_t next_buffer_gc_at = UINT64_MAX;
     while (1) {
         if (conf.shutdown_requested)
             break;
         update_listener_state(listeners);
         /* run the loop once */
-        h2o_evloop_run(conf.threads[thread_index].ctx.loop, INT32_MAX);
+        h2o_evloop_run(conf.threads[thread_index].ctx.loop, next_buffer_gc_at == UINT64_MAX ? INT32_MAX : 1000);
         /* cleanup */
         h2o_filecache_clear(conf.threads[thread_index].ctx.filecache);
-        if (last_buffer_gc_at + 1000 < h2o_now(conf.threads[thread_index].ctx.loop)) {
-            last_buffer_gc_at = h2o_now(conf.threads[thread_index].ctx.loop);
+        if (h2o_now(conf.threads[thread_index].ctx.loop) >= next_buffer_gc_at) {
             h2o_buffer_clear_recycle(0);
             h2o_mem_clear_recycle(&h2o_socket_ssl_buffer_allocator, 0);
+        }
+        if (h2o_buffer_recycle_is_empty() && h2o_mem_recycle_is_empty(&h2o_socket_ssl_buffer_allocator)) {
+            next_buffer_gc_at = UINT64_MAX;
+        } else if (next_buffer_gc_at == UINT64_MAX) {
+            next_buffer_gc_at = h2o_now(conf.threads[thread_index].ctx.loop) + 1000;
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -3224,12 +3224,11 @@ static void *run_loop(void *_thread_index)
         if (h2o_now(conf.threads[thread_index].ctx.loop) >= next_buffer_gc_at) {
             h2o_buffer_clear_recycle(0);
             h2o_mem_clear_recycle(&h2o_socket_ssl_buffer_allocator, 0);
-        }
-        if (h2o_buffer_recycle_is_empty() && h2o_mem_recycle_is_empty(&h2o_socket_ssl_buffer_allocator)) {
             next_buffer_gc_at = UINT64_MAX;
-        } else if (next_buffer_gc_at == UINT64_MAX) {
-            next_buffer_gc_at = h2o_now(conf.threads[thread_index].ctx.loop) + 1000;
         }
+        if (next_buffer_gc_at == UINT64_MAX &&
+            (!h2o_buffer_recycle_is_empty() || !h2o_mem_recycle_is_empty(&h2o_socket_ssl_buffer_allocator)))
+            next_buffer_gc_at = h2o_now(conf.threads[thread_index].ctx.loop) + 1000;
     }
 
     if (thread_index == 0)


### PR DESCRIPTION
Spin-off of #3007.

H2O has a struct called `h2o_mem_recycle_t`. Along with the functions that deal with the struct, it acts as a buffer between h2o and malloc, reducing fluctuation of memory requirement observed by malloc.

Without `h2o_mem_recycle_t`, the fluctuation being observed by malloc often becomes so large that it starts returning memory to kernel then soon asking for kernel to allocate again. This kind of behavior is especially painful for multi-threaded servers like h2o, because returning memory to kernel involves TLB shootdown that affects all the threads, not to mention the cost of pagefaults when writing to newly allocated memory.

Up until now, each `h2o_mem_recycle_t` has been provided a fixed number of slots (`h2o_mem_recycle_t::max`). With #3007 doing zero-copy, adequate value of `max` may become huge and therefore we need a method that either auto-tunes itself or provides a way of hand tuning.

This PR implements the auto-tuning approach.

Instead of having a fixed number, the recycler records the low watermark (i.e., the minimum number of chunks contained in the recycler), between each invocation of `h2o_mem_clear_reycle` (which is called every once a second). When `h2o_mem_clear_recycle` is invoked, the low watermark is adjusted to `current-level - low_watermark / 2`, and if more chunks are retained than that, they are freed.

The intent of this design is to release 1/2 of the buffers that were never used in the previous cycle. By repeating the cycle, we reduce unused memory to zero under stable condition, while keeping enough buffers around when the pressure is increasing or flattering.

Separately, this PR adds the capability to specify the memory alignment.