### PR TITLE
do not ignore `capabilities` directive when `user` directive is not set

### DIFF
--- a/t/50linux-capabilities.t
+++ b/t/50linux-capabilities.t
@@ -1,0 +1,32 @@
+#!perl
+use strict;
+use warnings FATAL => "all";
+use Test::More;
+use t::Util;
+
+my $client_prog = bindir() . "/h2o-httpclient";
+plan skip_all => "$client_prog not found"
+    unless -e $client_prog;
+plan skip_all => 'capabilities(7) support is off'
+    unless server_features()->{capabilities};
+
+run_as_root();
+
+my $h2o = spawn_h2o({
+    user => scalar(getpwuid($ENV{SUDO_UID})),
+    conf => << "EOT",
+capabilities:
+  - CAP_NET_ADMIN
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: t/assets/doc_root
+EOT
+});
+
+my ($headers, $content) = run_prog("$client_prog http://127.0.0.1:$h2o->{port}/");
+like $headers, qr{^HTTP/1\.1 200\b}, "req: HTTP/1.1 200";
+is $content, "hello\n", "content";
+
+done_testing;


### PR DESCRIPTION
The `capabilities` directive is ignored when no `user` directive is set. This is not a problem in production because most of prod config files will have `user` with root privileges.

However, it is a problem in making tests for `capabilities`. If one starts h2o with a normal user and `capabilities` in the config file, h2o starts with no messages even if `capabilities` is not effective. Instead, h2o should not start and show error messages such as:

> failed to setup capabilities: cap_set_proc: Operation not permitted

This is what the PR does. 

FWIW `t/50linux-capabilities.t` is not a test case for the above change, but I'm adding it because there is no test case that uses `capabilities`.