### PR TITLE
[mruby] fix handling of headers appearing more than once

### DIFF
--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -715,10 +715,12 @@ int h2o_mruby_iterate_native_headers(h2o_mruby_shared_context_t *shared_ctx, h2o
         /* build flattened value of the header field values that have the same name as sorted[i] */
         size_t num_values = 0;
         values[num_values++] = sorted[i]->value;
-        while (i < num_sorted - 1 && h2o_header_name_is_equal(sorted[i], sorted[i + 1])) {
-            ++i;
-            values[num_values++] = h2o_iovec_init(sorted[i]->name == &H2O_TOKEN_COOKIE->buf ? "; " : ", ", 2);
-            values[num_values++] = sorted[i]->value;
+        if (sorted[i]->name != &H2O_TOKEN_SET_COOKIE->buf) {
+            while (i < num_sorted - 1 && h2o_header_name_is_equal(sorted[i], sorted[i + 1])) {
+                ++i;
+                values[num_values++] = h2o_iovec_init(sorted[i]->name == &H2O_TOKEN_COOKIE->buf ? "; " : ", ", 2);
+                values[num_values++] = sorted[i]->value;
+            }
         }
         h2o_header_t h = *sorted[i];
         h.value = num_values == 1 ? values[0] : h2o_concat_list(pool, values, num_values);

--- a/lib/handler/mruby.c
+++ b/lib/handler/mruby.c
@@ -1185,6 +1185,29 @@ mrb_value h2o_mruby_each_to_array(h2o_mruby_shared_context_t *shared_ctx, mrb_va
                             shared_ctx->symbols.sym_call, 1, &src);
 }
 
+static int iterate_header_values_handle_str(h2o_mruby_shared_context_t *shared_ctx, h2o_iovec_t *namevec, mrb_value value,
+                                            int (*cb)(h2o_mruby_shared_context_t *, h2o_iovec_t *, h2o_iovec_t, void *),
+                                            void *cb_data)
+{
+    value = h2o_mruby_to_str(shared_ctx->mrb, value);
+
+    const char *vstart = RSTRING_PTR(value), *vend = vstart + RSTRING_LEN(value), *eol;
+
+    /* call the callback, splitting the values with '\n' */
+    while (1) {
+        for (eol = vstart; eol != vend; ++eol)
+            if (*eol == '\n')
+                break;
+        if (cb(shared_ctx, namevec, h2o_iovec_init(vstart, eol - vstart), cb_data) != 0)
+            return -1;
+        if (eol == vend)
+            break;
+        vstart = eol + 1;
+    }
+
+    return 0;
+}
+
 int h2o_mruby_iterate_header_values(h2o_mruby_shared_context_t *shared_ctx, mrb_value name, mrb_value value,
                                     int (*cb)(h2o_mruby_shared_context_t *, h2o_iovec_t *, h2o_iovec_t, void *), void *cb_data)
 {
@@ -1196,21 +1219,16 @@ int h2o_mruby_iterate_header_values(h2o_mruby_shared_context_t *shared_ctx, mrb_
     if (mrb->exc != NULL)
         return -1;
     namevec = (h2o_iovec_init(RSTRING_PTR(name), RSTRING_LEN(name)));
-    value = h2o_mruby_to_str(mrb, value);
-    if (mrb->exc != NULL)
-        return -1;
 
-    /* call the callback, splitting the values with '\n' */
-    const char *vstart = RSTRING_PTR(value), *vend = vstart + RSTRING_LEN(value), *eol;
-    while (1) {
-        for (eol = vstart; eol != vend; ++eol)
-            if (*eol == '\n')
-                break;
-        if (cb(shared_ctx, &namevec, h2o_iovec_init(vstart, eol - vstart), cb_data) != 0)
+    if (mrb_array_p(value)) {
+        mrb_int i, len = RARRAY_LEN(value);
+        for (i = 0; i != len; ++i) {
+            if (iterate_header_values_handle_str(shared_ctx, &namevec, mrb_ary_entry(value, i), cb, cb_data) != 0)
+                return -1;
+        }
+    } else {
+        if (iterate_header_values_handle_str(shared_ctx, &namevec, value, cb, cb_data) != 0)
             return -1;
-        if (eol == vend)
-            break;
-        vstart = eol + 1;
     }
 
     return 0;


### PR DESCRIPTION
In Rack, headers appearing more than once are represented as arrays of strings.

When h2o receives such an array,
1. if the name of the header is `set-cookie` they can be concatenated using semicolon,
2. if the name is `cookie` they must not be concatenated,
3. otherwise can be concatenated using comma.

In contrary to these rules, we have been concatenating `cookie` headers (violating rule 2), as well as  applying `Array#to_s` under certain occasions instead of concatenating them using a delimiter of comma or semicolon under certain occasions.

This PR adds tests and fixes the incorrect behaviors.

Closes #3120.