### PR TITLE
Add the ability to log header bytes

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1277,9 +1277,13 @@ struct st_h2o_req_t {
      */
     h2o_res_t res;
     /**
-     * number of bytes sent by the generator (excluding headers)
+     * number of body bytes sent by the generator (excluding headers)
      */
     uint64_t bytes_sent;
+    /**
+     * number of header bytes sent by the generator
+     */
+    uint64_t header_bytes_sent;
     /**
      * the number of times the request can be reprocessed (excluding delegation)
      */

--- a/include/h2o/http2_common.h
+++ b/include/h2o/http2_common.h
@@ -105,9 +105,9 @@ void h2o_hpack_flatten_push_promise(h2o_buffer_t **buf, h2o_hpack_header_table_t
                                     uint32_t stream_id, size_t max_frame_size, const h2o_url_scheme_t *scheme,
                                     h2o_iovec_t authority, h2o_iovec_t method, h2o_iovec_t path, const h2o_header_t *headers,
                                     size_t num_headers, uint32_t parent_stream_id);
-void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
-                                uint32_t stream_id, size_t max_frame_size, int status, const h2o_header_t *headers,
-                                size_t num_headers, const h2o_iovec_t *server_name, size_t content_length);
+size_t h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                                  uint32_t stream_id, size_t max_frame_size, int status, const h2o_header_t *headers,
+                                  size_t num_headers, const h2o_iovec_t *server_name, size_t content_length);
 void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
                                uint32_t stream_id, size_t max_frame_size, h2o_iovec_t method, h2o_url_t *url,
                                const h2o_header_t *headers, size_t num_headers, int is_end_stream);

