### PR TITLE
merge neverbleed PR #45

### DIFF
--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -997,7 +997,12 @@ void neverbleed_start_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const 
 
 void neverbleed_finish_digestsign(neverbleed_iobuf_t *buf, void **digest, size_t *digest_len)
 {
-    const void *src = iobuf_shift_bytes(buf, digest_len);
+    const void *src;
+
+    if ((src = iobuf_shift_bytes(buf, digest_len)) == NULL) {
+        errno = 0;
+        dief("failed to parse response");
+    }
     if ((*digest = malloc(*digest_len)) == NULL)
         dief("no memory");
     memcpy(*digest, src, *digest_len);


### PR DESCRIPTION
https://github.com/h2o/neverbleed/pull/45.

Even though h2o calls `neverbleed_finish_digest_sign` only after the bytes are being read, `iobuf_shift_bytes` may return NULL if the following conditions are met:
* the compiler returns NULL for `malloc(0)` (such behavior is allowed by ISO C), and
* neverbleed returns a zero-byte signature for whatever reason.

If that happens, `memcpy` below becomes an undefined behavior because it dereferences a NULL pointer (`src`).

The fix in https://github.com/h2o/neverbleed/pull/45 explicitly calls out that a zero-byte signature is invalid. Doing so is better than trying to handle a zero-byte signature "corectly," because a zero-byte signature makes no sense at all.