### PR TITLE
`tcp-fastopen` should be applied regardless of where it is set

### DIFF
--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -35,7 +35,7 @@ enum {
     H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE = 0x200,
     H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING = 0x400,
     H2O_CONFIGURATOR_FLAG_DEFERRED = 0x1000,
-    H2O_CONFIGURATOR_FLAG_SEMI_DEFERRED = 0x2000 /* used by file.custom-handler (invoked before hosts,paths,file-dir, etc.) */
+    H2O_CONFIGURATOR_FLAG_SEMI_DEFERRED = 0x2000 /* used by listen, file.custom-handler (invoked before hosts,paths,file-dir, etc.) */
 };
 
 #define H2O_CONFIGURATOR_NUM_LEVELS 4

--- a/src/main.c
+++ b/src/main.c
@@ -3605,11 +3605,13 @@ static void setup_configurators(void)
     if (getuid() == 0 && getpwnam("nobody") != NULL)
         conf.globalconf.user = "nobody";
 
-    {
+    { /* "listen" is invoked after global attributes like `tcp-fastopen`, but before `hosts`) */
         h2o_configurator_t *c = h2o_configurator_create(&conf.globalconf, sizeof(*c));
         c->enter = on_config_listen_enter;
         c->exit = on_config_listen_exit;
-        h2o_configurator_define_command(c, "listen", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST, on_config_listen);
+        h2o_configurator_define_command(
+            c, "listen", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_SEMI_DEFERRED,
+            on_config_listen);
     }
 
     {


### PR DESCRIPTION
At the moment, the `tcp-fastopen` configuration directive has effect only if it appears before the `listen` directive.

This PR address the problem by setting SEMI_DEFERRED flag for the `listen` directive. In essence, now the global-level directives are processed in the following order:
* all directives other than `file.custom-handler`, `listen`, `hosts`, in the order they appear
* `file-custom-handler` and `listen` in ther order they appear (this is fine because these two do not affect each other)
* `hosts`

This also helps #2415, as the `quic-dsr` directive introduced in that PR affects the ports being opened by the `listen` directive.