### PR TITLE
Do not read into buffer when we are about to yield to other sockets

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -169,6 +169,7 @@ static void *zerocopy_buffers_release(struct st_h2o_socket_zerocopy_buffers_t *b
 
 /* internal functions called from the backend */
 static const char *decode_ssl_input(h2o_socket_t *sock);
+static size_t flatten_sendvec(h2o_socket_t *sock, h2o_sendvec_t *sendvec);
 static void on_write_complete(h2o_socket_t *sock, const char *err);
 
 h2o_buffer_mmap_settings_t h2o_socket_buffer_mmap_settings = {
@@ -240,12 +241,16 @@ static int read_bio(BIO *b, char *out, int len)
 
 static void init_write_buf(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, size_t first_buf_written)
 {
+    /* Use smallbufs or allocate slots. An additional slot is reserved at the end so that sendvec can be flattened there for
+     * encryption. */
     if (bufcnt < PTLS_ELEMENTSOF(sock->_write_buf.smallbufs)) {
         sock->_write_buf.bufs = sock->_write_buf.smallbufs;
     } else {
-        sock->_write_buf.bufs = h2o_mem_alloc(sizeof(sock->_write_buf.bufs[0]) * bufcnt);
+        sock->_write_buf.bufs = h2o_mem_alloc(sizeof(sock->_write_buf.bufs[0]) * (bufcnt + 1));
         sock->_write_buf.alloced_ptr = sock->_write_buf.bufs;
     }
+
+    /* Initialize the vector. */
     if (bufcnt != 0) {
         sock->_write_buf.bufs[0].base = bufs[0].base + first_buf_written;
         sock->_write_buf.bufs[0].len = bufs[0].len - first_buf_written;
@@ -855,6 +860,21 @@ static size_t generate_tls_records(h2o_socket_t *sock, h2o_iovec_t **bufs, size_
     return first_buf_written;
 }
 
+size_t flatten_sendvec(h2o_socket_t *sock, h2o_sendvec_t *sendvec)
+{
+    assert(h2o_socket_ssl_buffer_allocator.conf->memsize >= H2O_PULL_SENDVEC_MAX_SIZE);
+    sock->_write_buf.flattened = h2o_mem_alloc_recycle(&h2o_socket_ssl_buffer_allocator);
+    size_t len = sendvec->len;
+
+    if (!sendvec->callbacks->read_(sendvec, sock->_write_buf.flattened, len)) {
+        /* failed */
+        h2o_mem_free_recycle(&h2o_socket_ssl_buffer_allocator, sock->_write_buf.flattened);
+        sock->_write_buf.flattened = NULL;
+        return SIZE_MAX;
+    }
+    return len;
+}
+
 void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_socket_cb cb)
 {
     SOCKET_PROBE(WRITE, sock, bufs, bufcnt, cb);
@@ -899,21 +919,17 @@ void h2o_socket_sendvec(h2o_socket_t *sock, h2o_sendvec_t *vecs, size_t cnt, h2o
         /* If the pull vector has a send callback, and if we have the necessary conditions to utilize it, Let it write directly to
          * the socket. */
 #if !H2O_USE_LIBUV
-        if (pull_index == cnt - 1 && vecs[pull_index].callbacks->send_ != NULL &&
+        if (pull_index == cnt - 1 && vecs[pull_index].callbacks != NULL &&
             do_write_with_sendvec(sock, bufs, cnt - 1, vecs + pull_index))
             return;
 #endif
         /* Load the vector onto memory now. */
-        assert(h2o_socket_ssl_buffer_allocator.conf->memsize >= H2O_PULL_SENDVEC_MAX_SIZE);
-        sock->_write_buf.flattened = h2o_mem_alloc_recycle(&h2o_socket_ssl_buffer_allocator);
-        bufs[pull_index] = h2o_iovec_init(sock->_write_buf.flattened, vecs[pull_index].len);
-        if (!vecs[pull_index].callbacks->read_(vecs + pull_index, bufs[pull_index].base, bufs[pull_index].len)) {
-            /* failed */
-            h2o_mem_free_recycle(&h2o_socket_ssl_buffer_allocator, sock->_write_buf.flattened);
-            sock->_write_buf.flattened = NULL;
+        size_t pulllen = flatten_sendvec(sock, &vecs[pull_index]);
+        if (pulllen == SIZE_MAX) {
             report_early_write_error(sock);
             return;
         }
+        bufs[pull_index] = h2o_iovec_init(sock->_write_buf.flattened, pulllen);
     }
 
     do_write(sock, bufs, cnt);

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -252,9 +252,18 @@ static size_t write_core(struct st_h2o_evloop_socket_t *sock, h2o_iovec_t **bufs
             dispose_ssl_output_buffer(sock->super.ssl);
         }
         /* bail out if complete */
-        if (*bufcnt == 0)
+        if (*bufcnt == 0 && sock->sendvec.callbacks == NULL)
             break;
         /* convert more cleartext to TLS records if possible, or bail out on fatal error */
+        if (sock->sendvec.callbacks != NULL) {
+            /* flatten given vector if that has not been done yet; `*bufs` is guaranteed to have one slot available at the end; see
+             * `do_write_with_sendvec`, `init_write_buf`. */
+            size_t veclen = flatten_sendvec(&sock->super, &sock->sendvec);
+            if (veclen == SIZE_MAX)
+                return SIZE_MAX;
+            sock->sendvec.callbacks = NULL;
+            (*bufs)[(*bufcnt)++] = h2o_iovec_init(sock->super._write_buf.flattened, veclen);
+        }
         if ((first_buf_written = generate_tls_records(&sock->super, bufs, bufcnt, first_buf_written)) == SIZE_MAX)
             break;
         /* as an optimization, if we have a flattened vector, release memory as soon as they have been encrypted */
@@ -292,7 +301,6 @@ static int sendvec_core(struct st_h2o_evloop_socket_t *sock)
 
 void write_pending(struct st_h2o_evloop_socket_t *sock)
 {
-
     assert(sock->super._cb.write != NULL);
 
     /* write from buffer, if we have anything */
@@ -531,23 +539,28 @@ Fail:
 }
 #endif
 
+/**
+ * `bufs` should be an array capable of storing `bufcnt + 1` objects, as we will be flattening `sendvec` at the end of `bufs` before
+ * encryption; see `write_core`.
+ */
 static int do_write_with_sendvec(h2o_socket_t *_sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_sendvec_t *sendvec)
 {
     struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;
 
-    assert(sendvec->callbacks->send_ != NULL);
+    assert(sendvec->callbacks->read_ != NULL);
     assert(sock->sendvec.callbacks == NULL);
 
-    /* If userspace TLS is currently in use, either switch to kTLS or refuse. */
+    /* If userspace TLS is used, rely on `read_` which is a mandatory callback. Otherwise, rely on `send_` if it is available. */
     if (sock->super.ssl != NULL) {
 #if H2O_USE_KTLS
         if (sock->super.ssl->offload == H2O_SOCKET_SSL_OFFLOAD_TBD)
             switch_to_ktls(sock);
-        if (sock->super.ssl->offload != H2O_SOCKET_SSL_OFFLOAD_ON)
+        if (sock->super.ssl->offload == H2O_SOCKET_SSL_OFFLOAD_ON && sendvec->callbacks->send_ == NULL)
             return 0;
-#else
-        return 0;
 #endif
+    } else {
+        if (sendvec->callbacks->send_ == NULL)
+            return 0;
     }
 
     /* handling writes with sendvec, here */


### PR DESCRIPTION
#3074 added code that delays writes to a socket. However, that happens _after_ the content is being read from a pull vector. That means that when serving files above 1MB (`h2o_socket_max_write_size`), each connection would retain 64KB buffer across one event loop.

This PR delays the read from a pull vector to when the content is to be encrypted and written to the socket for the first time, after `h2o_socket_sendvec` is invoked.

Another followup PR of #3074.