### PR TITLE
[httpclient][http3] fix incorrect assumption leading to crashes when streaming request

### DIFF
--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -757,8 +757,7 @@ void start_request(struct st_h2o_http3client_req_t *req)
         emit_data(req, body);
     if (req->proceed_req.cb != NULL) {
         req->super.write_req = do_write_req;
-        if (body.len != 0)
-            req->proceed_req.bytes_inflight = body.len;
+        req->proceed_req.bytes_inflight = body.len;
     }
     if (req->proceed_req.cb == NULL && req->super.upgrade_to == NULL)
         quicly_sendstate_shutdown(&req->quic->sendstate, req->sendbuf->size);

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -478,7 +478,6 @@ h2o_httpclient_head_cb on_connect(h2o_httpclient_t *client, const char *errstr, 
         size_t clbuf_len = sprintf(clbuf, "%zu", req.body_size);
         h2o_add_header(client->pool, &headers_vec, H2O_TOKEN_CONTENT_LENGTH, NULL, clbuf, clbuf_len);
         *proceed_req_cb = filler_proceed_request;
-        create_timeout(client->ctx->loop, io_interval, filler_on_io_timeout, client);
     }
 
     *headers = headers_vec.entries;


### PR DESCRIPTION
The API contract around `proceed_req` is that if the callback is available, the client implementation first sends the bytes then call `proceed_req` to obtain more data to send.

That is the design and production ready code like lib/common/http1client.c, lib/common/http2client.c, lib/core/proxy.c behaves according to the design.

However, src/httpclient.c and lib/common/http3client.c did not obey to the contract.

That led to src/httpclient.c raising assertion failure when command line arguments like `-b 100 -d 100 -t 1000 -m POST` is given. Once the problem was fixed, lib/common/httpclient.c started to stall because it shared the incorrect assumption with src/httpclient.c.