### PR TITLE
[test] check the test conf is written to the disk

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -295,7 +295,8 @@ sub spawn_h2o_raw {
     $conf = "num-threads: 2\n$conf" unless $conf =~ /^num-threads:/m;
 
     my ($conffh, $conffn) = tempfile(UNLINK => 1);
-    print $conffh $conf;
+    print $conffh $conf or confess("failed to write to $conffn: $!");
+    $conffh->flush or confess("failed to write to $conffn: $!");
     Test::More::diag($conf) if $ENV{TEST_DEBUG};
 
     # spawn the server


### PR DESCRIPTION
I was a bit confused by a test failure where h2o cannot parse the config file when `/tmp` was full. This patch should help us find such unusual situations. 