### PR TITLE
do not write more than 1MB at once

### DIFF
--- a/include/h2o/socket/evloop.h
+++ b/include/h2o/socket/evloop.h
@@ -52,6 +52,7 @@ typedef struct st_h2o_evloop_t {
     struct timeval _tv_at;
     h2o_timerwheel_t *_timeouts;
     h2o_sliding_counter_t exec_time_nanosec_counter;
+    uint64_t run_count;
 } h2o_evloop_t;
 
 typedef h2o_evloop_t h2o_loop_t;
@@ -60,6 +61,7 @@ typedef h2o_timerwheel_entry_t h2o_timer_t;
 typedef h2o_timerwheel_cb h2o_timer_cb;
 
 extern size_t h2o_evloop_socket_max_read_size;
+extern size_t h2o_evloop_socket_max_write_size;
 
 h2o_socket_t *h2o_evloop_socket_create(h2o_evloop_t *loop, int fd, int flags);
 h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *listener);

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -53,6 +53,11 @@ struct st_h2o_evloop_socket_t {
     size_t max_read_size;
     struct st_h2o_evloop_socket_t *_next_pending;
     struct st_h2o_evloop_socket_t *_next_statechanged;
+    struct {
+        uint64_t prev_loop;
+        uint64_t cur_loop;
+        uint64_t cur_run_count;
+    } bytes_written;
     /**
      * vector to be sent (or vec.callbacks is NULL when not used)
      */
@@ -102,6 +107,7 @@ static void evloop_do_on_socket_export(struct st_h2o_evloop_socket_t *sock);
 #endif
 
 size_t h2o_evloop_socket_max_read_size = 1024 * 1024; /* by default, we read up to 1MB at once */
+size_t h2o_evloop_socket_max_write_size = 1024 * 1024; /* by default, we write up to 1MB at once */
 
 void link_to_pending(struct st_h2o_evloop_socket_t *sock)
 {
@@ -312,6 +318,7 @@ void write_pending(struct st_h2o_evloop_socket_t *sock)
 
     /* operation completed or failed, schedule notification */
     SOCKET_PROBE(WRITE_COMPLETE, &sock->super, sock->super._write_buf.cnt == 0 && !has_pending_ssl_bytes(sock->super.ssl));
+    sock->bytes_written.cur_loop = sock->super.bytes_written;
     sock->_flags |= H2O_SOCKET_FLAG_IS_WRITE_NOTIFY;
     link_to_pending(sock);
     link_to_statechanged(sock); /* might need to disable the write polling */
@@ -379,6 +386,16 @@ void do_write(h2o_socket_t *_sock, h2o_iovec_t *bufs, size_t bufcnt)
     struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;
     size_t first_buf_written;
 
+    /* Don't write too much; if more than 1MB have been already written in the current invocation of `h2o_evloop_run`, wait until
+     * the event loop notifies us that the socket is writable. */
+    if (sock->bytes_written.cur_run_count != sock->loop->run_count) {
+        sock->bytes_written.prev_loop = sock->bytes_written.cur_loop;
+        sock->bytes_written.cur_run_count = sock->loop->run_count;
+    } else if (sock->bytes_written.cur_loop - sock->bytes_written.prev_loop >= h2o_evloop_socket_max_write_size) {
+        init_write_buf(&sock->super, bufs, bufcnt, 0);
+        goto Schedule_Write;
+    }
+
     /* try to write now */
     if ((first_buf_written = write_core(sock, &bufs, &bufcnt)) == SIZE_MAX) {
         report_early_write_error(&sock->super);
@@ -398,6 +415,7 @@ void do_write(h2o_socket_t *_sock, h2o_iovec_t *bufs, size_t bufcnt)
             if (sock->sendvec.callbacks != NULL)
                 goto Schedule_Write;
         }
+        sock->bytes_written.cur_loop = sock->super.bytes_written;
         sock->_flags |= H2O_SOCKET_FLAG_IS_WRITE_NOTIFY;
         link_to_pending(sock);
         return;
@@ -874,6 +892,8 @@ void h2o_evloop_destroy(h2o_evloop_t *loop)
 
 int h2o_evloop_run(h2o_evloop_t *loop, int32_t max_wait)
 {
+    ++loop->run_count;
+
     /* update socket states, poll, set readable flags, perform pending writes */
     if (evloop_do_proceed(loop, max_wait) != 0)
         return -1;


### PR DESCRIPTION
When HTTP/1 handler writes a huge response from the file handler through a very fast network, it might end up writing too much at once, as we do not cap the amount of data that can be written before yielding control to other sockets.

To be specific: `h2o_socket_write` always tries to write to socket, and if the write fully succeeds, the write completion callback is invoked before events for other sockets are handled. That in turn invokes the `do_proceed` callback of the file handler synchronously, then `h2o_sendvec`, `finalostream_send`, `h2o_socket_write`.

This PR fixes the problem by checking the amount of data being written for each socket within one invocation of `h2o_evloop_run`. When more than `h2o_evloop_socket_max_write_size` (default: 1MB) is written, we will wait for write ready event to be raised by the next invocation of `epoll_wait` (which is invoked by the next call to `h2o_evloop_run`).

HTTP/2 handler does not suffer from this problem (unless libuv is used), because it always calls `h2o_socket_notify_write` to see if data can be sent using the socket. The callback supplied to `h2o_socket_notify_write` is invoked once per `h2o_evloop_run`.