### PR TITLE
Fix a crash in the CONNECT handler after timeout with a write to client still pending.

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -737,6 +737,7 @@
 		0879B8CC2724DBF400F77220 /* 10socket.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = 10socket.t; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		08819C2C218C9FA90057ED23 /* qif */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = qif; sourceTree = BUILT_PRODUCTS_DIR; };
 		08819C2D218C9FF70057ED23 /* qif.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = qif.c; sourceTree = "<group>"; };
+		089FA83229BB6EB900F7B746 /* 50connect-inflight.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50connect-inflight.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		08A835E42996351100D872CE /* build.mk */ = {isa = PBXFileReference; lastKnownFileType = text; path = build.mk; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.make; };
 		08A835E529964B5C00D872CE /* Dockerfile.ubuntu1604 */ = {isa = PBXFileReference; lastKnownFileType = text; path = Dockerfile.ubuntu1604; sourceTree = "<group>"; };
 		08A835E629964B5C00D872CE /* Dockerfile.ubuntu2004 */ = {isa = PBXFileReference; lastKnownFileType = text; path = Dockerfile.ubuntu2004; sourceTree = "<group>"; };
@@ -2268,6 +2269,7 @@
 				E93BB45025DA530E009C24D8 /* 50connect.t */,
 				086850BE2752E20100F8CAD1 /* 50connect-eyeballs.t */,
 				08B3D43A26042CAF002F195C /* 50connect-deadlock.t */,
+				089FA83229BB6EB900F7B746 /* 50connect-inflight.t */,
 				0810E6A8286DACB600333FA4 /* 50connect-proxy-status.t */,
 				E9AFBF11212A9801000F5DB8 /* 50date-header.t */,
 				086001C42730B7170043886F /* 50dnsresolver.t */,

--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -290,6 +290,9 @@ static void close_readwrite(struct st_connect_generator_t *self)
 
     if (self->sock != NULL)
         send_inflight = close_socket(self);
+    else if (self->is_tcp)
+        send_inflight = self->tcp.recvbuf_detached->size != 0;
+
     if (h2o_timer_is_linked(&self->timeout))
         h2o_timer_unlink(&self->timeout);
 

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -77,14 +77,10 @@ subtest "handwritten-h1-client" => sub {
         is sysread($sync_read, my $buf, 1), 1;
     };
     # The writes incidentally re-arm the io-timeout.
