### PR TITLE
[picotls][async neverbleed] remove dependency on OpenSSL async API

### DIFF
--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -932,13 +932,16 @@ static int digestsign_stub(neverbleed_iobuf_t *buf)
         if (EVP_PKEY_CTX_set_rsa_mgf1_md(pkey_ctx, md) != 1)
             goto Softfail;
     }
-    if (EVP_DigestSign(mdctx, NULL, &digestlen, signdata, signlen) != 1)
+    /* ED25519 keys can never be loaded, so use the Update -> Final call chain without worrying about backward compatibility */
+    if (EVP_DigestSignUpdate(mdctx, signdata, signlen) != 1)
+        goto Softfail;
+    if (EVP_DigestSignFinal(mdctx, NULL, &digestlen) != 1)
         goto Softfail;
     if (sizeof(digestbuf) < digestlen) {
         warnf("%s: digest unexpectedly long as %zu bytes", __FUNCTION__, digestlen);
         goto Softfail;
     }
-    if (EVP_DigestSign(mdctx, digestbuf, &digestlen, signdata, signlen) != 1)
+    if (EVP_DigestSignFinal(mdctx, digestbuf, &digestlen) != 1)
         goto Softfail;
 
 Respond: /* build response */
@@ -962,9 +965,11 @@ void neverbleed_start_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const 
 
     /* obtain reference */
     switch (EVP_PKEY_base_id(pkey)) {
-    case EVP_PKEY_RSA:
-        get_privsep_data(EVP_PKEY_get0_RSA(pkey), &exdata, &thdata);
-        break;
+    case EVP_PKEY_RSA: {
+        RSA *rsa = EVP_PKEY_get1_RSA(pkey); /* get0 is available not available in OpenSSL 1.0.2 */
+        get_privsep_data(rsa, &exdata, &thdata);
+        RSA_free(rsa);
+    } break;
 #ifdef NEVERBLEED_ECDSA
     case EVP_PKEY_EC:
         ecdsa_get_privsep_data(EVP_PKEY_get0_EC_KEY(pkey), &exdata, &thdata);

--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -110,6 +110,8 @@ static void RSA_set_flags(RSA *r, int flags)
     r->flags |= flags;
 }
 
+#define EVP_PKEY_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_EVP_PKEY)
+
 #endif
 
 #include "neverbleed.h"
@@ -474,120 +476,61 @@ static void get_privsep_data(const RSA *rsa, struct st_neverbleed_rsa_exdata_t *
     *thdata = get_thread_data((*exdata)->nb);
 }
 
-static const size_t default_reserved_size = 8192;
-
-struct key_slots {
-    size_t size;
-    size_t reserved_size;
-    /* bit array slots:
-     *   1-bit slot available
-     *   0-bit slot unavailable
-     */
-    uint8_t *bita_avail;
-};
-
 static struct {
     struct {
         pthread_mutex_t lock;
-        RSA **keys;
-        struct key_slots rsa_slots;
-        EC_KEY **ecdsa_keys;
-        struct key_slots ecdsa_slots;
+        struct {
+            EVP_PKEY *pkey;
+            /**
+             * if the slot is currently empty, contains the index of the next empty slot, or SIZE_MAX if there is no more
+             */
+            size_t next_empty;
+        } *slots;
+        size_t num_slots;
+        size_t first_empty;
     } keys;
     neverbleed_t *nb;
-} daemon_vars = {{PTHREAD_MUTEX_INITIALIZER}};
+} daemon_vars = {{.lock = PTHREAD_MUTEX_INITIALIZER, .first_empty = SIZE_MAX}};
 
 static RSA *daemon_get_rsa(size_t key_index)
 {
-    RSA *rsa;
+    RSA *rsa = NULL;
 
     pthread_mutex_lock(&daemon_vars.keys.lock);
-    rsa = daemon_vars.keys.keys[key_index];
-    if (rsa)
-        RSA_up_ref(rsa);
+    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL)
+        rsa = EVP_PKEY_get1_RSA(daemon_vars.keys.slots[key_index].pkey);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     return rsa;
 }
 
