### PR TITLE
Improve spawn_forked

### DIFF
--- a/t/50http2_client_rst_streams.t
+++ b/t/50http2_client_rst_streams.t
@@ -48,9 +48,9 @@ EOR
     is $stderr, "h2get client exiting\n", "h2 client finished as expected";
 
     sleep 2;
-    $h2g->{kill}->();
-    my $out = read_with_timeout($h2g->{stdout}, 0.1);
-    my $err = read_with_timeout($h2g->{stderr}, 0.1);
+    my ($h2g_stdout, $h2g_stderr) = $h2g->{kill}->();
+    my $out = read_with_timeout($h2g_stdout, 0.1);
+    my $err = read_with_timeout($h2g_stderr, 0.1);
     $testfn->($err, $out);
 }
 

--- a/t/50http2_client_rst_streams.t
+++ b/t/50http2_client_rst_streams.t
@@ -48,9 +48,7 @@ EOR
     is $stderr, "h2get client exiting\n", "h2 client finished as expected";
 
     sleep 2;
-    my ($h2g_stdout, $h2g_stderr) = $h2g->{kill}->();
-    my $out = read_with_timeout($h2g_stdout, 0.1);
-    my $err = read_with_timeout($h2g_stderr, 0.1);
+    my ($out, $err) = $h2g->{kill}->();
     $testfn->($err, $out);
 }
 

--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -123,8 +123,7 @@ EOS
                 # (otherwise framing error happens)
                 `curl -ks https://127.0.0.1:$server->{tls_port}`;
 
-                my ($stdout) = $upstream->{kill}->();
-                my $log = join('', readline($stdout));
+                my ($log) = $upstream->{kill}->();
                 like $log, qr/received @{[1 + 1024 * 2]} bytes/;
                 like $log, qr/accepted request 2/;
             }

--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -123,8 +123,8 @@ EOS
                 # (otherwise framing error happens)
                 `curl -ks https://127.0.0.1:$server->{tls_port}`;
 
-                $upstream->{kill}->();
-                my $log = join('', readline($upstream->{stdout}));
+                my ($stdout) = $upstream->{kill}->();
+                my $log = join('', readline($stdout));
                 like $log, qr/received @{[1 + 1024 * 2]} bytes/;
                 like $log, qr/accepted request 2/;
             }

--- a/t/50reverse-proxy-http2-trailers.t
+++ b/t/50reverse-proxy-http2-trailers.t
@@ -12,12 +12,11 @@ subtest 'nghttp2 client and backend' => sub {
         unless prog_exists('nghttpd');
 
     my ($backend_port) = empty_ports(1, { host => '0.0.0.0' });
-    my $backend = spawn_server(
-        argv => ['nghttpd', '--htdocs', DOC_ROOT,
-                 '--trailer', 'x-backend-trailer: bar',
-                 $backend_port, 'examples/h2o/server.key', 'examples/h2o/server.crt'],
-        is_ready => sub { check_port($backend_port) },
-    );
+    my $backend = spawn_forked(sub {
+        exec('nghttpd', '-v', '--htdocs', DOC_ROOT,
+             '--trailer', 'x-backend-trailer: bar',
+             $backend_port, 'examples/h2o/server.key', 'examples/h2o/server.crt');
+    });
     my $server = spawn_h2o(<< "EOT");
 hosts:
   default:

--- a/t/50reverse-proxy-http2-trailers.t
+++ b/t/50reverse-proxy-http2-trailers.t
@@ -16,6 +16,7 @@ subtest 'nghttp2 client and backend' => sub {
         exec('nghttpd', '-v', '--htdocs', DOC_ROOT,
              '--trailer', 'x-backend-trailer: bar',
              $backend_port, 'examples/h2o/server.key', 'examples/h2o/server.crt');
+        die "failed to exec nghttpd: $?";
     });
     my $server = spawn_h2o(<< "EOT");
 hosts:

--- a/t/50reverse-proxy-http2-trailers.t
+++ b/t/50reverse-proxy-http2-trailers.t
@@ -30,7 +30,11 @@ EOT
                          "nghttp -vn -H ':method: POST' --data '-' --trailer 'x-client-trailer: foo' " .
                          "'https://127.0.0.1:$server->{tls_port}/index.txt'";
     my $client_log = `$client_command`;
-    like $client_log, qr/x-backend-trailer: bar/;
+    like $client_log, qr/recv DATA frame.+x-backend-trailer: bar/s;
+
+    my ($stdout) = $backend->{kill}->();
+    my $backend_log = join('', readline($stdout));
+    like $backend_log, qr/recv DATA frame.+x-client-trailer: foo/s;
 };
 
 done_testing;

--- a/t/50reverse-proxy-http2-trailers.t
+++ b/t/50reverse-proxy-http2-trailers.t
@@ -32,8 +32,7 @@ EOT
     my $client_log = `$client_command`;
     like $client_log, qr/recv DATA frame.+x-backend-trailer: bar/s;
 
-    my ($stdout) = $backend->{kill}->();
-    my $backend_log = join('', readline($stdout));
+    my ($backend_log) = $backend->{kill}->();
     like $backend_log, qr/recv DATA frame.+x-client-trailer: foo/s;
 };
 

