### PR TITLE
libressl-3.6.2

### DIFF
--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -52,7 +52,7 @@
 #include <openssl/opensslconf.h>
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL || LIBRESSL_VERSION_NUMBER >= 0x3060200fL
 /* RSA_METHOD is opaque, so RSA_meth* are used. */
 #define NEVERBLEED_OPAQUE_RSA_METHOD
 #endif


### PR DESCRIPTION
Fixed library yaml, hiredis and openssl or libressl so that the library is recognized by pkg-config. 
Partially modified so that neverbleed's RSA-related processing is also enabled for libreSSL-3.7.0, 3.6.2.

This change makes it easier to switch external libraries such as openssl and libressl by specifying the appropriate PKG_CONFIG_PATH.