### PR TITLE
add support for OpenSSL 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
       matrix:
         include:
           - name: default
-            command: make -f misc/docker-ci/check.mk ALL BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
+            command: make -f misc/docker-ci/check.mk ALL BUILD_ARGS=-j6 TEST_ENV='TEST_JOBS=4 TEST_PLATFORM=github-actions'
           - name: OpenSSL 1.1.0 + Fuzz
-            command: make -f misc/docker-ci/check.mk ossl1.1.0+fuzz BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
+            command: make -f misc/docker-ci/check.mk ossl1.1.0+fuzz BUILD_ARGS=-j6 TEST_ENV='TEST_JOBS=4 TEST_PLATFORM=github-actions'
           - name: OpenSSL 1.1.1
-            command: make -f misc/docker-ci/check.mk ossl1.1.1 BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
+            command: make -f misc/docker-ci/check.mk ossl1.1.1 BUILD_ARGS=-j6 TEST_ENV='TEST_JOBS=4 TEST_PLATFORM=github-actions'
           - name: OpenSSL 3.0 (Ubuntu 22.04 / DTrace)
-            command: make -f misc/docker-ci/check.mk ossl3.0 BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
+            command: make -f misc/docker-ci/check.mk ossl3.0 BUILD_ARGS=-j6 TEST_ENV='TEST_JOBS=4 TEST_PLATFORM=github-actions'
           - name: DTrace + ASan
-            command: make -f misc/docker-ci/check.mk dtrace+asan BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
+            command: make -f misc/docker-ci/check.mk dtrace+asan BUILD_ARGS=-j6 TEST_ENV='TEST_JOBS=4 TEST_PLATFORM=github-actions'
 
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
             command: make -f misc/docker-ci/check.mk ossl1.1.0+fuzz BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
           - name: OpenSSL 1.1.1
             command: make -f misc/docker-ci/check.mk ossl1.1.1 BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
+          - name: OpenSSL 3.0 (Ubuntu 22.04 / DTrace)
+            command: make -f misc/docker-ci/check.mk ossl3.0 BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
           - name: DTrace + ASan
             command: make -f misc/docker-ci/check.mk dtrace+asan BUILD_ARGS=-j6 TEST_ENV=TEST_JOBS=4
 

--- a/deps/neverbleed/Makefile
+++ b/deps/neverbleed/Makefile
@@ -10,7 +10,7 @@ all:    $(TARGET)
 	$(CC) $(CFLAGS) -c $<
 
 $(TARGET): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBS) $(LDFLAGS)
 
 clean:
 	rm -fr $(OBJS) $(TARGET)

--- a/misc/docker-ci/Dockerfile.ubuntu2204
+++ b/misc/docker-ci/Dockerfile.ubuntu2204
@@ -1,0 +1,76 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get --yes update
+RUN apt-get install --yes \
+	apache2-utils \
+	bison \
+	bpftrace \
+	clang \
+	cmake \
+	cmake-data \
+	curl \
+	dnsutils \
+	flex \
+	git \
+	libbpfcc-dev \
+	libbrotli-dev \
+	libc-ares-dev \
+	libcap-dev \
+	libclang-dev \
+	libedit-dev \
+	libelf-dev \
+	libev-dev \
+	libssl-dev \
+	liburing-dev \
+	libuv1-dev \
+	memcached \
+	net-tools \
+	netcat-openbsd \
+	nghttp2-client \
+	php-cgi \
+	pkgconf \
+	python3 \
+	python3-distutils \
+	redis-server \
+	ruby-dev \
+	sudo \
+	systemtap-sdt-dev \
+	time \
+	wget \
+	zlib1g-dev
+
+# perl
+RUN apt-get install --yes \
+	cpanminus \
+	libfcgi-perl \
+	libfcgi-procmanager-perl \
+	libipc-signal-perl \
+	libjson-perl \
+	liblist-moreutils-perl \
+	libplack-perl \
+	libscope-guard-perl \
+	libtest-exception-perl \
+	libwww-perl \
+	libio-socket-ssl-perl
+ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
+RUN cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
+
+# h2spec
+RUN curl -Ls https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin
+
+# use dumb-init
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 \
+ && chmod +x /usr/local/bin/dumb-init
+
+# komake
+RUN wget -O /usr/local/bin/komake https://raw.githubusercontent.com/kazuho/komake/main/komake && chmod +x /usr/local/bin/komake
+
+# create user
+RUN useradd --create-home ci
+RUN echo 'ci ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+WORKDIR /home/ci
+USER ci
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--rewrite", "1:0"]