--- a/include/h2o/qpack.h
+++ b/include/h2o/qpack.h
@@ -79,6 +79,7 @@ h2o_iovec_t h2o_qpack_flatten_request(h2o_qpack_encoder_t *qpack, h2o_mem_pool_t
  */
 h2o_iovec_t h2o_qpack_flatten_response(h2o_qpack_encoder_t *qpack, h2o_mem_pool_t *pool, int64_t stream_id,
                                        h2o_byte_vector_t *encoder_buf, int status, const h2o_header_t *headers, size_t num_headers,
-                                       const h2o_iovec_t *server_name, size_t content_length, h2o_iovec_t datagram_flow_id);
+                                       const h2o_iovec_t *server_name, size_t content_length, h2o_iovec_t datagram_flow_id,
+                                       size_t *serialized_header_len);
 
 #endif

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -28,7 +28,7 @@ enum {
     ELEMENT_TYPE_EMPTY,                         /* empty element (with suffix only) */
     ELEMENT_TYPE_LOCAL_ADDR,                    /* %A */
     ELEMENT_TYPE_BYTES_SENT,                    /* %b */
-    ELEMENT_TYPE_HEADER_BYTES_SENT,             /* %{header-bytes}x */
+    ELEMENT_TYPE_HEADER_BYTES_SENT,             /* %{response-header-bytes}x */
     ELEMENT_TYPE_PROTOCOL,                      /* %H */
     ELEMENT_TYPE_REMOTE_ADDR,                   /* %h */
     ELEMENT_TYPE_LOGNAME,                       /* %l */

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -28,6 +28,7 @@ enum {
     ELEMENT_TYPE_EMPTY,                         /* empty element (with suffix only) */
     ELEMENT_TYPE_LOCAL_ADDR,                    /* %A */
     ELEMENT_TYPE_BYTES_SENT,                    /* %b */
+    ELEMENT_TYPE_HEADER_BYTES_SENT,             /* %{header-bytes}x */
     ELEMENT_TYPE_PROTOCOL,                      /* %H */
     ELEMENT_TYPE_REMOTE_ADDR,                   /* %h */
     ELEMENT_TYPE_LOGNAME,                       /* %l */
@@ -266,6 +267,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_TOTAL_TIME);
                     MAP_EXT_TO_TYPE("total-time", ELEMENT_TYPE_TOTAL_TIME);
                     MAP_EXT_TO_TYPE("error", ELEMENT_TYPE_ERROR);
+                    MAP_EXT_TO_TYPE("header-bytes", ELEMENT_TYPE_HEADER_BYTES_SENT);
                     MAP_EXT_TO_TYPE("proxy.idle-time", ELEMENT_TYPE_PROXY_IDLE_TIME);
                     MAP_EXT_TO_TYPE("proxy.connect-time", ELEMENT_TYPE_PROXY_CONNECT_TIME);
                     MAP_EXT_TO_TYPE("proxy.request-time", ELEMENT_TYPE_PROXY_REQUEST_TIME);
@@ -591,6 +593,10 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
         case ELEMENT_TYPE_BYTES_SENT: /* %b */
             RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
             pos += sprintf(pos, "%" PRIu64, req->bytes_sent);
+            break;
+        case ELEMENT_TYPE_HEADER_BYTES_SENT: /* %{header_bytes} */
+            RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
+            pos += sprintf(pos, "%" PRIu64, req->header_bytes_sent);
             break;
         case ELEMENT_TYPE_PROTOCOL: /* %H */
             if (req->version == 0)

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -594,7 +594,7 @@ char *h2o_log_request(h2o_logconf_t *logconf, h2o_req_t *req, size_t *len, char 
             RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
             pos += sprintf(pos, "%" PRIu64, req->bytes_sent);
             break;
-        case ELEMENT_TYPE_HEADER_BYTES_SENT: /* %{header_bytes} */
+        case ELEMENT_TYPE_HEADER_BYTES_SENT: /* %{response-header-bytes}x */
             RESERVE(sizeof(H2O_UINT64_LONGEST_STR) - 1);
             pos += sprintf(pos, "%" PRIu64, req->header_bytes_sent);
             break;

--- a/lib/core/logconf.c
+++ b/lib/core/logconf.c
@@ -267,7 +267,7 @@ h2o_logconf_t *h2o_logconf_compile(const char *fmt, int escape, char *errbuf)
                     MAP_EXT_TO_TYPE("duration", ELEMENT_TYPE_TOTAL_TIME);
                     MAP_EXT_TO_TYPE("total-time", ELEMENT_TYPE_TOTAL_TIME);
                     MAP_EXT_TO_TYPE("error", ELEMENT_TYPE_ERROR);
-                    MAP_EXT_TO_TYPE("header-bytes", ELEMENT_TYPE_HEADER_BYTES_SENT);
+                    MAP_EXT_TO_TYPE("response-header-bytes", ELEMENT_TYPE_HEADER_BYTES_SENT);
                     MAP_EXT_TO_TYPE("proxy.idle-time", ELEMENT_TYPE_PROXY_IDLE_TIME);
                     MAP_EXT_TO_TYPE("proxy.connect-time", ELEMENT_TYPE_PROXY_CONNECT_TIME);
                     MAP_EXT_TO_TYPE("proxy.request-time", ELEMENT_TYPE_PROXY_REQUEST_TIME);

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -1035,7 +1035,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
             flatten_headers_estimate_size(&conn->req, conn->super.ctx->globalconf->server_name.len + strlen(connection));
         h2o_sendvec_init_raw(bufs + bufcnt, h2o_mem_alloc_pool(&conn->req.pool, char, headers_est_size), 0);
         bufs[bufcnt].len = flatten_headers(bufs[bufcnt].raw, &conn->req, connection);
-        conn->req.header_bytes_sent = bufs[bufcnt].len;
+        conn->req.header_bytes_sent += bufs[bufcnt].len;
         ++bufcnt;
         h2o_probe_log_response(&conn->req, conn->_req_index);
         conn->_ostr_final.state = OSTREAM_STATE_BODY;
@@ -1115,6 +1115,8 @@ static void finalostream_send_informational(h2o_ostream_t *_self, h2o_req_t *req
     dst += flatten_res_headers(dst, req);
     *dst++ = '\r';
     *dst++ = '\n';
+
+    req->header_bytes_sent += dst - buf.base;
 
     h2o_vector_reserve(&req->pool, &conn->_ostr_final.informational.pending, conn->_ostr_final.informational.pending.size + 1);
     conn->_ostr_final.informational.pending.entries[conn->_ostr_final.informational.pending.size++] = buf;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -1035,6 +1035,7 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
             flatten_headers_estimate_size(&conn->req, conn->super.ctx->globalconf->server_name.len + strlen(connection));
         h2o_sendvec_init_raw(bufs + bufcnt, h2o_mem_alloc_pool(&conn->req.pool, char, headers_est_size), 0);
         bufs[bufcnt].len = flatten_headers(bufs[bufcnt].raw, &conn->req, connection);
+        conn->req.header_bytes_sent = bufs[bufcnt].len;
         ++bufcnt;
         h2o_probe_log_response(&conn->req, conn->_req_index);
         conn->_ostr_final.state = OSTREAM_STATE_BODY;

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -1064,10 +1064,12 @@ size_t h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *
     if (content_length != SIZE_MAX)
         dst = encode_content_length(dst, content_length);
     (*buf)->size = (char *)dst - (*buf)->bytes;
+    size_t headers_size = (*buf)->size - start_at - H2O_HTTP2_FRAME_HEADER_SIZE;
 
     /* setup the frame headers */
     fixup_frame_headers(buf, start_at, H2O_HTTP2_FRAME_TYPE_HEADERS, stream_id, max_frame_size, 0);
-    return (*buf)->size - start_at - H2O_HTTP2_FRAME_HEADER_SIZE;
+
+    return header_size;
 }
 
 void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -1031,9 +1031,9 @@ void h2o_hpack_flatten_push_promise(h2o_buffer_t **buf, h2o_hpack_header_table_t
     fixup_frame_headers(buf, start_at, H2O_HTTP2_FRAME_TYPE_PUSH_PROMISE, parent_stream_id, max_frame_size, 0);
 }
 
-void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
-                                uint32_t stream_id, size_t max_frame_size, int status, const h2o_header_t *headers,
-                                size_t num_headers, const h2o_iovec_t *server_name, size_t content_length)
+size_t h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
+                                  uint32_t stream_id, size_t max_frame_size, int status, const h2o_header_t *headers,
+                                  size_t num_headers, const h2o_iovec_t *server_name, size_t content_length)
 {
     size_t capacity = calc_headers_capacity(headers, num_headers);
     capacity += H2O_HTTP2_FRAME_HEADER_SIZE; /* for the first header */
@@ -1067,6 +1067,7 @@ void h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *he
 
     /* setup the frame headers */
     fixup_frame_headers(buf, start_at, H2O_HTTP2_FRAME_TYPE_HEADERS, stream_id, max_frame_size, 0);
+    return (*buf)->size - start_at;
 }
 
 void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -1067,7 +1067,7 @@ size_t h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *
 
     /* setup the frame headers */
     fixup_frame_headers(buf, start_at, H2O_HTTP2_FRAME_TYPE_HEADERS, stream_id, max_frame_size, 0);
