### PR TITLE
[http/2 client] Make sure we don't invoke callbacks twice

### DIFF
--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -1080,7 +1080,8 @@ static void on_write_complete(h2o_socket_t *sock, const char *err)
 
     /* close by error if necessary */
     if (err != NULL) {
-        call_stream_callbacks_with_error(conn, h2o_httpclient_error_io);
+        if (conn->state != H2O_HTTP2CLIENT_CONN_STATE_IS_CLOSING)
+            call_stream_callbacks_with_error(conn, h2o_httpclient_error_io);
         close_connection_now(conn);
         return;
     }


### PR DESCRIPTION
A possible scenario before this PR is as follows:
1) Server does something that causes `parse_input` to receive an error
   when calling `conn->input.read_frame`.
   For example, receiving a HEADERS stream for a stream that we just
   reset appears to trigger `H2O_HTTP2_ERROR_STREAM_CLOSED`.
   In this case `parse_input` is going to call:
```
        call_stream_callbacks_with_error(conn, h2o_httpclient_error_protocol_violation);
        return close_connection(conn);

```
   when using the proxy handler, `call_stream_callbacks_with_error`
   can to call `proxy.c::on_head()`. That in turn detaches the client
   from the generator:
```
        h2o_httpclient_t *client = self->client;
        client->data = NULL;
```
   Then `close_connection` might have a non-empty write buffer, in which
   case the input buffer is going to be queued for a write.

2) When the write completes, `http2client.c::on_write_complete` gets
   invoked. If that also hits an error (the server in step 1 went away
   in the meantime.), we're going to invoke the following code:
```
        call_stream_callbacks_with_error(conn, h2o_httpclient_error_io);
        close_connection_now(conn);
```
   This is going to try to invoke the generator's callbacks again, and
   is going to fail since the client had been detached in step 1.

The fix in this commit relies on the fact that we always invoke either `close_connection` or `close_connection_now` after `call_stream_callbacks_with_error` was called. In the first case, we set `conn->state` to `H2O_HTTP2CLIENT_CONN_STATE_IS_CLOSING`, which we can then use that in order to avoid calling the callbacks a second time when the write completes. In the second case, the connection is closed immediately, so we won't be calling the callbacks a second time.