### PR TITLE
Add `misc/mruby_config.rb.lock` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ misc/test-ca/demoCA/newcerts/*.pem
 tmp/
 /doc/workdir/
 include/h2o/gitrev.h
+/misc/mruby_config.rb.lock


### PR DESCRIPTION
This untracked file seems to be new with the recent mruby upgrade.  Here is what is inside it:

```yaml
---
mruby:
  version: 3.1.0
  release_no: 30100
```

Should it be `.gitignore`d or checked-in?