### PR TITLE
GC resources at one place

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1467,9 +1467,10 @@ void h2o_add_server_timing_header(h2o_req_t *req, int uses_trailer);
 h2o_iovec_t h2o_build_server_timing_trailer(h2o_req_t *req, const char *prefix, size_t prefix_len, const char *suffix,
                                             size_t suffix_len);
 /**
- * release all thread-local resources used by h2o
+ * Garbage collects resources kept for future reuse in the current thread. If `now` is set to zero, performs full GC. If a valid
+ * pointer is passed to `ctx_optional`, resource associated to the context will be collected as well.
  */
-void h2o_cleanup_thread(void);
+void h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional);
 
 extern uint64_t h2o_connection_id;
 

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1468,9 +1468,11 @@ h2o_iovec_t h2o_build_server_timing_trailer(h2o_req_t *req, const char *prefix, 
                                             size_t suffix_len);
 /**
  * Garbage collects resources kept for future reuse in the current thread. If `now` is set to zero, performs full GC. If a valid
- * pointer is passed to `ctx_optional`, resource associated to the context will be collected as well.
+ * pointer is passed to `ctx_optional`, resource associated to the context will be collected as well. This function returns when
+ * it should be called the next time, or UINT64_MAX if there are no resources being held that can be acclaimed in the foreseeable
+ * future.
  */
-void h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional);
+uint64_t h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional);
 
 extern uint64_t h2o_connection_id;
 

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -939,8 +939,21 @@ const char h2o_npn_protocols[] = NPN_PROTOCOLS_CORE "\x08"
 
 uint64_t h2o_connection_id = 0;
 
-void h2o_cleanup_thread(void)
+void h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional)
 {
-    h2o_mem_clear_recycle(&h2o_mem_pool_allocator, 1);
-    h2o_buffer_clear_recycle(1);
+    int full = now == 0;
+
+    if (ctx_optional != NULL)
+        h2o_filecache_clear(ctx_optional->filecache);
+
+    static __thread uint64_t next_buffer_gc_at = UINT64_MAX;
+    if (full || now >= next_buffer_gc_at) {
+        h2o_buffer_clear_recycle(full);
+        h2o_socket_clear_recycle(full);
+        h2o_mem_clear_recycle(&h2o_mem_pool_allocator, full);
+        next_buffer_gc_at = UINT64_MAX;
+    }
+
+    if (next_buffer_gc_at == UINT64_MAX && (!h2o_buffer_recycle_is_empty() || !h2o_socket_recycle_is_empty()))
+        next_buffer_gc_at = now + 1000;
 }

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -944,10 +944,9 @@ uint64_t h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional)
     int full = now == 0;
 
     /* File descriptor cache is cleared fully per event loop and it is sufficient to do so, because:
-     * * if the file handler opens one file only once per event loop, then calling open (2) is relatively lightweight to other stuff
-     *   such as connection establishment,
-     * * if the file is large enough that it is not served in one event loop, the file descriptor remains open and will be reused.
-     */
+     * * if the file handler opens one file only once per event loop, then calling open (2) is relatively lightweight compared to
+     *   other stuff such as connection establishment, and
+     * * if a file is large enough that it is not served in one event loop, the file descriptor remains open within the cache. */
     if (ctx_optional != NULL)
         h2o_filecache_clear(ctx_optional->filecache);
 

--- a/src/main.c
+++ b/src/main.c
@@ -3345,13 +3345,15 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     h2o_barrier_wait(&conf.startup_sync_barrier_post);
 
     /* the main loop */
+    uint64_t next_buffer_gc_at = UINT64_MAX;
     while (1) {
         if (conf.shutdown_requested)
             break;
         update_listener_state(listeners);
         /* run the loop once */
         h2o_evloop_run(conf.threads[thread_index].ctx.loop, next_buffer_gc_at == UINT64_MAX ? INT32_MAX : 1000);
-        h2o_cleanup_thread(h2o_now(conf.threads[thread_index].ctx.loop), &conf.threads[thread_index].ctx);
+        if (h2o_now(conf.threads[thread_index].ctx.loop) >= next_buffer_gc_at)
+            next_buffer_gc_at = h2o_cleanup_thread(h2o_now(conf.threads[thread_index].ctx.loop), &conf.threads[thread_index].ctx);
     }
 
     if (thread_index == 0)

--- a/src/main.c
+++ b/src/main.c
@@ -3345,23 +3345,13 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     h2o_barrier_wait(&conf.startup_sync_barrier_post);
 
     /* the main loop */
-    uint64_t next_buffer_gc_at = UINT64_MAX;
     while (1) {
         if (conf.shutdown_requested)
             break;
         update_listener_state(listeners);
         /* run the loop once */
         h2o_evloop_run(conf.threads[thread_index].ctx.loop, next_buffer_gc_at == UINT64_MAX ? INT32_MAX : 1000);
-        /* cleanup */
-        h2o_filecache_clear(conf.threads[thread_index].ctx.filecache);
-        if (h2o_now(conf.threads[thread_index].ctx.loop) >= next_buffer_gc_at) {
-            h2o_buffer_clear_recycle(0);
-            h2o_socket_clear_recycle(0);
-            h2o_mem_clear_recycle(&h2o_mem_pool_allocator, 0);
-            next_buffer_gc_at = UINT64_MAX;
-        }
-        if (next_buffer_gc_at == UINT64_MAX && (!h2o_buffer_recycle_is_empty() || !h2o_socket_recycle_is_empty()))
-            next_buffer_gc_at = h2o_now(conf.threads[thread_index].ctx.loop) + 1000;
+        h2o_cleanup_thread(h2o_now(conf.threads[thread_index].ctx.loop), &conf.threads[thread_index].ctx);
     }
 
     if (thread_index == 0)


### PR DESCRIPTION
Up until now, we have had two location at which we GC resources that are recycled, the `run_loop` function in src/main.c, and the other is `h2o_cleanup_thread` function.

As pointed out by #3150, the former was failing to recycle memory retained by the mempool allocator. The latter seems to have been failing to invoke `h2o_socket_clear_recycle`.

This PR address streamlines the design, merging the two functions, in the hope that the chance would be reduced of failing to add invocation on either side.

See also: #1624.