### PR TITLE
[http2][http3] tighten header validation

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -679,6 +679,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		080590262A5E463A00B2B10E /* 40http2-header-softerror.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http2-header-softerror.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		080B3CC227E1AF6C004AC8E6 /* config.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = config.c; sourceTree = "<group>"; };
 		080D35EA1D5E060D0029B7E5 /* http2_debug_state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = http2_debug_state.c; sourceTree = "<group>"; };
 		0810E6A7286DACB600333FA4 /* 50reverse-proxy-null-host-header.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50reverse-proxy-null-host-header.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -2231,6 +2232,7 @@
 				E9D49A4F25FB561A00F4A80D /* 40http1-streaming-framing.t */,
 				E9414F9724ED1D7500273C59 /* 40http2-h2spec-client.t */,
 				E9F677CA1FF47BD0006476D3 /* 40http2-h2spec.t */,
+				080590262A5E463A00B2B10E /* 40http2-header-softerror.t */,
 				E9BCE6921FF344D4003CEA11 /* 40http2-request-window-size.t */,
 				E98041C22230C45E008B9745 /* 40http3.t */,
 				086001BE2730B6E30043886F /* 40http3-corrupted-scid-initial.t */,

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -236,7 +236,7 @@ static h2o_iovec_t *decode_string(h2o_mem_pool_t *pool, unsigned *soft_errors, c
         if ((ret->len = h2o_hpack_decode_huffman(ret->base, soft_errors, *src, len, is_header_name, err_desc)) == SIZE_MAX)
             return NULL;
         ret->base[ret->len] = '\0';
-        if (!header_value_valid_as_whole(ret->base, ret->len))
+        if (!is_header_name && !header_value_valid_as_whole(ret->base, ret->len))
             *soft_errors |= H2O_HPACK_SOFT_ERROR_BIT_INVALID_VALUE;
     } else {
         if (len > src_end - *src)

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -243,7 +243,8 @@ static h2o_iovec_t *decode_string(h2o_mem_pool_t *pool, unsigned *soft_errors, c
             return NULL;
         if (is_header_name) {
             /* pseudo-headers are checked later in `decode_header` */
-            if (**src != (uint8_t)':' && !h2o_hpack_validate_header_name(soft_errors, (char *)*src, len, err_desc))
+            if ((len == 0 || **src != (uint8_t)':') &&
+                !h2o_hpack_validate_header_name(soft_errors, (char *)*src, len, err_desc))
                 return NULL;
         } else {
             h2o_hpack_validate_header_value(soft_errors, (char *)*src, len);

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -643,6 +643,35 @@ static void test_dynamic_table_size_update(void)
     h2o_buffer_dispose(&buf);
 }
 
+static void test_empty_header_name(void)
+{
+    const uint8_t literal_huff[] = {0x80}, literal_nohuff[] = {0x00}, *src, *end;
+    h2o_mem_pool_t pool;
+    unsigned soft_errors;
+    const char *err_desc;
+    h2o_iovec_t *result;
+
+    h2o_mem_init_pool(&pool);
+
+    src = literal_huff;
+    end = literal_huff + sizeof(literal_huff);
+    soft_errors = 0;
+    result = decode_string(&pool, &soft_errors, &src, end, 1, &err_desc);
+    ok(result != NULL);
+    ok(result->len == 0);
+    ok(soft_errors == H2O_HPACK_SOFT_ERROR_BIT_INVALID_NAME);
+
+    src = literal_nohuff;
+    end = literal_nohuff + sizeof(literal_nohuff);
+    soft_errors = 0;
+    result = decode_string(&pool, &soft_errors, &src, end, 1, &err_desc);
+    ok(result != NULL);
+    ok(result->len == 0);
+    ok(soft_errors == H2O_HPACK_SOFT_ERROR_BIT_INVALID_NAME);
+
+    h2o_mem_clear_pool(&pool);
+}
+
 void test_lib__http2__hpack(void)
 {
     subtest("hpack", test_hpack);
@@ -651,4 +680,5 @@ void test_lib__http2__hpack(void)
     subtest("token-wo-hpack-id", test_token_wo_hpack_id);
     subtest("inherit-invalid", test_inherit_invalid);
     subtest("dynamic-table-size-update", test_dynamic_table_size_update);
+    subtest("empty-header-name", test_empty_header_name);
 }

--- a/t/00unit/lib/http2/hpack.c
+++ b/t/00unit/lib/http2/hpack.c
@@ -643,33 +643,40 @@ static void test_dynamic_table_size_update(void)
     h2o_buffer_dispose(&buf);
 }
 
-static void test_empty_header_name(void)
+static void do_test_more_soft_error(const uint8_t *src, size_t len, int is_header_name, h2o_iovec_t expected_result)
 {
-    const uint8_t literal_huff[] = {0x80}, literal_nohuff[] = {0x00}, *src, *end;
     h2o_mem_pool_t pool;
-    unsigned soft_errors;
-    const char *err_desc;
+    unsigned soft_errors = 0;
+    const char *err_desc = NULL;
     h2o_iovec_t *result;
 
     h2o_mem_init_pool(&pool);
 
-    src = literal_huff;
-    end = literal_huff + sizeof(literal_huff);
-    soft_errors = 0;
-    result = decode_string(&pool, &soft_errors, &src, end, 1, &err_desc);
+    result = decode_string(&pool, &soft_errors, &src, src + len, is_header_name, &err_desc);
     ok(result != NULL);
-    ok(result->len == 0);
-    ok(soft_errors == H2O_HPACK_SOFT_ERROR_BIT_INVALID_NAME);
-
-    src = literal_nohuff;
-    end = literal_nohuff + sizeof(literal_nohuff);
-    soft_errors = 0;
-    result = decode_string(&pool, &soft_errors, &src, end, 1, &err_desc);
-    ok(result != NULL);
-    ok(result->len == 0);
-    ok(soft_errors == H2O_HPACK_SOFT_ERROR_BIT_INVALID_NAME);
+    ok(h2o_memis(result->base, result->len, expected_result.base, expected_result.len));
+    ok(soft_errors == (is_header_name ? H2O_HPACK_SOFT_ERROR_BIT_INVALID_NAME : H2O_HPACK_SOFT_ERROR_BIT_INVALID_VALUE));
+    ok(err_desc == NULL);
 
     h2o_mem_clear_pool(&pool);
+}
+
+static void test_more_soft_errors(void)
+{
+    note("empty header name, huffman");
+    do_test_more_soft_error((const uint8_t[]){0x80}, 1, 1, h2o_iovec_init(H2O_STRLIT("")));
+    note("empty header name, no huffman");
+    do_test_more_soft_error((const uint8_t[]){0x00}, 1, 1, h2o_iovec_init(H2O_STRLIT("")));
+
+    /* whitespace around header values; see RFC 9113 8.2.1 */
+    note("header value w. preceding whitespace, huffman");
+    do_test_more_soft_error((const uint8_t[]){0x83, 0x50, 0x71, 0xff}, 4, 0, h2o_iovec_init(H2O_STRLIT(" ab")));
+    do_test_more_soft_error((const uint8_t[]){0x85, 0xff, 0xff, 0xea, 0x1c, 0x7f}, 6, 0, h2o_iovec_init(H2O_STRLIT("\tab")));
+    do_test_more_soft_error((const uint8_t[]){0x83, 0x1c, 0x6a, 0x7f}, 4, 0, h2o_iovec_init(H2O_STRLIT("ab ")));
+    note("header value w. preceding whitespace, no huffman");
+    do_test_more_soft_error((const uint8_t[]){0x03, 0x20, 'a', 'b'}, 4, 0, h2o_iovec_init(H2O_STRLIT(" ab")));
+    do_test_more_soft_error((const uint8_t[]){0x03, 0x09, 'a', 'b'}, 4, 0, h2o_iovec_init(H2O_STRLIT("\tab")));
+    do_test_more_soft_error((const uint8_t[]){0x03, 'a', 'b', 0x20}, 4, 0, h2o_iovec_init(H2O_STRLIT("ab ")));
 }
 
 void test_lib__http2__hpack(void)
@@ -680,5 +687,5 @@ void test_lib__http2__hpack(void)
     subtest("token-wo-hpack-id", test_token_wo_hpack_id);
     subtest("inherit-invalid", test_inherit_invalid);
     subtest("dynamic-table-size-update", test_dynamic_table_size_update);
-    subtest("empty-header-name", test_empty_header_name);
+    subtest("empty-header-name", test_more_soft_errors);
 }

