### PR TITLE
[ci] for https://github.com/h2o/picotls/pull/478, add libaegis to CI image

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -57,7 +57,8 @@ RUN apt-get install --yes \
 	libwww-perl \
 	libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
+RUN cpanm -n Test::More Starlet Protocol::HTTP2 Test::TCP
+RUN cpanm -n NLNETLABS/Net-DNS-1.36.tar.gz # Net-DNS 1.39 has issues around use of alarm, fork, etc.
 
 # h2spec
 RUN curl -Ls https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin

--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -75,6 +75,13 @@ RUN git clone --depth=1 https://github.com/axboe/liburing.git && \
 	make install && \
 	make clean
 
+# libaegis
+RUN git clone --depth=1 https://github.com/jedisct1/libaegis.git && \
+	cd libaegis && \
+	cmake . && \
+	make install && \
+	make clean
+
 # create user
 RUN useradd --create-home ci
 RUN echo 'ci ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
At the moment, it is only added to ubuntu2004 variant (which is the default used by picotls).