-/*
- *  Returns an available slot in bit array B
- *  or if not found, returns SIZE_MAX
- */
-static size_t bita_ffirst(const uint8_t *b, const size_t tot, size_t bits)
+size_t allocate_slot(void)
 {
-    if (bits >= tot)
-        return SIZE_MAX;
+    size_t index;
 
-    uint64_t w = *((uint64_t *) b);
-    /* __builtin_ffsll returns one plus the index of the least significant 1-bit, or zero if not found */
-    uint32_t r = __builtin_ffsll(w);
-    if (r)
-        return bits + r - 1; /* adjust result */
-
-    return bita_ffirst(&b[8], tot, bits + 64);
-}
-
-/*
- * bit operation helpers for the bit-array in key_slots
- */
-#define BITMASK(b) (1 << ((b) % CHAR_BIT))
-#define BITBYTE(b) ((b) / CHAR_BIT)
-#define BITSET(a, b) ((a)[BITBYTE(b)] |= BITMASK(b))
-#define BITUNSET(a, b) ((a)[BITBYTE(b)] &= ~BITMASK(b))
-#define BITBYTES(nb) ((nb + CHAR_BIT - 1) / CHAR_BIT)
-#define BITCHECK(a, b) ((a)[BITBYTE(b)] & BITMASK(b))
-
-static void adjust_slots_reserved_size(int type, struct key_slots *slots)
-{
-#define ROUND2WORD(n) (n + 64 - 1 - (n + 64 - 1) % 64)
-    if (!slots->reserved_size || (slots->size >= slots->reserved_size)) {
-        size_t size = slots->reserved_size ? ROUND2WORD((size_t)(slots->reserved_size * 0.50) + slots->reserved_size)
-                : default_reserved_size;
-#undef ROUND2WORD
-
-        switch (type) {
-        case NEVERBLEED_TYPE_RSA:
-            if ((daemon_vars.keys.keys = realloc(daemon_vars.keys.keys, sizeof(*daemon_vars.keys.keys) * size)) == NULL)
-                dief("no memory");
-            break;
-        case NEVERBLEED_TYPE_ECDSA:
-            if ((daemon_vars.keys.ecdsa_keys = realloc(daemon_vars.keys.ecdsa_keys, sizeof(*daemon_vars.keys.ecdsa_keys) * size)) == NULL)
-                dief("no memory");
-            break;
-        default:
-            dief("invalid type adjusting reserved");
-        }
-
-        uint8_t *b;
-        if ((b = realloc(slots->bita_avail, BITBYTES(size))) == NULL)
+    if ((index = daemon_vars.keys.first_empty) != SIZE_MAX) {
+        daemon_vars.keys.first_empty = daemon_vars.keys.slots[index].next_empty;
+    } else {
+        if ((daemon_vars.keys.slots = realloc(daemon_vars.keys.slots,
+                                              sizeof(daemon_vars.keys.slots[0]) * (daemon_vars.keys.num_slots + 1))) == NULL)
             dief("no memory");
-
-        /* set all bits to 1 making all slots available */
-        memset(&b[BITBYTES(slots->reserved_size)], 0xff, BITBYTES(size - slots->reserved_size));
-
-        slots->bita_avail = b;
-        slots->reserved_size = size;
+        index = daemon_vars.keys.num_slots++;
     }
+
+    daemon_vars.keys.slots[index].pkey = NULL;
+    daemon_vars.keys.slots[index].next_empty = SIZE_MAX;
+
+    return index;
 }
 
-static size_t daemon_set_rsa(RSA *rsa)
+static size_t daemon_set_pkey(EVP_PKEY *pkey)
 {
     pthread_mutex_lock(&daemon_vars.keys.lock);
 
-    adjust_slots_reserved_size(NEVERBLEED_TYPE_RSA, &daemon_vars.keys.rsa_slots);
+    size_t index = allocate_slot();
+    daemon_vars.keys.slots[index].pkey = pkey;
+    EVP_PKEY_up_ref(pkey);
 
-    size_t index = bita_ffirst(daemon_vars.keys.rsa_slots.bita_avail, daemon_vars.keys.rsa_slots.reserved_size, 0);
-
-    if (index == SIZE_MAX)
-        dief("no available slot for key");
-
-    /* set slot as unavailable */
-    BITUNSET(daemon_vars.keys.rsa_slots.bita_avail, index);
-
-    daemon_vars.keys.rsa_slots.size++;
-    daemon_vars.keys.keys[index] = rsa;
-    RSA_up_ref(rsa);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     return index;
@@ -768,37 +711,14 @@ static EVP_PKEY *create_pkey(neverbleed_t *nb, size_t key_index, const char *ebu
 
 static EC_KEY *daemon_get_ecdsa(size_t key_index)
 {
-    EC_KEY *ec_key;
+    EC_KEY *ec_key = NULL;
 
     pthread_mutex_lock(&daemon_vars.keys.lock);
-    ec_key = daemon_vars.keys.ecdsa_keys[key_index];
-    if (ec_key)
-        EC_KEY_up_ref(ec_key);
+    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL)
+        ec_key = EVP_PKEY_get1_EC_KEY(daemon_vars.keys.slots[key_index].pkey);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     return ec_key;
-}
-
-static size_t daemon_set_ecdsa(EC_KEY *ec_key)
-{
-    pthread_mutex_lock(&daemon_vars.keys.lock);
-
-    adjust_slots_reserved_size(NEVERBLEED_TYPE_ECDSA, &daemon_vars.keys.ecdsa_slots);
-
-    size_t index = bita_ffirst(daemon_vars.keys.ecdsa_slots.bita_avail, daemon_vars.keys.ecdsa_slots.reserved_size, 0);
-
-    if (index == SIZE_MAX)
-        dief("no available slot for key");
-
-    /* set slot as unavailable */
-    BITUNSET(daemon_vars.keys.ecdsa_slots.bita_avail, index);
-
-    daemon_vars.keys.ecdsa_slots.size++;
-    daemon_vars.keys.ecdsa_keys[index] = ec_key;
-    EC_KEY_up_ref(ec_key);
-    pthread_mutex_unlock(&daemon_vars.keys.lock);
-
-    return index;
 }
 
 static int ecdsa_sign_stub(neverbleed_iobuf_t *buf)
@@ -939,7 +859,7 @@ static void priv_ecdsa_finish(EC_KEY *key)
     neverbleed_iobuf_t buf = {NULL};
     size_t ret;
 
-    iobuf_push_str(&buf, "del_ecdsa_key");
+    iobuf_push_str(&buf, "del_pkey");
     iobuf_push_num(&buf, exdata->key_index);
     iobuf_transaction(&buf, thdata);
 
@@ -950,45 +870,127 @@ static void priv_ecdsa_finish(EC_KEY *key)
     iobuf_dispose(&buf);
 }
 
-static int del_ecdsa_key_stub(neverbleed_iobuf_t *buf)
-{
-    size_t key_index;
-    int ret = 0;
+#endif
 
-    if (iobuf_shift_num(buf, &key_index) != 0) {
+static EVP_PKEY *daemon_get_pkey(size_t key_index)
+{
+    EVP_PKEY *pkey = NULL;
+
+    pthread_mutex_lock(&daemon_vars.keys.lock);
+    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL) {
+        pkey = daemon_vars.keys.slots[key_index].pkey;
+        EVP_PKEY_up_ref(pkey);
+    }
+    pthread_mutex_unlock(&daemon_vars.keys.lock);
+
+    return pkey;
+}
+
+static int digestsign_stub(neverbleed_iobuf_t *buf)
+{
+    size_t key_index, md_nid, signlen;
+    void *signdata;
+    EVP_PKEY *pkey;
+    const EVP_MD *md;
+
+    /* parse input */
+    if (iobuf_shift_num(buf, &key_index) != 0 || iobuf_shift_num(buf, &md_nid) != 0 ||
+        (signdata = iobuf_shift_bytes(buf, &signlen)) == NULL) {
         errno = 0;
         warnf("%s: failed to parse request", __FUNCTION__);
         return -1;
     }
-
-    if (!daemon_vars.keys.ecdsa_keys || key_index >= daemon_vars.keys.ecdsa_slots.reserved_size) {
+    if ((pkey = daemon_get_pkey(key_index)) == NULL) {
         errno = 0;
-        warnf("%s: invalid key index %zu", __FUNCTION__, key_index);
-        goto respond;
+        warnf("%s: invalid key index:%zu", __FUNCTION__, key_index);
+        return -1;
+    }
+    if (md_nid != SIZE_MAX) {
+        if ((md = EVP_get_digestbynid((int)md_nid)) == NULL) {
+            errno = 0;
+            warnf("%s: invalid EVP_MD nid", __FUNCTION__);
+            return -1;
+        }
+    } else {
+        md = NULL;
     }
 
-    if (BITCHECK(daemon_vars.keys.ecdsa_slots.bita_avail, key_index)) {
-        warnf("%s: index not in use %zu", __FUNCTION__, key_index);
-        goto respond;
+    /* generate signature */
+    EVP_MD_CTX *mdctx = NULL;
+    EVP_PKEY_CTX *pkey_ctx = NULL;
+    unsigned char digestbuf[4096];
+    size_t digestlen;
+
+    if ((mdctx = EVP_MD_CTX_create()) == NULL)
+        goto Softfail;
+    if (EVP_DigestSignInit(mdctx, &pkey_ctx, md, NULL, pkey) != 1)
+        goto Softfail;
+    if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA) {
+        if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PSS_PADDING) != 1 ||
+            EVP_PKEY_CTX_set_rsa_pss_saltlen(pkey_ctx, -1) != 1)
+            goto Softfail;
+        if (EVP_PKEY_CTX_set_rsa_mgf1_md(pkey_ctx, md) != 1)
+            goto Softfail;
     }
+    if (EVP_DigestSign(mdctx, NULL, &digestlen, signdata, signlen) != 1)
+        goto Softfail;
+    if (sizeof(digestbuf) < digestlen) {
+        warnf("%s: digest unexpectedly long as %zu bytes", __FUNCTION__, digestlen);
+        goto Softfail;
+    }
+    if (EVP_DigestSign(mdctx, digestbuf, &digestlen, signdata, signlen) != 1)
+        goto Softfail;
 
-    pthread_mutex_lock(&daemon_vars.keys.lock);
-    /* set slot as available */
-    BITSET(daemon_vars.keys.ecdsa_slots.bita_avail, key_index);
-    daemon_vars.keys.ecdsa_slots.size--;
-    EC_KEY_free(daemon_vars.keys.ecdsa_keys[key_index]);
-    daemon_vars.keys.ecdsa_keys[key_index] = NULL;
-    pthread_mutex_unlock(&daemon_vars.keys.lock);
-
-    ret = 1;
-
-respond:
+Respond: /* build response */
     iobuf_dispose(buf);
-    iobuf_push_num(buf, ret);
+    iobuf_push_bytes(buf, digestbuf, digestlen);
+    if (mdctx != NULL)
+        EVP_MD_CTX_destroy(mdctx);
+    if (pkey != NULL)
+        EVP_PKEY_free(pkey);
     return 0;
+
+Softfail:
+    digestlen = 0;
+    goto Respond;
 }
 
+void neverbleed_start_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const EVP_MD *md, const void *input, size_t len)
+{
+    struct st_neverbleed_rsa_exdata_t *exdata;
+    struct st_neverbleed_thread_data_t *thdata;
+
+    /* obtain reference */
+    switch (EVP_PKEY_base_id(pkey)) {
+    case EVP_PKEY_RSA:
+        get_privsep_data(EVP_PKEY_get0_RSA(pkey), &exdata, &thdata);
+        break;
+#ifdef NEVERBLEED_ECDSA
+    case EVP_PKEY_EC:
+        ecdsa_get_privsep_data(EVP_PKEY_get0_EC_KEY(pkey), &exdata, &thdata);
+        break;
 #endif
+    default:
+        dief("unexpected private key");
+        break;
+    }
+
+    *buf = (neverbleed_iobuf_t){NULL};
+    iobuf_push_str(buf, "digestsign");
+    iobuf_push_num(buf, exdata->key_index);
+    iobuf_push_num(buf, md != NULL ? (size_t)EVP_MD_nid(md) : SIZE_MAX);
+    iobuf_push_bytes(buf, input, len);
+}
+
+void neverbleed_finish_digestsign(neverbleed_iobuf_t *buf, void **digest, size_t *digest_len)
+{
+    const void *src = iobuf_shift_bytes(buf, digest_len);
+    if ((*digest = malloc(*digest_len)) == NULL)
+        dief("no memory");
+    memcpy(*digest, src, *digest_len);
+
+    iobuf_dispose(buf);
+}
 
 int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char *fn, char *errbuf)
 {
@@ -1092,7 +1094,6 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
 
         rsa = EVP_PKEY_get1_RSA(pkey);
         type = NEVERBLEED_TYPE_RSA;
-        key_index = daemon_set_rsa(rsa);
         RSA_get0_key(rsa, &n, &e, NULL);
         estr = BN_bn2hex(e);
         nstr = BN_bn2hex(n);
@@ -1105,7 +1106,6 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
 
         ec_key = (EC_KEY *)EVP_PKEY_get0_EC_KEY(pkey);
         type = NEVERBLEED_TYPE_ECDSA;
-        key_index = daemon_set_ecdsa(ec_key);
         ec_group = EC_KEY_get0_group(ec_key);
         ec_pubkey = EC_KEY_get0_public_key(ec_key);
         ec_pubkeybn = BN_new();
@@ -1125,6 +1125,9 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
         snprintf(errbuf, sizeof(errbuf), "unsupported private key: %d", EVP_PKEY_base_id(pkey));
         goto Respond;
     }