--- a/misc/docker-ci/Dockerfile.ubuntu2204
+++ b/misc/docker-ci/Dockerfile.ubuntu2204
@@ -7,6 +7,7 @@ RUN apt-get install --yes \
 	apache2-utils \
 	bison \
 	bpftrace \
+	brotli \
 	clang \
 	cmake \
 	cmake-data \
@@ -29,6 +30,7 @@ RUN apt-get install --yes \
 	net-tools \
 	netcat-openbsd \
 	nghttp2-client \
+	nodejs \
 	php-cgi \
 	pkgconf \
 	python3 \

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -57,7 +57,7 @@ _mount:
 	# allow overwrite of include/h2o/version.h
 	sudo chown ci:ci $(SRC_DIR)/include/h2o
 	# allow write of mruby executables being generated (FIXME don't generate here)
-	for i in deps/mruby/bin misc/h2get/deps/mruby-1.2.0/bin; do \
+	for i in deps/mruby/bin misc/h2get/deps/mruby/bin; do \
 		sudo rm -rf $(SRC_DIR)/$$i; \
 		sudo mkdir $(SRC_DIR)/$$i; \
 		sudo chown ci:ci $(SRC_DIR)/$$i; \

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -35,8 +35,15 @@ ossl1.1.1:
 		BUILD_ARGS='$(BUILD_ARGS)' \
 		TEST_ENV='$(TEST_ENV)'
 
+ossl3.0:
+	docker run $(DOCKER_RUN_OPTS) h2oserver/h2o-ci:ubuntu2204 \
+		env DTRACE_TESTS=1 \
+		make -f $(SRC_DIR).ro/misc/docker-ci/check.mk _check \
+		BUILD_ARGS='$(BUILD_ARGS)' \
+		TEST_ENV='$(TEST_ENV)'
+
 dtrace+asan:
-	docker run $(DOCKER_RUN_OPTS) h2oserver/h2o-ci:ubuntu2004  \
+	docker run $(DOCKER_RUN_OPTS) h2oserver/h2o-ci:ubuntu2004 \
 		env DTRACE_TESTS=1 \
 		make -f $(SRC_DIR).ro/misc/docker-ci/check.mk _check \
 		CMAKE_ARGS='-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS=-fsanitize=address -DCMAKE_CXX_FLAGS=-fsanitize=address' \

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -56,6 +56,9 @@ _mount:
 	sudo mount --bind /tmp/src/upper $(SRC_DIR)
 	# allow overwrite of include/h2o/version.h
 	sudo chown -R ci:ci $(SRC_DIR)/include/h2o
+	# allow taking lock: mruby_config.rb.lock (which might or might not exist)
+	sudo touch $(SRC_DIR)/misc/mruby_config.rb.lock $(SRC_DIR)/misc/h2get/misc/mruby_config.rb.lock
+	sudo chown ci:ci $(SRC_DIR)/misc/mruby_config.rb.lock $(SRC_DIR)/misc/h2get/misc/mruby_config.rb.lock
 	# allow write of mruby executables being generated (FIXME don't generate here)
 	for i in deps/mruby/bin misc/h2get/deps/mruby/bin; do \
 		sudo rm -rf $(SRC_DIR)/$$i; \

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -55,12 +55,12 @@ _mount:
 	sudo mount -t overlay overlay -o lowerdir=$(SRC_DIR).ro,upperdir=/tmp/src/upper,workdir=/tmp/src/work /tmp/src/upper
 	sudo mount --bind /tmp/src/upper $(SRC_DIR)
 	# allow overwrite of include/h2o/version.h
-	sudo chown ci:ci $(SRC_DIR)/include/h2o
+	sudo chown -R ci:ci $(SRC_DIR)/include/h2o
 	# allow write of mruby executables being generated (FIXME don't generate here)
 	for i in deps/mruby/bin misc/h2get/deps/mruby/bin; do \
 		sudo rm -rf $(SRC_DIR)/$$i; \
 		sudo mkdir $(SRC_DIR)/$$i; \
