### PR TITLE
Drop `proxy-connection:` in requests and responses

### DIFF
--- a/include/h2o/token_table.h
+++ b/include/h2o/token_table.h
@@ -83,36 +83,37 @@
 #define H2O_TOKEN_PRIORITY (h2o__tokens + 56)
 #define H2O_TOKEN_PROXY_AUTHENTICATE (h2o__tokens + 57)
 #define H2O_TOKEN_PROXY_AUTHORIZATION (h2o__tokens + 58)
-#define H2O_TOKEN_PURPOSE (h2o__tokens + 59)
-#define H2O_TOKEN_RANGE (h2o__tokens + 60)
-#define H2O_TOKEN_REFERER (h2o__tokens + 61)
-#define H2O_TOKEN_REFRESH (h2o__tokens + 62)
-#define H2O_TOKEN_RETRY_AFTER (h2o__tokens + 63)
-#define H2O_TOKEN_SERVER (h2o__tokens + 64)
-#define H2O_TOKEN_SET_COOKIE (h2o__tokens + 65)
-#define H2O_TOKEN_STRICT_TRANSPORT_SECURITY (h2o__tokens + 66)
-#define H2O_TOKEN_TE (h2o__tokens + 67)
-#define H2O_TOKEN_TIMING_ALLOW_ORIGIN (h2o__tokens + 68)
-#define H2O_TOKEN_TRANSFER_ENCODING (h2o__tokens + 69)
-#define H2O_TOKEN_UPGRADE (h2o__tokens + 70)
-#define H2O_TOKEN_UPGRADE_INSECURE_REQUESTS (h2o__tokens + 71)
-#define H2O_TOKEN_USER_AGENT (h2o__tokens + 72)
-#define H2O_TOKEN_VARY (h2o__tokens + 73)
-#define H2O_TOKEN_VIA (h2o__tokens + 74)
-#define H2O_TOKEN_WWW_AUTHENTICATE (h2o__tokens + 75)
-#define H2O_TOKEN_X_COMPRESS_HINT (h2o__tokens + 76)
-#define H2O_TOKEN_X_CONTENT_TYPE_OPTIONS (h2o__tokens + 77)
-#define H2O_TOKEN_X_FORWARDED_FOR (h2o__tokens + 78)
-#define H2O_TOKEN_X_FRAME_OPTIONS (h2o__tokens + 79)
-#define H2O_TOKEN_X_REPROXY_URL (h2o__tokens + 80)
-#define H2O_TOKEN_X_TRAFFIC (h2o__tokens + 81)
-#define H2O_TOKEN_X_XSS_PROTECTION (h2o__tokens + 82)
+#define H2O_TOKEN_PROXY_CONNECTION (h2o__tokens + 59)
+#define H2O_TOKEN_PURPOSE (h2o__tokens + 60)
+#define H2O_TOKEN_RANGE (h2o__tokens + 61)
+#define H2O_TOKEN_REFERER (h2o__tokens + 62)
+#define H2O_TOKEN_REFRESH (h2o__tokens + 63)
+#define H2O_TOKEN_RETRY_AFTER (h2o__tokens + 64)
+#define H2O_TOKEN_SERVER (h2o__tokens + 65)
+#define H2O_TOKEN_SET_COOKIE (h2o__tokens + 66)
+#define H2O_TOKEN_STRICT_TRANSPORT_SECURITY (h2o__tokens + 67)
+#define H2O_TOKEN_TE (h2o__tokens + 68)
+#define H2O_TOKEN_TIMING_ALLOW_ORIGIN (h2o__tokens + 69)
+#define H2O_TOKEN_TRANSFER_ENCODING (h2o__tokens + 70)
+#define H2O_TOKEN_UPGRADE (h2o__tokens + 71)
+#define H2O_TOKEN_UPGRADE_INSECURE_REQUESTS (h2o__tokens + 72)
+#define H2O_TOKEN_USER_AGENT (h2o__tokens + 73)
+#define H2O_TOKEN_VARY (h2o__tokens + 74)
+#define H2O_TOKEN_VIA (h2o__tokens + 75)
+#define H2O_TOKEN_WWW_AUTHENTICATE (h2o__tokens + 76)
+#define H2O_TOKEN_X_COMPRESS_HINT (h2o__tokens + 77)
+#define H2O_TOKEN_X_CONTENT_TYPE_OPTIONS (h2o__tokens + 78)
+#define H2O_TOKEN_X_FORWARDED_FOR (h2o__tokens + 79)
+#define H2O_TOKEN_X_FRAME_OPTIONS (h2o__tokens + 80)
+#define H2O_TOKEN_X_REPROXY_URL (h2o__tokens + 81)
+#define H2O_TOKEN_X_TRAFFIC (h2o__tokens + 82)
+#define H2O_TOKEN_X_XSS_PROTECTION (h2o__tokens + 83)
 
 extern const h2o_hpack_static_table_entry_t h2o_hpack_static_table[61];
 extern const h2o_qpack_static_table_entry_t h2o_qpack_static_table[99];
 
 typedef int32_t (*h2o_qpack_lookup_static_cb)(h2o_iovec_t value, int *is_exact);
