### PR TITLE
recycle h2o_req_t allocations

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1362,6 +1362,11 @@ void h2o_accept(h2o_accept_ctx_t *ctx, h2o_socket_t *sock);
 static h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval connected_at,
                                          const h2o_conn_callbacks_t *callbacks);
 /**
+ * creates a new connection in a buffer
+ */
+static h2o_conn_t *h2o_create_connection_in_place(void *buf, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval connected_at,
+                                                  const h2o_conn_callbacks_t *callbacks);
+/**
  * returns the uuid of the connection as a null-terminated string.
  */
 static const char *h2o_conn_get_uuid(h2o_conn_t *conn);
@@ -2244,10 +2249,10 @@ void h2o_self_trace_register_configurator(h2o_globalconf_t *conf);
 extern pthread_mutex_t h2o_conn_id_mutex;
 #endif
 
-inline h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval connected_at,
+inline h2o_conn_t *h2o_create_connection_in_place(void *buf, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval connected_at,
                                          const h2o_conn_callbacks_t *callbacks)
 {
-    h2o_conn_t *conn = (h2o_conn_t *)h2o_mem_alloc(sz);
+    h2o_conn_t *conn = (h2o_conn_t *)buf;
 
     conn->ctx = ctx;
     conn->hosts = hosts;
@@ -2263,6 +2268,13 @@ inline h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_host
     conn->_uuid.is_initialized = 0;
 
     return conn;
+}
+
+inline h2o_conn_t *h2o_create_connection(size_t sz, h2o_context_t *ctx, h2o_hostconf_t **hosts, struct timeval connected_at,
+                                         const h2o_conn_callbacks_t *callbacks)
+{
+    h2o_conn_t *conn = (h2o_conn_t *)h2o_mem_alloc(sz);
+    return h2o_create_connection_in_place(conn, ctx, hosts, connected_at, callbacks);
 }
 
 inline const char *h2o_conn_get_uuid(h2o_conn_t *conn)

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -393,6 +393,7 @@ void h2o_dump_memory(FILE *fp, const char *buf, size_t len);
 void h2o_append_to_null_terminated_list(void ***list, void *element);
 
 extern __thread h2o_mem_recycle_t h2o_mem_pool_allocator;
+extern __thread h2o_mem_recycle_t h2o_mem_req_allocator;
 extern size_t h2o_mmap_errors;
 
 /* inline defs */

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -79,6 +79,8 @@ struct st_h2o_mem_pool_shared_ref_t {
 
 void *(*volatile h2o_mem__set_secure)(void *, int, size_t) = memset;
 
+static const size_t mem_req_allocator_memsize = 2048;
+__thread h2o_mem_recycle_t h2o_mem_req_allocator = {&mem_req_allocator_memsize, 10000};
 static const size_t mem_pool_allocator_memsize = sizeof(union un_h2o_mem_pool_chunk_t);
 __thread h2o_mem_recycle_t h2o_mem_pool_allocator = {&mem_pool_allocator_memsize, 16};
 size_t h2o_mmap_errors = 0;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1715,7 +1715,9 @@ static h2o_http2_conn_t *create_conn(h2o_context_t *ctx, h2o_hostconf_t **hosts,
         }},
     };
 
-    h2o_http2_conn_t *conn = (void *)h2o_create_connection(sizeof(*conn), ctx, hosts, connected_at, &callbacks);
+    void *_conn = h2o_mem_alloc_recycle(&h2o_mem_req_allocator);
+    h2o_http2_conn_t *conn = (void *)h2o_create_connection_in_place(_conn, ctx, hosts, connected_at, &callbacks);
+    H2O_BUILD_ASSERT(sizeof(*conn) < *h2o_mem_req_allocator.memsize);
 
     memset((char *)conn + sizeof(conn->super), 0, sizeof(*conn) - sizeof(conn->super));
     conn->sock = sock;


### PR DESCRIPTION
Both allocations are relatively large and could be reused from one protocol to the other