### PR TITLE
h3 server/proxy: It's possible that `proceed_request_streaming` gets called before a body chunk is received

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1066,7 +1066,7 @@ static void proceed_request_streaming(h2o_req_t *_req, const char *errstr)
     struct st_h2o_http3_server_conn_t *conn = get_conn(stream);
 
     assert(stream->req_body != NULL);
-    assert(!h2o_linklist_is_linked(&stream->link));
+    assert(errstr != NULL || !h2o_linklist_is_linked(&stream->link));
     assert(conn->num_streams_req_streaming != 0 || stream->req.is_tunnel_req);
 
     if (errstr != NULL || (quicly_recvstate_bytes_available(&stream->quic->recvstate) == 0 &&


### PR DESCRIPTION
```
h2o: /um/lib/http3/server.c:1069: proceed_request_streaming: Assertion `!h2o_linklist_is_linked(&stream->link)' failed.
(gdb) bt
 #4  0x00007ffff77629f6 in __assert_fail () from /usr/lib/libc.so.6
 #5  0x000055555567feb9 in proceed_request_streaming (_req=0x7fff3401ae30, errstr=0x5555557a4cd0 <h2o_httpclient_error_refused_stream> "refused stream")
     at /um/lib/http3/server.c:1075
 #6  0x0000555555630e67 in on_head (client=0x7fff3402e3d0, errstr=0x5555557a4cf8 <h2o_httpclient_error_io> "I/O error", args=0x0)
     at /um/lib/core/proxy.c:566
 #7  0x00005555555f3d92 in call_on_head (client=0x7fff3402e3d0, errstr=0x5555557a4cf8 <h2o_httpclient_error_io> "I/O error", args=0x0)
     at /um/lib/common/http1client.c:129
 #8  0x00005555555f3f40 in on_error (client=0x7fff3402e3d0, errstr=0x5555557a4cf8 <h2o_httpclient_error_io> "I/O error")
     at /um/lib/common/http1client.c:156
 #9  0x00005555555f4966 in on_head (sock=0x7fff34018b80, err=0x5555557a5e48 <h2o_socket_error_io> "I/O error") at /um/lib/common/http1client.c:399
 #10 0x0000555555607a3e in read_on_ready (sock=0x7fff34018b80) at /um/lib/common/socket/evloop.c.h:366
 #11 0x0000555555608ae5 in run_socket (sock=0x7fff34018b80) at /um/lib/common/socket/evloop.c.h:834
 #12 0x0000555555608cde in run_pending (loop=0x7fff34000b70) at /um/lib/common/socket/evloop.c.h:871
 #13 0x0000555555608edc in h2o_evloop_run (loop=0x7fff34000b70, max_wait=1000) at /um/lib/common/socket/evloop.c.h:925
 #14 0x0000555555781149 in run_loop (_thread_index=0x25) at /um/src/main.c:4103
```

This was possible to reproduce with https://github.com/h2o/h2o/pull/3234 , with clients doing:
```
while ./h2o-httpclient -b 100000 -t 1000 -o /dev/null -3  2> /dev/null; do; true; done
```

and a backend closing connections after accept:
```
while true; do timeout 0.01 nc -l -p 49999; done
```

I believe the fix is to handle error cases separately from the happy path in the h3 handler, and dispose of the stream.