-    return (*buf)->size - start_at;
+    return (*buf)->size - start_at - H2O_HTTP2_FRAME_HEADER_SIZE;
 }
 
 void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -1069,7 +1069,7 @@ size_t h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *
     /* setup the frame headers */
     fixup_frame_headers(buf, start_at, H2O_HTTP2_FRAME_TYPE_HEADERS, stream_id, max_frame_size, 0);
 
-    return header_size;
+    return headers_size;
 }
 
 void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -299,10 +299,10 @@ static int send_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *stream)
                               H2O_STRLIT("pushed"));
     if (stream->req.send_server_timing)
         h2o_add_server_timing_header(&stream->req, 1);
-    h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size,
-                               stream->stream_id, conn->peer_settings.max_frame_size, stream->req.res.status,
-                               stream->req.res.headers.entries, stream->req.res.headers.size,
-                               &conn->super.ctx->globalconf->server_name, stream->req.res.content_length);
+    stream->req.header_bytes_sent += h2o_hpack_flatten_response(
+        &conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size, stream->stream_id,
+        conn->peer_settings.max_frame_size, stream->req.res.status, stream->req.res.headers.entries, stream->req.res.headers.size,
+        &conn->super.ctx->globalconf->server_name, stream->req.res.content_length);
     h2o_http2_conn_request_write(conn);
     h2o_http2_stream_set_state(conn, stream, H2O_HTTP2_STREAM_STATE_SEND_BODY);
 
