### PR TITLE
CI: upgrade curl to 7.87.0 in ubuntu1604 and ubuntu2004, and more

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu1604
+++ b/misc/docker-ci/Dockerfile.ubuntu1604
@@ -35,24 +35,36 @@ RUN (cd openssl-${OPENSSL_VERSION} && \
 	make -j $(nproc) && make -j install_sw install_ssldirs)
 
 # nghttp2 and h2load
-ARG NGHTTP2_VERSION="1.30.0"
-ARG NGHTTP2_SHA256="089afb4c22a53f72384b71ea06194be255a8a73b50b1412589105d0e683c52ac"
+ARG NGHTTP2_VERSION="1.34.0"
 RUN apt-get install --yes autoconf automake autotools-dev libtool pkg-config
 RUN wget https://github.com/nghttp2/nghttp2/releases/download/v${NGHTTP2_VERSION}/nghttp2-${NGHTTP2_VERSION}.tar.xz
-RUN (echo "${NGHTTP2_SHA256} nghttp2-${NGHTTP2_VERSION}.tar.xz" | sha256sum -c -)
 RUN tar xf nghttp2-${NGHTTP2_VERSION}.tar.xz
 RUN cd nghttp2-${NGHTTP2_VERSION} && autoreconf -i && automake && autoconf && ./configure --enable-app --prefix=/usr/local && make && make install
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 # curl with http2 support
-RUN wget --no-verbose -O - https://curl.haxx.se/download/curl-7.81.0.tar.gz | tar xzf -
-RUN (cd curl-7.81.0 && ./configure --prefix=/usr/local --with-openssl --without-brotli --with-nghttp2 --disable-shared && make && make install)
+# NOTE: curl 7.88.0 seems to have a regression that http2 trailers are not handled correctly.
+ARG CURL_VERSION="7.87.0"
+RUN wget --no-verbose -O - https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz | tar xzf -
+RUN (cd curl-${CURL_VERSION} && ./configure --prefix=/usr/local --with-openssl --without-brotli --with-nghttp2 --disable-shared --disable-manual && make && make install)
 
-# cpan modules
-RUN apt-get install --yes cpanminus
-RUN apt-get install --yes libfcgi-perl libfcgi-procmanager-perl libipc-signal-perl libjson-perl liblist-moreutils-perl libplack-perl libscope-guard-perl libtest-exception-perl libwww-perl libio-socket-ssl-perl
+# perl
+RUN apt-get install --yes \
+	cpanminus \
+	libfcgi-perl \
+	libfcgi-procmanager-perl \
+	libipc-signal-perl \
+	libjson-perl \
+	liblist-moreutils-perl \
+	libplack-perl \
+	libscope-guard-perl \
+	libtest-exception-perl \
+	libwww-perl \
+	libio-socket-inet6-perl \
+	libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
+RUN cpanm -n Test::More Starlet Protocol::HTTP2 Test::TCP
+RUN cpanm -n NLNETLABS/Net-DNS-1.36.tar.gz # Net-DNS 1.39 has issues around use of alarm, fork, etc.
 
 # h2spec
 RUN curl -Ls https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin

--- a/misc/docker-ci/Dockerfile.ubuntu2004
+++ b/misc/docker-ci/Dockerfile.ubuntu2004
@@ -39,9 +39,11 @@ RUN apt-get install --yes \
 	wget
 
 # curl with http2 support
+# NOTE: curl 7.88.0 seems to have a regression that http2 trailers are not handled correctly.
+ARG CURL_VERSION="7.87.0"
 RUN apt-get install --yes libnghttp2-dev \
-	&& wget --no-verbose -O - https://curl.haxx.se/download/curl-7.81.0.tar.gz | tar xzf - \
-	&& (cd curl-7.81.0 && ./configure --prefix=/usr/local --with-openssl --without-brotli --with-nghttp2 --disable-shared && make && make install)
+	&& wget --no-verbose -O - https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz | tar xzf - \
+	&& (cd curl-${CURL_VERSION} && ./configure --prefix=/usr/local --with-openssl --without-brotli --with-nghttp2 --disable-shared --disable-manual && make && make install)
 
 # perl
 RUN apt-get install --yes \
@@ -55,9 +57,11 @@ RUN apt-get install --yes \
 	libscope-guard-perl \
 	libtest-exception-perl \
 	libwww-perl \
+	libio-socket-inet6-perl \
 	libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
-RUN cpanm -n Test::More Starlet Protocol::HTTP2 Net::DNS::Nameserver Test::TCP
+RUN cpanm -n Test::More Starlet Protocol::HTTP2 Test::TCP
+RUN cpanm -n NLNETLABS/Net-DNS-1.36.tar.gz # Net-DNS 1.39 has issues around use of alarm, fork, etc.
 
 # h2spec
 RUN curl -Ls https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz | tar zx -C /usr/local/bin

--- a/misc/docker-ci/Dockerfile.ubuntu2204
+++ b/misc/docker-ci/Dockerfile.ubuntu2204
@@ -59,6 +59,7 @@ RUN apt-get install --yes \
 	libscope-guard-perl \
 	libtest-exception-perl \
 	libwww-perl \
+	libio-socket-inet6-perl \
 	libio-socket-ssl-perl
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
 RUN cpanm -n Test::More Starlet Protocol::HTTP2 Test::TCP

--- a/misc/docker-ci/build.mk
+++ b/misc/docker-ci/build.mk
@@ -6,14 +6,23 @@ ALL:
 	@echo 'Usage: make -f misc/docker-ci/build.mk <command> VARIANT=<variant>'
 	@echo ''
 	@echo 'Command is either `build` or `push`.'
