### PR TITLE
Fix session ticket lifetime

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1133,7 +1133,7 @@ void ssl_setup_session_resumption(SSL_CTX **contexts, size_t num_contexts, struc
 void ssl_setup_session_resumption_ptls(ptls_context_t *ptls, quicly_context_t *quic)
 {
     if (conf.ticket.update_thread != NULL) {
-        ptls->ticket_lifetime = 86400 * 7; // FIXME conf.lifetime
+        ptls->ticket_lifetime = conf.lifetime;
         assert((quic != NULL) == ptls->omit_end_of_early_data && "detected contradictory setting");
         ptls->encrypt_ticket = create_encrypt_ticket_ptls(quic);
     }


### PR DESCRIPTION
```
commit 031d8a38a066f27ebfcd07105ce5832be1fd7f41
Author: Kazuho Oku <kazuhooku@gmail.com>
Date:   Tue Feb 21 16:00:05 2017 +0900

    set `ticket_lifetime` to maximum until https://bugzilla.mozilla.org/show_bug.cgi?id=1340841 gets resolved

diff --git a/src/ssl.c b/src/ssl.c
index e94156074..1b18e3f26 100644
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -897,7 +897,7 @@ void ssl_setup_session_resumption(SSL_CTX **contexts, size_t num_contexts)
 #if H2O_USE_PICOTLS
             static ptls_encrypt_ticket_t encryptor = {encrypt_ticket_key_ptls}, decryptor = {decrypt_ticket_key_ptls};
             ptls_context_t *pctx = h2o_socket_ssl_get_picotls_context(ctx);
-            pctx->ticket_lifetime = conf.lifetime;
+            pctx->ticket_lifetime = 86400 * 7; // FIXME conf.lifetime;
             pctx->encrypt_ticket = &encryptor;
             pctx->decrypt_ticket = &decryptor;
 #endif
```

* https://bugzilla.mozilla.org/show_bug.cgi?id=1340841 had fixed in nss 3.29.2.
* https://firefox-source-docs.mozilla.org/security/nss/legacy/nss_releases/nss_3.29.2_release_notes/index.html#bugs-fixed-in-nss-3-29-2