### PR TITLE
Allow `:scheme https` in draft-mode CONNECT-UDP.

### DIFF
--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -342,7 +342,8 @@ void h2o_dispose_request(h2o_req_t *req)
 int h2o_req_validate_pseudo_headers(h2o_req_t *req)
 {
     if (h2o_memis(req->input.method.base, req->input.method.len, H2O_STRLIT("CONNECT-UDP"))) {
-        if (req->input.scheme != &H2O_URL_SCHEME_MASQUE)
+        /* The draft requires "masque" in `:scheme` but we need to support clients that put "https" there instead. */
+        if (req->input.scheme != &H2O_URL_SCHEME_MASQUE && req->input.scheme != &H2O_URL_SCHEME_HTTPS)
             return 0;
         if (!h2o_memis(req->input.path.base, req->input.path.len, H2O_STRLIT("/")))
             return 0;

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -634,9 +634,8 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     } else if (h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("CONNECT-UDP"))) {
         /* Handling of masque draft-03. Method is CONNECT-UDP and :protocol is not used, so we set `:protocol` to "connect-udp" to
          * make it look like an upgrade. The method is preserved and can be used to distinguish between RFC 9298 version which uses
-         * "CONNECT". */
+         * "CONNECT". The draft requires "masque" in `:scheme` but we need to support clients that put "https" there instead. */
         if (!((header_exists_map & H2O_HPACK_PARSE_HEADERS_PROTOCOL_EXISTS) == 0 &&
-              stream->req.input.scheme == &H2O_URL_SCHEME_MASQUE &&
               h2o_memis(stream->req.input.path.base, stream->req.input.path.len, H2O_STRLIT("/")))) {
             ret = H2O_HTTP2_ERROR_PROTOCOL;
             goto SendRSTStream;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1378,9 +1378,9 @@ static int handle_input_expect_headers(struct st_h2o_http3_server_stream_t *stre
     } else {
         /* normal request */
         is_connect = 0;
-        must_exist_map = H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS | H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS |
-                         H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS | H2O_HPACK_PARSE_HEADERS_PATH_EXISTS;
-        may_exist_map = 0;
+        must_exist_map =
+            H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS | H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS | H2O_HPACK_PARSE_HEADERS_PATH_EXISTS;
+        may_exist_map = H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS;
     }
 
     /* check that all MUST pseudo headers exist, and that there are no other pseudo headers than MUST or MAY */

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1351,9 +1351,8 @@ static int handle_input_expect_headers(struct st_h2o_http3_server_stream_t *stre
     } else if (h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("CONNECT-UDP"))) {
         /* Handling of masque draft-03. Method is CONNECT-UDP and :protocol is not used, so we set `:protocol` to "connect-udp" to
          * make it look like an upgrade. The method is preserved and can be used to distinguish between RFC 9298 version which uses
-         * "CONNECT". */
+         * "CONNECT". The draft requires "masque" in `:scheme` but we need to support clients that put "https" there instead. */
         if (!((header_exists_map & H2O_HPACK_PARSE_HEADERS_PROTOCOL_EXISTS) == 0 &&
-              stream->req.input.scheme == &H2O_URL_SCHEME_MASQUE &&
               h2o_memis(stream->req.input.path.base, stream->req.input.path.len, H2O_STRLIT("/")))) {
             shutdown_stream(stream, H2O_HTTP3_ERROR_GENERAL_PROTOCOL, H2O_HTTP3_ERROR_GENERAL_PROTOCOL, 0);
             return 0;


### PR DESCRIPTION
For #3278

* Allow `:scheme https` in draft-mode CONNECT-UDP in HTTP/2 and HTTP/3.
* Make `:authority` optional in HTTP/3 like it is in HTTP/2.
* Convert `lib/http3/server.c` to `must_exist_map`/`may_exist_map` like `lib/http2/connection.c`.
