### PR TITLE
clang-format-all

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -135,8 +135,8 @@ static int call_on_body(struct st_h2o_http1client_t *client, const char *errstr)
 {
     assert(!client->_delay_free);
     client->_delay_free = 1;
-    int ret =
-        (client->reader == on_body_to_pipe ? client->pipe_reader.on_body_piped : client->super._cb.on_body)(&client->super, errstr, NULL, 0);
+    int ret = (client->reader == on_body_to_pipe ? client->pipe_reader.on_body_piped : client->super._cb.on_body)(&client->super,
+                                                                                                                  errstr, NULL, 0);
     client->_delay_free = 0;
     return ret;
 }

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -328,8 +328,8 @@ static int on_head(struct st_h2o_http2client_conn_t *conn, struct st_h2o_http2cl
         headers = &dummy_headers;
     }
 
-    if ((ret = h2o_hpack_parse_response(pool, h2o_hpack_decode_header, &conn->input.header_table,
-                                        status, headers, NULL, src, len, err_desc)) != 0) {
+    if ((ret = h2o_hpack_parse_response(pool, h2o_hpack_decode_header, &conn->input.header_table, status, headers, NULL, src, len,
+                                        err_desc)) != 0) {
         if (ret == H2O_HTTP2_ERROR_INVALID_HEADER_CHAR) {
             ret = H2O_HTTP2_ERROR_PROTOCOL;
             goto Failed;
@@ -400,8 +400,8 @@ SendRSTStream:
     return 0;
 }
 
-static int on_trailers(struct st_h2o_http2client_conn_t *conn, struct st_h2o_http2client_stream_t *stream,
-                       const uint8_t *src, size_t len, const char **err_desc)
+static int on_trailers(struct st_h2o_http2client_conn_t *conn, struct st_h2o_http2client_stream_t *stream, const uint8_t *src,
+                       size_t len, const char **err_desc)
 {
     int ret;
 
@@ -416,7 +416,8 @@ static int on_trailers(struct st_h2o_http2client_conn_t *conn, struct st_h2o_htt
         return ret;
     }
 
-    if (stream->super._cb.on_body(&stream->super, h2o_httpclient_error_is_eos, stream->input.trailers.entries, stream->input.trailers.size) != 0) {
+    if (stream->super._cb.on_body(&stream->super, h2o_httpclient_error_is_eos, stream->input.trailers.entries,
+                                  stream->input.trailers.size) != 0) {
         ret = H2O_HTTP2_ERROR_INTERNAL;
         goto SendRSTStream;
     }
@@ -463,8 +464,8 @@ static ssize_t expect_continuation_of_headers(struct st_h2o_http2client_conn_t *
         conn->input.read_frame = expect_default;
 
         if (stream != NULL && stream->state.res == STREAM_STATE_BODY) {
-            hret = on_trailers(conn, stream, (const uint8_t *)conn->input.headers_unparsed->bytes, conn->input.headers_unparsed->size,
-                              err_desc);
+            hret = on_trailers(conn, stream, (const uint8_t *)conn->input.headers_unparsed->bytes,
+                               conn->input.headers_unparsed->size, err_desc);
         } else {
             hret = on_head(conn, stream, (const uint8_t *)conn->input.headers_unparsed->bytes, conn->input.headers_unparsed->size,
                            err_desc, is_end_stream);

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -263,7 +263,7 @@ static __thread struct {
     struct buffer_recycle_bin_t {
         h2o_mem_recycle_conf_t conf;
         h2o_mem_recycle_t recycle;
-    } * bins;
+    } *bins;
     /**
      * Bins for capacicties no greater than this value exist.
      */

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -1485,14 +1485,17 @@ static int emit_writereq_of_openref(h2o_http2_scheduler_openref_t *ref, int *sti
     } else {
         if (stream->state == H2O_HTTP2_STREAM_STATE_END_STREAM) {
             h2o_iovec_t server_timing;
-            if (stream->req.send_server_timing && (server_timing = h2o_build_server_timing_trailer(&stream->req, NULL, 0, NULL, 0)).len != 0) {
-                    static const h2o_iovec_t name = {H2O_STRLIT("server-timing")};
-                    h2o_vector_reserve(&stream->req.pool, &stream->req.res.trailers, stream->req.res.trailers.size + 1);
-                    stream->req.res.trailers.entries[stream->req.res.trailers.size++] = (h2o_header_t){(h2o_iovec_t *)&name, NULL, server_timing};
+            if (stream->req.send_server_timing &&
+                (server_timing = h2o_build_server_timing_trailer(&stream->req, NULL, 0, NULL, 0)).len != 0) {
+                static const h2o_iovec_t name = {H2O_STRLIT("server-timing")};
+                h2o_vector_reserve(&stream->req.pool, &stream->req.res.trailers, stream->req.res.trailers.size + 1);
+                stream->req.res.trailers.entries[stream->req.res.trailers.size++] =
+                    (h2o_header_t){(h2o_iovec_t *)&name, NULL, server_timing};
             }
             if (stream->req.res.trailers.size != 0) {
                 h2o_hpack_flatten_trailers(&conn->_write.buf, &conn->_output_header_table, conn->peer_settings.header_table_size,
-                                       stream->stream_id, conn->peer_settings.max_frame_size, stream->req.res.trailers.entries, stream->req.res.trailers.size);
+                                           stream->stream_id, conn->peer_settings.max_frame_size, stream->req.res.trailers.entries,
+                                           stream->req.res.trailers.size);
             }
         }
         h2o_linklist_insert(&conn->_write.streams_to_proceed, &stream->_link);

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -247,8 +247,7 @@ static h2o_iovec_t *decode_string(h2o_mem_pool_t *pool, unsigned *soft_errors, c
             return NULL;
         if (is_header_name) {
             /* pseudo-headers are checked later in `decode_header` */
-            if ((len == 0 || **src != (uint8_t)':') &&
-                !h2o_hpack_validate_header_name(soft_errors, (char *)*src, len, err_desc))
+            if ((len == 0 || **src != (uint8_t)':') && !h2o_hpack_validate_header_name(soft_errors, (char *)*src, len, err_desc))
                 return NULL;
         } else {
             h2o_hpack_validate_header_value(soft_errors, (char *)*src, len);

--- a/lib/http2/stream.c
+++ b/lib/http2/stream.c
@@ -122,9 +122,8 @@ static void commit_data_header(h2o_http2_conn_t *conn, h2o_http2_stream_t *strea
     /* send a DATA frame if there's data or the END_STREAM flag to send */
     int is_end_stream = send_state == H2O_SEND_STATE_FINAL && !stream->req.send_server_timing && stream->req.res.trailers.size == 0;
     if (length != 0 || is_end_stream) {
-        h2o_http2_encode_frame_header(
-            (void *)((*outbuf)->bytes + (*outbuf)->size), length, H2O_HTTP2_FRAME_TYPE_DATA,
-            is_end_stream ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0, stream->stream_id);
+        h2o_http2_encode_frame_header((void *)((*outbuf)->bytes + (*outbuf)->size), length, H2O_HTTP2_FRAME_TYPE_DATA,
+                                      is_end_stream ? H2O_HTTP2_FRAME_FLAG_END_STREAM : 0, stream->stream_id);
         h2o_http2_window_consume_window(&conn->_write.window, length);
         h2o_http2_window_consume_window(&stream->output_window, length);
         (*outbuf)->size += length + H2O_HTTP2_FRAME_HEADER_SIZE;

--- a/src/main.c
+++ b/src/main.c
@@ -293,7 +293,7 @@ static struct {
         h2o_context_t ctx;
         h2o_multithread_receiver_t server_notifications;
         h2o_multithread_receiver_t memcached;
-    } * threads;
+    } *threads;
     volatile sig_atomic_t shutdown_requested;
     h2o_barrier_t startup_sync_barrier_init;
     h2o_barrier_t startup_sync_barrier_post;
@@ -4439,8 +4439,7 @@ static void setup_configurators(void)
         h2o_configurator_define_command(c, "tcp-reuseport", H2O_CONFIGURATOR_FLAG_GLOBAL, on_tcp_reuseport);
         h2o_configurator_define_command(c, "ssl-offload", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_ssl_offload);
-        h2o_configurator_define_command(c, "neverbleed-offload",
-                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+        h2o_configurator_define_command(c, "neverbleed-offload", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                         on_config_neverbleed_offload);
     }
 
@@ -4656,7 +4655,8 @@ int main(int argc, char **argv)
                     for (size_t i = 0; i != c->commands.size; ++i)
                         printf("%s\n", c->commands.entries[i].name);
                 }
-            } exit(0);
+            }
+                exit(0);
             default:
                 assert(0);
                 break;


### PR DESCRIPTION
To avoid any bikeshed, our coding style is dictated by clang-format (`make -f misc/regen.mk clang-format-all`).