-    subtest "fill-up-write-pipe" => sub {
-        write_until_blocked($sock);
-        pass;
-    };
-    subtest "wait-for-io-timeout" => sub {
-        sleep 6;
-        pass;
-    };
+    diag "fill-up-write-pipe";
+    write_until_blocked($sock);
+    diag "wait-for-io-timeout";
+    sleep 6;
     subtest "is-h2o-ok" => sub {
         my $sock2 = IO::Socket::INET->new(
             PeerAddr => "127.0.0.1:$server->{port}",

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -46,9 +46,8 @@ my $tcp_origin_guard = do {
             if (my $sock = $listener->accept) {
                 write_until_blocked($sock);
                 # Tell the client side of the test that we are done filling the pipe.
-                $!=0;
-                my $ret = syswrite($sync_write, 'x', 1);
-                die "sync pipe write failed:$!" unless $ret == 1;
+                syswrite($sync_write, 'x', 1) == 1
+                    or die "sync pipe write failed:$!";
                 # Keep the socket open.
                 push @sockets, $sock;
                 $sock=undef;

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -1,0 +1,137 @@
+use strict;
+use warnings;
+use Errno qw(EAGAIN EINTR EWOULDBLOCK);
+use Fcntl qw(F_SETFL O_NONBLOCK);
+use IO::Select;
+use IO::Socket::INET;
+use Scope::Guard;
+use Socket qw(IPPROTO_TCP TCP_NODELAY);
+use Time::HiRes qw(sleep);
+use Test::More;
+use Net::EmptyPort qw(empty_port);
+use t::Util;
+
+local $SIG{PIPE} = sub {};
+
+my $origin_port = empty_port();
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        proxy.connect:
+          - "+127.0.0.1:$origin_port"
+        proxy.timeout.io: 5000
+      "/ruok":
+        file.file: t/assets/doc_root/alice.txt
+EOT
+
+pipe SYNC_READ, SYNC_WRITE or die "pipe failed:$!";
+
+my $tcp_origin_guard = do {
+    my $listener = IO::Socket::INET->new(
+        Listen    => 5,
+        LocalAddr => "127.0.0.1:$origin_port",
+        Proto     => "tcp",
+    ) or die "failed to open listener:$!";
+    my $pid = fork;
+    die "fork failed:$!"
+        unless defined $pid;
+    if ($pid == 0) {
+        # child process
+        my @sockets;
+        while (1) {
+            if (my $sock = $listener->accept) {
+                write_until_blocked($sock);
+                # Tell the client side of the test that we are done filling the pipe.
+                $!=0;
+                my $ret = syswrite(SYNC_WRITE, 'x', 1);
+                die "sync pipe write failed:$!" unless $ret == 1;
+                # Keep the socket open.
+                push @sockets, $sock;
+                $sock=undef;
+            }
+        }
+        die "unreachable";
+    }
+    # parent process
+    undef $listener;
+    Scope::Guard->new(sub {
+        kill 'KILL', $pid;
+        while (waitpid($pid, 0) != $pid) {}
+    });
+};
+
+subtest "handwritten-h1-client" => sub {
+    my $sock = IO::Socket::INET->new(
+        PeerAddr => "127.0.0.1:$server->{port}",
+        Proto    => "tcp",
+    ) or BAIL_OUT("failed to connect to server:$!");
+    subtest "establish-tunnel" => sub {
+        my $req = "CONNECT 127.0.0.1:$origin_port HTTP/1.1\r\n\r\n";
+        is syswrite($sock, $req), length $req, "send request";
+        sysread $sock, my $resp, 1024;
+        like $resp, qr{^HTTP/1\.1 200}s, "got 200 response" or BAIL_OUT;
+    };
+    subtest "fill-up-read-pipe" => sub {
+        is sysread(SYNC_READ, my $buf, 1), 1, "sync pipe read";
+    };
+    # The writes incidentally re-arm the io-timeout.
+    subtest "fill-up-write-pipe" => sub {
+        write_until_blocked($sock);
+        pass;
+    };
+    subtest "wait-for-io-timeout" => sub {
+        sleep 6;
+        pass;
+    };
+    subtest "is-h2o-ok" => sub {
+        my $sock2 = IO::Socket::INET->new(
+            PeerAddr => "127.0.0.1:$server->{port}",
+            Proto    => "tcp",
+        );
+        ok defined($sock2), "connect to server";
+        my $req = "GET /ruok HTTP/1.1\r\n\r\n";
+        is syswrite($sock2, $req), length $req, "send request";
+        sysread $sock2, my $resp, 1024;
+        like $resp, qr{^HTTP/1\.1 200}s, "got 200 response";
+    };
+};
+
+done_testing;
+
+sub write_until_blocked {
+    my $sock = shift;
+    fcntl $sock, F_SETFL, O_NONBLOCK or die "failed to set O_NONBLOCK:$!";
+    if (!defined setsockopt($sock, IPPROTO_TCP, TCP_NODELAY, 1)) {
+        die "setsockopt(TCP_NODELAY) failed:$!";
+    }
+    my $blocked = 0;
+    while (1) {
+        my $buf = "x" x 65534;
+        my $ret = syswrite($sock, $buf, length $buf);
+        if (defined($ret) && $ret > 0) {
+            $blocked = 0;
+            next;
+        }
+        # After the write blocks, sleep a second and try again.
+        # If the write keeps blocking then we are done stuffing the pipe.
+        if ($! == EAGAIN || $! == EWOULDBLOCK) {
+            $! = 0;
+            if (!IO::Select->new([ $sock ])->can_write(1)) {
+                die "select failed:$!" if $!;
+                # timeout
+                $blocked += 1;
+                last if $blocked >= 2;
+            }
+        } elsif ($! == EINTR) {
+            # retry
+            next;
+        } else {
+            # error
+            die "socket write failed:$!";
+        }
+    }
+    fcntl $sock, F_SETFL, 0 or die "failed to clear O_NONBLOCK:$!";
+}

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -65,7 +65,7 @@ subtest "handwritten-h1-client" => sub {
     my $sock = IO::Socket::INET->new(
         PeerAddr => "127.0.0.1:$server->{port}",
         Proto    => "tcp",
-    ) or BAIL_OUT("failed to connect to server:$!");
+    ) or die "failed to connect to server:$!";
     subtest "establish-tunnel" => sub {
         my $req = "CONNECT 127.0.0.1:$origin_port HTTP/1.1\r\n\r\n";
         is syswrite($sock, $req), length $req, "send request";

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -50,7 +50,6 @@ my $tcp_origin_guard = do {
                     or die "sync pipe write failed:$!";
                 # Keep the socket open.
                 push @sockets, $sock;
-                $sock = undef;
             }
         }
         die "unreachable";

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -70,7 +70,8 @@ subtest "handwritten-h1-client" => sub {
         my $req = "CONNECT 127.0.0.1:$origin_port HTTP/1.1\r\n\r\n";
         is syswrite($sock, $req), length $req, "send request";
         sysread $sock, my $resp, 1024;
-        like $resp, qr{^HTTP/1\.1 200}s, "got 200 response" or BAIL_OUT;
+        like $resp, qr{^HTTP/1\.1 200}s, "got 200 response"
+            or BAIL_OUT;
     };
     subtest "fill-up-read-pipe" => sub {
         is sysread($sync_read, my $buf, 1), 1, "sync pipe read";

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -55,7 +55,6 @@ my $tcp_origin_guard = do {
         die "unreachable";
     }
     # parent process
-    undef $listener;
     Scope::Guard->new(sub {
         kill 'KILL', $pid;
         while (waitpid($pid, 0) != $pid) {}

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -86,7 +86,7 @@ subtest "handwritten-h1-client" => sub {
             PeerAddr => "127.0.0.1:$server->{port}",
             Proto    => "tcp",
         );
-        ok defined($sock2), "connect to server";
+        ok $sock2, "connect to server";
         my $req = "GET /ruok HTTP/1.1\r\n\r\n";
         is syswrite($sock2, $req), length $req, "send request";
         sysread $sock2, my $resp, 1024;

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -50,7 +50,7 @@ my $tcp_origin_guard = do {
                     or die "sync pipe write failed:$!";
                 # Keep the socket open.
                 push @sockets, $sock;
-                $sock=undef;
+                $sock = undef;
             }
         }
         die "unreachable";

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -74,7 +74,7 @@ subtest "handwritten-h1-client" => sub {
             or BAIL_OUT;
     };
     subtest "fill-up-read-pipe" => sub {
-        is sysread($sync_read, my $buf, 1), 1, "sync pipe read";
+        is sysread($sync_read, my $buf, 1), 1;
     };
     # The writes incidentally re-arm the io-timeout.
     subtest "fill-up-write-pipe" => sub {

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -106,7 +106,7 @@ sub write_until_blocked {
     while (1) {
         my $buf = "x" x 65534;
         my $ret = syswrite($sock, $buf, length $buf);
-        if (defined($ret) && $ret > 0) {
+        if (defined($ret)) {
             $blocked = 0;
             next;
         }

--- a/t/50connect-inflight.t
+++ b/t/50connect-inflight.t
@@ -98,10 +98,10 @@ done_testing;
 
 sub write_until_blocked {
     my $sock = shift;
-    fcntl $sock, F_SETFL, O_NONBLOCK or die "failed to set O_NONBLOCK:$!";
-    if (!defined setsockopt($sock, IPPROTO_TCP, TCP_NODELAY, 1)) {
-        die "setsockopt(TCP_NODELAY) failed:$!";
-    }
+    fcntl($sock, F_SETFL, O_NONBLOCK)
+        or die "failed to set O_NONBLOCK:$!";
+    setsockopt($sock, IPPROTO_TCP, TCP_NODELAY, 1)
+        or die "setsockopt(TCP_NODELAY) failed:$!";
     my $blocked = 0;
     while (1) {
         my $buf = "x" x 65534;
@@ -128,5 +128,6 @@ sub write_until_blocked {
             die "socket write failed:$!";
         }
     }
-    fcntl $sock, F_SETFL, 0 or die "failed to clear O_NONBLOCK:$!";
+    fcntl($sock, F_SETFL, 0)
+        or die "failed to clear O_NONBLOCK:$!";
 }


### PR DESCRIPTION
If a write to the client is in progress when `proxy.timeout.io` expires, and there is data in the send buffer from the client to the origin, then `close_readwrite` will run the first time, close the origin socket, set `self->sock` to NULL, and it will schedule itself to run again.

When `close_readwrite` runs the second time, `self->sock` is already NULL, `close_socket` will not be called and `send_inflight` will not be determined correctly.  As a result of that, `close_readwrite` will call `h2o_send` even though a write to the client is still in progress.

The test `t/50connect-inflight.t` replicates the problem.

The fix in this PR is to determine `send_inflight` from the detached write buffer when `self->sock` is NULL.

#3200 (06f8e782a) fixed a problem with CONNECT-UDP when a write to the client is in progress, but the fix introduced a regression for TCP because the `self->tcp.recvbuf_detached` check which used to run unconditionally changed to only run when `sock->sock` is not NULL, that is only when `close_readwrite` runs for the first time.

#3199 does not fix the problem, because even though `tcp_on_read` unlinks the timer when the write to the client starts, a write in the other direction re-arms the io-timeout in `tcp_do_write` and therefore `close_readwrite` still must handle being called when a write to the client is in progress.

With the fix in this PR removed, the test `t/50connect-inflight.t` runs into the write-in-progress assert:

```
h2o: …/lib/common/socket.c:935: h2o_socket_sendvec: Assertion `sock->_cb.write == NULL' failed.
received fatal signal 6
[11751] …/build/h2o(+0x16acb9)[0x55a80c3f1cb9] on_sigfatal at …/src/main.c:3432
[11751] /lib/x86_64-linux-gnu/libpthread.so.0(+0x143c0)[0x7f408f28c3c0] __restore_rt at ??:?
[11751] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0xcb)[0x7f408f0c703b] ?? ??:0
[11751] /lib/x86_64-linux-gnu/libc.so.6(abort+0x12b)[0x7f408f0a6859] ?? ??:0
[11751] /lib/x86_64-linux-gnu/libc.so.6(+0x22729)[0x7f408f0a6729] ?? ??:0
[11751] /lib/x86_64-linux-gnu/libc.so.6(+0x34006)[0x7f408f0b8006] __assert_fail at ??:?
[11751] …/build/h2o(h2o_socket_sendvec+0x4c9)[0x55a80c33ea99] ?? ??:0
[11751] …/build/h2o(+0xf08b5)[0x55a80c3778b5] finalostream_send at …/lib/http1.c:1063
[11751] …/build/h2o(h2o_send+0xbe)[0x55a80c35bb0e] ?? ??:0
[11751] …/build/h2o(h2o_evloop_run+0x9b)[0x55a80c34177b] ?? ??:0
[11751] …/build/h2o(+0x16d169)[0x55a80c3f4169] run_loop at …/src/main.c:4040
[11751] …/build/h2o(main+0x1667)[0x55a80c2e4ee7] ?? ??:0
[11751] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3)[0x7f408f0a80b3] ?? ??:0
[11751] …/build/h2o(_start+0x2e)[0x55a80c2e50ce] ?? ??:0
```
