### PR TITLE
Fix fcgi encoding length problem

### DIFF
--- a/lib/handler/fastcgi.c
+++ b/lib/handler/fastcgi.c
@@ -153,7 +153,7 @@ static void *append(h2o_mem_pool_t *pool, iovec_vector_t *blocks, const void *s,
 
 static char *encode_length_of_pair(char *p, size_t len)
 {
-    if (len < 127) {
+    if (len < 0x80) {
         *p++ = (char)len;
     } else {
         *p++ = (unsigned char)(len >> 24) | 0x80;


### PR DESCRIPTION
According to FastCGI specification (https://fastcgi-archives.github.io/FastCGI_Specification.html ): "Lengths of 127 bytes and less can be encoded in one byte, while longer lengths are always encoded in four bytes"