### PR TITLE
[RFC][http/2 client] Do not reset recently closed streams

### DIFF
--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -446,7 +446,6 @@ static int handle_recently_rst_stream(struct st_h2o_http2client_conn_t *conn, ui
                 h2o_headers_t dummy_headers = {};
                 const char *err = NULL;
                 int ret = h2o_hpack_parse_response(&conn->recently_rst_streams.pool, h2o_hpack_decode_header, &conn->input.header_table, &dummy_status, &dummy_headers, NULL, src, len, &err);
-                free(dummy_headers.entries);
                 h2o_mem_clear_pool(&conn->recently_rst_streams.pool);
                 return ret;
             } else {

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -49,8 +49,6 @@ enum enum_h2o_http2client_conn_state {
 struct st_h2o_http2client_stream_t;
 KHASH_MAP_INIT_INT64(stream, struct st_h2o_http2client_stream_t *)
 
-#define NR_RECENTLY_RST_STREAMS 100
-
 struct st_h2o_http2client_conn_t {
     h2o_httpclient__h2_conn_t super;
     enum enum_h2o_http2client_conn_state state;
@@ -76,12 +74,7 @@ struct st_h2o_http2client_conn_t {
         ssize_t (*read_frame)(struct st_h2o_http2client_conn_t *conn, const uint8_t *src, size_t len, const char **err_desc);
         h2o_buffer_t *headers_unparsed;
     } input;
-    struct {
-        uint32_t id[NR_RECENTLY_RST_STREAMS];
-        size_t idx;
-        /* must be the last member of the struct */
-        h2o_mem_pool_t pool;
-    } recently_rst_streams;
+    h2o_mem_pool_t rst_streams_pool;
 };
 
 struct st_h2o_http2client_stream_t {
@@ -140,7 +133,6 @@ static void stream_send_error(struct st_h2o_http2client_conn_t *conn, uint32_t s
     assert(conn->state != H2O_HTTP2CLIENT_CONN_STATE_IS_CLOSING);
 
     h2o_http2_encode_rst_stream_frame(&conn->output.buf, stream_id, -errnum);
-    conn->recently_rst_streams.id[conn->recently_rst_streams.idx++ % PTLS_ELEMENTSOF(conn->recently_rst_streams.id)] = stream_id;
     request_write(conn);
 }
 
@@ -319,17 +311,33 @@ static int on_head(struct st_h2o_http2client_conn_t *conn, struct st_h2o_http2cl
                    size_t len, const char **err_desc, int is_end_stream)
 {
     int ret;
+    h2o_mem_pool_t *pool;
+    int *status;
+    h2o_headers_t *headers;
+    int dummy_status;
+    h2o_headers_t dummy_headers = {0};
 
-    //    assert(stream->state == H2O_HTTP2CLIENT_STREAM_STATE_RECV_HEADERS);
+    if (stream != NULL) {
+        pool = stream->super.pool;
+        status = &stream->input.status;
+        headers = &stream->input.headers;
+    } else {
+        pool = &conn->rst_streams_pool;
+        status = &dummy_status;
+        headers = &dummy_headers;
+    }
 
-    if ((ret = h2o_hpack_parse_response(stream->super.pool, h2o_hpack_decode_header, &conn->input.header_table,
-                                        &stream->input.status, &stream->input.headers, NULL, src, len, err_desc)) != 0) {
+    if ((ret = h2o_hpack_parse_response(pool, h2o_hpack_decode_header, &conn->input.header_table,
+                                        status, headers, NULL, src, len, err_desc)) != 0) {
         if (ret == H2O_HTTP2_ERROR_INVALID_HEADER_CHAR) {
             ret = H2O_HTTP2_ERROR_PROTOCOL;
             goto Failed;
         }
         return ret;
     }
+
+    if (stream == NULL)
+        return 0;
 
     if (100 <= stream->input.status && stream->input.status <= 199) {
         if (stream->input.status == 101) {
@@ -407,12 +415,13 @@ static ssize_t expect_continuation_of_headers(struct st_h2o_http2client_conn_t *
         return H2O_HTTP2_ERROR_PROTOCOL;
     }
 
-    if ((stream = get_stream(conn, frame.stream_id)) == NULL || stream->state.res == STREAM_STATE_CLOSED) {
+    stream = get_stream(conn, frame.stream_id);
+    if (stream != NULL && stream->state.res == STREAM_STATE_CLOSED) {
         *err_desc = "unexpected stream id in CONTINUATION frame";
         return H2O_HTTP2_ERROR_PROTOCOL;
     }
 
-    if (stream->state.res == STREAM_STATE_BODY) {
+    if (stream != NULL && stream->state.res == STREAM_STATE_BODY) {
         /* is a trailer, do nothing */
         return ret;
     }
@@ -435,31 +444,6 @@ static ssize_t expect_continuation_of_headers(struct st_h2o_http2client_conn_t *
     return ret;
 }
 
-static int handle_recently_rst_stream(struct st_h2o_http2client_conn_t *conn, uint32_t stream_id, uint8_t flags, const uint8_t *src, size_t len, int headers_frame)
-{
-    for (size_t i = 0; i < PTLS_ELEMENTSOF(conn->recently_rst_streams.id); i++) {
-        if (conn->recently_rst_streams.id[i] == stream_id) {
-            if (headers_frame) {
-                int dummy_status;
-                h2o_headers_t dummy_headers = {};
-                const char *err = NULL;
-                int ret = h2o_hpack_parse_response(&conn->recently_rst_streams.pool, h2o_hpack_decode_header, &conn->input.header_table, &dummy_status, &dummy_headers, NULL, src, len, &err);
-                h2o_mem_clear_pool(&conn->recently_rst_streams.pool);
-                return ret;
-            } else {
-                /* DATA frame */
-                h2o_http2_window_consume_window(&conn->input.window, len);
-                enqueue_window_update(stream->conn, 0, &stream->conn->input.window, H2O_HTTP2_SETTINGS_CLIENT_CONNECTION_WINDOW_SIZE);
-                return 0;
-            }
-            /* when we see an END_STREAM flag, the peer must have closed the stream as well */
-            if (flags & H2O_HTTP2_FRAME_FLAG_END_STREAM)
-                conn->recently_rst_streams.id[i] = 0;
-        }
-    }
-    return H2O_HTTP2_ERROR_STREAM_CLOSED;
-}
-
 static void do_update_window(h2o_httpclient_t *client);
 static int handle_data_frame(struct st_h2o_http2client_conn_t *conn, h2o_http2_frame_t *frame, const char **err_desc)
 {
@@ -473,9 +457,8 @@ static int handle_data_frame(struct st_h2o_http2client_conn_t *conn, h2o_http2_f
     /* save the input in the request body buffer, or send error (and close the stream) */
     if ((stream = get_stream(conn, frame->stream_id)) == NULL) {
         if (frame->stream_id <= conn->max_open_stream_id) {
-            ret = handle_recently_rst_stream(conn, frame->stream_id, frame->flags, NULL, payload.length, 0);
-            if (ret < 0)
-                return ret;
+            h2o_http2_window_consume_window(&conn->input.window, payload.length);
+            enqueue_window_update(conn, 0, &conn->input.window, H2O_HTTP2_SETTINGS_CLIENT_CONNECTION_WINDOW_SIZE);
             return 0;
         } else {
             *err_desc = "invalid DATA frame";
@@ -583,26 +566,27 @@ static int handle_headers_frame(struct st_h2o_http2client_conn_t *conn, h2o_http
     }
 
     if ((stream = get_stream(conn, frame->stream_id)) == NULL) {
-        ret = handle_recently_rst_stream(conn, frame->stream_id, frame->flags, payload.headers, payload.headers_len, 1);
-        if (ret < 0)
+        if (frame->stream_id > conn->max_open_stream_id) {
             *err_desc = "invalid stream id in HEADERS frame";
-
-        return ret;
-    }
-
-    h2o_timer_unlink(&stream->super._timeout);
-
-    if (stream->state.res == STREAM_STATE_BODY) {
-        /* is a trailer (ignore after only validating it) */
-        if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_STREAM) == 0) {
-            *err_desc = "trailing HEADERS frame MUST have END_STREAM flag set";
             return H2O_HTTP2_ERROR_PROTOCOL;
         }
-        if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_HEADERS) == 0) {
-            /* read following continuation frames without initializing `headers_unparsed` */
-            conn->input.read_frame = expect_continuation_of_headers;
+    }
+
+    if (stream != NULL) {
+        h2o_timer_unlink(&stream->super._timeout);
+
+        if (stream->state.res == STREAM_STATE_BODY) {
+            /* is a trailer (ignore after only validating it) */
+            if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_STREAM) == 0) {
+                *err_desc = "trailing HEADERS frame MUST have END_STREAM flag set";
+                return H2O_HTTP2_ERROR_PROTOCOL;
+            }
+            if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_HEADERS) == 0) {
+                /* read following continuation frames without initializing `headers_unparsed` */
+                conn->input.read_frame = expect_continuation_of_headers;
+            }
+            return 0;
         }
-        return 0;
     }
 
     if ((frame->flags & H2O_HTTP2_FRAME_FLAG_END_HEADERS) == 0) {
@@ -917,7 +901,7 @@ static void close_connection_now(struct st_h2o_http2client_conn_t *conn)
     if (conn->input.headers_unparsed != NULL)
         h2o_buffer_dispose(&conn->input.headers_unparsed);
 
-    h2o_mem_clear_pool(&conn->recently_rst_streams.pool);
+    h2o_mem_clear_pool(&conn->rst_streams_pool);
     free(conn);
 }
 
@@ -1257,8 +1241,8 @@ static struct st_h2o_http2client_conn_t *create_connection(h2o_httpclient_ctx_t 
 {
     struct st_h2o_http2client_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
-    memset(conn, 0, offsetof(struct st_h2o_http2client_conn_t, recently_rst_streams.pool));
-    h2o_mem_init_pool(&conn->recently_rst_streams.pool);
+    memset(conn, 0, offsetof(struct st_h2o_http2client_conn_t, rst_streams_pool));
+    h2o_mem_init_pool(&conn->rst_streams_pool);
 
     conn->super.ctx = ctx;
     conn->super.sock = sock;

--- a/t/50http2_client_rst_streams.t
+++ b/t/50http2_client_rst_streams.t
@@ -4,7 +4,7 @@ use Test::More;
 use Test::Exception;
 use t::Util;
 use File::Temp qw(tempfile tempdir);
-use Net::EmptyPort qw(check_port);
+use Net::EmptyPort qw(check_port wait_port);
 use JSON;
 
 plan skip_all => "ss not found"
@@ -28,7 +28,7 @@ hosts:
         proxy.timeout.keepalive: 100000
 EOT
 
-    wait_tcp_listen_port($h2g->{tls_port}, 10);
+    wait_port($h2g->{tls_port});
 
     my ($stdout, $stderr) = run_with_h2get_simple($server, <<"EOR");
     req = {

--- a/t/50http2_client_rst_streams.t
+++ b/t/50http2_client_rst_streams.t
@@ -57,6 +57,9 @@ EOC
     , sub {
         my ($err, $out) = @_;
         ok !$err, "no error from h2 backend";
+        if ($err) {
+            diag($err);
+        }
         is $out, "HEADERS\nSETTINGS\nRST_STREAM\n", "no GOAWAY frame seen";
     });
 };
@@ -70,6 +73,9 @@ EOC
     , sub {
         my ($err, $out) = @_;
         ok !$err, "no error from h2 backend";
+        if ($err) {
+            diag($err);
+        }
         is $out, "HEADERS\nSETTINGS\nRST_STREAM\nWINDOW_UPDATE\n", "no GOAWAY frame seen, WINDOW_UPDATE seen";
     });
 };

--- a/t/50http2_client_rst_streams.t
+++ b/t/50http2_client_rst_streams.t
@@ -7,6 +7,8 @@ use File::Temp qw(tempfile tempdir);
 use Net::EmptyPort qw(check_port);
 use JSON;
 
+plan skip_all => "ss not found"
+    unless prog_exists("ss");
 
 sub dotest {
     my $code = shift;

--- a/t/50http2_client_rst_streams.t
+++ b/t/50http2_client_rst_streams.t
@@ -13,7 +13,7 @@ plan skip_all => "ss not found"
 sub dotest {
     my $code = shift;
     my $testfn = shift;
-    my $h2g = spawn_h2get_backend($code, $testfn);
+    my $h2g = spawn_h2get_backend($code);
 
     my $server = spawn_h2o(<< "EOT");
 http2-idle-timeout: 20
@@ -48,7 +48,10 @@ EOR
     is $stderr, "h2get client exiting\n", "h2 client finished as expected";
 
     sleep 2;
-    undef $h2g;
+    $h2g->{kill}->();
+    my $out = read_with_timeout($h2g->{stdout}, 0.1);
+    my $err = read_with_timeout($h2g->{stderr}, 0.1);
+    $testfn->($err, $out);
 }
 
 subtest "late headers frame", sub {

--- a/t/50http2_client_rst_streams.t
+++ b/t/50http2_client_rst_streams.t
@@ -8,15 +8,6 @@ use Net::EmptyPort qw(check_port);
 use JSON;
 
 
-sub h2backend_test_headers {
-    my ($err, $out) = @_;
-    ok !$err, "no error from h2 backend";
-    if ($err) {
-        diag $err;
-    }
-    is $out, "HEADERS\nSETTINGS\nRST_STREAM\n", "no GOAWAY frame seen";
-}
-
 sub dotest {
     my $code = shift;
     my $testfn = shift;
@@ -34,6 +25,8 @@ hosts:
         proxy.http2.force-cleartext: OFF
         proxy.timeout.keepalive: 100000
 EOT
+
+    wait_tcp_listen_port($h2g->{tls_port}, 10);
 
     my ($stdout, $stderr) = run_with_h2get_simple($server, <<"EOR");
     req = {

--- a/t/50http2_client_rst_streams.t
+++ b/t/50http2_client_rst_streams.t
@@ -1,0 +1,84 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use t::Util;
+use File::Temp qw(tempfile tempdir);
+use Net::EmptyPort qw(check_port);
+use JSON;
+
+
+sub h2backend_test_headers {
+    my ($err, $out) = @_;
+    ok !$err, "no error from h2 backend";
+    if ($err) {
+        diag $err;
+    }
+    is $out, "HEADERS\nSETTINGS\nRST_STREAM\n", "no GOAWAY frame seen";
+}
+
+sub dotest {
+    my $code = shift;
+    my $testfn = shift;
+    my $h2g = spawn_h2get_backend($code, $testfn);
+
+    my $server = spawn_h2o(<< "EOT");
+http2-idle-timeout: 20
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: https://127.0.0.1:$h2g->{tls_port}/
+        proxy.ssl.verify-peer: OFF
+        proxy.http2.ratio: 100
+        proxy.http2.force-cleartext: OFF
+        proxy.timeout.keepalive: 100000
+EOT
+
+    my ($stdout, $stderr) = run_with_h2get_simple($server, <<"EOR");
+    req = {
+        ":method" => "GET",
+        ":authority" => host,
+        ":scheme" => "https",
+        ":path" => "/",
+    }
+
+    h2g.send_headers(req, 1, END_HEADERS | END_STREAM)
+    sleep(1)
+    h2g.send_rst_stream(1, 0x8)
+    h2g.read(1000)
+    puts("h2get client exiting")
+EOR
+
+    is $stderr, "h2get client exiting\n", "h2 client finished as expected";
+
+    sleep 2;
+    undef $h2g;
+}
+
+subtest "late headers frame", sub {
+    dotest(<< "EOC"
+    puts f.type
+    conn.send_headers({":status" => "200"}, f.stream_id, END_HEADERS | END_STREAM) if f.type == 'RST_STREAM'
+EOC
+    , sub {
+        my ($err, $out) = @_;
+        ok !$err, "no error from h2 backend";
+        is $out, "HEADERS\nSETTINGS\nRST_STREAM\n", "no GOAWAY frame seen";
+    });
+};
+
+subtest "late data frame", sub {
+    dotest(<< "EOC"
+    puts f.type
+    conn.send_headers({":status" => "200"}, f.stream_id, END_HEADERS) if f.type == 'HEADERS'
+    conn.send_data(f.stream_id, 0, 'racy DATA frame') if f.type == 'RST_STREAM'
+EOC
+    , sub {
+        my ($err, $out) = @_;
+        ok !$err, "no error from h2 backend";
+        is $out, "HEADERS\nSETTINGS\nRST_STREAM\nWINDOW_UPDATE\n", "no GOAWAY frame seen, WINDOW_UPDATE seen";
+    });
+};
+
+done_testing();

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -734,13 +734,12 @@ sub spawn_h2get_backend {
     my $h2_snippet = shift;
     my $testfn = shift;
     my ($backend_port) = empty_ports(1, { host => '0.0.0.0' });
-    my $bd = bindir();
     my $backend = spawn_forked(sub {
         my $code = <<"EOC";
 STDOUT.sync = true
 h2g = H2.server({
-    'cert_path' => '$bd/examples/h2o/server.crt',
-    'key_path' => '$bd/examples/h2o/server.key',
+    'cert_path' => 'examples/h2o/server.crt',
+    'key_path' => 'examples/h2o/server.key',
 });
 h2g.listen("https://127.0.0.1:$backend_port", 10000)
 

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -53,7 +53,6 @@ our @EXPORT = qw(
     spawn_h2get_backend
     one_shot_http_upstream
     wait_debugger
-    wait_tcp_listen_port
     make_guard
     spawn_forked
     spawn_h2_server
@@ -569,17 +568,6 @@ sub wait_debugger {
     undef;
 }
 
-sub wait_tcp_listen_port {
-    my ($port, $timeout) = @_;
-    while ($timeout-- != 0) {
-        my $out = `ss -tlnp | grep ":$port" 2>&1`;
-        return 1 if (scalar(split(/\n/, $out)) == 1);
-        sleep 1;
-    }
-    print STDERR "Failed to wait for TCP port $port\n";
-    undef;
-}
-
 sub make_guard {
     my $code = shift;
     return Scope::Guard->new(sub {
@@ -746,7 +734,10 @@ h2g.listen("https://127.0.0.1:$backend_port")
 connpool = {}
 
 loop do
-  conn = h2g.accept(100)
+  begin
+    conn = h2g.accept(100)
+  rescue => e
+  end
   if conn
     connpool[conn] = true;
     conn.expect_prefix

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -741,7 +741,7 @@ h2g = H2.server({
     'cert_path' => 'examples/h2o/server.crt',
     'key_path' => 'examples/h2o/server.key',
 });
-h2g.listen("https://127.0.0.1:$backend_port", 10000)
+h2g.listen("https://127.0.0.1:$backend_port")
 
 connpool = {}
 

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -53,6 +53,7 @@ our @EXPORT = qw(
     spawn_h2get_backend
     one_shot_http_upstream
     wait_debugger
+    wait_tcp_listen_port
     make_guard
     spawn_forked
     spawn_h2_server
@@ -565,6 +566,17 @@ sub wait_debugger {
         sleep 1;
     }
     print STDERR "no debugger attached\n";
+    undef;
+}
+
+sub wait_tcp_listen_port {
+    my ($port, $timeout) = @_;
+    while ($timeout-- != 0) {
+        my $out = `ss -tlnp | grep ":$port" 2>&1`;
+        return 1 if (scalar(split(/\n/, $out)) == 1);
+        sleep 1;
+    }
+    print STDERR "Failed to wait for TCP port $port\n";
     undef;
 }
 


### PR DESCRIPTION
In the current code base, the following can happen:

1) h2o h2 client sends HEADERS
2) h2o h2 client sends RST_STREAM
3) server sees HEADERS, processes it, and sends a HEADERS back
4) h2o h2 client sees the HEADERS belonging to a closed stream and closes
   the entire connection: https://github.com/h2o/h2o/blob/326ab4671639f9321a2288fbb8735411c320420f/lib/common/http2client.c#L974-L980

Attached is a PoC, but it's unsatisfying:
- reset streams are kept forever
- the number of streams to record might be more than the 10 i've hardcoded.

Better options seem to include:
- add a timer and periodically reset `recently_rst_streams`
- sending a PING frame along with the reset, and clear the stream when receiving the PONG

But before embarking in this i figured i would ask for opinions.