### PR TITLE
make sure files are closed, unused resources are freed

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1472,11 +1472,10 @@ h2o_iovec_t h2o_build_server_timing_trailer(h2o_req_t *req, const char *prefix, 
                                             size_t suffix_len);
 /**
  * Garbage collects resources kept for future reuse in the current thread. If `now` is set to zero, performs full GC. If a valid
- * pointer is passed to `ctx_optional`, resource associated to the context will be collected as well. This function returns when
- * it should be called the next time, or UINT64_MAX if there are no resources being held that can be acclaimed in the foreseeable
- * future.
+ * pointer is passed to `ctx_optional`, resource associated to the context will be collected as well. This function returns how long
+ * the next event loop can block before calling `h2o_cleanup_thread` again, in milliseconds.
  */
-uint64_t h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional);
+uint32_t h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional);
 
 extern uint64_t h2o_connection_id;
 

--- a/lib/core/util.c
+++ b/lib/core/util.c
@@ -939,10 +939,8 @@ const char h2o_npn_protocols[] = NPN_PROTOCOLS_CORE "\x08"
 
 uint64_t h2o_connection_id = 0;
 
-uint64_t h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional)
+uint32_t h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional)
 {
-    int full = now == 0;
-
     /* File descriptor cache is cleared fully per event loop and it is sufficient to do so, because:
      * * if the file handler opens one file only once per event loop, then calling open (2) is relatively lightweight compared to
      *   other stuff such as connection establishment, and
@@ -950,15 +948,20 @@ uint64_t h2o_cleanup_thread(uint64_t now, h2o_context_t *ctx_optional)
     if (ctx_optional != NULL)
         h2o_filecache_clear(ctx_optional->filecache);
 
-    /* recycle either fully or partially */
-    h2o_buffer_clear_recycle(full);
-    h2o_socket_clear_recycle(full);
-    h2o_mem_clear_recycle(&h2o_mem_pool_allocator, full);
+    /* recycle either fully, or partially if at least 1 second has elasped since previous gc */
+    static __thread uint64_t next_gc_at;
+    if (now >= next_gc_at) {
+        int full = now == 0;
+        h2o_buffer_clear_recycle(full);
+        h2o_socket_clear_recycle(full);
+        h2o_mem_clear_recycle(&h2o_mem_pool_allocator, full);
+        next_gc_at = now + 1000;
+    }
 
-    /* if all the recyclers are empty, we can sleep forever */
-    if (h2o_buffer_recycle_is_empty() && h2o_socket_recycle_is_empty() && h2o_mem_recycle_is_empty(&h2o_mem_pool_allocator))
-        return UINT64_MAX;
-
-    /* otherwise, `h2o_clean_thread` should be invoked one second later */
-    return now + 1000;
+    /* if all the recyclers are empty, we can sleep forever; otherwise request to be invoked again within no more than one second */
+    if (h2o_buffer_recycle_is_empty() && h2o_socket_recycle_is_empty() && h2o_mem_recycle_is_empty(&h2o_mem_pool_allocator)) {
+        return INT32_MAX;
+    } else {
+        return 1000;
+    }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -3954,15 +3954,11 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     h2o_barrier_wait(&conf.startup_sync_barrier_post);
 
     /* the main loop */
-    uint64_t next_buffer_gc_at = UINT64_MAX;
-    while (1) {
-        if (conf.shutdown_requested)
-            break;
+    while (!conf.shutdown_requested) {
+        h2o_context_t *ctx = &conf.threads[thread_index].ctx;
+        uint32_t max_wait = h2o_cleanup_thread(h2o_now(ctx->loop), ctx);
         update_listener_state(listeners);
-        /* run the loop once */
-        h2o_evloop_run(conf.threads[thread_index].ctx.loop, next_buffer_gc_at == UINT64_MAX ? INT32_MAX : 1000);
-        if (h2o_now(conf.threads[thread_index].ctx.loop) >= next_buffer_gc_at)
-            next_buffer_gc_at = h2o_cleanup_thread(h2o_now(conf.threads[thread_index].ctx.loop), &conf.threads[thread_index].ctx);
+        h2o_evloop_run(ctx->loop, max_wait);
     }
 
     if (thread_index == 0)

--- a/t/50file.t
+++ b/t/50file.t
@@ -34,11 +34,11 @@ EOT
     my $write_file = sub {
         # use write-then-rename pattern; otherwise the behavior would become identical to shrinking an existing file that is covered
         # in t/50file-shrink.t
-        open my $fh, ">", "index.txt.tmp"
-            or die "failed to open index.txt.tmp:$!";
+        open my $fh, ">", "$tempdir/.tmpfile"
+            or die "failed to open $tempdir/.tmpfile:$!";
         print $fh shift;
         close $fh;
-        rename "index.txt.tmp", "$tempdir/$fn"
+        rename "$tempdir/.tmpfile", "$tempdir/$fn"
             or die "rename failed:$!";
     };
     run_with_curl($server, sub {

--- a/t/50file.t
+++ b/t/50file.t
@@ -1,7 +1,10 @@
 use strict;
 use warnings;
+use File::Temp qw(tempdir);
 use Test::More;
 use t::Util;
+
+my $tempdir = tempdir(CLEANUP => 1);
 
 plan skip_all => 'curl not found'
     unless prog_exists('curl');
@@ -17,6 +20,37 @@ EOT
 
   my $resp = `curl --silent --dump-header /dev/stderr http://127.0.0.1:$server->{port}/index.txt/ 2>&1 > /dev/null`;
   like $resp, qr{^HTTP/1.1 404 File Not Found}s, "status";
+};
+
+subtest 'update' => sub {
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: $tempdir
+EOT
+    my $fn = 1;
+    my $write_file = sub {
+        # use write-then-rename pattern; otherwise the behavior would become identical to shrinking an existing file that is covered
+        # in t/50file-shrink.t
+        open my $fh, ">", "index.txt.tmp"
+            or die "failed to open index.txt.tmp:$!";
+        print $fh shift;
+        close $fh;
+        rename "index.txt.tmp", "$tempdir/$fn"
+            or die "rename failed:$!";
+    };
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        $write_file->("hello world");
+        my $content = `$curl --silent --show-error $proto://127.0.0.1:$port/$fn`;
+        is $content, "hello world";
+        $write_file->("good bye");
+        $content = `$curl --silent --show-error $proto://127.0.0.1:$port/$fn`;
+        is $content, "good bye";
+        ++$fn;
+    });
 };
 
 done_testing;


### PR DESCRIPTION
#3151 has been the last change in the area though it has introduced the following issues:
* `h2o_cleanup_thread` is never called, because `next_buffer_gc_at` is initially set to `UINT64_MAX` and remains as such, because `h2o_now(...)` is always smaller than `UINT64_MAX`.
* Apparently, the (failed) intent has been to call `h2o_cleanup_thread` when `h2o_now(...)` becomes no less than `next_buffer_gc_at`. But that design is also incorrect. `h2o_filecache_clear` has to be called once per event loop, because otherwise we would not reopen the files that have been replaced.

This PR addresses these two issues, as well as adding a test for the latter.