### PR TITLE
[neverbleed]: Fix memory leaks

### DIFF
--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -1005,6 +1005,7 @@ static void priv_ecdsa_finish(EC_KEY *key)
     iobuf_push_num(&buf, exdata->key_index);
     // "del_pkey" command is fire-and-forget, it cannot fail, so doesn't have a response
     iobuf_transaction_no_response(&buf, thdata);
+    free(exdata);
 }
 
 #endif
@@ -1648,6 +1649,7 @@ static int priv_rsa_finish(RSA *rsa)
     // "del_pkey" command is fire-and-forget, it cannot fail, so doesn't have a response
     iobuf_transaction_no_response(&buf, thdata);
 
+    free(exdata);
     return 1;
 }
 

--- a/deps/neverbleed/neverbleed.h
+++ b/deps/neverbleed/neverbleed.h
@@ -26,6 +26,10 @@
 #include <sys/un.h>
 #include <openssl/engine.h>
 
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/deps/neverbleed/neverbleed.h
+++ b/deps/neverbleed/neverbleed.h
@@ -103,6 +103,8 @@ int neverbleed_setaffinity(neverbleed_t *nb, NEVERBLEED_CPU_SET_T *cpuset);
 extern void (*neverbleed_post_fork_cb)(void);
 /**
  * An optional callback used for replacing `iobuf_transaction`; i.e., the logic that sends the request and receives the response.
+ *
+ * If `responseless` equals `1`, the ownership of stack-allocated `req` is given to the callback. In this case, `req` must be free'd using `neverbleed_iobuf_dispose`
  */
 extern void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *req, int responseless);
 

--- a/src/main.c
+++ b/src/main.c
@@ -416,7 +416,7 @@ struct async_nb_transaction_t {
     neverbleed_iobuf_t *buf;
     size_t write_size;
     h2o_linklist_t link;
-    int reponseless;
+    int responseless;
     void (*on_read_complete)(struct async_nb_transaction_t *transaction);
 };
 
@@ -471,7 +471,7 @@ static void async_nb_on_write_complete(h2o_socket_t *sock, const char *err)
 {
     /* add to the read queue the entry for which we have written the request, and start reading from the socket */
     struct async_nb_transaction_t *transaction = async_nb_pop(&async_nb.write_queue);
-    if (!transaction->reponseless) {
+    if (!transaction->responseless) {
         async_nb_push(&async_nb.read_queue, transaction);
         if (!h2o_socket_is_reading(async_nb.sock))
             h2o_socket_read_start(async_nb.sock, async_nb_read_ready);
@@ -633,7 +633,7 @@ static void async_nb_transaction(neverbleed_iobuf_t *buf, int reponseless)
         *transaction = (struct async_nb_transaction_t){
             .buf = h2o_mem_alloc(sizeof(*transaction->buf)),
             .link = (h2o_linklist_t){},
-            .reponseless = 1,
+            .responseless = 1,
         };
 
         /* transfer ownership of stack `buf` to heap allocated `transaction->buf` */

--- a/src/main.c
+++ b/src/main.c
@@ -647,8 +647,11 @@ static void async_nb_transaction(neverbleed_iobuf_t *buf, int reponseless)
 
         async_nb_run_sync(buf, neverbleed_transaction_write);
 
-        if (!reponseless)
+        if (!reponseless) {
             async_nb_run_sync(buf, neverbleed_transaction_read);
+        } else {
+            neverbleed_iobuf_dispose(buf);
+        }
     }
 }
 


### PR DESCRIPTION
neverbleed exdata: https://github.com/h2o/neverbleed/pull/55

responless `buf`: if the async socket isn't available, the transaction will be performed synchronously and the buf must be free'd after use