-		sudo chown ci:ci $(SRC_DIR)/$$i; \
+		sudo chown -R ci:ci $(SRC_DIR)/$$i; \
 	done
 
 _do_check:

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -581,6 +581,7 @@ int main(int argc, char **argv)
         h3ctx.tls.random_bytes(random_key, sizeof(random_key));
         h3ctx.quic.cid_encryptor = quicly_new_default_cid_encryptor(
             &ptls_openssl_bfecb, &ptls_openssl_aes128ecb, &ptls_openssl_sha256, ptls_iovec_init(random_key, sizeof(random_key)));
+        assert(h3ctx.quic.cid_encryptor != NULL);
         ptls_clear_memory(random_key, sizeof(random_key));
     }
     h3ctx.quic.stream_open = &h2o_httpclient_http3_on_stream_open;

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -31,6 +31,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <openssl/opensslv.h>
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
+#define LOAD_OPENSSL_PROVIDER 1
+#endif
 #include "picotls.h"
 #include "picotls/openssl.h"
 #include "quicly.h"
@@ -568,6 +573,12 @@ int main(int argc, char **argv)
     SSL_load_error_strings();
     SSL_library_init();
     OpenSSL_add_all_algorithms();
+
+    /* When using OpenSSL >= 3.0, load legacy provider so that blowfish can be used for 64-bit QUIC CIDs. */
+#if LOAD_OPENSSL_PROVIDER
+    OSSL_PROVIDER_load(NULL, "legacy");
+    OSSL_PROVIDER_load(NULL, "default");
+#endif
 
     quicly_amend_ptls_context(&h3ctx.tls);
     h3ctx.quic = quicly_spec_context;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29,6 +29,10 @@
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
+#define LOAD_OPENSSL_PROVIDER 1
+#endif
 #include "h2o/hiredis_.h"
 #include "yoml-parser.h"
 #include "yrmcds.h"
@@ -1175,6 +1179,12 @@ void init_openssl(void)
     SSL_load_error_strings();
     SSL_library_init();
     OpenSSL_add_all_algorithms();
+
+    /* When using OpenSSL >= 3.0, load legacy provider so that blowfish can be used for 64-bit QUIC CIDs. */
+#if LOAD_OPENSSL_PROVIDER
+    OSSL_PROVIDER_load(NULL, "legacy");
+    OSSL_PROVIDER_load(NULL, "default");
+#endif
 
     cache_init_defaults();
 #if H2O_USE_SESSION_TICKETS

--- a/t/50origin-frame.t
+++ b/t/50origin-frame.t
@@ -54,6 +54,6 @@ EOR
 
 test_origin_frame('', '');
 test_origin_frame('http2-origin-frame: [ ]', "0\n\"\"");
-test_origin_frame('http2-origin-frame: [ "https://a.localhost.examp1e.net" ]', "33\n\"\\000\\037https://a.localhost.examp1e.net\"");
-test_origin_frame('http2-origin-frame: [ "https://a.localhost.examp1e.net", "https://b.localhost.examp1e.net" ]', "66\n\"\\000\\037https://a.localhost.examp1e.net\\000\\037https://b.localhost.examp1e.net\"");
+test_origin_frame('http2-origin-frame: [ "https://a.localhost.examp1e.net" ]', "33\n\"\\x00\\x1fhttps://a.localhost.examp1e.net\"");
+test_origin_frame('http2-origin-frame: [ "https://a.localhost.examp1e.net", "https://b.localhost.examp1e.net" ]', "66\n\"\\x00\\x1fhttps://a.localhost.examp1e.net\\x00\\x1fhttps://b.localhost.examp1e.net\"");
 done_testing();

