### PR TITLE
add `h2o_mem_asprintf()` as an easy-to-use utility

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -254,6 +254,13 @@ void *h2o_mem__do_alloc_pool_aligned(h2o_mem_pool_t *pool, size_t alignment, siz
  * @param pool pool to which the allocated chunk should be linked (or NULL to allocate an orphan chunk)
  */
 void *h2o_mem_alloc_shared(h2o_mem_pool_t *pool, size_t sz, void (*dispose)(void *));
+
+/**
+ * builds a string like asprintf(3) but uses the memory pool to allocate the memory.
+ */
+int h2o_mem_asprintf(h2o_mem_pool_t *pool, char **dest, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+int h2o_mem_vasprintf(h2o_mem_pool_t *pool, char **dest, const char *fmt, va_list ap);
+
 /**
  * links a ref-counted chunk to a memory pool.
  * The ref-count of the chunk will be decremented when the pool is cleared.

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -622,3 +622,29 @@ void h2o_perror(const char *msg)
 
     h2o_error_printf("%s: %s\n", msg, h2o_strerror_r(errno, buf, sizeof(buf)));
 }
+
+int h2o_mem_asprintf(h2o_mem_pool_t *pool, char **dest, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    int ret = h2o_mem_vasprintf(pool, dest, fmt, args);
+    va_end(args);
+    return ret;
+}
+
+int h2o_mem_vasprintf(h2o_mem_pool_t *pool, char **dest, const char *fmt, va_list args)
+{
+    va_list args_copy;
+    va_copy(args_copy, args);
+    int ret = vsnprintf(NULL, 0, fmt, args_copy);
+    va_end(args_copy);
+    if (H2O_UNLIKELY(ret < 0))
+        return ret;
+
+    char *s = h2o_mem_alloc_pool(pool, char, ret + 1);
+    ret = vsprintf(s, fmt, args);
+    if (H2O_UNLIKELY(ret < 0))
+        return ret;
+    *dest = s;
+    return ret;
+}


### PR DESCRIPTION
This PR is a proposal to implement new string utilities. It might be slower than the hand-calculated buffer size + snprintf, but it is definitely easy to use and thus saves our time. However, we have to beware of its costs, which could be a drawback of the utilities. What do you think?