### PR TITLE
[t/50throttle-response.t] relax time-sensitivity

### DIFF
--- a/t/50throttle-response.t
+++ b/t/50throttle-response.t
@@ -75,7 +75,7 @@ EOT
         is $resp, "hello world";
         my $elapsed = time - $start_time;
         cmp_ok $elapsed, '>', 0.9;
-        cmp_ok $elapsed, '<', 1.1;
+        cmp_ok $elapsed, '<', 1.3;
     });
 };
 


### PR DESCRIPTION
We see it fail occasionally, e.g., https://github.com/h2o/h2o/runs/7478611158.