### PR TITLE
Backport to v2.2.x: [http2] delay processing requests upon observing suspicious behavior

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -378,6 +378,10 @@ struct st_h2o_globalconf_t {
          * list of callbacks
          */
         h2o_protocol_callbacks_t callbacks;
+        /**
+         * milliseconds to delay processing requests when suspicious behavior is detected
+         */
+        uint64_t dos_delay;
     } http2;
 
     struct {
@@ -590,6 +594,10 @@ struct st_h2o_context_t {
          * timeout entry used for graceful shutdown
          */
         h2o_timeout_entry_t _graceful_shutdown_timeout;
+        /*
+         * dos timeout
+         */
+        h2o_timeout_t dos_delay_timeout;
         struct {
             /**
              * counter for http2 errors internally emitted by h2o

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -189,6 +189,7 @@ void h2o_config_init(h2o_globalconf_t *config)
     config->http2.latency_optimization.min_rtt = 50; // milliseconds
     config->http2.latency_optimization.max_additional_delay = 10;
     config->http2.latency_optimization.max_cwnd = 65535;
+    config->http2.dos_delay = 100; /* 100ms processing delay when observing suspicious behavior */
     config->http2.callbacks = H2O_HTTP2_CALLBACKS;
     config->mimemap = h2o_mimemap_create();
 

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -531,6 +531,12 @@ static int on_config_http2_casper(h2o_configurator_command_t *cmd, h2o_configura
     return 0;
 }
 
+
+static int on_config_http2_dos_delay(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    return config_timeout(cmd, node, &ctx->globalconf->http2.dos_delay);
+}
+
 static int assert_is_mimetype(h2o_configurator_command_t *cmd, yoml_t *node)
 {
     if (node->type != YOML_TYPE_SCALAR) {
@@ -910,6 +916,9 @@ void h2o_configurator__init_core(h2o_globalconf_t *conf)
                                         on_config_http2_push_preload);
         h2o_configurator_define_command(&c->super, "http2-casper", H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST,
                                         on_config_http2_casper);
+        h2o_configurator_define_command(&c->super, "http2-dos-delay",
+                                        H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                        on_config_http2_dos_delay);
         h2o_configurator_define_command(&c->super, "file.mime.settypes",
                                         (H2O_CONFIGURATOR_FLAG_ALL_LEVELS & ~H2O_CONFIGURATOR_FLAG_EXTENSION) |
                                             H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -101,6 +101,7 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     h2o_linklist_init_anchor(&ctx->http1._conns);
     h2o_timeout_init(ctx->loop, &ctx->http2.idle_timeout, config->http2.idle_timeout);
     h2o_timeout_init(ctx->loop, &ctx->http2.graceful_shutdown_timeout, config->http2.graceful_shutdown_timeout);
+    h2o_timeout_init(ctx->loop, &ctx->http2.dos_delay_timeout, config->http2.dos_delay);
     h2o_linklist_init_anchor(&ctx->http2._conns);
     ctx->proxy.client_ctx.loop = loop;
     h2o_timeout_init(ctx->loop, &ctx->proxy.io_timeout, config->proxy.io_timeout);
@@ -146,6 +147,7 @@ void h2o_context_dispose(h2o_context_t *ctx)
     h2o_timeout_dispose(ctx->loop, &ctx->http1.req_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http2.idle_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->http2.graceful_shutdown_timeout);
+    h2o_timeout_dispose(ctx->loop, &ctx->http2.dos_delay_timeout);
     h2o_timeout_dispose(ctx->loop, &ctx->proxy.io_timeout);
     /* what should we do here? assert(!h2o_linklist_is_empty(&ctx->http2._conns); */
 


### PR DESCRIPTION
Hi!

This is a backport of 94fbc54b6c9309912fe3d53e7b63408bbe9a1b0d from https://github.com/h2o/h2o/pull/3291 to the v2.2.x branch.

I know that all the tagged releases should be considered deprecated, and that no new version will be released in the future, therefore I don't expect this pull request to be merged. While we are transitioning from `libh2o-evloop` to `nghttp2` in DNSdist, we unfortunately need to keep our `h2o` support alive for a little bit longer while the transition is complete, so we have been working on backporting the HTTP2 rapid reset fix on top of 2.2.6, and we decided to share the result in case it helps others. 
Please note that we unfortunately had to break the ABI to introduce the new timer, so this change will require a rebuild of applications dynamically linked against `libh2o`. 
Any feedback would be of course appreciated!

Best regards,

Remi Gacogne
PowerDNS.COM BV - https://www.powerdns.com/
