### PR TITLE
run_openssl_client: do not delay by $timeout before writing request

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -855,7 +855,6 @@ sub run_openssl_client {
     diag("run_openssl_client: $cmd");
 
     my $cpid = open3(my $chld_in, my $chld_out, my $chld_err = gensym, $cmd);
-    sleep $timeout;
     $chld_in->autoflush(1);
 
     {


### PR DESCRIPTION
#2947 introduced `run_openssl_client` with an unconditional `sleep $timeout` after `open3` before the point at which the request is written (if set).  I do not think that that sleep is necessary.  

The correct use of `$timeout` is in the loop later that waits (at most `$timeout` seconds) for openssl to exit.