### PR TITLE
Enable -Werror=format only on clang, beause gcc may detect false positive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ IF (PKG_CONFIG_FOUND)
     ENDIF (LIBCAP_FOUND)
 ENDIF (PKG_CONFIG_FOUND)
 
-SET(CC_WARNING_FLAGS "-Wall -Wno-unused-value -Wno-unused-function -Wno-nullability-completeness -Wno-expansion-to-defined -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=format")
+SET(CC_WARNING_FLAGS "-Wall -Wno-unused-value -Wno-unused-function -Wno-nullability-completeness -Wno-expansion-to-defined -Werror=implicit-function-declaration -Werror=incompatible-pointer-types")
 
 IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     IF (NOT ("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS "4.6"))
@@ -271,6 +271,10 @@ IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     IF (NOT ("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS "4.5"))
         SET(CC_WARNING_FLAGS "${CC_WARNING_FLAGS} -Wno-unused-result")
     ENDIF ()
+ENDIF ()
+IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    # gcc may detect false positive. See issue#3105.
+    SET(CC_WARNING_FLAGS "${CC_WARNING_FLAGS} -Werror=format")
 ENDIF ()
 
 # setup compile flags


### PR DESCRIPTION
#3105 (@kazuho):

> I think we should just stop using -Werror=format as a default. We might want to turn it on on CI, but not in everybody's build.

That's good enough, but it would be better if CMakeLists.txt could switch the flag by the compiler, as this PR does. 