### PR TITLE
Enable build with musl alpine (#3109)

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -28,6 +28,7 @@ extern "C" {
 
 #include <stdint.h>
 #include <sys/socket.h>
+#include <time.h>
 #ifdef __linux__
 #include <linux/errqueue.h>
 #endif

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -603,7 +603,7 @@ void h2o_append_to_null_terminated_list(void ***list, void *element)
 
 char *h2o_strerror_r(int err, char *buf, size_t len)
 {
-#ifndef _GNU_SOURCE
+#if !(defined(_GNU_SOURCE) && defined(__gnu_linux__))
     strerror_r(err, buf, len);
     return buf;
 #else


### PR DESCRIPTION
Fixes #3109 

It can be compiled both ubuntu latest and alpine latest(with docker).

At first, it can be removed the compile error
to add time.h. It refferred to here.
https://www.openembedded.org/pipermail/openembedded-core/2016-January/115069.html

Second, it doesn't choose XSI-compliant strerror_r. Because the alpine with musl isn't considered to gnu linux distributions (it has not `__gnu_linux__`) despite it defined `_GNU_SOURCE`.


