### PR TITLE
skip checking for dependency executables if SKIP_PROG_EXISTS is set

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu2204
+++ b/misc/docker-ci/Dockerfile.ubuntu2204
@@ -61,7 +61,8 @@ RUN apt-get install --yes \
 	libwww-perl \
 	libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
+RUN cpanm -n Test::More Starlet Protocol::HTTP2 Test::TCP
+RUN cpanm -n NLNETLABS/Net-DNS-1.36.tar.gz # Net-DNS 1.39 has issues around use of alarm, fork, etc.
 
 # boringssl
 RUN apt-get install --yes golang-go

--- a/misc/docker-ci/Dockerfile.ubuntu2204
+++ b/misc/docker-ci/Dockerfile.ubuntu2204
@@ -15,6 +15,7 @@ RUN apt-get install --yes \
 	dnsutils \
 	flex \
 	git \
+	iproute2 \
 	libbpfcc-dev \
 	libbrotli-dev \
 	libc-ares-dev \

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -41,14 +41,14 @@ ossl3.0:
 		make -f $(SRC_DIR)/misc/docker-ci/check.mk _check \
 		CMAKE_ARGS='-DCMAKE_C_FLAGS=-Werror=format' \
 		BUILD_ARGS='$(BUILD_ARGS)' \
-		TEST_ENV='$(TEST_ENV)'
+		TEST_ENV='SKIP_PROG_EXISTS=1 $(TEST_ENV)'
 
 boringssl:
 	docker run $(DOCKER_RUN_OPTS) h2oserver/h2o-ci:ubuntu2204 \
 		make -f $(SRC_DIR)/misc/docker-ci/check.mk _check \
 		CMAKE_ARGS='-DOPENSSL_ROOT_DIR=/opt/boringssl' \
 		BUILD_ARGS='$(BUILD_ARGS)' \
-		TEST_ENV='$(TEST_ENV)'
+		TEST_ENV='SKIP_PROG_EXISTS=1 $(TEST_ENV)'
 
 asan:
 	docker run $(DOCKER_RUN_OPTS) h2oserver/h2o-ci:ubuntu2004 \
@@ -63,7 +63,7 @@ coverage:
 		make -f $(SRC_DIR)/misc/docker-ci/check.mk _check _coverage_report \
 		CMAKE_ARGS='-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping -mllvm -runtime-counter-relocation" -DCMAKE_CXX_FLAGS= -DCMAKE_BUILD_TYPE=Debug -DWITH_H2OLOG=OFF' \
 		BUILD_ARGS='$(BUILD_ARGS)' \
-		TEST_ENV='LLVM_PROFILE_FILE=/home/ci/profraw/%c%p.profraw $(TEST_ENV)'
+		TEST_ENV='SKIP_PROG_EXISTS=1 LLVM_PROFILE_FILE=/home/ci/profraw/%c%p.profraw $(TEST_ENV)'
 
 _coverage_report:
 	llvm-profdata merge -sparse -o h2o.profdata /home/ci/profraw/*.profraw
@@ -86,7 +86,7 @@ _do_check:
 	time komake $(BUILD_ARGS) all checkdepends
 	if [ -e h2o-fuzzer-http1 ] ; then export $(FUZZ_ASAN); fi; \
 		ulimit -n 1024; \
-		env SKIP_PROG_EXISTS=1 $(TEST_ENV) make check
+		env $(TEST_ENV) make check
 
 enter:
 	docker run $(DOCKER_RUN_OPTS) -it $(CONTAINER_NAME) bash

--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -86,7 +86,7 @@ _do_check:
 	time komake $(BUILD_ARGS) all checkdepends
 	if [ -e h2o-fuzzer-http1 ] ; then export $(FUZZ_ASAN); fi; \
 		ulimit -n 1024; \
-		env $(TEST_ENV) make check
+		env SKIP_PROG_EXISTS=1 $(TEST_ENV) make check
 
 enter:
 	docker run $(DOCKER_RUN_OPTS) -it $(CONTAINER_NAME) bash

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -354,6 +354,9 @@ sub etag_file {
 
 sub prog_exists {
     my $prog = shift;
+    # if SKIP_PROG_EXISTS environment variable is set (e.g., in case of running on CI image), all programs are assumed to exist
+    return 1
+        if $ENV{SKIP_PROG_EXISTS};
     system("which $prog > /dev/null 2>&1") == 0;
 }
 


### PR DESCRIPTION
ToDo: forbid skip in other forms too (e.g., `curl_supports_http2`, `perl -MStarlet`), if SKIP_PROG_EXISTS is set.