-extern const h2o_qpack_lookup_static_cb h2o_qpack_lookup_static[83];
+extern const h2o_qpack_lookup_static_cb h2o_qpack_lookup_static[84];
 
 int32_t h2o_qpack_lookup_authority(h2o_iovec_t value, int *is_exact);
 int32_t h2o_qpack_lookup_method(h2o_iovec_t value, int *is_exact);
@@ -173,6 +174,7 @@ int32_t h2o_qpack_lookup_origin(h2o_iovec_t value, int *is_exact);
 int32_t h2o_qpack_lookup_priority(h2o_iovec_t value, int *is_exact);
 int32_t h2o_qpack_lookup_proxy_authenticate(h2o_iovec_t value, int *is_exact);
 int32_t h2o_qpack_lookup_proxy_authorization(h2o_iovec_t value, int *is_exact);
+int32_t h2o_qpack_lookup_proxy_connection(h2o_iovec_t value, int *is_exact);
 int32_t h2o_qpack_lookup_purpose(h2o_iovec_t value, int *is_exact);
 int32_t h2o_qpack_lookup_range(h2o_iovec_t value, int *is_exact);
 int32_t h2o_qpack_lookup_referer(h2o_iovec_t value, int *is_exact);

--- a/lib/common/token_table.h
+++ b/lib/common/token_table.h
@@ -80,6 +80,7 @@ h2o_token_t h2o__tokens[] = {{{H2O_STRLIT(":authority")}, {1, 0, 0, 0, 0, 0, 0, 
                              {{H2O_STRLIT("priority")}, {0, 0, 0, 0, 0, 0, 0, 1}},
                              {{H2O_STRLIT("proxy-authenticate")}, {48, 1, 0, 0, 0, 0, 0, 0}},
                              {{H2O_STRLIT("proxy-authorization")}, {49, 1, 0, 0, 0, 0, 0, 0}},
+                             {{H2O_STRLIT("proxy-connection")}, {0, 1, 1, 0, 0, 0, 0, 0}},
                              {{H2O_STRLIT("purpose")}, {0, 0, 0, 0, 0, 0, 0, 1}},
                              {{H2O_STRLIT("range")}, {50, 0, 0, 0, 0, 0, 0, 0}},
                              {{H2O_STRLIT("referer")}, {51, 0, 0, 0, 0, 0, 0, 1}},
@@ -104,7 +105,7 @@ h2o_token_t h2o__tokens[] = {{{H2O_STRLIT(":authority")}, {1, 0, 0, 0, 0, 0, 0, 
                              {{H2O_STRLIT("x-reproxy-url")}, {0, 0, 0, 0, 0, 0, 0, 0}},
                              {{H2O_STRLIT("x-traffic")}, {0, 0, 0, 0, 0, 0, 0, 0}},
                              {{H2O_STRLIT("x-xss-protection")}, {0, 0, 0, 0, 0, 0, 0, 1}}};
-size_t h2o__num_tokens = 83;
+size_t h2o__num_tokens = 84;
 
 const h2o_hpack_static_table_entry_t h2o_hpack_static_table[61] = {{H2O_TOKEN_AUTHORITY, {H2O_STRLIT("")}},
                                                                    {H2O_TOKEN_METHOD, {H2O_STRLIT("GET")}},
@@ -569,6 +570,8 @@ const h2o_token_t *h2o_lookup_token(const char *name, size_t len)
         case 'n':
             if (memcmp(name, "content-locatio", 15) == 0)
                 return H2O_TOKEN_CONTENT_LOCATION;
+            if (memcmp(name, "proxy-connectio", 15) == 0)
+                return H2O_TOKEN_PROXY_CONNECTION;
             if (memcmp(name, "x-xss-protectio", 15) == 0)
                 return H2O_TOKEN_X_XSS_PROTECTION;
             break;
@@ -1367,6 +1370,12 @@ int32_t h2o_qpack_lookup_proxy_authorization(h2o_iovec_t value, int *is_exact)
     return -1;
 }
 
+int32_t h2o_qpack_lookup_proxy_connection(h2o_iovec_t value, int *is_exact)
+{
+    *is_exact = 0;
+    return -1;
+}
+
 int32_t h2o_qpack_lookup_purpose(h2o_iovec_t value, int *is_exact)
 {
     if (h2o_memis(value.base, value.len, H2O_STRLIT("prefetch"))) {
@@ -1583,7 +1592,7 @@ int32_t h2o_qpack_lookup_x_xss_protection(h2o_iovec_t value, int *is_exact)
     return 62;
 }
 
-const h2o_qpack_lookup_static_cb h2o_qpack_lookup_static[83] = {h2o_qpack_lookup_authority,
+const h2o_qpack_lookup_static_cb h2o_qpack_lookup_static[84] = {h2o_qpack_lookup_authority,
                                                                 h2o_qpack_lookup_method,
                                                                 h2o_qpack_lookup_path,
                                                                 h2o_qpack_lookup_scheme,
@@ -1642,6 +1651,7 @@ const h2o_qpack_lookup_static_cb h2o_qpack_lookup_static[83] = {h2o_qpack_lookup
                                                                 h2o_qpack_lookup_priority,
                                                                 h2o_qpack_lookup_proxy_authenticate,
                                                                 h2o_qpack_lookup_proxy_authorization,
+                                                                h2o_qpack_lookup_proxy_connection,
                                                                 h2o_qpack_lookup_purpose,
                                                                 h2o_qpack_lookup_range,
                                                                 h2o_qpack_lookup_referer,

--- a/misc/tokens.pl
+++ b/misc/tokens.pl
@@ -312,6 +312,7 @@ __DATA__
 0 0 0 0 0 0 0 1 priority
 0 0 0 0 0 0 0 1 no-early-hints
 0 1 1 0 1 0 0 0 datagram-flow-id
+0 1 1 0 0 0 0 0 proxy-connection
 
 # QPACK static table (index, name, value)
 0 :authority


### PR DESCRIPTION
The use of the header is discouraged in general:

https://www.rfc-editor.org/rfc/rfc9112#appendix-C.2.2-4
> As a result, clients are encouraged not to send the Proxy-Connection
> header field in any requests.

https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1-7
> Furthermore, intermediaries SHOULD remove or replace fields that are
> known to require removal before forwarding, whether or not they appear
> as a connection-option, after applying those fields' semantics. This
> includes but is not limited to:

> - Proxy-Connection (Appendix C.2.2 of [HTTP/1.1])
> - Keep-Alive (Section 19.7.1 of [RFC2068])
> - TE (Section 10.1.4)
> - Transfer-Encoding (Section 6.1 of [HTTP/1.1])
> - Upgrade (Section 7.8)

And responses can't use the header in HTTP/2:
https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2-1
> An endpoint MUST NOT generate an HTTP/2 message containing
> connection-specific header fields. This includes the Connection
> header field and those listed as having connection-specific semantics
> in Section 7.6.1 of [HTTP] (that is, Proxy-Connection, Keep-Alive,
> Transfer-Encoding, and Upgrade).

This PR takes the approach to just drop the headers when going through h2o's proxy handler.

Another approach would be to only filter those when translating from HTTP/1.