### PR TITLE
fix incorrect assignment and condition on platforms that do not have eventfd

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -501,10 +501,10 @@ static void async_nb_send_notification(struct async_nb_transaction_t *transactio
         abort();
     }
 #else
-    int ret;
-    while ((ret = write(transaction->efd_write, "x", 1) == -1 && errno == EINTR))
+    ssize_t ret;
+    while ((ret = write(transaction->efd_write, "x", 1)) == -1 && errno == EINTR)
         ;
-    if (ret == 1) {
+    if (ret != 1) {
         perror("write");
         abort();
     }


### PR DESCRIPTION
This bug was overlooked in #3162 because the incorrect assignment yields always as zero in practice.