### PR TITLE
Suppress legacy API warnings generated by OpenSSL 3.0 and above

### DIFF
--- a/deps/neverbleed/neverbleed.c
+++ b/deps/neverbleed/neverbleed.c
@@ -50,6 +50,9 @@
 #include <priv.h>
 #endif
 
+/* to maximize code-reuse between different stacks, we intentionally use API declared by OpenSSL as legacy */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <openssl/opensslconf.h>
 #include <openssl/opensslv.h>
 
@@ -1737,6 +1740,7 @@ static int offload_start(int (*stub)(neverbleed_iobuf_t *), neverbleed_iobuf_t *
         register_wait_fd(req);
         return 0;
     case ASYNC_FINISH: /* completed synchronously */
+        buf->processing = 0;
         break;
     default:
         dief("ASYNC_start_job errored\n");

--- a/lib/http2/cache_digests.c
+++ b/lib/http2/cache_digests.c
@@ -20,8 +20,11 @@
  * IN THE SOFTWARE.
  */
 #include <limits.h>
-#include <openssl/sha.h>
 #include <stdlib.h>
+#ifndef H2O_NO_OPENSSL_SUPPRESS_DEPRECATED
+#define OPENSSL_SUPPRESS_DEPRECATED /* cache-digests is legacy and we do not want to pay the cost of switchng away from SHA256_* */
+#endif
+#include <openssl/sha.h>
 #include "golombset.h"
 #include "h2o/string_.h"
 #include "h2o/cache_digests.h"

--- a/lib/http2/casper.c
+++ b/lib/http2/casper.c
@@ -19,6 +19,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#ifndef H2O_NO_OPENSSL_SUPPRESS_DEPRECATED
+#define OPENSSL_SUPPRESS_DEPRECATED /* casper is legacy and we do not want to pay the cost of switchng away from SHA1_* */
+#endif
 #include <openssl/sha.h>
 #include "golombset.h"
 #include "h2o/string_.h"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -24,6 +24,10 @@
 #include <limits.h>
 #include <pthread.h>
 #include <sys/stat.h>
+#ifndef H2O_NO_OPENSSL_SUPPRESS_DEPRECATED
+#define OPENSSL_SUPPRESS_DEPRECATED /* we'd like to use HMAC_Init_ex while it exists, to minimize code divergence between          \
+                                     * different TLS stacks. */
+#endif
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>


### PR DESCRIPTION
As pointed out in #3285, we have code that uses OpenSSL API declared legacy in 3.0.

This PR suppress them instead of diverging code between different TLS stacks, as suppression is considered to be the lower-cost option.