### PR TITLE
[http/2 client] Do not reject responses containing a `host:` header

### DIFF
--- a/include/h2o/hpack.h
+++ b/include/h2o/hpack.h
@@ -32,9 +32,9 @@
 
 extern const char h2o_hpack_err_missing_mandatory_pseudo_header[];
 extern const char h2o_hpack_err_invalid_pseudo_header[];
-extern const char h2o_hpack_err_invalid_status_pseudo_header[];
 extern const char h2o_hpack_err_found_upper_case_in_header_name[];
 extern const char h2o_hpack_err_unexpected_connection_specific_header[];
+extern const char h2o_hpack_err_invalid_content_length_header[];
 extern const char h2o_hpack_soft_err_found_invalid_char_in_header_name[];
 extern const char h2o_hpack_soft_err_found_invalid_char_in_header_value[];
 

--- a/include/h2o/hpack.h
+++ b/include/h2o/hpack.h
@@ -30,7 +30,11 @@
 
 #define H2O_HPACK_ENCODE_INT_MAX_LENGTH 10 /* first byte + 9 bytes (7*9==63 bits to hold positive numbers of int64_t) */
 
+extern const char h2o_hpack_err_missing_mandatory_pseudo_header[];
+extern const char h2o_hpack_err_invalid_pseudo_header[];
+extern const char h2o_hpack_err_invalid_status_pseudo_header[];
 extern const char h2o_hpack_err_found_upper_case_in_header_name[];
+extern const char h2o_hpack_err_unexpected_connection_specific_header[];
 extern const char h2o_hpack_soft_err_found_invalid_char_in_header_name[];
 extern const char h2o_hpack_soft_err_found_invalid_char_in_header_value[];
 

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -671,7 +671,7 @@ int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb de
                 h2o_token_t *token = H2O_STRUCT_FROM_MEMBER(h2o_token_t, buf, name);
                 /* reject headers as defined in draft-16 8.1.2.2 */
                 if (token->flags.is_hpack_special) {
-                    if (token == H2O_TOKEN_CONTENT_LENGTH || token == H2O_TOKEN_CACHE_DIGEST) {
+                    if (token == H2O_TOKEN_CONTENT_LENGTH || token == H2O_TOKEN_CACHE_DIGEST || token == H2O_TOKEN_HOST) {
                         /* pass them through when found in response headers (TODO reconsider?) */
                     } else if (token == H2O_TOKEN_DATAGRAM_FLOW_ID) {
                         if (datagram_flow_id != NULL)


### PR DESCRIPTION
This PR also contains a change to have `h2o_hpack_parse_response` document the reason for the rejection, which would have made troubleshooting the `host:` issue easier.