### PR TITLE
Serialize h2olog tests to prevent CI failure

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -1337,7 +1337,7 @@
 		E9D49A4F25FB561A00F4A80D /* 40http1-streaming-framing.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http1-streaming-framing.t"; sourceTree = "<group>"; };
 		E9D49A5025FB561A00F4A80D /* 40http3-forward-initial.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http3-forward-initial.t"; sourceTree = "<group>"; };
 		E9D49A5125FB562800F4A80D /* 50http1-proxy-full-uri.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50http1-proxy-full-uri.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
-		E9D49A5225FB562800F4A80D /* 90h2olog.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 90h2olog.t; sourceTree = "<group>"; };
+		E9D49A5225FB562800F4A80D /* 90h2olog.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 90h2olog.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E9D49A5325FB562800F4A80D /* quic-ndec-initial-gen.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "quic-ndec-initial-gen.c"; sourceTree = "<group>"; };
 		E9DF012724E4CDEE0002EEC7 /* cc-cubic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cc-cubic.c"; sourceTree = "<group>"; };
 		E9E50472214A5B8A004DC170 /* http3client.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = http3client.c; sourceTree = "<group>"; };

--- a/t/90h2olog-selective-tracing.t
+++ b/t/90h2olog-selective-tracing.t
@@ -9,6 +9,7 @@ use JSON;
 use Time::HiRes qw(sleep);
 use t::Util;
 
+get_exclusive_lock(); # take exclusive lock before sudo closes LOCKFD
 run_as_root();
 
 my $h2olog_prog = bindir() . "/h2olog";

--- a/t/90h2olog.t
+++ b/t/90h2olog.t
@@ -8,6 +8,7 @@ use Test::More;
 use JSON;
 use t::Util;
 
+get_exclusive_lock(); # take exclusive lock before sudo closes LOCKFD
 run_as_root();
 
 my $h2olog_prog = bindir() . "/h2olog";

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -907,8 +907,12 @@ sub get_exclusive_lock {
     my $lockfh = IO::Handle->new();
     $lockfh->fdopen($ENV{LOCKFD}, "w")
         or die "failed to open file descriptor $ENV{LOCKFD}:$!";
+    print STDERR "taking exclusive lock...\n";
+    STDERR->flush;
     flock($lockfh, LOCK_EX)
         or die "failed to obtain exclusive lock for fd $ENV{LOCKFD}:$!";
+    print STDERR "lock taken\n";
+    STDERR->flush;
 
     $ENV{LOCKFD} = "SKIP";
 }

--- a/t/run-tests
+++ b/t/run-tests
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use Fcntl qw(:flock F_SETFD F_GETFD FD_CLOEXEC);
 use File::Temp qw(tempdir);
 use Getopt::Long qw(:config posix_default no_ignore_case gnu_compat);
 use POSIX qw(:sys_wait_h);
@@ -68,6 +69,15 @@ sub spawn_script {
 
     # return the spawned PID if in parent process
     return $pid if $pid != 0;
+
+    # obtain shared lock for lockfile
+    open my $lockfh, ">>", "$tempdir/lock"
+        or die "failed to open $tempdir/lock:$!";
+    fcntl($lockfh, F_SETFD, fcntl($lockfh, F_GETFD, 0) & ~FD_CLOEXEC)
+        or die "failed to clear FD_CLOEXEC:$!";
+    flock($lockfh, LOCK_SH)
+        or die "failed to obtain shared lock fo $tempdir/lock:$!";
+    $ENV{LOCKFD} = fileno $lockfh;
 
     # child process, redirect STDOUT, STDERR to tempfile and exec
     $logfh = log_add_timestamp($logfh);


### PR DESCRIPTION
Tentative fix for #3057.

When running h2olog on Ubuntu 22.04, the monitored process is specified by the executable *[and PID -1](https://github.com/h2o/h2o/issues/3057#issuecomment-1189121025)* meaning that any h2o running on the same host will be traced.

This leads to CI failures, as we run several tests in parallel.

While we expect this to be a bug inside libbcc that should be fixed, we cannot rely on such a fix even after it gets released, because we have to support distros that already exist with this bug.

Therefore, in this PR, we introduce a lock that is taken when running h2olog tests, as a tentative workaround.