### PR TITLE
fix typo leading to miscalculation of record size when tls1.2 w. chachapoly is used

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1368,10 +1368,10 @@ static void on_handshake_complete(h2o_socket_t *sock, const char *err)
             case TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:
                 sock->ssl->record_overhead = 5 /* header */ + 8 /* record_iv_length (RFC 5288 3) */ + 16 /* tag (RFC 5116 5.1) */;
                 break;
-#if defined(TLS1_CK_DHE_RSA_CHACHA20_POLY1305)
-            case TLS1_CK_DHE_RSA_CHACHA20_POLY1305:
-            case TLS1_CK_ECDHE_RSA_CHACHA20_POLY1305:
-            case TLS1_CK_ECDHE_ECDSA_CHACHA20_POLY1305:
+#if defined(TLS1_CK_DHE_RSA_WITH_CHACHA20_POLY1305)
+            case TLS1_CK_DHE_RSA_WITH_CHACHA20_POLY1305:
+            case TLS1_CK_ECDHE_RSA_WITH_CHACHA20_POLY1305:
+            case TLS1_CK_ECDHE_ECDSA_WITH_CHACHA20_POLY1305:
                 sock->ssl->record_overhead = 5 /* header */ + 16 /* tag */;
                 break;
 #endif


### PR DESCRIPTION
The negative effect impact is cosmetic, as this at worst leads to some overlap of one TLS record across multiple TCP packets.