+
+    /* store the key */
+    key_index = daemon_set_pkey(pkey);
 
 Respond:
     iobuf_dispose(buf);
@@ -1324,7 +1327,7 @@ static int priv_rsa_finish(RSA *rsa)
     neverbleed_iobuf_t buf = {NULL};
     size_t ret;
 
-    iobuf_push_str(&buf, "del_rsa_key");
+    iobuf_push_str(&buf, "del_pkey");
     iobuf_push_num(&buf, exdata->key_index);
     iobuf_transaction(&buf, thdata);
 
@@ -1337,7 +1340,7 @@ static int priv_rsa_finish(RSA *rsa)
     return (int)ret;
 }
 
-static int del_rsa_key_stub(neverbleed_iobuf_t *buf)
+static int del_pkey_stub(neverbleed_iobuf_t *buf)
 {
     size_t key_index;
 
@@ -1349,23 +1352,17 @@ static int del_rsa_key_stub(neverbleed_iobuf_t *buf)
         return -1;
     }
 
-    if (!daemon_vars.keys.keys || key_index >= daemon_vars.keys.rsa_slots.reserved_size) {
-        errno = 0;
+    pthread_mutex_lock(&daemon_vars.keys.lock);
+    /* set slot as available */
+    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL) {
+        EVP_PKEY_free(daemon_vars.keys.slots[key_index].pkey);
+        daemon_vars.keys.slots[key_index].pkey = NULL;
+        daemon_vars.keys.slots[key_index].next_empty = daemon_vars.keys.first_empty;
+        daemon_vars.keys.first_empty = key_index;
+    } else {
         warnf("%s: invalid key index %zu", __FUNCTION__, key_index);
         goto respond;
     }
