### PR TITLE
Disable http1 req timeout after upgrade

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -175,28 +175,24 @@ static void cleanup_connection(struct st_h2o_http1_conn_t *conn)
  */
 static void set_req_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, h2o_timer_cb cb)
 {
+    if (conn->req.is_tunnel_req)
+        cb = NULL;
     if (conn->_timeout_entry.cb != NULL)
         h2o_timer_unlink(&conn->_timeout_entry);
-    if (conn->req.is_tunnel_req) {
-        conn->_timeout_entry.cb = NULL;
-    } else {
-        conn->_timeout_entry.cb = cb;
-        if (cb != NULL)
-            h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_timeout_entry);
-    }
+    conn->_timeout_entry.cb = cb;
+    if (cb != NULL)
+        h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_timeout_entry);
 }
 
 static void set_req_io_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, h2o_timer_cb cb)
 {
+    if (conn->req.is_tunnel_req)
+        cb = NULL;
     if (conn->_io_timeout_entry.cb != NULL)
         h2o_timer_unlink(&conn->_io_timeout_entry);
-    if (conn->req.is_tunnel_req) {
-        conn->_timeout_entry.cb = NULL;
-    } else {
-        conn->_io_timeout_entry.cb = cb;
-        if (cb != NULL)
-            h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_io_timeout_entry);
-    }
+    conn->_io_timeout_entry.cb = cb;
+    if (cb != NULL)
+        h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_io_timeout_entry);
 }
 
 static void clear_timeouts(struct st_h2o_http1_conn_t *conn)

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -177,18 +177,26 @@ static void set_req_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, 
 {
     if (conn->_timeout_entry.cb != NULL)
         h2o_timer_unlink(&conn->_timeout_entry);
-    conn->_timeout_entry.cb = cb;
-    if (cb != NULL)
-        h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_timeout_entry);
+    if (conn->req.is_tunnel_req) {
+        conn->_timeout_entry.cb = NULL;
+    } else {
+        conn->_timeout_entry.cb = cb;
+        if (cb != NULL)
+            h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_timeout_entry);
+    }
 }
 
 static void set_req_io_timeout(struct st_h2o_http1_conn_t *conn, uint64_t timeout, h2o_timer_cb cb)
 {
     if (conn->_io_timeout_entry.cb != NULL)
         h2o_timer_unlink(&conn->_io_timeout_entry);
-    conn->_io_timeout_entry.cb = cb;
-    if (cb != NULL)
-        h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_io_timeout_entry);
+    if (conn->req.is_tunnel_req) {
+        conn->_timeout_entry.cb = NULL;
+    } else {
+        conn->_io_timeout_entry.cb = cb;
+        if (cb != NULL)
+            h2o_timer_link(conn->super.ctx->loop, timeout, &conn->_io_timeout_entry);
+    }
 }
 
 static void clear_timeouts(struct st_h2o_http1_conn_t *conn)


### PR DESCRIPTION
After upgrading a h1 connection to bi-directional data stream, both of `http1-request-timeout` and `http1-request-io-timeout` become meaningless and should not be fired (we can rely on `proxy.timeout.io` for general idle timeout). This PR disables those timeout mechanisms by respecting `req->is_tunnel_req` field.