--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -152,11 +152,11 @@ run_with_curl($server, sub {
         my $content = `$curl --silent --show-error --data-binary \@$huge_file $proto://127.0.0.1:$port/echo`;
         is length($content), $huge_file_size, "$proto://127.0.0.1/echo (POST, mmap-backed, size)";
         is md5_hex($content), $huge_file_md5, "$proto://127.0.0.1/echo (POST, mmap-backed, md5)";
-    }
-    if ($curl !~ /--http2/) {
-        my $content = `$curl --silent --show-error --header 'Transfer-Encoding: chunked' --data-binary \@$huge_file $proto://127.0.0.1:$port/echo`;
-        is length($content), $huge_file_size, "$proto://127.0.0.1/echo (POST, chunked, mmap-backed, size)";
-        is md5_hex($content), $huge_file_md5, "$proto://127.0.0.1/echo (POST, chunked, mmap-backed, md5)";
+        if ($curl !~ /--http2/) {
+            $content = `$curl --silent --show-error --header 'Transfer-Encoding: chunked' --data-binary \@$huge_file $proto://127.0.0.1:$port/echo`;
+            is length($content), $huge_file_size, "$proto://127.0.0.1/echo (POST, chunked, mmap-backed, size)";
+            is md5_hex($content), $huge_file_md5, "$proto://127.0.0.1/echo (POST, chunked, mmap-backed, md5)";
+        }
     }
     subtest 'rewrite-redirect' => sub {
         my $content = `$curl --silent --dump-header /dev/stdout --max-redirs 0 "$proto://127.0.0.1:$port/?resp:status=302&resp:location=http://@{[uri_escape($upstream)]}/abc"`;

--- a/t/50reverse-proxy/test.pl
+++ b/t/50reverse-proxy/test.pl
@@ -146,16 +146,20 @@ run_with_curl($server, sub {
             is md5_hex($content), $files{$file}->{md5}, "$proto://127.0.0.1/echo (POST, chunked, $file, md5)";
         }
     }
-    my $content = `$curl --silent --show-error --data-binary \@$huge_file $proto://127.0.0.1:$port/echo`;
-    is length($content), $huge_file_size, "$proto://127.0.0.1/echo (POST, mmap-backed, size)";
-    is md5_hex($content), $huge_file_md5, "$proto://127.0.0.1/echo (POST, mmap-backed, md5)";
+    SKIP: {
+        skip "On GitHub Actions, too few pages can be pinned", 2
+            if $ssl_offload eq 'zerocopy' and ($ENV{TEST_PLATFORM} || '') eq 'github-actions';
+        my $content = `$curl --silent --show-error --data-binary \@$huge_file $proto://127.0.0.1:$port/echo`;
+        is length($content), $huge_file_size, "$proto://127.0.0.1/echo (POST, mmap-backed, size)";
+        is md5_hex($content), $huge_file_md5, "$proto://127.0.0.1/echo (POST, mmap-backed, md5)";
+    }
     if ($curl !~ /--http2/) {
-        $content = `$curl --silent --show-error --header 'Transfer-Encoding: chunked' --data-binary \@$huge_file $proto://127.0.0.1:$port/echo`;
+        my $content = `$curl --silent --show-error --header 'Transfer-Encoding: chunked' --data-binary \@$huge_file $proto://127.0.0.1:$port/echo`;
         is length($content), $huge_file_size, "$proto://127.0.0.1/echo (POST, chunked, mmap-backed, size)";
         is md5_hex($content), $huge_file_md5, "$proto://127.0.0.1/echo (POST, chunked, mmap-backed, md5)";
     }
     subtest 'rewrite-redirect' => sub {
-        $content = `$curl --silent --dump-header /dev/stdout --max-redirs 0 "$proto://127.0.0.1:$port/?resp:status=302&resp:location=http://@{[uri_escape($upstream)]}/abc"`;
+        my $content = `$curl --silent --dump-header /dev/stdout --max-redirs 0 "$proto://127.0.0.1:$port/?resp:status=302&resp:location=http://@{[uri_escape($upstream)]}/abc"`;
         like $content, qr{HTTP/[^ ]+ 302\s}m;
         like $content, qr{^location: ?$proto://127.0.0.1:$port/abc\r$}m;
     };

--- a/t/50server-starter.t
+++ b/t/50server-starter.t
@@ -44,7 +44,7 @@ subtest "daemon-mode" => sub {
         opts => [ qw(--mode=daemon) ],
         conf => << "EOT",
 pid-file: $tempdir/h2o.pid
-error-log: $tempdir/h2o.error
+error-log: /dev/stderr # $tempdir/h2o.error
 hosts:
   default:
     paths:


### PR DESCRIPTION
* [x] load legacy provider so that blowfish can be used for 64-bit QUIC CIDs
* [x] CI (probably it'd be easier to create and use an Ubuntu 22.04 image that comes by default with openssl 3.0, rather than trying to install 3.0 to a non-standard directory; see https://github.com/h2o/h2o/pull/2895).