-	@echo 'Variant might be ubuntu1604, ubuntu2004 (corresponds to misc/docker-ci/Dockerfile.$$variant).'
+	@echo 'Variant might be ubuntu1604, ubuntu2004, or ubuntu2204 (corresponds to misc/docker-ci/Dockerfile.$$variant).'
 	@echo ''
 
-
 build:
-	cd misc/docker-ci/docker-root && docker build --tag "$(IMAGE_NAME):$(VARIANT)" -f "../Dockerfile.$(VARIANT)" .
+	cd misc/docker-ci/docker-root && docker build --progress=plain --tag "$(IMAGE_NAME):$(VARIANT)" -f "../Dockerfile.$(VARIANT)" .
 
 push: build
 	docker push "$(IMAGE_NAME):$(VARIANT)"
 
-.PHONY: build push
+# to test dockerfiles locally, it builds and tests a particular Dockerfile variant.
+test:
+	$(MAKE) -f $(firstword $(MAKEFILE_LIST)) build IMAGE_NAME=$(IMAGE_NAME) VARIANT=$(VARIANT)
+	$(MAKE) -f $(dir $(firstword $(MAKEFILE_LIST)))/check.mk CINTAINER_NAME=$(IMAGE_NAME):$(VARIANT)
+
+test-all:
+	$(MAKE) -f $(firstword $(MAKEFILE_LIST)) test VARIANT=ubuntu1604
+	$(MAKE) -f $(firstword $(MAKEFILE_LIST)) test VARIANT=ubuntu2004
+	$(MAKE) -f $(firstword $(MAKEFILE_LIST)) test VARIANT=ubuntu2204
+
+.PHONY: ALL build push

--- a/t/50access-log.t
+++ b/t/50access-log.t
@@ -342,7 +342,7 @@ subtest 'escape' => sub {
             doit(
                 sub {
                     my $server = shift;
-                    system("curl --silent http://127.0.0.1:$server->{port}/\xe3\x81\x82 > /dev/null");
+                    system(qq{$client_prog 'http://127.0.0.1:$server->{port}/\xe3\x81\x82' > /dev/null});
                 },
                 $escape eq 'default' ? '%U' : { format => '%U', escape => $escape },
                 [ $expected ],

--- a/t/50connect.t
+++ b/t/50connect.t
@@ -80,32 +80,32 @@ EOS
 subtest "curl-h1" => sub {
     subtest "basic", sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://127.0.0.1:$origin_port/echo 2>&1`;
-        like $content, qr{Proxy replied 200 to CONNECT request}m, "Connect got a 200 response to CONNECT";
+        like $content, qr{Proxy replied 200 to CONNECT request|CONNECT tunnel established, response 200}m, "Connect got a 200 response to CONNECT";
         my @c = $content =~ /$ok_resp/g;
         is @c, 2, "Got two 200 responses";
         unlike $content, qr{proxy-status:}i;
     };
     subtest "timeout", sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://127.0.0.1:$origin_port/sleep-and-respond?sleep=1 2>&1`;
-        like $content, qr{Proxy replied 200 to CONNECT request}m, "Connect got a 200";
+        like $content, qr{Proxy replied 200 to CONNECT request|CONNECT tunnel established, response 200}m, "Connect got a 200";
         my @c = $content =~ /$ok_resp/g;
         is @c, 2, "Got two 200 responses, no timeout";
         unlike $content, qr{proxy-status:}i;
 
         $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://127.0.0.1:$origin_port/sleep-and-respond?sleep=10 2>&1`;
-        like $content, qr{Proxy replied 200 to CONNECT request}m, "Connect got a 200";
+        like $content, qr{Proxy replied 200 to CONNECT request|CONNECT tunnel established, response 200}m, "Connect got a 200";
         @c = $content =~ /$ok_resp/g;
         is @c, 1, "Only got one 200 response";
         unlike $content, qr{proxy-status:}i;
     };
     subtest "acl" => sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error https://8.8.8.8/ 2>&1 2>&1`;
-        like $content, qr{Received HTTP code 403 from proxy after CONNECT};
+        like $content, qr{Received HTTP code 403 from proxy after CONNECT|CONNECT tunnel failed, response 403};
         unlike $content, qr{proxy-status:}i;
     };
     subtest "immediate connect failure" => sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://255.255.255.255:$origin_port/ 2>&1 2>&1`;
-        like $content, qr{Received HTTP code 502 from proxy after CONNECT};
+        like $content, qr{Received HTTP code 502 from proxy after CONNECT|CONNECT tunnel failed, response 502};
     };
 };
 


### PR DESCRIPTION
This PR includes a couple of changes for dockerfiles.

* Upgrade curl and fix tests for that (note: "the latest curl" means v8.2.1, though the PR is upgradding curl to v7.78.0):
  * `t/50access-log.t` - swithced to use h2o-httpclient because the latest curl seems to encode the given URL in a different way.
  * `t/50connect-proxy-status.t` and `t/50connect-proxy-status.t` - support different variants of response contents about `CONNECT`, which curl has changed recently.
  * `t/50reverse-proxy-timings.t` - added messages about trailers. curl v7.88.0 and later seem to have a regression about HTTP2+trailers.
* added a Makefile target `test` and `test-all` for `build.mk` to easily make sure the update of a Dockerfile breaks nothing.
  * it would be nice if CI automatically runs `make -f build.mk test push` when the corresponding Dockerfile is edited; I'll try to do it if this idea seems worth doing. 
* Lock Net::DNS for every Dockerfile. 
* Add `IO::Socket::INET6` for testing, which is not used yet in `h2o/h2o/master` but is used in other private branches.
