### PR TITLE
Do not touch src/h2olog/generated_raw_tracer.cc unless necessary

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -31,6 +31,7 @@ RUN apt-get install --yes \
 	python3 \
 	python3-distutils \
 	redis-server \
+	rsync \
 	ruby-dev \
 	sudo \
 	systemtap-sdt-dev \

--- a/misc/docker-ci/Dockerfile.ubuntu2204
+++ b/misc/docker-ci/Dockerfile.ubuntu2204
@@ -38,6 +38,7 @@ RUN apt-get install --yes \
 	python3 \
 	python3-distutils \
 	redis-server \
+	rsync \
 	ruby-dev \
 	sudo \
 	systemtap-sdt-dev \

--- a/misc/regen.mk
+++ b/misc/regen.mk
@@ -5,6 +5,8 @@ exec $${H2O_PERL:-perl} -x $$0 "$$@"
 endef
 export FATPACK_SHEBANG
 
+GEN_RAW_TRACER_TMPFILE := $(shell mktemp -t gen_raw_tracer.XXXXXXXX)
+
 all: tokens lib/handler/mruby/embedded.c.h lib/http2/hpack_huffman_table.h lib/handler/file/templates.c.h clang-format-all share/h2o/start_server share/h2o/fastcgi-cgi share/h2o/ca-bundle.crt src/h2olog/generated_raw_tracer.cc
 
 tokens:
@@ -30,8 +32,9 @@ lib/handler/file/templates.c.h: misc/picotemplate-conf.pl lib/handler/file/_temp
 H2O_PROBES_D=h2o-probes.d
 QUICLY_PROBES_D=deps/quicly/quicly-probes.d
 
-src/h2olog/generated_raw_tracer.cc: src/h2olog/misc/gen_raw_tracer.py $(H2O_PROBES_D) $(QUICLY_PROBES_D) deps/quicly/include/quicly.h
-	src/h2olog/misc/gen_raw_tracer.py $@ $(QUICLY_PROBES_D) $(H2O_PROBES_D)
+src/h2olog/generated_raw_tracer.cc: FORCE
+	src/h2olog/misc/gen_raw_tracer.py $(GEN_RAW_TRACER_TMPFILE) $(QUICLY_PROBES_D) $(H2O_PROBES_D)
+	rsync --checksum $(GEN_RAW_TRACER_TMPFILE) $@
 
 clang-format-all:
 	misc/clang-format-all.sh


### PR DESCRIPTION
This PR amends #3215.

In #3215, we changed the source directory to read-only. However, we have kept the Make rule in misc/regen.mk that overwrites src/h2olog/generated_raw_tracer.cc if it is older than its dependencies.

While such rule is ordinary for a Makefile, it becomes problemsome when the CI process clones the source code from a remote repository then immediately starts building the code, as Git does not preserve the modification date of the files.

This PR changes the Make rule so that the .cc file will be overwritten only when it has to be changed. With the change, we would have two guarantees:
* the CI would fail if .cc is stale and has to be updated (CI fails because it cannot be overwritten), and
* the CI would succeed if .cc is not stale (because the file would never be overwritten).