### PR TITLE
[daily coverity] Ubuntu 20.04 is `focal`

### DIFF
--- a/.github/workflows/daily_coverity.yml
+++ b/.github/workflows/daily_coverity.yml
@@ -27,15 +27,15 @@ jobs:
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
       run: |
           cat <<EOF > /tmp/deb-src.list
-          deb-src http://archive.ubuntu.com/ubuntu bionic main restricted
-          deb-src http://archive.ubuntu.com/ubuntu bionic-updates main restricted
-          deb-src http://archive.ubuntu.com/ubuntu bionic universe
-          deb-src http://archive.ubuntu.com/ubuntu bionic-updates universe
-          deb-src http://archive.ubuntu.com/ubuntu bionic multiverse
-          deb-src http://archive.ubuntu.com/ubuntu bionic-updates multiverse
-          deb-src http://archive.ubuntu.com/ubuntu bionic-security main restricted
-          deb-src http://archive.ubuntu.com/ubuntu bionic-security universe
-          deb-src http://archive.ubuntu.com/ubuntu bionic-security multiverse
+          deb-src http://archive.ubuntu.com/ubuntu focal main restricted
+          deb-src http://archive.ubuntu.com/ubuntu focal-updates main restricted
+          deb-src http://archive.ubuntu.com/ubuntu focal universe
+          deb-src http://archive.ubuntu.com/ubuntu focal-updates universe
+          deb-src http://archive.ubuntu.com/ubuntu focal multiverse
+          deb-src http://archive.ubuntu.com/ubuntu focal-updates multiverse
+          deb-src http://archive.ubuntu.com/ubuntu focal-security main restricted
+          deb-src http://archive.ubuntu.com/ubuntu focal-security universe
+          deb-src http://archive.ubuntu.com/ubuntu focal-security multiverse
           EOF
           sudo cp /tmp/deb-src.list /etc/apt/sources.list.d/
           sudo apt-get update


### PR DESCRIPTION
This is a follow up to https://github.com/h2o/h2o/pull/3100, which failed to update the distribution code name from `bionic` to `focal`.