### PR TITLE
[test] define standard way of emitting debug output (call `debug(args)`)

### DIFF
--- a/t/50access-log-delivery-rate.t
+++ b/t/50access-log-delivery-rate.t
@@ -51,7 +51,7 @@ sub truncate_access_log {
 sub load_logs {
     open my $fh, "<", "$tempdir/access_log" or die $!;
     my @json_logs = <$fh>;
-    diag(@json_logs) if $ENV{TEST_DEBUG};
+    debug(@json_logs);
     return map { decode_json($_) } @json_logs;
 }
 

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -65,6 +65,7 @@ our @EXPORT = qw(
     run_fuzzer
     test_is_passing
     get_exclusive_lock
+    debug
 );
 
 use constant ASSETS_DIR => 't/assets';
@@ -303,7 +304,7 @@ sub spawn_h2o_raw {
     my ($conffh, $conffn) = tempfile(UNLINK => 1);
     print $conffh $conf or confess("failed to write to $conffn: $!");
     $conffh->flush or confess("failed to write to $conffn: $!");
-    Test::More::diag($conf) if $ENV{TEST_DEBUG};
+    debug($conf);
 
     # spawn the server
     my ($guard, $pid) = spawn_server(
@@ -1058,6 +1059,11 @@ sub get_exclusive_lock {
 
     # prevent waring above when trying to lock again
     $ENV{LOCKFD} = "SKIP";
+}
+
+sub debug {
+    return unless $ENV{TEST_DEBUG};
+    Test::More::diag(@_);
 }
 
 1;


### PR DESCRIPTION
It is often helpful to retain debug logging in tests, because they help us find out why the test are failing. The requirement for such debug logging is that they should be off by default and have a way to be turned on.

This pull request introduces a convenient function called `debug`.

Test cases can call `debug()` to supply information that would be helpful for debugging issues with tests.

`debug()` will be a no-op by default, but will call `diag()` if the TEST_DEBUG environment variable is set to a truthy value.