### PR TITLE
[CI] fix t/90h2olog.t timing out

### DIFF
--- a/t/50dnsresolver.t
+++ b/t/50dnsresolver.t
@@ -32,4 +32,6 @@ subtest "dns_resp" => sub {
     ok(($after - $before) >= 2);
 };
 
+undef $mock_dns;
+
 done_testing;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -526,7 +526,7 @@ sub spawn_forked {
         close $cerr;
         my $guard = make_guard(sub {
             return unless defined $pid;
-            kill 'KILL', $pid;
+            kill 'TERM', $pid;
             while (waitpid($pid, 0) != $pid) {}
         });
         return +{

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -527,6 +527,7 @@ sub spawn_forked {
         my $guard = make_guard(sub {
             return unless defined $pid;
             kill 'KILL', $pid;
+            while (waitpid($pid, 0) != $pid) {}
         });
         return +{
             pid => $pid,

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -524,18 +524,16 @@ sub spawn_forked {
     if ($pid) {
         close $cout;
         close $cerr;
-        my $upstream; $upstream = +{
+        my $guard = make_guard(sub {
+            return unless defined $pid;
+            kill 'KILL', $pid;
+        });
+        return +{
             pid => $pid,
-            kill => sub {
-                return unless defined $pid;
-                kill 'KILL', $pid;
-                undef $pid;
-            },
-            guard => make_guard(sub { $upstream->{kill}->() }),
+            kill => sub { undef $guard; },
             stdout => $pin,
             stderr => $pin2,
         };
-        return $upstream;
     }
     close $pin;
     close $pin2;


### PR DESCRIPTION
In CI, we have occasionally seen t/90h2olog.t time out.

It seems that this is due to a stale process with the name being `t/50dnsresolver.t` hanging around. As the process owns the shared lock of the lock file that is used for serializing the h2olog-related tests, t/90h2olog.t fails to obtain an exclusive lock and times out.

This PR addresses the issue by switching the signal used from KILL to TERM, so that whatever child process spawned by Net::DNS::Nameserver will be collected, as well as making sure that child processes will be collected before global destruction which could be unstable.