### PR TITLE
to avoid compiler warnings, use c99 flexible array member nonation

### DIFF
--- a/deps/yoml/Makefile
+++ b/deps/yoml/Makefile
@@ -1,3 +1,3 @@
 test:
-	$(CC) -Wall -g -I deps/picotest deps/picotest/picotest.c test-yoml.c -lyaml -o test-yoml
+	$(CC) -g -Wall $(COPTS) -I deps/picotest deps/picotest/picotest.c test-yoml.c -lyaml -o test-yoml
 	./test-yoml

--- a/deps/yoml/README.md
+++ b/deps/yoml/README.md
@@ -5,7 +5,7 @@ YOML is a DOM-like interface to YAML, implemented as a wrapper around [libyaml](
 
 It is a header-only library.  Just include the .h files to use the library.
 
-```
+```C
 #include "yoml.h" /* defines the structures */
 #include "yoml-parser.h" /* defines the parser */
 
@@ -34,16 +34,16 @@ static void dump_node(yoml_t *node, int indent)
     break;
   case YOML_TYPE_SEQUENCE:
     printf("%*s[SEQUENCE] (size:%zu)\n", indent, "", node->data.sequence.size);
-    for (i = 0; i != node.data.sequence.size; ++i)
+    for (i = 0; i != node->data.sequence.size; ++i)
       dump_node(node->data.sequence.elements[i], indent + 2);
     break;
   case YOML_TYPE_MAPPING:
     printf("%*s[MAPPING] (size:%zu)\n", indent, "", node->data.mapping.size);
     indent += 2;
-    for (i = 0; i != node.data.mapping.size; ++i) {
-      printf(%*s[KEY]\n", indent, "");
+    for (i = 0; i != node->data.mapping.size; ++i) {
+      printf("%*s[KEY]\n", indent, "");
       dump_node(node->data.mapping.elements[i].key, indent + 2);
-      printf(%*s[VALUE]\n", indent, "");
+      printf("%*s[VALUE]\n", indent, "");
       dump_node(node->data.mapping.elements[i].value, indent + 2);
     }
     indent -= 2;

--- a/deps/yoml/deps/picotest
+++ b/deps/yoml/deps/picotest
@@ -1,0 +1,1 @@
+../../../deps/picotest

--- a/deps/yoml/yoml.h
+++ b/deps/yoml/yoml.h
@@ -35,7 +35,7 @@ typedef struct st_yoml_t yoml_t;
 
 typedef struct st_yoml_sequence_t {
     size_t size;
-    yoml_t *elements[1];
+    yoml_t *elements[];
 } yoml_sequence_t;
 
 typedef struct st_yoml_mapping_element_t {
@@ -45,7 +45,7 @@ typedef struct st_yoml_mapping_element_t {
 
 typedef struct st_yoml_mapping_t {
     size_t size;
-    yoml_mapping_element_t elements[1];
+    yoml_mapping_element_t elements[];
 } yoml_mapping_t;
 
 struct st_yoml_t {

--- a/lib/common/timerwheel.c
+++ b/lib/common/timerwheel.c
@@ -58,7 +58,7 @@ struct st_h2o_timerwheel_t {
      * number of wheels and the wheel
      */
     size_t num_wheels;
-    h2o_linklist_t wheels[1][H2O_TIMERWHEEL_SLOTS_PER_WHEEL];
+    h2o_linklist_t wheels[][H2O_TIMERWHEEL_SLOTS_PER_WHEEL];
 };
 
 void h2o_timerwheel_dump(h2o_timerwheel_t *ctx)

--- a/src/main.c
+++ b/src/main.c
@@ -2576,9 +2576,13 @@ static yoml_t *resolve_file_tag(yoml_t *node, resolve_tag_arg_t *arg)
     }
 
     yoml_parse_args_t parse_args = {
-        filename,          /* filename */
-        NULL,              /* mem_set */
-        {resolve_tag, arg} /* resolve_tag */
+        .filename = filename,
+        .resolve_tag = {
+            .cb = resolve_tag,
+            .cb_arg = arg,
+        },
+        .resolve_alias = 1,
+        .resolve_merge = 1,
     };
     loaded = load_config(&parse_args, node);
 
@@ -3882,9 +3886,13 @@ int main(int argc, char **argv)
         yoml_t *yoml;
         resolve_tag_arg_t resolve_tag_arg = {{NULL}};
         yoml_parse_args_t parse_args = {
-            opt_config_file,                /* filename */
-            NULL,                           /* mem_set */
-            {resolve_tag, &resolve_tag_arg} /* resolve_tag */
+            .filename = opt_config_file,
+            .resolve_tag = {
+                .cb = resolve_tag,
+                .cb_arg = &resolve_tag_arg
+            },
+            .resolve_alias = 1,
+            .resolve_merge = 1,
         };
         if ((yoml = load_config(&parse_args, NULL)) == NULL)
             exit(EX_CONFIG);


### PR DESCRIPTION
We have been using `-std=c99` for some time though we have refrained from using all features of C99. It would be reasonable to assume that all compilers support FAM.

We might start seeing compile errors with C++ projects using libh2o, because yoml.h included by h2o.h is now using FAM. If that turns out to be an issue, then we can fix it.