### PR TITLE
add a fast path to avoid unnecessary allocation and copy

### DIFF
--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -245,7 +245,10 @@ static void build_request(h2o_req_t *req, h2o_iovec_t *method, h2o_url_t *url, h
         }
     }
 
-    if (cookie_values.size != 0) {
+    if (cookie_values.size == 1) {
+        /* fast path */
+        h2o_add_header(&req->pool, headers, H2O_TOKEN_COOKIE, NULL, cookie_values.entries[0].base, cookie_values.entries[0].len);
+    } else if (cookie_values.size > 1) {
         /* merge the cookie headers; see HTTP/2 8.1.2.5 and HTTP/1 (RFC6265 5.4) */
         h2o_iovec_t cookie_buf = h2o_join_list(&req->pool, cookie_values.entries, cookie_values.size, h2o_iovec_init(H2O_STRLIT("; ")));
         h2o_add_header(&req->pool, headers, H2O_TOKEN_COOKIE, NULL, cookie_buf.base, cookie_buf.len);


### PR DESCRIPTION
We merged https://github.com/h2o/h2o/pull/3121 but it'd be better to have a fast path when we only have one cookie header, especially for h1 requests which is expected to have already merge headers.