### PR TITLE
Configure version file in binary instead of source to fix race condition in cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ INCLUDE(ExternalProject)
 INCLUDE(deps/picotls/cmake/dtrace-utils.cmake)
 INCLUDE(deps/picotls/cmake/boringssl-adjust.cmake)
 
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/h2o/version.h)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/h2o/version.h)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/libh2o.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libh2o.pc @ONLY)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/libh2o-evloop.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libh2o-evloop.pc @ONLY)
 
@@ -207,7 +207,8 @@ INCLUDE_DIRECTORIES(
     deps/quicly/include
     deps/yaml/include
     deps/yoml
-    ${CMAKE_CURRENT_BINARY_DIR})
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 IF (PKG_CONFIG_FOUND)
     PKG_CHECK_MODULES(LIBUV libuv>=1.0.0)
@@ -1034,7 +1035,7 @@ IF (WITH_H2OLOG)
         "src/h2olog/http_tracer.cc"
         "src/h2olog/json.h"
         "src/h2olog/json.cc"
-        "include/h2o/version.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/include/h2o/version.h"
     )
 
     # This phony target is required to force to trigger a custom command.


### PR DESCRIPTION
When configuring a file, cmake creates a temporary file in the target location. When the target location is in source, this introduces a race condition if multiple cmake processes are configuring the same CMakeLists.txt at the same time, as they are both trying to write and read the same temporary file. If one cmake process deletes the temporary file while the other attempts to read it, it can cause the following spurious error, completely at random:

```
CMake Error at h2o/CMakeLists.txt:43 (CONFIGURE_FILE):
  No such file or directory
```
Moving the target to the build folder avoids this issue since it will write two different temporary files and no longer have a race condition.