-
-    if (BITCHECK(daemon_vars.keys.rsa_slots.bita_avail, key_index)) {
-        warnf("%s: index not in use %zu", __FUNCTION__, key_index);
-        goto respond;
-    }
-
-    pthread_mutex_lock(&daemon_vars.keys.lock);
-    /* set slot as available */
-    BITSET(daemon_vars.keys.rsa_slots.bita_avail, key_index);
-    daemon_vars.keys.rsa_slots.size--;
-    RSA_free(daemon_vars.keys.keys[key_index]);
-    daemon_vars.keys.keys[key_index] = NULL;
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     ret = 1;
@@ -1443,15 +1440,15 @@ static void *daemon_conn_thread(void *_sock_fd)
         } else if (strcmp(cmd, "ecdsa_sign") == 0) {
             if (ecdsa_sign_stub(&buf) != 0)
                 break;
-        } else if (strcmp(cmd, "del_ecdsa_key") == 0) {
-            if (del_ecdsa_key_stub(&buf) != 0)
-                break;
 #endif
+        } else if (strcmp(cmd, "digestsign") == 0) {
+            if (digestsign_stub(&buf) != 0)
+                break;
         } else if (strcmp(cmd, "load_key") == 0) {
             if (load_key_stub(&buf) != 0)
                 break;
-        } else if (strcmp(cmd, "del_rsa_key") == 0) {
-            if (del_rsa_key_stub(&buf) != 0)
+        } else if (strcmp(cmd, "del_pkey") == 0) {
+            if (del_pkey_stub(&buf) != 0)
                 break;
         } else if (strcmp(cmd, "setuidgid") == 0) {
             if (setuidgid_stub(&buf) != 0)

--- a/deps/neverbleed/neverbleed.h
+++ b/deps/neverbleed/neverbleed.h
@@ -69,6 +69,15 @@ int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char 
  */
 int neverbleed_setuidgid(neverbleed_t *nb, const char *user, int change_socket_ownership);
 
+/**
+ * builds a digestsign request
+ */
+void neverbleed_start_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const EVP_MD *md, const void *input, size_t len);
+/**
+ * parses a digestsign response
+ */
+void neverbleed_finish_digestsign(neverbleed_iobuf_t *buf, void **digest, size_t *digest_len);
+
 #if NEVERBLEED_HAS_PTHREAD_SETAFFINITY_NP
 /**
  * set the cpu affinity for the neverbleed thread (returns 0 if successful)
@@ -82,7 +91,7 @@ int neverbleed_setaffinity(neverbleed_t *nb, NEVERBLEED_CPU_SET_T *cpuset);
  */
 extern void (*neverbleed_post_fork_cb)(void);
 /**
- * An optional callback used for replacing `expbuf_send`; i.e., the logic that sends the request and receives the response. The
+ * An optional callback used for replacing `iobuf_transaction`; i.e., the logic that sends the request and receives the response. The
  * callback returns a boolean indicating if it handled the task. It may return false to delagate the task back to the default logic.
  */
 extern void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *);

--- a/deps/picotls/include/picotls.h
+++ b/deps/picotls/include/picotls.h
@@ -654,6 +654,14 @@ PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *e
  */
 typedef struct st_ptls_async_job_t {
     void (*destroy_)(struct st_ptls_async_job_t *self);
+    /**
+     * optional callback returning a file descriptor that becomes readable when the job is complete
+     */
+    int (*get_fd)(struct st_ptls_async_job_t *self);
+    /**
+     * optional callback for setting a completion callback
+     */
+    void (*set_completion_callback)(struct st_ptls_async_job_t *self, void (*cb)(void *), void *cbdata);
 } ptls_async_job_t;
 /**
  * When gerenating CertificateVerify, the core calls the callback to sign the handshake context using the certificate. This callback

--- a/deps/picotls/include/picotls.h
+++ b/deps/picotls/include/picotls.h
@@ -650,7 +650,12 @@ PTLS_CALLBACK_TYPE(int, on_client_hello, ptls_t *tls, ptls_on_client_hello_param
 PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *emitter, ptls_key_schedule_t *key_sched,
                    ptls_iovec_t context, int push_status_request, const uint16_t *compress_algos, size_t num_compress_algos);
 /**
- * context object of an async operation (e.g., RSA signature generation)
+ * An object that represents an asynchronous task (e.g., RSA signature generation).
+ * When `ptls_handshake` returns `PTLS_ERROR_ASYNC_OPERATION`, it has an associated task in flight. The user should obtain the
+ * reference to the associated task by calling `ptls_get_async_job`, then either wait for the file descriptor obtained from
+ * the `get_fd` callback to become readable, or set a completion callback via `set_completion_callback` and wait for its
+ * invocation. Once notified, the user should invoke `ptls_handshake` again.
+ * Async jobs typically provide support for only one of the two methods.
  */
 typedef struct st_ptls_async_job_t {
     void (*destroy_)(struct st_ptls_async_job_t *self);

--- a/deps/picotls/include/picotls/openssl.h
+++ b/deps/picotls/include/picotls/openssl.h
@@ -125,22 +125,25 @@ void ptls_openssl_random_bytes(void *buf, size_t len);
  */
 int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY *pkey);
 
-#if PTLS_OPENSSL_HAVE_ASYNC
-/**
- * Returns the file descriptor of the asynchronous operation in flight.
- */
-OSSL_ASYNC_FD ptls_openssl_get_async_fd(ptls_t *ptls);
-#endif
-
-struct st_ptls_openssl_signature_scheme_t {
+typedef struct st_ptls_openssl_signature_scheme_t {
     uint16_t scheme_id;
     const EVP_MD *(*scheme_md)(void);
-};
+} ptls_openssl_signature_scheme_t;
+
+/**
+ * Given a private key, returns a list of compatible signature schemes. This list is terminated by scheme_id of UINT16_MAX.
+ */
+const ptls_openssl_signature_scheme_t *ptls_openssl_lookup_signature_schemes(EVP_PKEY *key);
+/**
+ * Given available schemes and input, choses one, or returns NULL if none is available.
+ */
+const ptls_openssl_signature_scheme_t *ptls_openssl_select_signature_scheme(const ptls_openssl_signature_scheme_t *available,
+                                                                            const uint16_t *algorithms, size_t num_algorithms);
 
 typedef struct st_ptls_openssl_sign_certificate_t {
     ptls_sign_certificate_t super;
     EVP_PKEY *key;
-    const struct st_ptls_openssl_signature_scheme_t *schemes; /* terminated by .scheme_id == UINT16_MAX */
+    const ptls_openssl_signature_scheme_t *schemes; /* terminated by .scheme_id == UINT16_MAX */
     /**
      * When set to true, indicates to the backend that the signature can be generated asynchronously. When the backend decides to
      * generate the signature asynchronously, `ptls_handshake` will return PTLS_ERROR_ASYNC_OPERATION. When receiving that error

--- a/deps/picotls/lib/fusion.c
+++ b/deps/picotls/lib/fusion.c
@@ -61,6 +61,9 @@
 
 #ifdef _WINDOWS
 #define aligned_alloc(a, s) _aligned_malloc((s), (a))
+#define aligned_free(p) _aligned_free(p)
+#else
+#define aligned_free(p) free(p)
 #endif
 
 struct ptls_fusion_aesgcm_context {
@@ -1026,7 +1029,7 @@ ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm
         return NULL;
     memcpy(newp, ctx, old_ctx_size);
     ptls_clear_memory(ctx, old_ctx_size);
-    free(ctx);
+    aligned_free(ctx);
     ctx = newp;
 
     ctx->capacity = capacity;
@@ -1041,7 +1044,7 @@ void ptls_fusion_aesgcm_free(ptls_fusion_aesgcm_context_t *ctx)
     ptls_clear_memory(ctx, calc_aesgcm_context_size(&ctx->ghash_cnt, ctx->ecb.aesni256));
     /* skip ptls_fusion_aesecb_dispose, based on the knowledge that it does not allocate memory elsewhere */
 
-    free(ctx);
+    aligned_free(ctx);
 }
 
 static void ctr_dispose(ptls_cipher_context_t *_ctx)

