### PR TITLE
[neverbleed]: Response-less "del_pkey"

### DIFF
--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -1924,8 +1924,9 @@ static void *daemon_conn_thread(void *_sock_fd)
         }
         /* add response to chain */
         *conn_ctx.responses.next = buf;
-        buf = NULL; /* do not free */
         conn_ctx.responses.next = &buf->next;
+        buf = NULL; /* do not free */
+
         /* send responses if possible */
         if (send_responses(0) != 0)
             break;

--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -1906,6 +1906,7 @@ static void *daemon_conn_thread(void *_sock_fd)
             if (del_pkey_stub(buf) != 0)
                 break;
             iobuf_dispose(buf);
+            free(buf);
             // "del_pkey" command is fire-and-forget, it cannot fail, so doesn't have a response
             continue;
         } else if (strcmp(cmd, "setuidgid") == 0) {

--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -350,6 +350,11 @@ static int iobuf_read(neverbleed_iobuf_t *buf, int fd)
     return 0;
 }
 
+void neverbleed_iobuf_dispose(neverbleed_iobuf_t *buf)
+{
+    iobuf_dispose(buf);
+}
+
 static void iobuf_transaction_write(neverbleed_iobuf_t *buf, struct st_neverbleed_thread_data_t *thdata)
 {
     if (iobuf_write(buf, thdata->fd) == -1) {
@@ -379,7 +384,7 @@ static void iobuf_transaction_read(neverbleed_iobuf_t *buf, struct st_neverbleed
 static void iobuf_transaction_no_response(neverbleed_iobuf_t *buf, struct st_neverbleed_thread_data_t *thdata)
 {
     if (neverbleed_transaction_cb != NULL) {
-        neverbleed_transaction_cb(buf, 0);
+        neverbleed_transaction_cb(buf, 1);
     } else {
         iobuf_transaction_write(buf, thdata);
         iobuf_dispose(buf);
@@ -392,7 +397,7 @@ static void iobuf_transaction_no_response(neverbleed_iobuf_t *buf, struct st_nev
 static void iobuf_transaction(neverbleed_iobuf_t *buf, struct st_neverbleed_thread_data_t *thdata)
 {
     if (neverbleed_transaction_cb != NULL) {
-        neverbleed_transaction_cb(buf, 1);
+        neverbleed_transaction_cb(buf, 0);
     } else {
         iobuf_transaction_write(buf, thdata);
         iobuf_transaction_read(buf, thdata);
@@ -498,11 +503,6 @@ void neverbleed_transaction_write(neverbleed_t *nb, neverbleed_iobuf_t *buf)
 {
     struct st_neverbleed_thread_data_t *thdata = get_thread_data(nb);
     iobuf_transaction_write(buf, thdata);
-}
-
-void neverbleed_transaction_dispose(neverbleed_iobuf_t *buf)
-{
-    iobuf_dispose(buf);
 }
 
 static void get_privsep_data(const RSA *rsa, struct st_neverbleed_rsa_exdata_t **exdata,

--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -374,12 +374,25 @@ static void iobuf_transaction_read(neverbleed_iobuf_t *buf, struct st_neverbleed
 }
 
 /**
+ * Only sends a request, does not read a response
+ */
+static void iobuf_transaction_no_response(neverbleed_iobuf_t *buf, struct st_neverbleed_thread_data_t *thdata)
+{
+    if (neverbleed_transaction_cb != NULL) {
+        neverbleed_transaction_cb(buf, 0);
+    } else {
+        iobuf_transaction_write(buf, thdata);
+        iobuf_dispose(buf);
+    }
+}
+
+/**
  * Sends a request and reads a response.
  */
 static void iobuf_transaction(neverbleed_iobuf_t *buf, struct st_neverbleed_thread_data_t *thdata)
 {
     if (neverbleed_transaction_cb != NULL) {
-        neverbleed_transaction_cb(buf);
+        neverbleed_transaction_cb(buf, 1);
     } else {
         iobuf_transaction_write(buf, thdata);
         iobuf_transaction_read(buf, thdata);
@@ -485,6 +498,11 @@ void neverbleed_transaction_write(neverbleed_t *nb, neverbleed_iobuf_t *buf)
 {
     struct st_neverbleed_thread_data_t *thdata = get_thread_data(nb);
     iobuf_transaction_write(buf, thdata);
+}
+
+void neverbleed_transaction_dispose(neverbleed_iobuf_t *buf)
+{
+    iobuf_dispose(buf);
 }
 
 static void get_privsep_data(const RSA *rsa, struct st_neverbleed_rsa_exdata_t **exdata,
@@ -983,17 +1001,10 @@ static void priv_ecdsa_finish(EC_KEY *key)
     ecdsa_get_privsep_data(key, &exdata, &thdata);
 
     neverbleed_iobuf_t buf = {NULL};
-    size_t ret;
-
     iobuf_push_str(&buf, "del_pkey");
     iobuf_push_num(&buf, exdata->key_index);
-    iobuf_transaction(&buf, thdata);
-
-    if (iobuf_shift_num(&buf, &ret) != 0) {
-        errno = 0;
-        dief("failed to parse response");
-    }
-    iobuf_dispose(&buf);
+    // "del_pkey" command is fire-and-forget, it cannot fail, so doesn't have a response
+    iobuf_transaction_no_response(&buf, thdata);
 }
 
 #endif
@@ -1632,26 +1643,17 @@ static int priv_rsa_finish(RSA *rsa)
     get_privsep_data(rsa, &exdata, &thdata);
 
     neverbleed_iobuf_t buf = {NULL};
-    size_t ret;
-
     iobuf_push_str(&buf, "del_pkey");
     iobuf_push_num(&buf, exdata->key_index);
-    iobuf_transaction(&buf, thdata);
+    // "del_pkey" command is fire-and-forget, it cannot fail, so doesn't have a response
+    iobuf_transaction_no_response(&buf, thdata);
 
-    if (iobuf_shift_num(&buf, &ret) != 0) {
-        errno = 0;
-        dief("failed to parse response");
-    }
-    iobuf_dispose(&buf);
-
-    return (int)ret;
+    return 1;
 }
 
 static int del_pkey_stub(neverbleed_iobuf_t *buf)
 {
     size_t key_index;
-
-    int ret = 0;
 
     if (iobuf_shift_num(buf, &key_index) != 0) {
         errno = 0;
@@ -1667,15 +1669,9 @@ static int del_pkey_stub(neverbleed_iobuf_t *buf)
         daemon_vars.keys.first_empty = key_index;
     } else {
         warnf("%s: invalid key index %zu", __FUNCTION__, key_index);
-        goto respond;
     }
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
-    ret = 1;
-
-respond:
-    iobuf_dispose(buf);
-    iobuf_push_num(buf, ret);
     return 0;
 }
 
@@ -1909,6 +1905,9 @@ static void *daemon_conn_thread(void *_sock_fd)
         } else if (strcmp(cmd, "del_pkey") == 0) {
             if (del_pkey_stub(buf) != 0)
                 break;
+            iobuf_dispose(buf);
+            // "del_pkey" command is fire-and-forget, it cannot fail, so doesn't have a response
+            continue;
         } else if (strcmp(cmd, "setuidgid") == 0) {
             if (setuidgid_stub(buf) != 0)
                 break;
@@ -2200,5 +2199,5 @@ Fail:
 }
 
 void (*neverbleed_post_fork_cb)(void) = NULL;
-void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *) = NULL;
+void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *, int) = NULL;
 enum neverbleed_offload_type neverbleed_offload = NEVERBLEED_OFFLOAD_OFF;

--- a/deps/neverbleed/neverbleed.h
+++ b/deps/neverbleed/neverbleed.h
@@ -106,7 +106,7 @@ extern void (*neverbleed_post_fork_cb)(void);
  * The callback returns a boolean indicating if it handled the task. It may return false to delagate the task back to the default
  * logic.
  */
-extern void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *);
+extern void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *, int);
 
 typedef void (*neverbleed_cb)(int);
 
@@ -114,6 +114,7 @@ int neverbleed_get_fd(neverbleed_t *nb);
 static size_t neverbleed_iobuf_size(neverbleed_iobuf_t *buf);
 void neverbleed_transaction_read(neverbleed_t *nb, neverbleed_iobuf_t *buf);
 void neverbleed_transaction_write(neverbleed_t *nb, neverbleed_iobuf_t *buf);
+void neverbleed_transaction_dispose(neverbleed_iobuf_t *buf);
 
 /**
  * if set to a non-zero value, RSA operations are offloaded

--- a/deps/neverbleed/neverbleed.h
+++ b/deps/neverbleed/neverbleed.h
@@ -103,10 +103,8 @@ int neverbleed_setaffinity(neverbleed_t *nb, NEVERBLEED_CPU_SET_T *cpuset);
 extern void (*neverbleed_post_fork_cb)(void);
 /**
  * An optional callback used for replacing `iobuf_transaction`; i.e., the logic that sends the request and receives the response.
- * The callback returns a boolean indicating if it handled the task. It may return false to delagate the task back to the default
- * logic. When the second argument is 1, this indicates no reponse is expected for this transaction.
  */
-extern void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *, int);
+extern void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *req, int responseless);
 
 typedef void (*neverbleed_cb)(int);
 

--- a/deps/neverbleed/neverbleed.h
+++ b/deps/neverbleed/neverbleed.h
@@ -104,7 +104,7 @@ extern void (*neverbleed_post_fork_cb)(void);
 /**
  * An optional callback used for replacing `iobuf_transaction`; i.e., the logic that sends the request and receives the response.
  * The callback returns a boolean indicating if it handled the task. It may return false to delagate the task back to the default
- * logic.
+ * logic. When the second argument is 1, this indicates no reponse is expected for this transaction.
  */
 extern void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *, int);
 
@@ -112,9 +112,9 @@ typedef void (*neverbleed_cb)(int);
 
 int neverbleed_get_fd(neverbleed_t *nb);
 static size_t neverbleed_iobuf_size(neverbleed_iobuf_t *buf);
+void neverbleed_iobuf_dispose(neverbleed_iobuf_t *buf);
 void neverbleed_transaction_read(neverbleed_t *nb, neverbleed_iobuf_t *buf);
 void neverbleed_transaction_write(neverbleed_t *nb, neverbleed_iobuf_t *buf);
-void neverbleed_transaction_dispose(neverbleed_iobuf_t *buf);
 
 /**
  * if set to a non-zero value, RSA operations are offloaded

--- a/src/main.c
+++ b/src/main.c
@@ -557,8 +557,7 @@ static void async_nb_notify_fd(struct async_nb_transaction_t *_transaction)
 
 static void async_nb_do_async_transaction(ASYNC_JOB *job, neverbleed_iobuf_t *buf)
 {
-    struct async_nb_transaction_fd_notify_t transaction = {
-        {.buf = buf, .on_read_complete = async_nb_notify_fd}};
+    struct async_nb_transaction_fd_notify_t transaction = {{.buf = buf, .on_read_complete = async_nb_notify_fd}};
     int readfd;
 
     /* setup fd to notify OpenSSL; eventfd is used if available, as it is lightweight and uses only one file descriptor */


### PR DESCRIPTION
In an environment where keys are frequently deleted/updated, the overhead of draining the asynchronous transaction queue to perform the synchronous "del_pkey" operation can be noticed.

This PR proposes an optimization to this specific command, by not requiring a response (fire-and-forget). In this case, the error condition is a warning and can't really be handled by the application which is why it can be response-less.

neverbleed: https://github.com/h2o/neverbleed/pull/52

(note by Kazuho): update of neverbleed incorporates https://github.com/h2o/neverbleed/pull/54