### PR TITLE
Fall back to `ftruncate` if `posix_fallocate` returns EINVAL

### DIFF
--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -449,12 +449,11 @@ h2o_iovec_t h2o_buffer_try_reserve(h2o_buffer_t **_inbuf, size_t min_guarantee)
                 int fallocate_ret;
 #if USE_POSIX_FALLOCATE
                 fallocate_ret = posix_fallocate(fd, 0, new_allocsize);
-                if (fallocate_ret != 0) {
+                if (fallocate_ret != EINVAL) {
                     errno = fallocate_ret;
-                }
-#else
-                fallocate_ret = ftruncate(fd, new_allocsize);
+                } else
 #endif
+                    fallocate_ret = ftruncate(fd, new_allocsize);
                 if (fallocate_ret != 0) {
                     h2o_perror("failed to resize temporary file");
                     goto MapError;


### PR DESCRIPTION
Because `posix_fallocate` may fail due to the underlying fs not supporting the semantics (of reserving disk blocks), see [`man posix_fallocate`](https://manpages.ubuntu.com/manpages/xenial/man3/posix_fallocate.3.html) as well as the behavior of zfs on FreeBSD.