### PR TITLE
tidy up the use of pthread API

### DIFF
--- a/lib/common/hostinfo.c
+++ b/lib/common/hostinfo.c
@@ -153,9 +153,9 @@ static void create_lookup_thread_if_necessary(void)
     pthread_attr_t attr;
     int ret;
     pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, 1);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     pthread_attr_setstacksize(&attr, 100 * 1024);
-    if ((ret = pthread_create(&tid, NULL, lookup_thread_main, NULL)) != 0) {
+    if ((ret = pthread_create(&tid, &attr, lookup_thread_main, NULL)) != 0) {
         char buf[128];
         if (queue.num_threads == 0) {
             h2o_fatal("failed to start first thread for getaddrinfo: %s", h2o_strerror_r(ret, buf, sizeof(buf)));
@@ -164,6 +164,7 @@ static void create_lookup_thread_if_necessary(void)
         }
         return;
     }
+    pthread_attr_destroy(&attr);
 
     ++queue.num_threads;
     ++queue.num_threads_idle;

--- a/lib/common/memcached.c
+++ b/lib/common/memcached.c
@@ -420,7 +420,7 @@ h2o_memcached_context_t *h2o_memcached_create_context(const char *host, uint16_t
         pthread_attr_t attr;
         size_t i;
         pthread_attr_init(&attr);
-        pthread_attr_setdetachstate(&attr, 1);
+        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
         for (i = 0; i != num_threads; ++i)
             h2o_multithread_create_thread(&tid, &attr, thread_main, ctx);
         pthread_attr_destroy(&attr);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -119,8 +119,9 @@ static void spawn_cache_cleanup_thread(SSL_CTX **_contexts, size_t num_contexts)
     pthread_t tid;
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, 1);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
     h2o_multithread_create_thread(&tid, &attr, cache_cleanup_thread, contexts);
+    pthread_attr_destroy(&attr);
 }
 
 static void setup_cache_disable(SSL_CTX **contexts, size_t num_contexts)
@@ -1112,8 +1113,9 @@ void ssl_setup_session_resumption(SSL_CTX **contexts, size_t num_contexts, struc
         pthread_t tid;
         pthread_attr_t attr;
         pthread_attr_init(&attr);
-        pthread_attr_setdetachstate(&attr, 1);
+        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
         h2o_multithread_create_thread(&tid, &attr, conf.ticket.update_thread, NULL);
+        pthread_attr_destroy(&attr);
         size_t i;
         for (i = 0; i != num_contexts; ++i) {
             SSL_CTX *ctx = contexts[i];


### PR DESCRIPTION
* Use `PTHREAD_CREATE_DETACHED` instead of the constant `1` for `pthread_attr_setdetachstate(3`
* Call `pthread_attr_destroy(3)` to release pthread attrs