### PR TITLE
Potential assert when the timeout coincides with a write

### DIFF
--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -589,8 +589,7 @@ static void tcp_on_read(h2o_socket_t *_sock, const char *err)
     struct st_connect_generator_t *self = _sock->data;
 
     h2o_socket_read_stop(self->sock);
-    reset_io_timeout(self); /* for simplicity, we call out I/O timeout even when downstream fails to deliver data to the client
-                             * within given interval */
+    h2o_timer_unlink(&self->timeout);
 
     if (err == NULL) {
         h2o_iovec_t vec = h2o_iovec_init(self->sock->input->bytes, self->sock->input->size);
@@ -813,8 +812,7 @@ static void udp_on_read(h2o_socket_t *_sock, const char *err)
         self->src_req->forward_datagram.read_(self->src_req, &vec, 1);
     } else {
         h2o_socket_read_stop(self->sock);
-        reset_io_timeout(self); /* for simplicity, we call out I/O timeout even when downstream fails to deliver data to the client
-                                 * within given interval */
+        h2o_timer_unlink(&self->timeout);
         size_t off = 0;
         self->udp.ingress.buf[off++] = 0; /* chunk type = UDP_PACKET */
         off = quicly_encodev(self->udp.ingress.buf + off, (uint64_t)rret) - self->udp.ingress.buf;


### PR DESCRIPTION
The connect handler currently keeps the the io timeout armed after a write has been issues to front end handlers. This is a problem because it's possible that the timeout fires when there's a write is already in filght, which is not the contract that handlers have with frontends (only one outstanding h2o_send can be inflight).

We fix this by simply disabling the timeout when a write is in flight, relying on the frontend idle timeout instead in these cases. The timeout is re-armed in the 'proceed' callbacks, as soon as the frontend is done with the write.