--- a/t/40http2-header-softerror.t
+++ b/t/40http2-header-softerror.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use IO::Socket::IP;
+use Test::More;
+use t::Util;
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        file.dir: @{[DOC_ROOT]}
+access-log:
+  format: '\%s'
+  path: $tempdir/access_log
+EOT
+
+sleep 0.5;
+
+open my $logfh, "<", "$tempdir/access_log"
+    or die "failed to open $tempdir/access_log:$!";
+
+subtest "empty-header-name" => sub {
+    submit("GET / HTTP/1.0\r\n\r\n");
+    is get_status(), 200;
+    submit("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00=\x01\x05\x00\x00\x00\x01\x00\n:authority\tlocalhost\x00\x05:path\x01/\x00\x07:method\x03GET\x00\x07:scheme\x04http\x00\x00\x00");
+    is get_status(), 400;
+};
+
+subtest "header-values-with-surronding-space" => sub {
+    submit("GET / HTTP/1.0\r\n\r\n");
+    is get_status(), 200;
+    submit("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00E\x01\x05\x00\x00\x00\x01\x00\n:authority\tlocalhost\x00\x05:path\x01/\x00\x07:method\x03GET\x00\x07:scheme\x04http\x00\x05test1\x03\ta\t");
+    is get_status(), 400;
+};
+
+done_testing;
+
+# connect, send (broken) request, read something
+sub submit {
+    my $msg = shift;
+
+    my $sock = IO::Socket::IP->new(
+        PeerHost => "127.0.0.1",
+        PeerPort => $server->{port},
+        Type     => SOCK_STREAM,
+    ) or die "failed to connect to 127.0.0.1:@{[$server->{port}]}:$!";
+    $sock->syswrite($msg);
+    $sock->sysread(my $resp, 1024);
+}
+
+# read status from access log
+sub get_status {
+    my $line = <$logfh>;
+    chomp $line;
+    $line;
+}

