### PR TITLE
change h2get repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/h2o/cache-digest.js.git
 [submodule "misc/h2get"]
 	path = misc/h2get
-	url = https://github.com/deweerdt/h2get.git
+	url = https://github.com/kazuho/h2get.git
 [submodule "deps/theft"]
 	path = deps/theft
 	url = https://github.com/silentbicycle/theft


### PR DESCRIPTION
amends #3053 

It seems that GitHub Actions seems no problem fetching correct commit of misc/h2get without this change (maybe because there's a PR?), but we needed this at least on Ubuntu 22.04 that already had h2get from an older commit being fetched.