### PR TITLE
[build] add -Werror=format to easily detect such errors in development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ IF (PKG_CONFIG_FOUND)
     ENDIF (LIBCAP_FOUND)
 ENDIF (PKG_CONFIG_FOUND)
 
-SET(CC_WARNING_FLAGS "-Wall -Wno-unused-value -Wno-unused-function -Wno-nullability-completeness -Wno-expansion-to-defined -Werror=implicit-function-declaration -Werror=incompatible-pointer-types")
+SET(CC_WARNING_FLAGS "-Wall -Wno-unused-value -Wno-unused-function -Wno-nullability-completeness -Wno-expansion-to-defined -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=format")
 
 IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     IF (NOT ("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS "4.6"))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,10 @@ IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     IF (NOT ("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS "4.5"))
         SET(CC_WARNING_FLAGS "${CC_WARNING_FLAGS} -Wno-unused-result")
     ENDIF ()
+
+    # -Werror=format implies -Werror=nonull in gcc, which introduces compile errors in some test files,
+    # but all of them are false positive.
+    SET(CC_WARNING_FLAGS "${CC_WARNING_FLAGS} -Wno-nonnull")
 ENDIF ()
 
 # setup compile flags


### PR DESCRIPTION
Just for developer experience. 

---

FWIW I'm adding `-Wno-nonnull` as well for gcc because [gcc's -Wformat implies -Wnonnull](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html) and thus `-Werror=nonnull` introduces compile errors in test files; I think all of them are false positive, though. So I have to add `-Wno-nonnull` to override `-Werror=nonull` for gcc.