@@ -383,9 +383,9 @@ static void finalostream_send_informational(h2o_ostream_t *self, h2o_req_t *req)
     h2o_http2_stream_t *stream = H2O_STRUCT_FROM_MEMBER(h2o_http2_stream_t, _ostr_final, self);
     h2o_http2_conn_t *conn = (h2o_http2_conn_t *)req->conn;
 
-    h2o_hpack_flatten_response(&conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size,
-                               stream->stream_id, conn->peer_settings.max_frame_size, req->res.status, req->res.headers.entries,
-                               req->res.headers.size, NULL, SIZE_MAX);
+    stream->req.header_bytes_sent += h2o_hpack_flatten_response(
+        &conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size, stream->stream_id,
+        conn->peer_settings.max_frame_size, req->res.status, req->res.headers.entries, req->res.headers.size, NULL, SIZE_MAX);
     h2o_http2_conn_request_write(conn);
 }
 

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -1238,7 +1238,7 @@ static void prepare_flatten(struct st_h2o_qpack_flatten_context_t *ctx, h2o_qpac
     ctx->headers_buf.size = PREFIX_CAPACITY;
 }
 
-static h2o_iovec_t finalize_flatten(struct st_h2o_qpack_flatten_context_t *ctx)
+static h2o_iovec_t finalize_flatten(struct st_h2o_qpack_flatten_context_t *ctx, size_t *serialized_header_len)
 {
     if (ctx->largest_ref == 0) {
         ctx->base_index = 0;
@@ -1279,6 +1279,8 @@ static h2o_iovec_t finalize_flatten(struct st_h2o_qpack_flatten_context_t *ctx)
 
     /* prepend frame header */
     size_t len_len = quicly_encodev_capacity(ctx->headers_buf.size - start_off);
+    if (serialized_header_len != NULL)
+        *serialized_header_len = ctx->headers_buf.size - start_off;
     quicly_encodev(ctx->headers_buf.entries + start_off - len_len, ctx->headers_buf.size - start_off);
     start_off -= len_len;
     ctx->headers_buf.entries[--start_off] = H2O_HTTP3_FRAME_TYPE_HEADERS;
@@ -1320,12 +1322,13 @@ h2o_iovec_t h2o_qpack_flatten_request(h2o_qpack_encoder_t *_qpack, h2o_mem_pool_
         flatten_known_header_with_static_lookup(&ctx, h2o_qpack_lookup_datagram_flow_id, H2O_TOKEN_DATAGRAM_FLOW_ID,
                                                 datagram_flow_id);
 
-    return finalize_flatten(&ctx);
+    return finalize_flatten(&ctx, NULL);
 }
 
 h2o_iovec_t h2o_qpack_flatten_response(h2o_qpack_encoder_t *_qpack, h2o_mem_pool_t *_pool, int64_t _stream_id,
                                        h2o_byte_vector_t *_encoder_buf, int status, const h2o_header_t *headers, size_t num_headers,
-                                       const h2o_iovec_t *server_name, size_t content_length, h2o_iovec_t datagram_flow_id)
+                                       const h2o_iovec_t *server_name, size_t content_length, h2o_iovec_t datagram_flow_id,
+                                       size_t *serialized_header_len)
 {
     struct st_h2o_qpack_flatten_context_t ctx;
 
@@ -1386,5 +1389,5 @@ h2o_iovec_t h2o_qpack_flatten_response(h2o_qpack_encoder_t *_qpack, h2o_mem_pool
         flatten_known_header_with_static_lookup(&ctx, h2o_qpack_lookup_datagram_flow_id, H2O_TOKEN_DATAGRAM_FLOW_ID,
                                                 datagram_flow_id);
 
-    return finalize_flatten(&ctx);
+    return finalize_flatten(&ctx, serialized_header_len);
 }

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -1277,10 +1277,11 @@ static h2o_iovec_t finalize_flatten(struct st_h2o_qpack_flatten_context_t *ctx, 
         start_off -= p - buf;
     }
 
-    /* prepend frame header */
-    size_t len_len = quicly_encodev_capacity(ctx->headers_buf.size - start_off);
     if (serialized_header_len != NULL)
         *serialized_header_len = ctx->headers_buf.size - start_off;
+
+    /* prepend frame header */
+    size_t len_len = quicly_encodev_capacity(ctx->headers_buf.size - start_off);
     quicly_encodev(ctx->headers_buf.entries + start_off - len_len, ctx->headers_buf.size - start_off);
     start_off -= len_len;
     ctx->headers_buf.entries[--start_off] = H2O_HTTP3_FRAME_TYPE_HEADERS;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1414,11 +1414,12 @@ static int handle_input_expect_headers(struct st_h2o_http3_server_stream_t *stre
 
 static void write_response(struct st_h2o_http3_server_stream_t *stream, h2o_iovec_t datagram_flow_id)
 {
+    size_t serialized_header_len = 0;
     h2o_iovec_t frame = h2o_qpack_flatten_response(
         get_conn(stream)->h3.qpack.enc, &stream->req.pool, stream->quic->stream_id, NULL, stream->req.res.status,
         stream->req.res.headers.entries, stream->req.res.headers.size, &get_conn(stream)->super.ctx->globalconf->server_name,
-        stream->req.res.content_length, datagram_flow_id);
-    stream->req.header_bytes_sent += frame.len;
+        stream->req.res.content_length, datagram_flow_id, &serialized_header_len);
+    stream->req.header_bytes_sent += serialized_header_len;
 
     h2o_vector_reserve(&stream->req.pool, &stream->sendbuf.vecs, stream->sendbuf.vecs.size + 1);
     struct st_h2o_http3_server_sendvec_t *vec = stream->sendbuf.vecs.entries + stream->sendbuf.vecs.size++;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1418,6 +1418,7 @@ static void write_response(struct st_h2o_http3_server_stream_t *stream, h2o_iove
         get_conn(stream)->h3.qpack.enc, &stream->req.pool, stream->quic->stream_id, NULL, stream->req.res.status,
         stream->req.res.headers.entries, stream->req.res.headers.size, &get_conn(stream)->super.ctx->globalconf->server_name,
         stream->req.res.content_length, datagram_flow_id);
+    stream->req.header_bytes_sent += frame.len;
 
     h2o_vector_reserve(&stream->req.pool, &stream->sendbuf.vecs, stream->sendbuf.vecs.size + 1);
     struct st_h2o_http3_server_sendvec_t *vec = stream->sendbuf.vecs.entries + stream->sendbuf.vecs.size++;

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -96,7 +96,7 @@ subtest "custom-log" => sub {
             system("curl --http2 -k --silent --referer http://example.com/ https://127.0.0.1:$server->{tls_port}/ > /dev/null");
             system("$client_prog -3 100 -Huser-agent:curl/not-really -Hreferer:http://example.com/ -k https://127.0.0.1:$server->{quic_port} > /dev/null 2>&1");
         },
-        '%h %l %u %t "%r" %s %b %{header-bytes}x "%{Referer}i" "%{User-agent}i"',
+        '%h %l %u %t "%r" %s %b %{response-header-bytes}x "%{Referer}i" "%{User-agent}i"',
         [ qr{^127\.0\.0\.1 - - \[[0-9]{2}/[A-Z][a-z]{2}/20[0-9]{2}:[0-9]{2}:[0-9]{2}:[0-9]{2} [+\-][0-9]{4}\] "GET / HTTP/1\.1" 200 6 24\d "http://example.com/" "curl/.*"$},
           qr{^127\.0\.0\.1 - - \[[0-9]{2}/[A-Z][a-z]{2}/20[0-9]{2}:[0-9]{2}:[0-9]{2}:[0-9]{2} [+\-][0-9]{4}\] "GET / HTTP/1\.1" 200 6 24\d "http://example.com/" "curl/.*"$},
           qr{^127\.0\.0\.1 - - \[[0-9]{2}/[A-Z][a-z]{2}/20[0-9]{2}:[0-9]{2}:[0-9]{2}:[0-9]{2} [+\-][0-9]{4}\] "GET / HTTP/2" 200 6 1\d\d "http://example.com/" "curl/.*"$} ,


### PR DESCRIPTION
We currently have the ability to log body bytes via %b. This PR adds the ability to also log the header bytes via %{header_bytes}