--- a/t/50reverse-proxy-http2-trailers.t
+++ b/t/50reverse-proxy-http2-trailers.t
@@ -31,8 +31,9 @@ EOT
     my $client_log = `$client_command`;
     like $client_log, qr/recv DATA frame.+x-backend-trailer: bar/s;
 
-    my ($backend_log) = $backend->{kill}->();
-    like $backend_log, qr/recv DATA frame.+x-client-trailer: foo/s;
+    # TODO: uncomment after þtps://github.com/h2o/h2o/pull/3241 gets merged
+    # my ($backend_log) = $backend->{kill}->();
+    # like $backend_log, qr/recv DATA frame.+x-client-trailer: foo/s;
 };
 
 done_testing;

--- a/t/50reverse-proxy-http2.t
+++ b/t/50reverse-proxy-http2.t
@@ -84,8 +84,8 @@ subtest 'invalid content-length' => sub {
     ok check_port($server->{port}), 'live check';
 
     Time::HiRes::sleep(0.1);
-    $upstream->{kill}->();
-    my $log = join('', readline($upstream->{stdout}));
+    my ($stdout) = $upstream->{kill}->();
+    my $log = join('', readline($stdout));
     like $log, qr{Receive reset stream with error code PROTOCOL_ERROR};
 };
 
@@ -109,8 +109,8 @@ subtest 'multiple content-length' => sub {
     ok check_port($server->{port}), 'live check';
 
     Time::HiRes::sleep(0.1);
-    $upstream->{kill}->();
-    my $log = join('', readline($upstream->{stdout}));
+    my ($stdout) = $upstream->{kill}->();
+    my $log = join('', readline($stdout));
     like $log, qr{Receive reset stream with error code PROTOCOL_ERROR};
 };
 
@@ -284,8 +284,8 @@ subtest 'request body streaming' => sub {
             h2g.read_loop(100)
         EOR
     }
-    $upstream->{kill}->();
-    my $log = join('', readline($upstream->{stdout}));
+    my ($stdout) = $upstream->{kill}->();
+    my $log = join('', readline($stdout));
     like $log, qr{TYPE = DATA\(0\), FLAGS = 00000000, STREAM_ID = 1, LENGTH = 1};
     like $log, qr{TYPE = DATA\(0\), FLAGS = 00000001, STREAM_ID = 1, LENGTH = 1024};
     my $http2_streaming_requests_str = 'http2.streaming-requests';

--- a/t/50reverse-proxy-http2.t
+++ b/t/50reverse-proxy-http2.t
@@ -84,8 +84,7 @@ subtest 'invalid content-length' => sub {
     ok check_port($server->{port}), 'live check';
 
     Time::HiRes::sleep(0.1);
-    my ($stdout) = $upstream->{kill}->();
-    my $log = join('', readline($stdout));
+    my ($log) = $upstream->{kill}->();
     like $log, qr{Receive reset stream with error code PROTOCOL_ERROR};
 };
 
@@ -109,8 +108,7 @@ subtest 'multiple content-length' => sub {
     ok check_port($server->{port}), 'live check';
 
     Time::HiRes::sleep(0.1);
-    my ($stdout) = $upstream->{kill}->();
-    my $log = join('', readline($stdout));
+    my ($log) = $upstream->{kill}->();
     like $log, qr{Receive reset stream with error code PROTOCOL_ERROR};
 };
 
@@ -284,8 +282,7 @@ subtest 'request body streaming' => sub {
             h2g.read_loop(100)
         EOR
     }
-    my ($stdout) = $upstream->{kill}->();
-    my $log = join('', readline($stdout));
+    my ($log) = $upstream->{kill}->();
     like $log, qr{TYPE = DATA\(0\), FLAGS = 00000000, STREAM_ID = 1, LENGTH = 1};
     like $log, qr{TYPE = DATA\(0\), FLAGS = 00000001, STREAM_ID = 1, LENGTH = 1024};
     my $http2_streaming_requests_str = 'http2.streaming-requests';

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -628,10 +628,19 @@ sub spawn_forked {
         return +{
             pid => $pid,
             kill => sub {
-                seek $outfh, 0, 0 if $outfh;
-                seek $errfh, 0, 0 if $errfh;
                 undef $guard;
-                ($outfh, $errfh)
+                my ($out, $err);
+                if ($outfh) {
+                    seek $outfh, 0, 0;
+                    $out = join('', readline($outfh));
+                    close($outfh);
+                }
+                if ($errfh) {
+                    seek $errfh, 0, 0;
+                    $err = join('', readline($errfh));
+                    close($errfh);
+                }
+                ($out, $err)
             },
         };
     }


### PR DESCRIPTION
1. As https://github.com/h2o/h2o/pull/3270 revealed that `spawn_forked` captures stderr and it may make debugging hard from time to time. This PR makes that behavior OFF by default. To capture stderr, the user has to pass `+{ stderr => 1 }` options explicitly.
2. Writing to pipes can be blocked. This PR uses temporary files instead of pipes.
3. Since reading stdout and stderr implicitly requires `kill` callback has been called beforehand. This PR has modified it to return `(stdout, stderr)` as the return value of `kill`.