--- a/deps/picotls/lib/openssl.c
+++ b/deps/picotls/lib/openssl.c
@@ -89,22 +89,22 @@ static int EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *ctx)
 
 #endif
 
-static const struct st_ptls_openssl_signature_scheme_t rsa_signature_schemes[] = {{PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256, EVP_sha256},
+static const ptls_openssl_signature_scheme_t rsa_signature_schemes[] = {{PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256, EVP_sha256},
                                                                                   {PTLS_SIGNATURE_RSA_PSS_RSAE_SHA384, EVP_sha384},
                                                                                   {PTLS_SIGNATURE_RSA_PSS_RSAE_SHA512, EVP_sha512},
                                                                                   {UINT16_MAX, NULL}};
-static const struct st_ptls_openssl_signature_scheme_t secp256r1_signature_schemes[] = {
+static const ptls_openssl_signature_scheme_t secp256r1_signature_schemes[] = {
     {PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256, EVP_sha256}, {UINT16_MAX, NULL}};
 #if PTLS_OPENSSL_HAVE_SECP384R1
-static const struct st_ptls_openssl_signature_scheme_t secp384r1_signature_schemes[] = {
+static const ptls_openssl_signature_scheme_t secp384r1_signature_schemes[] = {
     {PTLS_SIGNATURE_ECDSA_SECP384R1_SHA384, EVP_sha384}, {UINT16_MAX, NULL}};
 #endif
 #if PTLS_OPENSSL_HAVE_SECP521R1
-static const struct st_ptls_openssl_signature_scheme_t secp521r1_signature_schemes[] = {
+static const ptls_openssl_signature_scheme_t secp521r1_signature_schemes[] = {
     {PTLS_SIGNATURE_ECDSA_SECP521R1_SHA512, EVP_sha512}, {UINT16_MAX, NULL}};
 #endif
 #if PTLS_OPENSSL_HAVE_ED25519
-static const struct st_ptls_openssl_signature_scheme_t ed25519_signature_schemes[] = {{PTLS_SIGNATURE_ED25519, NULL},
+static const ptls_openssl_signature_scheme_t ed25519_signature_schemes[] = {{PTLS_SIGNATURE_ED25519, NULL},
                                                                                       {UINT16_MAX, NULL}};
 #endif
 
@@ -127,9 +127,9 @@ static const uint16_t default_signature_schemes[] = {
     PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256,
     UINT16_MAX};
 
-static const struct st_ptls_openssl_signature_scheme_t *lookup_signature_schemes(EVP_PKEY *key)
+const ptls_openssl_signature_scheme_t *ptls_openssl_lookup_signature_schemes(EVP_PKEY *key)
 {
-    const struct st_ptls_openssl_signature_scheme_t *schemes = NULL;
+    const ptls_openssl_signature_scheme_t *schemes = NULL;
 
     switch (EVP_PKEY_id(key)) {
     case EVP_PKEY_RSA:
@@ -166,6 +166,20 @@ static const struct st_ptls_openssl_signature_scheme_t *lookup_signature_schemes
     }
 
     return schemes;
+}
+
+const ptls_openssl_signature_scheme_t *ptls_openssl_select_signature_scheme(const ptls_openssl_signature_scheme_t *available,
+                                                                            const uint16_t *algorithms, size_t num_algorithms)
+{
+    const ptls_openssl_signature_scheme_t *scheme;
+
+    /* select the algorithm, driven by server-isde preference of `available` */
+    for (scheme = available; scheme->scheme_id != UINT16_MAX; ++scheme)
+        for (size_t i = 0; i != num_algorithms; ++i)
+            if (algorithms[i] == scheme->scheme_id)
+                return scheme;
+
+    return NULL;
 }
 
 void ptls_openssl_random_bytes(void *buf, size_t len)
@@ -698,7 +712,7 @@ int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY
 
 struct async_sign_ctx {
     ptls_async_job_t super;
-    const struct st_ptls_openssl_signature_scheme_t *scheme;
+    const ptls_openssl_signature_scheme_t *scheme;
     EVP_MD_CTX *ctx;
     ASYNC_WAIT_CTX *waitctx;
     ASYNC_JOB *job;
@@ -724,14 +738,26 @@ static void async_sign_ctx_free(ptls_async_job_t *_self)
     free(self);
 }
 
-static ptls_async_job_t *async_sign_ctx_new(const struct st_ptls_openssl_signature_scheme_t *scheme, EVP_MD_CTX *ctx, size_t siglen)
+int async_sign_ctx_get_fd(ptls_async_job_t *_self)
+{
+    struct async_sign_ctx *self = (void *)_self;
+    OSSL_ASYNC_FD fds[1];
+    size_t numfds;
+
+    ASYNC_WAIT_CTX_get_all_fds(self->waitctx, NULL, &numfds);
+    assert(numfds == 1);
+    ASYNC_WAIT_CTX_get_all_fds(self->waitctx, fds, &numfds);
+    return (int)fds[0];
+}
+
+static ptls_async_job_t *async_sign_ctx_new(const ptls_openssl_signature_scheme_t *scheme, EVP_MD_CTX *ctx, size_t siglen)
 {
     struct async_sign_ctx *self;
 
     if ((self = malloc(offsetof(struct async_sign_ctx, sig) + siglen)) == NULL)
         return NULL;
 
-    self->super = (ptls_async_job_t){async_sign_ctx_free};
+    self->super = (ptls_async_job_t){async_sign_ctx_free, async_sign_ctx_get_fd};
     self->scheme = scheme;
     self->ctx = ctx;
     self->waitctx = ASYNC_WAIT_CTX_new();
@@ -740,18 +766,6 @@ static ptls_async_job_t *async_sign_ctx_new(const struct st_ptls_openssl_signatu
     memset(self->sig, 0, siglen);
 
     return &self->super;
-}
-
-OSSL_ASYNC_FD ptls_openssl_get_async_fd(ptls_t *ptls)
-{
-    OSSL_ASYNC_FD fds[1];
-    size_t numfds;
-    struct async_sign_ctx *async = (void *)ptls_get_async_job(ptls);
-    assert(async != NULL);
-    ASYNC_WAIT_CTX_get_all_fds(async->waitctx, NULL, &numfds);
-    assert(numfds == 1);
-    ASYNC_WAIT_CTX_get_all_fds(async->waitctx, fds, &numfds);
-    return fds[0];
 }
 
 static int do_sign_async_job(void *_async)
@@ -792,7 +806,7 @@ Exit:
 
 #endif
 
-static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *scheme, ptls_buffer_t *outbuf,
+static int do_sign(EVP_PKEY *key, const ptls_openssl_signature_scheme_t *scheme, ptls_buffer_t *outbuf,
                    ptls_iovec_t input, ptls_async_job_t **async)
 {
     EVP_MD_CTX *ctx = NULL;
@@ -1161,7 +1175,7 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, ptls_as
                             ptls_buffer_t *outbuf, ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms)
 {
     ptls_openssl_sign_certificate_t *self = (ptls_openssl_sign_certificate_t *)_self;
-    const struct st_ptls_openssl_signature_scheme_t *scheme;
+    const ptls_openssl_signature_scheme_t *scheme;
 
     /* Just resume the asynchronous operation, if one is in flight. */
 #if PTLS_OPENSSL_HAVE_ASYNC
@@ -1172,17 +1186,11 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, ptls_as
     }
 #endif
 
-    /* Select the algorithm (driven by server-side preference of `self->schemes`), or return failure if none found. */
-    for (scheme = self->schemes; scheme->scheme_id != UINT16_MAX; ++scheme) {
-        size_t i;
-        for (i = 0; i != num_algorithms; ++i)
-            if (algorithms[i] == scheme->scheme_id)
-                goto Found;
-    }
-    return PTLS_ALERT_HANDSHAKE_FAILURE;
-
-Found:
+    /* Select the algorithm or return failure if none found. */
+    if ((scheme = ptls_openssl_select_signature_scheme(self->schemes, algorithms, num_algorithms)) == NULL)
+        return PTLS_ALERT_HANDSHAKE_FAILURE;
     *selected_algorithm = scheme->scheme_id;
+
 #if PTLS_OPENSSL_HAVE_ASYNC
     if (!self->async && async != NULL) {
         /* indicate to `do_sign` that async mode is disabled for this operation */
@@ -1202,7 +1210,7 @@ static X509 *to_x509(ptls_iovec_t vec)
 static int verify_sign(void *verify_ctx, uint16_t algo, ptls_iovec_t data, ptls_iovec_t signature)
 {
     EVP_PKEY *key = verify_ctx;
-    const struct st_ptls_openssl_signature_scheme_t *scheme;
+    const ptls_openssl_signature_scheme_t *scheme;
     EVP_MD_CTX *ctx = NULL;
     EVP_PKEY_CTX *pkey_ctx = NULL;
     int ret = 0;
@@ -1210,7 +1218,7 @@ static int verify_sign(void *verify_ctx, uint16_t algo, ptls_iovec_t data, ptls_
     if (data.base == NULL)
         goto Exit;
 
-    if ((scheme = lookup_signature_schemes(key)) == NULL) {
+    if ((scheme = ptls_openssl_lookup_signature_schemes(key)) == NULL) {
         ret = PTLS_ERROR_LIBRARY;
         goto Exit;
     }
@@ -1282,7 +1290,7 @@ int ptls_openssl_init_sign_certificate(ptls_openssl_sign_certificate_t *self, EV
 {
     *self = (ptls_openssl_sign_certificate_t){.super = {sign_certificate}, .async = 0 /* libssl has it off by default too */};
 
-    if ((self->schemes = lookup_signature_schemes(key)) == NULL)
+    if ((self->schemes = ptls_openssl_lookup_signature_schemes(key)) == NULL)
         return PTLS_ERROR_INCOMPATIBLE_KEY;
     EVP_PKEY_up_ref(key);
     self->key = key;

--- a/deps/picotls/t/openssl.c
+++ b/deps/picotls/t/openssl.c
@@ -143,7 +143,7 @@ static void test_key_exchanges(void)
 #endif
 }
 
-static void test_sign_verify(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *schemes)
+static void test_sign_verify(EVP_PKEY *key, const ptls_openssl_signature_scheme_t *schemes)
 {
     for (size_t i = 0; schemes[i].scheme_id != UINT16_MAX; ++i) {
         note("scheme 0x%04x", schemes[i].scheme_id);
@@ -198,7 +198,7 @@ static void test_rsa_sign(void)
     test_sign_verify(sc->key, sc->schemes);
 }
 
-static void do_test_ecdsa_sign(int nid, const struct st_ptls_openssl_signature_scheme_t *schemes)
+static void do_test_ecdsa_sign(int nid, const ptls_openssl_signature_scheme_t *schemes)
 {
     EVP_PKEY *pkey;
 
@@ -464,10 +464,12 @@ static void many_handshakes(void)
                 if (num_issued < num_total)
                     qat_set_pending(offending);
                 break;
-            case PTLS_ERROR_ASYNC_OPERATION:
-                qat.conns[offending].wait_fd = ptls_openssl_get_async_fd(qat.conns[offending].tls);
+            case PTLS_ERROR_ASYNC_OPERATION: {
+                ptls_async_job_t *job = ptls_get_async_job(qat.conns[offending].tls);
+                assert(job->get_fd != NULL);
+                qat.conns[offending].wait_fd = job->get_fd(job);
                 assert(qat.conns[offending].wait_fd != -1);
-                break;
+            } break;
             default:
                 fprintf(stderr, "ptls_handshake returned %d\n", hsret);
                 abort();

--- a/include/h2o/openssl_backport.h
+++ b/include/h2o/openssl_backport.h
@@ -55,6 +55,7 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
 #ifndef OPENSSL_IS_BORINGSSL
 #define SSL_CTX_up_ref(ctx) CRYPTO_add(&(ctx)->references, 1, CRYPTO_LOCK_SSL_CTX)
 #define X509_STORE_up_ref(store) CRYPTO_add(&(store)->references, 1, CRYPTO_LOCK_X509_STORE)
+#define EVP_PKEY_up_ref(pkey) CRYPTO_add(&(pkey)->references, 1, CRYPTO_LOCK_EVP_PKEY)
 #define X509_STORE_get0_param(p) ((p)->param)
 #endif
 

--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -35,7 +35,7 @@ extern "C" {
 #include <openssl/ssl.h>
 #include <openssl/opensslconf.h>
 #include "picotls.h"
-#include "picotls/openssl.h" /* for H2O_CAN_ASYNC_SSL */
+#include "picotls/openssl.h" /* for H2O_CAN_OSSL_ASYNC */
 #include "h2o/cache.h"
 #include "h2o/ebpf.h"
 #include "h2o/memory.h"
@@ -73,7 +73,7 @@ extern "C" {
 #define H2O_USE_OPENSSL_CLIENT_HELLO_CB 1
 #endif
 #if PTLS_OPENSSL_HAVE_ASYNC && H2O_USE_OPENSSL_CLIENT_HELLO_CB
-#define H2O_CAN_ASYNC_SSL 1
+#define H2O_CAN_OSSL_ASYNC 1
 #endif
 
 /**
@@ -492,7 +492,7 @@ static int h2o_socket_skip_tracing(h2o_socket_t *sock);
  */
 void h2o_socket_set_skip_tracing(h2o_socket_t *sock, int skip_tracing);
 
-#if H2O_CAN_ASYNC_SSL
+#if H2O_CAN_OSSL_ASYNC
 /**
  * When generating a TLS handshake signature asynchronously, it is necessary to wait for a notification on a file descriptor at
  * which point the TLS handshake machinery is to be resumed. This function sets up a callback that would be called when that

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -137,13 +137,11 @@ struct st_h2o_socket_ssl_t {
         unsigned zerocopy_owned : 1;
         unsigned allocated_for_zerocopy : 1;
     } output;
-#if H2O_CAN_ASYNC_SSL
     struct {
         unsigned inflight : 1;
         unsigned sock_is_closed : 1;
         ptls_buffer_t ptls_wbuf;
     } async;
-#endif
 };
 
 struct st_h2o_ssl_context_t {
@@ -489,10 +487,8 @@ static void flush_pending_ssl(h2o_socket_t *sock, h2o_socket_cb cb)
 
 static void destroy_ssl(struct st_h2o_socket_ssl_t *ssl)
 {
-#if H2O_CAN_ASYNC_SSL
     assert(!ssl->async.inflight);
     assert(ssl->async.ptls_wbuf.base == NULL);
-#endif
 
     if (ssl->ptls != NULL) {
         ptls_free(ssl->ptls);
@@ -601,9 +597,7 @@ int h2o_socket_export(h2o_socket_t *sock, h2o_socket_export_t *info)
 
     assert(sock->_zerocopy == NULL);
     assert(!h2o_socket_is_writing(sock));
-#if H2O_CAN_ASYNC_SSL
     assert(sock->ssl == NULL || !sock->ssl->async.inflight);
-#endif
 
     if (do_export(sock, info) == -1)
         return -1;
@@ -643,12 +637,10 @@ void h2o_socket_close(h2o_socket_t *sock)
     if (sock->ssl == NULL) {
         dispose_socket(sock, 0);
     } else {
-#if H2O_CAN_ASYNC_SSL
         if (sock->ssl->async.inflight) {
             sock->ssl->async.sock_is_closed = 1;
             return;
         }
-#endif
         shutdown_ssl(sock, 0);
     }
 }
@@ -1582,13 +1574,11 @@ static void on_handshake_complete(h2o_socket_t *sock, const char *err)
 {
     assert(sock->ssl->handshake.cb != NULL);
 
-#if H2O_CAN_ASYNC_SSL
     assert(!sock->ssl->async.inflight);
     if (sock->ssl->async.sock_is_closed) {
         shutdown_ssl(sock, NULL);
         return;
     }
-#endif
     if (err == NULL) {
         /* Post-handshake setup: set record_overhead, zerocopy, switch to picotls */
         if (sock->ssl->ptls == NULL) {
@@ -1666,7 +1656,7 @@ static void on_handshake_fail_complete(h2o_socket_t *sock, const char *err)
 
 static void proceed_handshake(h2o_socket_t *sock, const char *err);
 
-#if H2O_CAN_ASYNC_SSL
+#if H2O_CAN_OSSL_ASYNC
 
 void h2o_socket_start_async_handshake(h2o_loop_t *loop, int async_fd, void *data, h2o_socket_cb cb)
 {
@@ -1712,6 +1702,8 @@ static void on_async_proceed_handshake(h2o_socket_t *async_sock, const char *err
     proceed_handshake(sock, NULL);
 }
 
+#endif
+
 static void on_async_job_complete(void *_sock)
 {
     h2o_socket_t *sock = _sock;
@@ -1728,8 +1720,7 @@ static void do_proceed_handshake_async(h2o_socket_t *sock, ptls_buffer_t *ptls_w
     sock->ssl->async.inflight = 1;
     h2o_socket_read_stop(sock);
 
-    /* retain wbuf, get async fd */
-    int async_fd;
+    /* retain wbuf, wait for notification */
     if (sock->ssl->ptls != NULL) {
         sock->ssl->async.ptls_wbuf = *ptls_wbuf;
         *ptls_wbuf = (ptls_buffer_t){NULL};
@@ -1737,36 +1728,39 @@ static void do_proceed_handshake_async(h2o_socket_t *sock, ptls_buffer_t *ptls_w
         if (job->set_completion_callback != NULL) {
             /* completion is notified via a callback */
             job->set_completion_callback(job, on_async_job_complete, sock);
-            return;
+        } else {
+#if H2O_CAN_OSSL_ASYNC
+            assert(job->get_fd != NULL);
+            int async_fd = job->get_fd(job);
+            h2o_socket_start_async_handshake(h2o_socket_get_loop(sock), async_fd, sock, on_async_proceed_handshake);
+#else
+            h2o_fatal("callback-based approach must have been chosen as the only option when OpenSSL async API is unavailable");
+#endif
         }
-        assert(job->get_fd != NULL);
-        async_fd = job->get_fd(job);
     } else {
+#if H2O_CAN_OSSL_ASYNC
         assert(ptls_wbuf == NULL);
+        int async_fd;
         size_t numfds;
         SSL_get_all_async_fds(sock->ssl->ossl, NULL, &numfds);
         assert(numfds == 1);
         SSL_get_all_async_fds(sock->ssl->ossl, &async_fd, &numfds);
-        assert(numfds == 1);
-    }
-
-    h2o_socket_start_async_handshake(h2o_socket_get_loop(sock), async_fd, sock, on_async_proceed_handshake);
-}
-
+        h2o_socket_start_async_handshake(h2o_socket_get_loop(sock), async_fd, sock, on_async_proceed_handshake);
+#else
+        h2o_fatal("how can OpenSSL ask async when the async API is unavailable");
 #endif
+    }
+}
 
 static void proceed_handshake_picotls(h2o_socket_t *sock)
 {
     size_t consumed = sock->ssl->input.encrypted->size;
     ptls_buffer_t wbuf;
 
-#if H2O_CAN_ASYNC_SSL
     if (sock->ssl->async.ptls_wbuf.base != NULL) {
         wbuf = sock->ssl->async.ptls_wbuf;
         sock->ssl->async.ptls_wbuf = (ptls_buffer_t){NULL};
-    } else
-#endif
-    {
+    } else {
         ptls_buffer_init(&wbuf, "", 0);
     }
 
@@ -1774,12 +1768,8 @@ static void proceed_handshake_picotls(h2o_socket_t *sock)
     h2o_buffer_consume(&sock->ssl->input.encrypted, consumed);
 
     if (ret == PTLS_ERROR_ASYNC_OPERATION) {
-#if H2O_CAN_ASYNC_SSL
         do_proceed_handshake_async(sock, &wbuf);
         return;
-#else
-        h2o_fatal("PTLS_ERROR_ASYNC_OPERATION returned but cannot be handled");
-#endif
     }
 
     /* determine the next action */
@@ -1843,7 +1833,7 @@ Redo:
         case ASYNC_RESUMPTION_STATE_REQUEST_SENT: {
             /* sent async request, reset the ssl state, and wait for async response */
             assert(ret < 0);
-#if H2O_CAN_ASYNC_SSL
+#if H2O_CAN_OSSL_ASYNC
             assert(SSL_get_error(sock->ssl->ossl, ret) != SSL_ERROR_WANT_ASYNC &&
                    "async operation should start only after resumption state is obtained and OpenSSL decides not to resume");
 #endif
@@ -1868,7 +1858,7 @@ Redo:
 
     /* handshake failed either in strict mTLS mode or others */
     if (ret == 0 || (ret < 0 && SSL_get_error(sock->ssl->ossl, ret) != SSL_ERROR_WANT_READ)) {
-#if H2O_CAN_ASYNC_SSL
+#if H2O_CAN_OSSL_ASYNC
         if (SSL_get_error(sock->ssl->ossl, ret) == SSL_ERROR_WANT_ASYNC) {
             do_proceed_handshake_async(sock, NULL);
             return;
@@ -1967,12 +1957,8 @@ static void proceed_handshake_undetermined(h2o_socket_t *sock)
         sock->ssl->handshake.server.async_resumption.state = ASYNC_RESUMPTION_STATE_COMPLETE;
         h2o_buffer_consume(&sock->ssl->input.encrypted, consumed);
         if (ret == PTLS_ERROR_ASYNC_OPERATION) {
-#if H2O_CAN_ASYNC_SSL
             do_proceed_handshake_async(sock, &wbuf);
             return;
-#else
-            h2o_fatal("PTLS_ERROR_ASYNC_OPERATION returned but cannot be handled");
-#endif
         }
         /* stop reading, send response */
         h2o_socket_read_stop(sock);
@@ -1997,9 +1983,7 @@ static void proceed_handshake_undetermined(h2o_socket_t *sock)
 
 static void proceed_handshake(h2o_socket_t *sock, const char *err)
 {
-#if H2O_CAN_ASYNC_SSL
     assert(!sock->ssl->async.inflight && "while async operation is inflight, the socket should be neither reading nor writing");
-#endif
 
     sock->_cb.write = NULL;
 

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1721,7 +1721,9 @@ static void do_proceed_handshake_async(h2o_socket_t *sock, ptls_buffer_t *ptls_w
     /* get async fd and retain wbuf */
     int async_fd;
     if (sock->ssl->ptls != NULL) {
-        async_fd = ptls_openssl_get_async_fd(sock->ssl->ptls);
+        ptls_async_job_t *job = ptls_get_async_job(sock->ssl->ptls);
+        assert(job->get_fd != NULL);
+        async_fd = job->get_fd(job);
         sock->ssl->async.ptls_wbuf = *ptls_wbuf;
         *ptls_wbuf = (ptls_buffer_t){NULL};
     } else {

--- a/src/main.c
+++ b/src/main.c
@@ -3877,14 +3877,12 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
                                       on_server_notification);
     h2o_multithread_register_receiver(conf.threads[thread_index].ctx.queue, &conf.threads[thread_index].memcached,
                                       h2o_memcached_receiver);
-#if H2O_CAN_OSSL_ASYNC
     if (neverbleed != NULL) {
         int fd = neverbleed_get_fd(neverbleed);
         async_nb.sock = h2o_evloop_socket_create(conf.threads[thread_index].ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
         h2o_linklist_init_anchor(&async_nb.read_queue.anchor);
         h2o_linklist_init_anchor(&async_nb.write_queue.anchor);
     }
-#endif
     if (conf.thread_map.entries[thread_index] >= 0) {
 #if H2O_HAS_PTHREAD_SETAFFINITY_NP
         int r;

--- a/src/main.c
+++ b/src/main.c
@@ -613,7 +613,9 @@ static void async_nb_on_quic_notify(h2o_socket_t *async_sock, const char *err)
 
 static void async_nb_start_quic(quicly_async_handshake_t *self, ptls_t *tls)
 {
-    int async_fd = ptls_openssl_get_async_fd(tls);
+    ptls_async_job_t *job = ptls_get_async_job(tls);
+    assert(job->get_fd != NULL);
+    int async_fd = job->get_fd(job);
     h2o_socket_start_async_handshake(conf.threads[thread_index].ctx.loop, async_fd, tls, async_nb_on_quic_notify);
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1181,7 +1181,7 @@ void init_openssl(void)
     SSL_load_error_strings();
     SSL_library_init();
     OpenSSL_add_all_algorithms();
-#if H2O_CAN_ASYNC_SSL
+#if H2O_CAN_OSSL_ASYNC
     ERR_load_ASYNC_strings();
 #endif
 


### PR DESCRIPTION
At the moment, async neverbleed support with picotls depends on OpenSSL async API. There are some drawbacks with the approach:
* Async neverbleed cannot be used when h2o is built with libressl. It would also be the case with boringssl (should we support it).
* There is the cost of using fibers and notification file descriptors, though that cost might be negligible compared to calculating signatures and doing IPC.

This pull request builds on top of the new high-level API added to neverbleed (that wraps EVP_DigestSign* rather than the ENGINE API backend calls and hence assumed to be compatible with async API of boringssl). It does not create a separate stack, nor allocates a file descriptor. A callback is used for resuming the handshake.

As picotls only handles TLS/1.3 handshakes, we continue to rely on OpenSSL async API for TLS/1.2 handshakes. Also, libh2o continues to provide support for OpenSSL-based async signature generation with TLS/1.3.

Builds on top of https://github.com/h2o/neverbleed/pull/42, https://github.com/h2o/picotls/pull/457.