### PR TITLE
[proxy] reject max_buffer_size of zero

### DIFF
--- a/lib/handler/configurator/proxy.c
+++ b/lib/handler/configurator/proxy.c
@@ -514,7 +514,13 @@ static int on_config_preserve_x_forwarded_proto(h2o_configurator_command_t *cmd,
 static int on_config_max_buffer_size(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     struct proxy_configurator_t *self = (void *)cmd->configurator;
-    return h2o_configurator_scanf(cmd, node, "%zu", &self->vars->conf.max_buffer_size);
+    if (h2o_configurator_scanf(cmd, node, "%zu", &self->vars->conf.max_buffer_size) != 0)
+        return -1;
+    if (self->vars->conf.max_buffer_size == 0) {
+        h2o_configurator_errprintf(cmd, node, "proxy.buffer_size must be a positive value");
+        return -1;
+    }
+    return 0;
 }
 
 static int on_config_http2_max_concurrent_streams(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -188,6 +188,8 @@ static void on_handler_dispose(h2o_handler_t *_self)
 
 void h2o_proxy_register_reverse_proxy(h2o_pathconf_t *pathconf, h2o_proxy_config_vars_t *config, h2o_socketpool_t *sockpool)
 {
+    assert(config->max_buffer_size != 0);
+
     struct rp_handler_t *self = (void *)h2o_create_handler(pathconf, sizeof(*self));
 
     self->super.on_context_init = on_context_init;


### PR DESCRIPTION
The connect handler and the proxy handler requires the value of `max_buffer_size` be set to a non-zero value (this value designates the capacity of the internal buffer used for forwarding the bytes).

Inside the connect handler we have had an assert that complains if the value is set to zero.

However, neither in the proxy handler nor the configurator have we had the logic to reject such configuration, as pointed out by #3225.

This PR adds such logic that enforce correct setup.