### PR TITLE
Update HTTP/3 `PRIORITY_UPDATE` handling as per RFC9218

### DIFF
--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -38,7 +38,8 @@
 #define H2O_HTTP3_FRAME_TYPE_PUSH_PROMISE 5
 #define H2O_HTTP3_FRAME_TYPE_GOAWAY 7
 #define H2O_HTTP3_FRAME_TYPE_MAX_PUSH_ID 13
-#define H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE 15
+#define H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE_REQUEST 0xF0700
+#define H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE_PUSH 0xF0701
 
 #define H2O_HTTP3_STREAM_TYPE_CONTROL 0
 #define H2O_HTTP3_STREAM_TYPE_PUSH_STREAM 1
@@ -361,7 +362,7 @@ typedef struct st_h2o_http3_qpack_context_t {
 
 typedef struct st_h2o_http3_conn_callbacks_t {
     h2o_quic_conn_callbacks_t super;
-    void (*handle_control_stream_frame)(h2o_http3_conn_t *conn, uint8_t type, const uint8_t *payload, size_t len);
+    void (*handle_control_stream_frame)(h2o_http3_conn_t *conn, uint64_t type, const uint8_t *payload, size_t len);
 } h2o_http3_conn_callbacks_t;
 
 struct st_h2o_http3_conn_t {

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -306,7 +306,7 @@ static void on_getaddr(h2o_hostinfo_getaddr_req_t *getaddr_req, const char *errs
     start_connect(conn, selected->ai_addr);
 }
 
-static void handle_control_stream_frame(h2o_http3_conn_t *_conn, uint8_t type, const uint8_t *payload, size_t len)
+static void handle_control_stream_frame(h2o_http3_conn_t *_conn, uint64_t type, const uint8_t *payload, size_t len)
 {
     struct st_h2o_httpclient__h3_conn_t *conn = (void *)_conn;
     int err;

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -958,19 +958,20 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
         }                                                                                                                          \
         break
         /* clang-format off */
-        /*   +-----------------+-------------+-------------+
-         *   |                 | req-stream  | ctrl-stream |
-         *   |      frame      +------+------+------+------+
-         *   |                 |client|server|client|server|
-         *   +-----------------+------+------+------+------+ */
-        FRAME( DATA            ,    1 ,    1 ,    0 ,    0 );
-        FRAME( HEADERS         ,    1 ,    1 ,    0 ,    0 );
-        FRAME( CANCEL_PUSH     ,    0 ,    0 ,    1 ,    1 );
-        FRAME( SETTINGS        ,    0 ,    0 ,    1 ,    1 );
-        FRAME( PUSH_PROMISE    ,    0 ,    1 ,    0 ,    0 );
-        FRAME( GOAWAY          ,    0 ,    0 ,    1 ,    1 );
-        FRAME( MAX_PUSH_ID     ,    0 ,    0 ,    1 ,    0 );
-        FRAME( PRIORITY_UPDATE ,    0 ,    0 ,    1 ,    0 );
+        /*   +-------------------------+-------------+-------------+
+         *   |                         | req-stream  | ctrl-stream |
+         *   |      frame              +------+------+------+------+
+         *   |                         |client|server|client|server|
+         *   +-------------------------+------+------+------+------+ */
+        FRAME( DATA                    ,    1 ,    1 ,    0 ,    0 );
+        FRAME( HEADERS                 ,    1 ,    1 ,    0 ,    0 );
+        FRAME( CANCEL_PUSH             ,    0 ,    0 ,    1 ,    1 );
+        FRAME( SETTINGS                ,    0 ,    0 ,    1 ,    1 );
+        FRAME( PUSH_PROMISE            ,    0 ,    1 ,    0 ,    0 );
+        FRAME( GOAWAY                  ,    0 ,    0 ,    1 ,    1 );
+        FRAME( MAX_PUSH_ID             ,    0 ,    0 ,    1 ,    0 );
+        FRAME( PRIORITY_UPDATE_REQUEST ,    0 ,    0 ,    1 ,    0 );
+        FRAME( PRIORITY_UPDATE_PUSH    ,    0 ,    0 ,    1 ,    0 );
         /*   +-----------------+------+------+------+------+ */
         /* clang-format on */
 #undef FRAME

--- a/lib/http3/frame.c
+++ b/lib/http3/frame.c
@@ -24,8 +24,9 @@
 
 uint8_t *h2o_http3_encode_priority_update_frame(uint8_t *dst, const h2o_http3_priority_update_frame_t *frame)
 {
-    *dst++ = H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE;
-    *dst++ = frame->element_is_push ? 0x80 : 0;
+    *dst++ = frame->element_is_push
+        ? H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE_PUSH
+        : H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE_REQUEST;
     dst = quicly_encodev(dst, frame->element);
     *dst++ = 'u';
     *dst++ = '=';
@@ -45,7 +46,6 @@ int h2o_http3_decode_priority_update_frame(h2o_http3_priority_update_frame_t *fr
 
     if (src == end)
         return H2O_HTTP3_ERROR_FRAME;
-    frame->element_is_push = (*src++ & 0x80) != 0;
     if ((frame->element = quicly_decodev(&src, end)) == UINT64_MAX) {
         *err_desc = "invalid PRIORITY frame";
         return H2O_HTTP3_ERROR_FRAME;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1515,7 +1515,7 @@ static int handle_priority_update_frame(struct st_h2o_http3_server_conn_t *conn,
     return 0;
 }
 
-static void handle_control_stream_frame(h2o_http3_conn_t *_conn, uint8_t type, const uint8_t *payload, size_t len)
+static void handle_control_stream_frame(h2o_http3_conn_t *_conn, uint64_t type, const uint8_t *payload, size_t len)
 {
     struct st_h2o_http3_server_conn_t *conn = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_conn_t, h3, _conn);
     int err;
@@ -1535,8 +1535,10 @@ static void handle_control_stream_frame(h2o_http3_conn_t *_conn, uint8_t type, c
             err = H2O_HTTP3_ERROR_FRAME_UNEXPECTED;
             err_desc = "unexpected SETTINGS frame";
             goto Fail;
-        case H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE: {
+        case H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE_REQUEST:
+        case H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE_PUSH: {
             h2o_http3_priority_update_frame_t frame;
+            frame.element_is_push = (type == H2O_HTTP3_FRAME_TYPE_PRIORITY_UPDATE_PUSH);
             if ((err = h2o_http3_decode_priority_update_frame(&frame, payload, len, &err_desc)) != 0)
                 goto Fail;
             if ((err = handle_priority_update_frame(conn, &frame)) != 0) {


### PR DESCRIPTION
The HTTP/3 `PRIORITY_UPDATE` frame format [changed](https://www.ietf.org/rfcdiff?url1=draft-ietf-httpbis-priority-01&url2=draft-ietf-httpbis-priority-02&difftype=--html) in `draft-ietf-httpbis-priority-02` and h2o still expects the old one.