### PR TITLE
`h2o-httpclient`: lowercase the header field name from `-H`.

### DIFF
--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -705,7 +705,10 @@ int main(int argc, char **argv)
             }
             for (value_start = colon + 1; *value_start == ' ' || *value_start == '\t'; ++value_start)
                 ;
-            req.headers[req.num_headers].name = h2o_iovec_init(optarg, colon - optarg);
+            /* lowercase the header field name (HTTP/2: RFC 9113 Section 8.2, HTTP/3: RFC 9114 Section 4.2) */
+            h2o_iovec_t name = h2o_strdup(NULL, optarg, colon - optarg);
+            h2o_strtolower(name.base, name.len);
+            req.headers[req.num_headers].name = name;
             req.headers[req.num_headers].value = h2o_iovec_init(value_start, strlen(value_start));
             ++req.num_headers;
         } break;

--- a/t/10httpclient-lowercase.t
+++ b/t/10httpclient-lowercase.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+use Net::EmptyPort qw(check_port empty_port);
+
+my $progname = "h2o-httpclient";
+my $progpath = bindir() . "/$progname";
+plan skip_all => "$progname not found"
+    unless -x $progpath;
+
+my $upstream_port = empty_port();
+my $quic_port = empty_port({ host  => "0.0.0.0", proto => "udp" });
+
+my $upstream = spawn_server(
+    argv     => [ qw(plackup -s Starlet --keepalive-timeout 100 --access-log /dev/null --listen), $upstream_port, ASSETS_DIR . "/upstream.psgi" ],
+    is_ready =>  sub {
+        check_port($upstream_port);
+    },
+);
+
+my $server = spawn_h2o(<< "EOT");
+listen:
+  type: quic
+  host: 127.0.0.1
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+my $out = `$progpath -3 100 -H sArCaSmCaSe:Enabled http://127.0.0.1:$quic_port/echo-headers`;
+
+like($out, qr/^sarcasmcase: *Enabled$/m);
+
+done_testing;


### PR DESCRIPTION
This is for user convenience, as it is easy to forget the fact that header field names on the wire are supposed to be in lower case in HTTP/3 (and in HTTP/2).

HTTP/2 https://datatracker.ietf.org/doc/html/rfc9113.html#section-8.2
> Field names MUST be converted to lowercase when constructing an HTTP/2 message.

HTTP/3 https://datatracker.ietf.org/doc/html/rfc9114.html#section-4.2
> Characters in field names MUST be converted to lowercase prior to their encoding.  A request or response containing uppercase characters in field names MUST be treated as malformed.