### PR TITLE
doc: Fix tls minimum protocol version

### DIFF
--- a/doc/configure/base_directives.html
+++ b/doc/configure/base_directives.html
@@ -335,7 +335,7 @@ The <code style="font-weight: bold;">ssl</code> attribute must be defined as a m
 <dd>path of the SSL private key file (mandatory)</dd>
 <dt id="minimum-version">minimum-version:</dt>
 <dd>
-minimum protocol version, should be one of: <code>SSLv2</code>, <code>SSLv3</code>, <code>TLSv1</code>, <code>TLSv1.1</code>, <code>TLSv1.2</code>.
+minimum protocol version, should be one of: <code>SSLv2</code>, <code>SSLv3</code>, <code>TLSv1</code>, <code>TLSv1.1</code>, <code>TLSv1.2</code>, <code>TLSv1.3</code>.
 Default is <code>TLSv1</code>
 </dd>
 <dt id="min-version">min-version:</dt>


### PR DESCRIPTION
Fixes #3026 

It seems that we can set the `min_version: TLSv1.3` in which can be found in src/main.c below. https://github.com/h2o/h2o/blob/36a23af525d2b4a2249d7a36191b6de74c71c6be/src/main.c#L1185-L1204

The official docs says we can restrict until the TLSv1.2. It seems to be different from the actuals, I don't know obviously why incorrect is this. We prefer to be fix this doc.

https://h2o.examp1e.net/configure/base_directives.html#listen
```
minimum-version:
minimum protocol version, should be one of: SSLv2, SSLv3, TLSv1, TLSv1.1, TLSv1.2. Default is TLSv1

```