--- a/t/40http2-header-softerror.t
+++ b/t/40http2-header-softerror.t
@@ -3,6 +3,7 @@ use warnings;
 use File::Temp qw(tempdir);
 use IO::Socket::IP;
 use Test::More;
+use Time::HiRes qw(sleep);
 use t::Util;
 
 my $tempdir = tempdir(CLEANUP => 1);
@@ -25,15 +26,19 @@ open my $logfh, "<", "$tempdir/access_log"
 
 subtest "empty-header-name" => sub {
     submit("GET / HTTP/1.0\r\n\r\n");
+    sleep 0.1;
     is get_status(), 200;
     submit("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00=\x01\x05\x00\x00\x00\x01\x00\n:authority\tlocalhost\x00\x05:path\x01/\x00\x07:method\x03GET\x00\x07:scheme\x04http\x00\x00\x00");
+    sleep 0.1;
     is get_status(), 400;
 };
 
 subtest "header-values-with-surronding-space" => sub {
     submit("GET / HTTP/1.0\r\n\r\n");
+    sleep 0.1;
     is get_status(), 200;
     submit("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00E\x01\x05\x00\x00\x00\x01\x00\n:authority\tlocalhost\x00\x05:path\x01/\x00\x07:method\x03GET\x00\x07:scheme\x04http\x00\x05test1\x03\ta\t");
+    sleep 0.1;
     is get_status(), 400;
 };
 


### PR DESCRIPTION
As pointed out and discussed in #3250, RFC 9113 (2nd revision of HTTP/2 specification) tightened the requirements against HTTP/2 intermediaries rejecting invalid header fields.

This PR makes necessary changes so that we are conformant to the new revision. Specifically, header fields carrying values surrounded by whitespace are rejected, and also those with empty (i.e., zero-length) names.

Latter is not an explicit requirement of RFC 9113 though RFC 9110 defines field names as carrying at least one character.