### PR TITLE
[reverse proxy] invalid memory read

### DIFF
--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -861,8 +861,10 @@ void h2o__proxy_process_request(h2o_req_t *req)
         if (!overrides->proxy_preserve_host)
             target = NULL;
     }
-    if (target == &target_buf)
-        h2o_url_init(&target_buf, req->scheme, req->authority, h2o_iovec_init(H2O_STRLIT("/")));
+    if (target == &target_buf && h2o_url_init(&target_buf, req->scheme, req->authority, h2o_iovec_init(H2O_STRLIT("/"))) != 0) {
+        h2o_send_error_400(req, "Invalid Request", "Invalid Request", H2O_SEND_ERROR_HTTP1_CLOSE_CONNECTION);
+        return;
+    }
 
     const char *upgrade_to = NULL;
     if (req->is_tunnel_req) {

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -165,7 +165,8 @@ static void build_request(h2o_req_t *req, h2o_iovec_t *method, h2o_url_t *url, h
     *method = h2o_strdup(&req->pool, req->method.base, req->method.len);
 
     /* url */
-    h2o_url_init(url, origin->scheme, req->authority, h2o_strdup(&req->pool, req->path.base, req->path.len));
+    if (h2o_url_init(url, origin->scheme, req->authority, h2o_strdup(&req->pool, req->path.base, req->path.len)) != 0)
+        h2o_fatal("h2o_url_init failed");
 
     if (props->connection_header != NULL) {
         if (upgrade_to != NULL && upgrade_to != h2o_httpclient_upgrade_to_connect) {


### PR DESCRIPTION
When handling certain type of malformed request received in HTTP/1, the reverse proxy uses an uninitialized pointer to read from memory.

Closes #3228. Security Advisory is coming.