### PR TITLE
Make sure limit is not too short

### DIFF
--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -697,6 +697,7 @@ static size_t append_with_limit(char *dst, h2o_iovec_t input, size_t limit)
         memcpy(dst, input.base, input.len);
         return input.len;
     } else {
+        assert(limit >= 3);
         memcpy(dst, input.base, (limit - 3));
         memcpy(dst + (limit - 3), "...", 3);
         return limit;


### PR DESCRIPTION
This is a follow up of h2o/h2o#2635, to ensure `limit` is long enough to include "...".