### PR TITLE
Use Ubuntu 20.04 for daily Coverity job

### DIFF
--- a/.github/workflows/daily_coverity.yml
+++ b/.github/workflows/daily_coverity.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   submit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 18.04 is no longer supported as a runner image.
See https://github.com/actions/runner-images/issues/6002