### PR TITLE
Log the request to h2olog before defaulting `stream->req.input.scheme` for HTTP/2 and 3.

### DIFF
--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -614,11 +614,11 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
             return ret;
     }
 
+    h2o_probe_log_request(&stream->req, stream->stream_id);
+
     /* fixup the scheme so that it would never be a NULL pointer (note: checks below are done using `header_exists_map`) */
     if (stream->req.input.scheme == NULL)
         stream->req.input.scheme = conn->sock->ssl != NULL ? &H2O_URL_SCHEME_HTTPS : &H2O_URL_SCHEME_HTTP;
-
-    h2o_probe_log_request(&stream->req, stream->stream_id);
 
     int is_connect = h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("CONNECT"));
 

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1347,10 +1347,10 @@ static int handle_input_expect_headers(struct st_h2o_http3_server_stream_t *stre
     if (header_ack_len != 0)
         h2o_http3_send_qpack_header_ack(&conn->h3, header_ack, header_ack_len);
 
+    h2o_probe_log_request(&stream->req, stream->quic->stream_id);
+
     if (stream->req.input.scheme == NULL)
         stream->req.input.scheme = &H2O_URL_SCHEME_HTTPS;
-
-    h2o_probe_log_request(&stream->req, stream->quic->stream_id);
 
     int is_connect = h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("CONNECT"));
     int is_connect_udp = h2o_memis(stream->req.input.method.base, stream->req.input.method.len, H2O_STRLIT("CONNECT-UDP"));


### PR DESCRIPTION
This makes it clear from `h2olog` output whether the request actually came in with `:scheme` or not.