### PR TITLE
async signature generation for HTTP/3

### DIFF
--- a/deps/picotls/include/picotls.h
+++ b/deps/picotls/include/picotls.h
@@ -579,6 +579,7 @@ typedef struct st_ptls_hpke_cipher_suite_id_t {
 
 typedef const struct st_ptls_hpke_cipher_suite_t {
     ptls_hpke_cipher_suite_id_t id;
+    const char *name; /* in form of "<kdf>/<aead>" using the sames specified in IANA HPKE registry */
     ptls_hash_algorithm_t *hash;
     ptls_aead_algorithm_t *aead;
 } ptls_hpke_cipher_suite_t;
@@ -942,7 +943,8 @@ typedef struct st_ptls_handshake_properties_t {
              */
             struct {
                 /**
-                 * config offered by server e.g., by HTTPS RR
+                 * Config offered by server e.g., by HTTPS RR. If config.base is non-NULL but config.len is zero, a grease ECH will
+                 * be sent, assuming that X25519-SHA256 KEM and SHA256-AES-128-GCM HPKE cipher is available.
                  */
                 ptls_iovec_t configs;
                 /**

--- a/deps/picotls/include/picotls.h
+++ b/deps/picotls/include/picotls.h
@@ -1630,7 +1630,7 @@ static size_t ptls_aead_encrypt_final(ptls_aead_context_t *ctx, void *output);
 static size_t ptls_aead_decrypt(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
                                 const void *aad, size_t aadlen);
 /**
- * Return the current read epoch.
+ * Return the current read epoch (i.e., that of the message being received or to be)
  */
 size_t ptls_get_read_epoch(ptls_t *tls);
 /**

--- a/deps/picotls/lib/openssl.c
+++ b/deps/picotls/lib/openssl.c
@@ -2009,19 +2009,23 @@ ptls_hpke_kem_t *ptls_openssl_hpke_kems[] = {&ptls_openssl_hpke_kem_p384sha384,
 
 ptls_hpke_cipher_suite_t ptls_openssl_hpke_aes128gcmsha256 = {
     .id = {.kdf = PTLS_HPKE_HKDF_SHA256, .aead = PTLS_HPKE_AEAD_AES_128_GCM},
+    .name = "HKDF-SHA256/AES-128-GCM",
     .hash = &ptls_openssl_sha256,
     .aead = &ptls_openssl_aes128gcm};
 ptls_hpke_cipher_suite_t ptls_openssl_hpke_aes128gcmsha512 = {
     .id = {.kdf = PTLS_HPKE_HKDF_SHA512, .aead = PTLS_HPKE_AEAD_AES_128_GCM},
+    .name = "HKDF-SHA512/AES-128-GCM",
     .hash = &ptls_openssl_sha512,
     .aead = &ptls_openssl_aes128gcm};
 ptls_hpke_cipher_suite_t ptls_openssl_hpke_aes256gcmsha384 = {
     .id = {.kdf = PTLS_HPKE_HKDF_SHA384, .aead = PTLS_HPKE_AEAD_AES_256_GCM},
+    .name = "HKDF-SHA384/AES-256-GCM",
     .hash = &ptls_openssl_sha384,
     .aead = &ptls_openssl_aes256gcm};
 #if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
 ptls_hpke_cipher_suite_t ptls_openssl_hpke_chacha20poly1305sha256 = {
     .id = {.kdf = PTLS_HPKE_HKDF_SHA256, .aead = PTLS_HPKE_AEAD_CHACHA20POLY1305},
+    .name = "HKDF-SHA256/ChaCha20Poly1305",
     .hash = &ptls_openssl_sha256,
     .aead = &ptls_openssl_chacha20poly1305};
 #endif

--- a/deps/picotls/lib/picotls.c
+++ b/deps/picotls/lib/picotls.c
@@ -6245,6 +6245,7 @@ size_t ptls_get_read_epoch(ptls_t *tls)
     case PTLS_STATE_CLIENT_EXPECT_CERTIFICATE:
     case PTLS_STATE_CLIENT_EXPECT_CERTIFICATE_VERIFY:
     case PTLS_STATE_CLIENT_EXPECT_FINISHED:
+    case PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY:
     case PTLS_STATE_SERVER_EXPECT_CERTIFICATE:
     case PTLS_STATE_SERVER_EXPECT_CERTIFICATE_VERIFY:
     case PTLS_STATE_SERVER_EXPECT_FINISHED:
@@ -6293,12 +6294,11 @@ int ptls_server_handle_message(ptls_t *tls, ptls_buffer_t *sendbuf, size_t epoch
     struct st_ptls_record_t rec = {PTLS_CONTENT_TYPE_HANDSHAKE, 0, inlen, input};
 
     if (tls->state == PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY) {
-        int ret;
-        if ((ret = server_finish_handshake(tls, &emitter.super, 1, NULL)) != 0)
-            return ret;
+        assert(input == NULL || inlen == 0);
+        return server_finish_handshake(tls, &emitter.super, 1, NULL);
     }
 
-    assert(input);
+    assert(input != NULL);
 
     if (ptls_get_read_epoch(tls) != in_epoch)
         return PTLS_ALERT_UNEXPECTED_MESSAGE;

--- a/deps/picotls/picotls-probes.d
+++ b/deps/picotls/picotls-probes.d
@@ -26,4 +26,5 @@ provider picotls {
     probe client_random(struct st_ptls_t *tls, const void *bytes);
     probe receive_message(struct st_ptls_t *tls, uint8_t message, const void *bytes, size_t len, int result);
     probe new_secret(struct st_ptls_t *tls, const char *label, const char *secret_hex);
+    probe ech_selection(struct st_ptls_t *tls, int is_ech);
 };

--- a/deps/picotls/picotls.xcodeproj/project.pbxproj
+++ b/deps/picotls/picotls.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		081F00CC291A358800534A86 /* asn1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = asn1.h; sourceTree = "<group>"; };
 		081F00CD291A358800534A86 /* pembase64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pembase64.h; sourceTree = "<group>"; };
 		081F00CE291A358800534A86 /* ptlsbcrypt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ptlsbcrypt.h; sourceTree = "<group>"; };
+		08B3298229419DFC009D6766 /* ech-live.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "ech-live.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		08F0FDF52910F67A00EE657D /* hpke.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = hpke.c; sourceTree = "<group>"; };
 		105900241DC8D37500FB4085 /* aes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = aes.c; path = src/aes.c; sourceTree = "<group>"; };
 		105900251DC8D37500FB4085 /* aes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = aes.h; path = src/aes.h; sourceTree = "<group>"; };
@@ -260,7 +261,7 @@
 		E95EBCCA227EA0180022C32D /* dtrace-utils.cmake */ = {isa = PBXFileReference; lastKnownFileType = text; path = "dtrace-utils.cmake"; sourceTree = "<group>"; };
 		E97577002212405300D1EF74 /* ffx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ffx.h; sourceTree = "<group>"; };
 		E97577022212405D00D1EF74 /* ffx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ffx.c; sourceTree = "<group>"; };
-		E97577072213148800D1EF74 /* e2e.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.perl; path = e2e.t; sourceTree = "<group>"; };
+		E97577072213148800D1EF74 /* e2e.t */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.perl; path = e2e.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		E99B75DE1F5CDDB500CF503E /* asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = asn1.c; sourceTree = "<group>"; };
 		E99B75DF1F5CDDB500CF503E /* pembase64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pembase64.c; sourceTree = "<group>"; };
 		E9B43DBF24619D1700824E51 /* fusion.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fusion.c; sourceTree = "<group>"; };
@@ -452,6 +453,7 @@
 			children = (
 				106530FE1DAD8A3C005B2C60 /* cli.c */,
 				E97577072213148800D1EF74 /* e2e.t */,
+				08B3298229419DFC009D6766 /* ech-live.t */,
 				E9B43DE224619D7E00824E51 /* fusion.c */,
 				081F00C92918823200534A86 /* hpke.c */,
 				1059003D1DC8D4E300FB4085 /* minicrypto.c */,

--- a/deps/picotls/t/cli.c
+++ b/deps/picotls/t/cli.c
@@ -57,21 +57,6 @@
 /* sentinels indicating that the endpoint is in benchmark mode */
 static const char input_file_is_benchmark[] = "is:benchmark";
 
-static struct {
-    ptls_iovec_t config_list;
-    struct {
-        struct {
-            ptls_hpke_kem_t *kem;
-            ptls_key_exchange_context_t *ctx;
-        } list[16];
-        size_t count;
-    } keyex;
-    struct {
-        ptls_iovec_t configs;
-        char *fn;
-    } retry;
-} ech;
-
 static ptls_hpke_kem_t *find_kem(ptls_key_exchange_algorithm_t *algo)
 {
     for (size_t i = 0; ptls_openssl_hpke_kems[i] != NULL; ++i)
@@ -79,65 +64,6 @@ static ptls_hpke_kem_t *find_kem(ptls_key_exchange_algorithm_t *algo)
             return ptls_openssl_hpke_kems[i];
 
     fprintf(stderr, "HPKE KEM not found for %s\n", algo->name);
-    return NULL;
-}
-
-static ptls_aead_context_t *create_ech_opener(ptls_ech_create_opener_t *self, ptls_hpke_kem_t **kem,
-                                              ptls_hpke_cipher_suite_t **cipher, ptls_t *tls, uint8_t config_id,
-                                              ptls_hpke_cipher_suite_id_t cipher_id, ptls_iovec_t enc, ptls_iovec_t info_prefix)
-{
-    const uint8_t *src = ech.config_list.base, *const end = src + ech.config_list.len;
-    size_t index = 0;
-    int ret = 0;
-
-    /* look for the cipher implementation; this should better be specific to each ECHConfig (as each of them may advertise different
-     * set of values) */
-    *cipher = NULL;
-    for (size_t i = 0; ptls_openssl_hpke_cipher_suites[i] != NULL; ++i) {
-        if (ptls_openssl_hpke_cipher_suites[i]->id.kdf == cipher_id.kdf &&
-            ptls_openssl_hpke_cipher_suites[i]->id.aead == cipher_id.aead) {
-            *cipher = ptls_openssl_hpke_cipher_suites[i];
-            break;
-        }
-    }
-    if (*cipher == NULL)
-        goto Exit;
-
-    ptls_decode_open_block(src, end, 2, {
-        uint16_t version;
-        if ((ret = ptls_decode16(&version, &src, end)) != 0)
-            goto Exit;
-        do {
-            ptls_decode_open_block(src, end, 2, {
-                if (src == end) {
-                    ret = PTLS_ALERT_DECODE_ERROR;
-                    goto Exit;
-                }
-                if (*src == config_id) {
-                    /* this is the ECHConfig that we have been looking for */
-                    if (index >= ech.keyex.count) {
-                        fprintf(stderr, "ECH key missing for config %zu\n", index);
-                        return NULL;
-                    }
-                    uint8_t *info = malloc(info_prefix.len + end - (src - 4));
-                    memcpy(info, info_prefix.base, info_prefix.len);
-                    memcpy(info + info_prefix.len, src - 4, end - (src - 4));
-                    ptls_aead_context_t *aead;
-                    ptls_hpke_setup_base_r(ech.keyex.list[index].kem, *cipher, ech.keyex.list[index].ctx, &aead, enc,
-                                           ptls_iovec_init(info, info_prefix.len + end - (src - 4)));
-                    free(info);
-                    *kem = ech.keyex.list[index].kem;
-                    return aead;
-                }
-                ++index;
-                src = end;
-            });
-        } while (src != end);
-    });
-
-Exit:
-    if (ret != 0)
-        fprintf(stderr, "ECH decode error:%d\n", ret);
     return NULL;
 }
 
@@ -243,6 +169,7 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                     if ((ret = ptls_handshake(tls, &encbuf, bytebuf + off, &leftlen, hsprop)) == 0) {
                         state = IN_1RTT;
                         assert(ptls_is_server(tls) || hsprop->client.early_data_acceptance != PTLS_EARLY_DATA_ACCEPTANCE_UNKNOWN);
+                        ech_save_retry_configs();
                         /* release data sent as early-data, if server accepted it */
                         if (hsprop->client.early_data_acceptance == PTLS_EARLY_DATA_ACCEPTED)
                             shift_buffer(&ptbuf, early_bytes_sent);
@@ -253,15 +180,7 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                     } else {
                         if (ret == PTLS_ALERT_ECH_REQUIRED) {
                             assert(!ptls_is_server(tls));
-                            if (ech.retry.configs.base != NULL) {
-                                FILE *fp;
-                                if ((fp = fopen(ech.retry.fn, "wt")) == NULL) {
-                                    fprintf(stderr, "failed to write to ECH config file:%s:%s\n", ech.retry.fn, strerror(errno));
-                                    exit(1);
-                                }
-                                fwrite(ech.retry.configs.base, 1, ech.retry.configs.len, fp);
-                                fclose(fp);
-                            }
+                            ech_save_retry_configs();
                         }
                         if (encbuf.off != 0)
                             repeat_while_eintr(write(sockfd, encbuf.base, encbuf.off), { break; });
@@ -465,8 +384,9 @@ static void usage(const char *cmd)
            "  -N named-group       named group to be used (default: secp256r1)\n"
            "  -s session-file      file to read/write the session ticket\n"
            "  -S                   require public key exchange when resuming a session\n"
-           "  -E echconfiglist     file that contains ECHConfigList; overwritten when\n"
-           "                       receiving retry_configs from the server\n"
+           "  -E echconfiglist     file that contains ECHConfigList or an empty file to\n"
+           "                       grease ECH; will be overwritten when receiving\n"
+           "                       retry_configs from the server\n"
            "  -e                   when resuming a session, send first 8,192 bytes of input\n"
            "                       as early data\n"
            "  -r public-key-file   use raw public keys (RFC 7250). When set and running as a\n"
@@ -520,7 +440,6 @@ int main(int argc, char **argv)
 
     ptls_key_exchange_algorithm_t *key_exchanges[128] = {NULL};
     ptls_cipher_suite_t *cipher_suites[128] = {NULL};
-    ptls_ech_create_opener_t ech_opener = {.cb = create_ech_opener};
     ptls_context_t ctx = {
         .random_bytes = ptls_openssl_random_bytes,
         .get_time = &ptls_get_time,
@@ -594,42 +513,12 @@ int main(int argc, char **argv)
         case 'S':
             ctx.require_dhe_on_psk = 1;
             break;
-        case 'E': {
-            FILE *fp;
-            if ((fp = fopen(optarg, "rt")) == NULL) {
-                fprintf(stderr, "failed to open ECHConfigList file:%s:%s\n", optarg, strerror(errno));
-                return 1;
-            }
-            ech.config_list.base = malloc(65536);
-            if ((ech.config_list.len = fread(ech.config_list.base, 1, 65536, fp)) == 65536) {
-                fprintf(stderr, "ECHConfigList is too large:%s\n", optarg);
-                return 1;
-            }
-            fclose(fp);
-            ech.retry.fn = optarg;
-        } break;
-        case 'K': {
-            FILE *fp;
-            EVP_PKEY *pkey;
-            int ret;
-            if ((fp = fopen(optarg, "rt")) == NULL) {
-                fprintf(stderr, "failed to open ECH private key file:%s:%s\n", optarg, strerror(errno));
-                return 1;
-            }
-            if ((pkey = PEM_read_PrivateKey(fp, NULL, NULL, NULL)) == NULL) {
-                fprintf(stderr, "failed to load private key from file:%s\n", optarg);
-                return 1;
-            }
-            if ((ret = ptls_openssl_create_key_exchange(&ech.keyex.list[ech.keyex.count].ctx, pkey)) != 0) {
-                fprintf(stderr, "failed to load private key from file:%s:picotls-error:%d", optarg, ret);
-                return 1;
-            }
-            ech.keyex.list[ech.keyex.count].kem = find_kem(ech.keyex.list[ech.keyex.count].ctx->algo);
-            ++ech.keyex.count;
-            EVP_PKEY_free(pkey);
-            fclose(fp);
-            ctx.ech.server.create_opener = &ech_opener;
-        } break;
+        case 'E':
+            ech_setup_configs(optarg);
+            break;
+        case 'K':
+            ech_setup_key(&ctx, optarg);
+            break;
         case 'l':
             setup_log_event(&ctx, optarg);
             break;

--- a/deps/picotls/t/ech-live.t
+++ b/deps/picotls/t/ech-live.t
@@ -1,0 +1,46 @@
+#! /usr/bin/env perl
+
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use POSIX ":sys_wait_h";
+use Test::More;
+
+$ENV{BINARY_DIR} ||= ".";
+my $cli = "$ENV{BINARY_DIR}/cli";
+my $tempdir = tempdir(CLEANUP => 1);
+
+plan skip_all => "skipping live tests (setenv LIVE_TESTS=1 to run them)"
+    unless $ENV{LIVE_TESTS};
+
+subtest "crypto.cloudflare.com" => sub {
+    my $req_fn = "$tempdir/req";
+    my $ech_config_fn = "$tempdir/echconfiglist";
+    my $fetch = sub {
+        open my $fh, "$cli -I -E $ech_config_fn crypto.cloudflare.com 443 < $req_fn |"
+            or die "failed to open $cli to connect to crypto.cloudflare.com";
+        join "", <$fh>;
+    };
+
+    { # build request as a temporary file
+        open my $fh, ">", $req_fn
+            or die "failed to create file:$req_fn:$!";
+        print $fh "GET /cdn-cgi/trace HTTP/1.0\r\nHost: crypto.cloudflare.com\r\n\r\n";
+        close $fh;
+    }
+
+    { # create empty ECHConfigList file so as to grease and obtain true config
+        open my $fh, ">", $ech_config_fn
+            or die "failed to create file:$ech_config_fn:$!";
+        close $fh;
+    }
+
+    my $resp = $fetch->();
+    like $resp, qr/^sni=plaintext$/m, "response to grease";
+    isnt +(stat $req_fn)[7], 0, "echconfiglist is non-empty";
+
+    $resp = $fetch->();
+    like $resp, qr/^sni=encrypted$/m, "response to innerCH";
+};
+
+done_testing;

--- a/deps/picotls/t/minicrypto.c
+++ b/deps/picotls/t/minicrypto.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
                              ptls_minicrypto_key_exchanges,
                              ptls_minicrypto_cipher_suites,
                              {&cert, 1},
-                             {NULL},
+                             {{NULL}},
                              NULL,
                              NULL,
                              &sign_certificate.super};

--- a/deps/picotls/t/openssl.c
+++ b/deps/picotls/t/openssl.c
@@ -599,7 +599,7 @@ int main(int argc, char **argv)
                                      ptls_minicrypto_key_exchanges,
                                      ptls_minicrypto_cipher_suites,
                                      {&minicrypto_certificate, 1},
-                                     {NULL},
+                                     {{NULL}},
                                      NULL,
                                      NULL,
                                      &minicrypto_sign_certificate.super};

--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -161,6 +161,11 @@ QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t 
  * delta must be either 1 or -1.
  */
 QUICLY_CALLBACK_TYPE(void, update_open_count, ssize_t delta);
+/**
+ * Called when picotls return PTLS_ERROR_ASYNC_OPERATION. The application must call `ptls_resume_handshake` once the async operation
+ * is complete.
+ */
+QUICLY_CALLBACK_TYPE(void, async_handshake, ptls_t *tls);
 
 /**
  * crypto offload API
@@ -369,6 +374,10 @@ struct st_quicly_context_t {
      * optional refcount callback
      */
     quicly_update_open_count_t *update_open_count;
+    /**
+     *
+     */
+    quicly_async_handshake_t *async_handshake;
 };
 
 /**
@@ -1087,6 +1096,10 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
  *
  */
 ptls_t *quicly_get_tls(quicly_conn_t *conn);
+/**
+ * resumes an async TLS handshake; see `quicly_async_handshake_t`
+ */
+void quicly_resume_handshake(ptls_t *tls);
 /**
  *
  */

--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -1097,9 +1097,10 @@ int quicly_accept(quicly_conn_t **conn, quicly_context_t *ctx, struct sockaddr *
  */
 ptls_t *quicly_get_tls(quicly_conn_t *conn);
 /**
- * resumes an async TLS handshake; see `quicly_async_handshake_t`
+ * Resumes an async TLS handshake, and returns a pointer to the QUIC connection or NULL if the corresponding QUIC connection has
+ * been discarded. See `quicly_async_handshake_t`.
  */
-void quicly_resume_handshake(ptls_t *tls);
+quicly_conn_t *quicly_resume_handshake(ptls_t *tls);
 /**
  *
  */

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -1038,23 +1038,24 @@ void crypto_stream_receive(quicly_stream_t *stream, size_t off, const void *src,
     }
 }
 
-void quicly_resume_handshake(ptls_t *tls)
+quicly_conn_t *quicly_resume_handshake(ptls_t *tls)
 {
     quicly_conn_t *conn;
 
     if ((conn = *ptls_get_data_ptr(tls)) == NULL) {
         /* QUIC connection has been closed while TLS async operation was inflight. */
         ptls_free(tls);
-        return;
+        return NULL;
     }
 
     assert(conn->crypto.async_in_progress);
     conn->crypto.async_in_progress = 0;
 
     if (conn->super.state >= QUICLY_STATE_CLOSING)
-        return;
+        return conn;
 
     crypto_handshake(conn, 0, ptls_iovec_init(NULL, 0));
+    return conn;
 }
 
 static void init_stream_properties(quicly_stream_t *stream, uint32_t initial_max_stream_data_local,

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -362,6 +362,7 @@ struct st_quicly_conn_t {
             ptls_raw_extension_t ext[3];
             ptls_buffer_t buf;
         } transport_params;
+        unsigned async_in_progress : 1;
     } crypto;
     /**
      * token (if the token is a Retry token can be determined by consulting the length of retry_scid)
@@ -961,56 +962,99 @@ static int write_crypto_data(quicly_conn_t *conn, ptls_buffer_t *tlsbuf, size_t 
     return 0;
 }
 
-void crypto_stream_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
+static void crypto_handshake(quicly_conn_t *conn, size_t in_epoch, ptls_iovec_t input)
 {
-    quicly_conn_t *conn = stream->conn;
-    size_t in_epoch = -(1 + stream->stream_id), epoch_offsets[5] = {0};
-    ptls_iovec_t input;
     ptls_buffer_t output;
+    size_t epoch_offsets[5] = {0};
 
-    if (quicly_streambuf_ingress_receive(stream, off, src, len) != 0)
-        return;
+    assert(!conn->crypto.async_in_progress);
 
     ptls_buffer_init(&output, "", 0);
 
-    /* send handshake messages to picotls, and let it fill in the response */
-    while ((input = quicly_streambuf_ingress_get(stream)).len != 0) {
-        int handshake_result = ptls_handle_message(conn->crypto.tls, &output, epoch_offsets, in_epoch, input.base, input.len,
-                                                   &conn->crypto.handshake_properties);
-        quicly_streambuf_ingress_shift(stream, input.len);
-        QUICLY_PROBE(CRYPTO_HANDSHAKE, conn, conn->stash.now, handshake_result);
-        QUICLY_LOG_CONN(crypto_handshake, conn, { PTLS_LOG_ELEMENT_SIGNED(ret, handshake_result); });
-        switch (handshake_result) {
-        case 0:
-        case PTLS_ERROR_IN_PROGRESS:
-            break;
-        default:
-            initiate_close(conn,
-                           PTLS_ERROR_GET_CLASS(handshake_result) == PTLS_ERROR_CLASS_SELF_ALERT ? handshake_result
-                                                                                                 : QUICLY_TRANSPORT_ERROR_INTERNAL,
-                           QUICLY_FRAME_TYPE_CRYPTO, NULL);
-            goto Exit;
-        }
-        /* drop 0-RTT write key if 0-RTT is rejected by remote peer */
-        if (conn->application != NULL && !conn->application->one_rtt_writable &&
-            conn->application->cipher.egress.key.aead != NULL) {
-            assert(quicly_is_client(conn));
-            if (conn->crypto.handshake_properties.client.early_data_acceptance == PTLS_EARLY_DATA_REJECTED) {
-                dispose_cipher(&conn->application->cipher.egress.key);
-                conn->application->cipher.egress.key = (struct st_quicly_cipher_context_t){NULL};
-                /* retire all packets with ack_epoch == 3; they are all 0-RTT packets */
-                int ret;
-                if ((ret = discard_sentmap_by_epoch(conn, 1u << QUICLY_EPOCH_1RTT)) != 0) {
-                    initiate_close(conn, ret, QUICLY_FRAME_TYPE_CRYPTO, NULL);
-                    goto Exit;
-                }
+    int handshake_result = ptls_handle_message(conn->crypto.tls, &output, epoch_offsets, in_epoch, input.base, input.len,
+                                               &conn->crypto.handshake_properties);
+    QUICLY_PROBE(CRYPTO_HANDSHAKE, conn, conn->stash.now, handshake_result);
+    QUICLY_LOG_CONN(crypto_handshake, conn, { PTLS_LOG_ELEMENT_SIGNED(ret, handshake_result); });
+    switch (handshake_result) {
+    case 0:
+    case PTLS_ERROR_IN_PROGRESS:
+        break;
+    case PTLS_ERROR_ASYNC_OPERATION:
+        assert(conn->super.ctx->async_handshake != NULL &&
+               "async handshake is used but the quicly_context_t::async_handshake is NULL");
+        conn->crypto.async_in_progress = 1;
+        conn->super.ctx->async_handshake->cb(conn->super.ctx->async_handshake, conn->crypto.tls);
+        break;
+    default:
+        initiate_close(conn,
+                       PTLS_ERROR_GET_CLASS(handshake_result) == PTLS_ERROR_CLASS_SELF_ALERT ? handshake_result
+                                                                                             : QUICLY_TRANSPORT_ERROR_INTERNAL,
+                       QUICLY_FRAME_TYPE_CRYPTO, NULL);
+        goto Exit;
+    }
+    /* drop 0-RTT write key if 0-RTT is rejected by remote peer */
+    if (conn->application != NULL && !conn->application->one_rtt_writable &&
+        conn->application->cipher.egress.key.aead != NULL) {
+        assert(quicly_is_client(conn));
+        if (conn->crypto.handshake_properties.client.early_data_acceptance == PTLS_EARLY_DATA_REJECTED) {
+            dispose_cipher(&conn->application->cipher.egress.key);
+            conn->application->cipher.egress.key = (struct st_quicly_cipher_context_t){NULL};
+            /* retire all packets with ack_epoch == 3; they are all 0-RTT packets */
+            int ret;
+            if ((ret = discard_sentmap_by_epoch(conn, 1u << QUICLY_EPOCH_1RTT)) != 0) {
+                initiate_close(conn, ret, QUICLY_FRAME_TYPE_CRYPTO, NULL);
+                goto Exit;
             }
         }
     }
+
     write_crypto_data(conn, &output, epoch_offsets);
 
 Exit:
     ptls_buffer_dispose(&output);
+}
+
+void crypto_stream_receive(quicly_stream_t *stream, size_t off, const void *src, size_t len)
+{
+    quicly_conn_t *conn = stream->conn;
+    ptls_iovec_t input;
+
+    /* store input */
+    if (quicly_streambuf_ingress_receive(stream, off, src, len) != 0)
+        return;
+
+    /* While the server generates the handshake signature asynchronously, clients would not send additional messages. They cannot
+     * generate Finished. They would not send Certificate / CertificateVerify before authenticating the server identity. */
+    if (conn->crypto.async_in_progress) {
+        initiate_close(conn, PTLS_ALERT_UNEXPECTED_MESSAGE, QUICLY_FRAME_TYPE_CRYPTO, NULL);
+        return;
+    }
+
+    /* feed the input into TLS, send result */
+    if ((input = quicly_streambuf_ingress_get(stream)).len != 0) {
+        size_t in_epoch = -(1 + stream->stream_id);
+        crypto_handshake(conn, in_epoch, input);
+        quicly_streambuf_ingress_shift(stream, input.len);
+    }
+}
+
+void quicly_resume_handshake(ptls_t *tls)
+{
+    quicly_conn_t *conn;
+
+    if ((conn = *ptls_get_data_ptr(tls)) == NULL) {
+        /* QUIC connection has been closed while TLS async operation was inflight. */
+        ptls_free(tls);
+        return;
+    }
+
+    assert(conn->crypto.async_in_progress);
+    conn->crypto.async_in_progress = 0;
+
+    if (conn->super.state >= QUICLY_STATE_CLOSING)
+        return;
+
+    crypto_handshake(conn, 0, ptls_iovec_init(NULL, 0));
 }
 
 static void init_stream_properties(quicly_stream_t *stream, uint32_t initial_max_stream_data_local,
@@ -1632,7 +1676,12 @@ void quicly_free(quicly_conn_t *conn)
     free_application_space(&conn->application);
 
     ptls_buffer_dispose(&conn->crypto.transport_params.buf);
-    ptls_free(conn->crypto.tls);
+    if (conn->crypto.async_in_progress) {
+        /* When async signature generation is inflight, `ptls_free` will be called from `quicly_resume_handshake` laterwards. */
+        *ptls_get_data_ptr(conn->crypto.tls) = NULL;
+    } else {
+        ptls_free(conn->crypto.tls);
+    }
 
     unlock_now(conn);
 

--- a/deps/quicly/src/cli.c
+++ b/deps/quicly/src/cli.c
@@ -91,6 +91,7 @@ static ptls_context_t tlsctx = {.random_bytes = ptls_openssl_random_bytes,
                                 .get_time = &ptls_get_time,
                                 .key_exchanges = key_exchanges,
                                 .cipher_suites = cipher_suites,
+                                .ech.client = {ptls_openssl_hpke_cipher_suites, ptls_openssl_hpke_kems},
                                 .require_dhe_on_psk = 1,
                                 .save_ticket = &save_session_ticket,
                                 .on_client_hello = &on_client_hello};
@@ -608,6 +609,7 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
         if (conn != NULL) {
             ret = send_pending(fd, conn);
             if (ret != 0) {
+                ech_save_retry_configs();
                 quicly_free(conn);
                 conn = NULL;
                 if (ret == QUICLY_ERROR_FREE_CONNECTION) {
@@ -1020,6 +1022,11 @@ static void usage(const char *cmd)
            "                            29)\n"
            "  -e event-log-file         file to log events\n"
            "  -E                        expand Client Hello (sends multiple client Initials)\n"
+           "  --ech-config <file>       file that contains ECHConfigList or an empty file to\n"
+           "                            grease ECH; will be overwritten when receiving\n"
+           "                            retry_configs from the server\n"
+           "  --ech-key <file>          ECH private key for each ECH config provided by\n"
+           "                            --ech-config\n"
            "  -f fraction               increases the induced ack frequency to specified\n"
            "                            fraction of CWND (default: 0)\n"
            "  -G                        enable UDP generic segmentation offload\n"
@@ -1073,7 +1080,7 @@ int main(int argc, char **argv)
     struct sockaddr_storage sa;
     socklen_t salen;
     unsigned udpbufsize = 0;
-    int ch, fd;
+    int ch, opt_index, fd;
 
     reqs = malloc(sizeof(*reqs));
     memset(reqs, 0, sizeof(*reqs));
@@ -1094,8 +1101,20 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    while ((ch = getopt(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h")) != -1) {
+    static const struct option longopts[] = {
+        {"ech-key", required_argument, NULL, 0}, {"ech-configs", required_argument, NULL, 0}, {NULL}};
+    while ((ch = getopt_long(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h", longopts,
+                             &opt_index)) != -1) {
         switch (ch) {
+        case 0: /* longopts */
+            if (strcmp(longopts[opt_index].name, "ech-key") == 0) {
+                ech_setup_key(&tlsctx, optarg);
+            } else if (strcmp(longopts[opt_index].name, "ech-configs") == 0) {
+                ech_setup_configs(optarg);
+            } else {
+                assert(!"unexpected longname");
+            }
+            break;
         case 'a':
             assert(negotiated_protocols.count < PTLS_ELEMENTSOF(negotiated_protocols.list));
             negotiated_protocols.list[negotiated_protocols.count++] = ptls_iovec_init(optarg, strlen(optarg));
@@ -1401,6 +1420,8 @@ int main(int argc, char **argv)
         hs_properties.client.negotiated_protocols.count = negotiated_protocols.count;
         if (session_file != NULL)
             load_session();
+        hs_properties.client.ech.configs = ech.config_list;
+        hs_properties.client.ech.retry_configs = &ech.retry.configs;
     }
     if (argc != 2) {
         fprintf(stderr, "missing host and port\n");

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -488,6 +488,21 @@ static int h2o_socket_skip_tracing(h2o_socket_t *sock);
  */
 void h2o_socket_set_skip_tracing(h2o_socket_t *sock, int skip_tracing);
 
+#if H2O_CAN_ASYNC_SSL
+/**
+ * When generating a TLS handshake signature asynchronously, it is necessary to wait for a notification on a file descriptor at
+ * which point the TLS handshake machinery is to be resumed. This function sets up a callback that would be called when that
+ * notification is received. The callback must invoke `h2o_socket_async_handshake_on_notify` to do the necessary clean up, as well
+ * as obtain the `data` pointer it has supplied.
+ */
+void h2o_socket_start_async_handshake(h2o_loop_t *loop, int async_fd, void *data, h2o_socket_cb cb);
+/**
+ * The function to be called by the callback supplied to `h2o_socket_start_async_handshake`. It returns the `data` pointer supplied
+ * to `h2o_socket_start_async_handshake`.
+ */
+void *h2o_socket_async_handshake_on_notify(h2o_socket_t *async_sock, const char *err);
+#endif
+
 /**
  * Initializes a send vector that refers to mutable memory region. When the `proceed` callback is invoked, it is possible for the
  * generator to reuse (or release) that memory region.

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1627,7 +1627,7 @@ void h2o_socket_start_async_handshake(h2o_loop_t *loop, int async_fd, void *data
 
     /* add async fd to event loop in order to retry when openssl engine is ready */
 #if H2O_USE_LIBUV
-    h2o_socket_t *async_sock = h2o_uv__poll_create(h2o_socket_get_loop(sock), async_fd, (uv_close_cb)free);
+    h2o_socket_t *async_sock = h2o_uv__poll_create(loop, async_fd, (uv_close_cb)free);
 #else
     h2o_socket_t *async_sock = h2o_evloop_socket_create(loop, async_fd, H2O_SOCKET_FLAG_DONT_READ);
 #endif

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1617,20 +1617,46 @@ static void proceed_handshake(h2o_socket_t *sock, const char *err);
 
 #if H2O_CAN_ASYNC_SSL
 
-static void on_async_proceed_handshake(h2o_socket_t *async_sock, const char *err)
+void h2o_socket_start_async_handshake(h2o_loop_t *loop, int async_fd, void *data, h2o_socket_cb cb)
+{
+    /* dup async_fd as h2o socket handling will close it */
+    if ((async_fd = dup(async_fd)) == -1) {
+        char errbuf[256];
+        h2o_fatal("dup failed:%s", h2o_strerror_r(errno, errbuf, sizeof(errbuf)));
+    }
+
+    /* add async fd to event loop in order to retry when openssl engine is ready */
+#if H2O_USE_LIBUV
+    h2o_socket_t *async_sock = h2o_uv__poll_create(h2o_socket_get_loop(sock), async_fd, (uv_close_cb)free);
+#else
+    h2o_socket_t *async_sock = h2o_evloop_socket_create(loop, async_fd, H2O_SOCKET_FLAG_DONT_READ);
+#endif
+    async_sock->data = data;
+    h2o_socket_read_start(async_sock, cb);
+}
+
+void *h2o_socket_async_handshake_on_notify(h2o_socket_t *async_sock, const char *err)
 {
     if (err != NULL)
         h2o_fatal("error on internal notification fd:%s", err);
 
-    /* Do we need to handle spurious events for eventfds / pipes used for intra-process communication? If so, we have to read
-     * something here (or let `async_cb` read and return if it succeeded). */
+    /* Do we need to handle spurious events for eventfds / pipes used for intra-process communication? If so, maybe we should call
+     * select (2) here to assert that the socket is actually readable, and return NULL if it is not. */
 
-    h2o_socket_t *sock = async_sock->data;
-    assert(sock->ssl->async.inflight);
-    sock->ssl->async.inflight = 0;
+    void *data = async_sock->data;
 
     h2o_socket_read_stop(async_sock);
     dispose_socket(async_sock, NULL);
+
+    return data;
+}
+
+static void on_async_proceed_handshake(h2o_socket_t *async_sock, const char *err)
+{
+    h2o_socket_t *sock = h2o_socket_async_handshake_on_notify(async_sock, err);
+
+    assert(sock->ssl->async.inflight);
+    sock->ssl->async.inflight = 0;
 
     proceed_handshake(sock, NULL);
 }
@@ -1656,20 +1682,7 @@ static void do_proceed_handshake_async(h2o_socket_t *sock, ptls_buffer_t *ptls_w
         assert(numfds == 1);
     }
 
-    /* dup async_fd as h2o socket handling will close it */
-    if ((async_fd = dup(async_fd)) == -1) {
-        char errbuf[256];
-        h2o_fatal("dup failed:%s", h2o_strerror_r(errno, errbuf, sizeof(errbuf)));
-    }
-
-    /* add async fd to event loop in order to retry when openssl engine is ready */
-#if H2O_USE_LIBUV
-    h2o_socket_t *async_sock = h2o_uv__poll_create(h2o_socket_get_loop(sock), async_fd, (uv_close_cb)free);
-#else
-    h2o_socket_t *async_sock = h2o_evloop_socket_create(h2o_socket_get_loop(sock), async_fd, H2O_SOCKET_FLAG_DONT_READ);
-#endif
-    async_sock->data = sock;
-    h2o_socket_read_start(async_sock, on_async_proceed_handshake);
+    h2o_socket_start_async_handshake(h2o_socket_get_loop(sock), async_fd, sock, on_async_proceed_handshake);
 }
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -627,6 +627,20 @@ static void async_nb_transaction(neverbleed_iobuf_t *buf)
     async_nb_run_sync(buf, neverbleed_transaction_read);
 }
 
+static void async_nb_on_quic_notify(h2o_socket_t *async_sock, const char *err)
+{
+    ptls_t *tls = h2o_socket_async_handshake_on_notify(async_sock, err);
+    quicly_resume_handshake(tls);
+}
+
+static void async_nb_start_quic(quicly_async_handshake_t *self, ptls_t *tls)
+{
+    int async_fd = ptls_openssl_get_async_fd(tls);
+    h2o_socket_start_async_handshake(conf.threads[thread_index].ctx.loop, async_fd, tls, async_nb_on_quic_notify);
+}
+
+static quicly_async_handshake_t async_nb_quic_handler = {async_nb_start_quic};
+
 #endif
 
 static int on_openssl_print_errors(const char *str, size_t len, void *fp)
@@ -1173,9 +1187,6 @@ static const char *listener_setup_ssl_picotls(struct listener_config_t *listener
             pctx->ctx.cipher_suites = replace_ciphersuites(pctx->ctx.cipher_suites, fusion_all);
         }
 #endif
-        // disable async handshaking in quic until it is supported in quicly
-        pctx->sc.async = 0;
-
         quicly_amend_ptls_context(&pctx->ctx);
     }
 
@@ -2294,6 +2305,9 @@ static int on_config_listen_element(h2o_configurator_command_t *cmd, h2o_configu
                 *quic = quicly_spec_context;
                 quic->cid_encryptor = &quic_cid_encryptor;
                 quic->generate_resumption_token = &quic_resumption_token_generator;
+#if H2O_CAN_ASYNC_SSL
+                quic->async_handshake = &async_nb_quic_handler;
+#endif
                 listener = add_listener(fd, ai->ai_addr, ai->ai_addrlen, ctx->hostconf == NULL, 0, 0, 0);
                 listener->quic.ctx = quic;
                 if (quic_node != NULL) {


### PR DESCRIPTION
This is a followup on #3064 / #3162, that enables async signature generation on HTTP/3 / QUIC.

Builds on top of https://github.com/h2o/picotls/pull/452, https://github.com/h2o/quicly/pull/538.