### PR TITLE
Fix deadlock while gracefully shutting down

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3870,7 +3870,7 @@ int main(int argc, char **argv)
         size_t i;
         for (i = 0; i != conf.server_starter.num_fds; ++i)
             set_cloexec(conf.server_starter.fds[i]);
-        conf.server_starter.bound_fd_map = alloca(conf.server_starter.num_fds);
+        conf.server_starter.bound_fd_map = malloc(conf.server_starter.num_fds);
         memset(conf.server_starter.bound_fd_map, 0, conf.server_starter.num_fds);
     }
 
@@ -4146,9 +4146,8 @@ int main(int argc, char **argv)
     }
 
     /* start the threads */
-    conf.threads = alloca(sizeof(conf.threads[0]) * conf.thread_map.size);
-    size_t i;
-    for (i = 1; i != conf.thread_map.size; ++i) {
+    conf.threads = malloc(sizeof(conf.threads[0]) * conf.thread_map.size);
+    for (size_t i = 1; i != conf.thread_map.size; ++i) {
         pthread_t tid;
         h2o_multithread_create_thread(&tid, NULL, run_loop, (void *)i);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -3341,13 +3341,13 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     }
     h2o_context_request_shutdown(&conf.threads[thread_index].ctx);
 
-    /* Wait until all the connection gets closed. At least one worker thread that closed the last connection, turning
-     * `num_connections(0)`to zero, will exit from this loop. That worker threads does the cleanup. Other worker threads might get
-     * stuck, as `h2o_evloop_run` does not return when a different worker thread closes a connection. */
+    /* Wait until all the connections get closed. At least one worker thread that closed the last connection, turning
+     * `num_connections(0)` to zero, will exit from this loop. Other worker threads might get stuck, as `h2o_evloop_run` does not
+     * return when a different worker thread closes a connection. */
     while (num_connections(0) != 0)
         h2o_evloop_run(conf.threads[thread_index].ctx.loop, INT32_MAX);
 
-    /* Take a lock so that only one thread does the cleanup. */
+    /* More than one thread might reach here; take a lock so that the first thread does the cleanup. */
     static pthread_mutex_t cleanup_lock = PTHREAD_MUTEX_INITIALIZER;
     pthread_mutex_lock(&cleanup_lock);
 

--- a/src/main.c
+++ b/src/main.c
@@ -3342,14 +3342,14 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     h2o_context_request_shutdown(&conf.threads[thread_index].ctx);
 
     /* Wait until all the connection gets closed. At least one worker thread that closed the last connection, turning
-     * `num_connections(0)`to zero, will exit from this loop. Others might get stuck, as `h2o_evloop_run` does not return when a
-     * different worker thread closes a connection. */
+     * `num_connections(0)`to zero, will exit from this loop. That worker threads does the cleanup. Other worker threads might get
+     * stuck, as `h2o_evloop_run` does not return when a different worker thread closes a connection. */
     while (num_connections(0) != 0)
         h2o_evloop_run(conf.threads[thread_index].ctx.loop, INT32_MAX);
 
-    /* the thread that detects num_connections becoming zero performs the last cleanup */
-    if (conf.pid_file != NULL)
-        unlink(conf.pid_file);
+    /* Take a lock so that only one thread does the cleanup. */
+    static pthread_mutex_t cleanup_lock = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&cleanup_lock);
 
     /* remove the pid file */
     if (conf.pid_file != NULL)

--- a/t/50server-starter.t
+++ b/t/50server-starter.t
@@ -71,7 +71,7 @@ EOT
     };
 
     kill 'TERM', $pid;
-    sleep 3;
+    sleep 1;
     ok ! stat("$tempdir/h2o.pid"), "pid-file is unlinked";
 };
 


### PR DESCRIPTION
In #2460, we decided that the main thread should call `_exit` after waiting for all worker threads to exit from `run_loop`. However, the very last portion of `run_loop` has a race condition, and `run_loop` might not return forever, in which case h2o gets stuck while trying to shut down gracefully.

https://github.com/h2o/h2o/blob/c84934285d92c0936e93409f8830c99295b3cf91/src/main.c#L3345-L3349

The problem here is that if the main thread owns zero connections, while other threads own some, the main thread can call `h2o_evloop_run` and that would block forever.

This behavior has likely lead us to seeing t/50server-starter.t fail often. In retrospect, it is no wonder because the test creates one connection to the server and then sends SIGTERM immediately. If the connection was accepted by a worker thread other than the main thread, it would be not that difficult to hit this condition.

As a fix, this PR reverts to the original design pre-#2460 that allows any worker thread to do the final cleanup once `num_connections(0)` becomes zero, while:
* using `malloc` instead of `alloca` so that worker threads would not refer to the stack of the main thread, and
* using a mutex to ensure that only one thread does the cleanup.