### PR TITLE
improve FUSION check, ensure compiler can handle VAES instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,8 +146,17 @@ ENDIF ()
 
 CMAKE_PUSH_CHECK_STATE()
 SET(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -mavx2 -maes -mpclmul -mvaes -mvpclmulqdq")
-CHECK_C_SOURCE_COMPILES("#include <emmintrin.h>
-int main(void) {}" CC_HAS_AESNI256)
+CHECK_C_SOURCE_COMPILES("
+#include <emmintrin.h>
+#include <immintrin.h>
+int main(void) {
+    __m256i  ord0, ord1, ord2, ord3 = _mm256_setzero_si256();
+    ord0 = _mm256_aesenc_epi128(ord1, ord2);
+    ord3 = _mm256_aesenclast_epi128(ord0, ord1);
+    ord1 = _mm256_clmulepi64_epi128(ord3, ord2, 0x00);
+    return 0;
+}
+" CC_HAS_AESNI256)
 CMAKE_POP_CHECK_STATE()
 IF (CC_HAS_AESNI256)
     SET(WITH_FUSION_DEFAULT "ON")
@@ -155,6 +164,7 @@ ELSE ()
     SET(WITH_FUSION_DEFAULT "OFF")
 ENDIF ()
 OPTION(WITH_FUSION "build with fusion AES-GCM engine" ${WITH_FUSION_DEFAULT})
+MESSAGE(STATUS "FUSION support : ${WITH_FUSION}")
 
 # KTLS
 IF (CMAKE_SYSTEM_NAME STREQUAL "Linux")


### PR DESCRIPTION
Extend checking code from #3179.
Some versions of x86 CPU  do NOT support [AVX-512](https://en.wikipedia.org/wiki/AVX-512#CPUs_with_AVX-512), which provides following instructions and corresponding inline functions used in `deps/picotls/lib/fusion.c` . That will lead to compile error at assembly level.

| instruction (opcode) |  C inline functions |
|----------------------------|-----------------------|
|`vaesenc` | `__m256i _mm256_aesenc_epi128 (__m256i data, __m256i RoundKey)` |
|`vaesenclast` | `__m256i _mm256_aesenclast_epi128 (__m256i a, __m256i RoundKey)` |
|`vpclmulqdq` | `__m256i _mm256_clmulepi64_epi128 (__m256i b, __m256i c, const int Imm8)` |

reference:
[Intel Intrinsics Guide](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html)