### PR TITLE
[http3] support ECN

### DIFF
--- a/deps/quicly/examples/echo.c
+++ b/deps/quicly/examples/echo.c
@@ -215,7 +215,7 @@ static int run_loop(int fd, quicly_conn_t *client)
                 tv.tv_sec = delta / 1000;
                 tv.tv_usec = (delta % 1000) * 1000;
             } else {
-                tv.tv_sec = 1000;
+                tv.tv_sec = 0;
                 tv.tv_usec = 0;
             }
             FD_ZERO(&readfds);

--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -493,6 +493,16 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t stream_data_resent;                                                                                               \
     } num_bytes;                                                                                                                   \
+    struct {                                                                                                                       \
+        /**                                                                                                                        \
+         * number of paths that were ECN-capable                                                                                   \
+         */                                                                                                                        \
+        uint64_t ecn_validated;                                                                                                    \
+        /**                                                                                                                        \
+         * number of paths that were deemed as ECN black holes                                                                     \
+         */                                                                                                                        \
+        uint64_t ecn_failed;                                                                                                       \
+    } num_paths;                                                                                                                   \
     /**                                                                                                                            \
      * Total number of each frame being sent / received.                                                                           \
      */                                                                                                                            \

--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -459,9 +459,13 @@ struct st_quicly_conn_streamgroup_state_t {
          */                                                                                                                        \
         uint64_t received_out_of_order;                                                                                            \
         /**                                                                                                                        \
-         * connection-wide ACK-ECN counters for ECT(0), ECT(1), CE                                                                 \
+         * connection-wide counters for ECT(0), ECT(1), CE                                                                         \
          */                                                                                                                        \
-        uint64_t ack_ecn_counts[3];                                                                                                \
+        uint64_t received_ecn_counts[3];                                                                                           \
+        /**                                                                                                                        \
+         * connection-wide ack-received counters for ECT(0), ECT(1), CE                                                            \
+         */                                                                                                                        \
+        uint64_t acked_ecn_counts[3];                                                                                              \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
         /**                                                                                                                        \

--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -331,6 +331,10 @@ struct st_quicly_context_t {
      */
     unsigned expand_client_hello : 1;
     /**
+     * whether to use ECN on the send side; ECN is always on on the receive side
+     */
+    unsigned enable_ecn : 1;
+    /**
      *
      */
     quicly_cid_encryptor_t *cid_encryptor;
@@ -450,6 +454,14 @@ struct st_quicly_conn_streamgroup_state_t {
          * Total number of Initial and Handshake packets sent.                                                                     \
          */                                                                                                                        \
         uint64_t initial_handshake_sent;                                                                                           \
+        /**                                                                                                                        \
+         * Total number of packets received out of order.                                                                          \
+         */                                                                                                                        \
+        uint64_t received_out_of_order;                                                                                            \
+        /**                                                                                                                        \
+         * connection-wide ACK-ECN counters for ECT(0), ECT(1), CE                                                                 \
+         */                                                                                                                        \
+        uint64_t ack_ecn_counts[3];                                                                                                \
     } num_packets;                                                                                                                 \
     struct {                                                                                                                       \
         /**                                                                                                                        \
@@ -815,6 +827,10 @@ typedef struct st_quicly_decoded_packet_t {
         uint64_t key_phase;
     } decrypted;
     /**
+     * ECN bits
+     */
+    uint8_t ecn : 2;
+    /**
      *
      */
     enum {
@@ -1031,6 +1047,10 @@ size_t quicly_send_retry(quicly_context_t *ctx, ptls_aead_context_t *token_encry
  */
 int quicly_send(quicly_conn_t *conn, quicly_address_t *dest, quicly_address_t *src, struct iovec *datagrams, size_t *num_datagrams,
                 void *buf, size_t bufsize);
+/**
+ * returns ECN bits to be set for the packets built by the last invocation of `quicly_send`
+ */
+uint8_t quicly_send_get_ecn_bits(quicly_conn_t *conn);
 /**
  *
  */

--- a/deps/quicly/include/quicly/frame.h
+++ b/deps/quicly/include/quicly/frame.h
@@ -234,7 +234,7 @@ typedef struct st_quicly_stop_sending_frame_t {
 
 static int quicly_decode_stop_sending_frame(const uint8_t **src, const uint8_t *end, quicly_stop_sending_frame_t *frame);
 
-uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t ack_delay);
+uint8_t *quicly_encode_ack_frame(uint8_t *dst, uint8_t *dst_end, quicly_ranges_t *ranges, uint64_t *ecn_counts, uint64_t ack_delay);
 
 typedef struct st_quicly_ack_frame_t {
     uint64_t largest_acknowledged;
@@ -243,6 +243,7 @@ typedef struct st_quicly_ack_frame_t {
     uint64_t num_gaps;
     uint64_t ack_block_lengths[QUICLY_ACK_MAX_GAPS + 1];
     uint64_t gaps[QUICLY_ACK_MAX_GAPS];
+    uint64_t ecn_counts[3];
 } quicly_ack_frame_t;
 
 int quicly_decode_ack_frame(const uint8_t **src, const uint8_t *end, quicly_ack_frame_t *frame, int is_ack_ecn);

--- a/deps/quicly/lib/cc-cubic.c
+++ b/deps/quicly/lib/cc-cubic.c
@@ -105,6 +105,8 @@ static void cubic_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t 
 static void cubic_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                           int64_t now, uint32_t max_udp_payload_size)
 {
+    quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
+
     /* Nothing to do if loss is in recovery window. */
     if (lost_pn < cc->recovery_end)
         return;

--- a/deps/quicly/lib/cc-pico.c
+++ b/deps/quicly/lib/cc-pico.c
@@ -95,6 +95,8 @@ static void pico_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                          int64_t now, uint32_t max_udp_payload_size)
 {
+    quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
+
     /* Nothing to do if loss is in recovery window. */
     if (lost_pn < cc->recovery_end)
         return;

--- a/deps/quicly/lib/cc-reno.c
+++ b/deps/quicly/lib/cc-reno.c
@@ -53,6 +53,8 @@ static void reno_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
 void quicly_cc_reno_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t bytes, uint64_t lost_pn, uint64_t next_pn,
                             int64_t now, uint32_t max_udp_payload_size)
 {
+    quicly_cc__update_ecn_episodes(cc, bytes, lost_pn);
+
     /* Nothing to do if loss is in recovery window. */
     if (lost_pn < cc->recovery_end)
         return;

--- a/deps/quicly/lib/defaults.c
+++ b/deps/quicly/lib/defaults.c
@@ -50,6 +50,7 @@ const quicly_context_t quicly_spec_context = {NULL,                             
                                               DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                               DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                               0, /* enlarge_client_hello */
+                                              1, /* enable_ecn */
                                               NULL,
                                               NULL, /* on_stream_open */
                                               &quicly_default_stream_scheduler,
@@ -80,6 +81,7 @@ const quicly_context_t quicly_performant_context = {NULL,                       
                                                     DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
                                                     DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
                                                     0, /* enlarge_client_hello */
+                                                    1, /* enable_ecn */
                                                     NULL,
                                                     NULL, /* on_stream_open */
                                                     &quicly_default_stream_scheduler,

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -3097,8 +3097,14 @@ int64_t quicly_get_first_timeout(quicly_conn_t *conn)
     uint64_t amp_window = calc_amplification_limit_allowance(conn);
 
     if (calc_send_window(conn, 0, amp_window, 0) > 0) {
-        if (conn->egress.pending_flows != 0)
-            return 0;
+        if (conn->egress.pending_flows != 0) {
+            /* crypto streams (as indicated by lower 4 bits) can be sent whenever CWND is available; other flows need application
+             * packet number space */
+            if (conn->application != NULL && conn->application->cipher.egress.key.header_protection != NULL)
+                return 0;
+            if ((conn->egress.pending_flows & 0xf) != 0)
+                return 0;
+        }
         if (quicly_linklist_is_linked(&conn->egress.pending_streams.control))
             return 0;
         if (scheduler_can_send(conn))

--- a/deps/quicly/quicly-probes.d
+++ b/deps/quicly/quicly-probes.d
@@ -126,6 +126,9 @@ provider quicly {
     probe stream_data_blocked_send(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
     probe stream_data_blocked_receive(struct st_quicly_conn_t *conn, int64_t at, int64_t stream_id, uint64_t maximum);
 
+    probe ecn_validation(struct st_quicly_conn_t *conn, int64_t at, int ecn_state);
+    probe ecn_congestion(struct st_quicly_conn_t *conn, int64_t at, uint64_t ce_count);
+
     probe datagram_send(struct st_quicly_conn_t *conn, int64_t at, const void *payload, size_t payload_len);
     probe datagram_receive(struct st_quicly_conn_t *conn, int64_t at, const void *payload, size_t payload_len);
 

--- a/deps/quicly/src/cli.c
+++ b/deps/quicly/src/cli.c
@@ -142,14 +142,17 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
 
     quicly_get_stats(conn, &stats);
     fprintf(fp,
-            "packets-received: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
+            "packets-received: %" PRIu64 ", received-ecn-ect0: %" PRIu64 ", received-ecn-ect1: %" PRIu64
+            ", received-ecn-ce: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
             ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", ack-ecn-ect0: %" PRIu64 ", ack-ecn-ect1: %" PRIu64
             ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
             ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 "\n",
-            stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
-            stats.num_packets.ack_received, stats.num_packets.ack_ecn_counts[0], stats.num_packets.ack_ecn_counts[1],
-            stats.num_packets.ack_ecn_counts[2], stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent,
-            stats.rtt.smoothed, stats.cc.num_loss_episodes, stats.cc.num_ecn_loss_episodes);
+            stats.num_packets.received, stats.num_packets.received_ecn_counts[0], stats.num_packets.received_ecn_counts[1],
+            stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed, stats.num_packets.sent,
+            stats.num_packets.lost, stats.num_packets.ack_received, stats.num_packets.acked_ecn_counts[0],
+            stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2], stats.num_packets.late_acked,
+            stats.num_bytes.received, stats.num_bytes.sent, stats.rtt.smoothed, stats.cc.num_loss_episodes,
+            stats.cc.num_ecn_loss_episodes);
 }
 
 static int validate_path(const char *path)

--- a/deps/quicly/src/cli.c
+++ b/deps/quicly/src/cli.c
@@ -25,6 +25,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <getopt.h>
+#include <netinet/ip.h>
 #include <netinet/udp.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -142,11 +143,13 @@ static void dump_stats(FILE *fp, quicly_conn_t *conn)
     quicly_get_stats(conn, &stats);
     fprintf(fp,
             "packets-received: %" PRIu64 ", packets-decryption-failed: %" PRIu64 ", packets-sent: %" PRIu64
-            ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64
-            ", bytes-sent: %" PRIu64 ", srtt: %" PRIu32 "\n",
+            ", packets-lost: %" PRIu64 ", ack-received: %" PRIu64 ", ack-ecn-ect0: %" PRIu64 ", ack-ecn-ect1: %" PRIu64
+            ", ack-ecn-ce: %" PRIu64 ", late-acked: %" PRIu64 ", bytes-received: %" PRIu64 ", bytes-sent: %" PRIu64
+            ", srtt: %" PRIu32 ", num-loss-episodes: %" PRIu32 ", num-ecn-loss-episodes: %" PRIu32 "\n",
             stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
-            stats.num_packets.ack_received, stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent,
-            stats.rtt.smoothed);
+            stats.num_packets.ack_received, stats.num_packets.ack_ecn_counts[0], stats.num_packets.ack_ecn_counts[1],
+            stats.num_packets.ack_ecn_counts[2], stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent,
+            stats.rtt.smoothed, stats.cc.num_loss_episodes, stats.cc.num_ecn_loss_episodes);
 }
 
 static int validate_path(const char *path)
@@ -416,15 +419,80 @@ static int on_generate_resumption_token(quicly_generate_resumption_token_t *self
 
 static quicly_generate_resumption_token_t generate_resumption_token = {&on_generate_resumption_token};
 
-static void send_packets_default(int fd, struct sockaddr *dest, struct iovec *packets, size_t num_packets)
+/* buf should be ctx.transport_params.max_udp_payload_size bytes long */
+static ssize_t receive_datagram(int fd, void *buf, quicly_address_t *src, uint8_t *ecn)
+{
+    struct iovec vec = {.iov_base = buf, .iov_len = ctx.transport_params.max_udp_payload_size};
+    char cmsgbuf[CMSG_SPACE(sizeof(int) /* == max(V4_TOS, V6_TCLASS) */)] = {};
+    struct msghdr mess = {
+        .msg_name = &src->sa,
+        .msg_namelen = sizeof(*src),
+        .msg_iov = &vec,
+        .msg_iovlen = 1,
+        .msg_control = cmsgbuf,
+        .msg_controllen = sizeof(cmsgbuf),
+    };
+    quicly_address_t localaddr = {};
+    socklen_t localaddrlen = sizeof(localaddr);
+    ssize_t rret;
+
+    if (getsockname(fd, &localaddr.sa, &localaddrlen) != 0)
+        perror("getsockname failed");
+
+    while ((rret = recvmsg(fd, &mess, 0)) == -1 && errno == EINTR)
+        ;
+
+    if (rret >= 0) {
+        *ecn = 0;
+        for (struct cmsghdr *cmsg = CMSG_FIRSTHDR(&mess); cmsg != NULL; cmsg = CMSG_NXTHDR(&mess, cmsg)) {
+#ifdef IP_RECVTOS
+            if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type ==
+#ifdef __APPLE__
+                IP_RECVTOS
+#else
+                IP_TOS
+#endif
+                ) {
+                assert((char *)CMSG_DATA(cmsg) - (char *)cmsg + 1 == cmsg->cmsg_len);
+                *ecn = *(uint8_t *)CMSG_DATA(cmsg) & IPTOS_ECN_MASK;
+            }
+#endif
+        }
+    }
+
+    return rret;
+}
+
+static void set_ecn(struct msghdr *mess, int ecn)
+{
+    if (ecn == 0)
+        return;
+
+    struct cmsghdr *cmsg = (struct cmsghdr *)((char *)mess->msg_control + mess->msg_controllen);
+
+    cmsg->cmsg_level = IPPROTO_IP;
+    cmsg->cmsg_type = IP_TOS;
+    cmsg->cmsg_len = CMSG_LEN(sizeof(ecn));
+    memcpy(CMSG_DATA(cmsg), &ecn, sizeof(ecn));
+
+    mess->msg_controllen += CMSG_SPACE(sizeof(ecn));
+}
+
+static void send_packets_default(int fd, struct sockaddr *dest, struct iovec *packets, size_t num_packets, uint8_t ecn)
 {
     for (size_t i = 0; i != num_packets; ++i) {
-        struct msghdr mess;
-        memset(&mess, 0, sizeof(mess));
-        mess.msg_name = dest;
-        mess.msg_namelen = quicly_get_socklen(dest);
-        mess.msg_iov = &packets[i];
-        mess.msg_iovlen = 1;
+        char cmsgbuf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
+        struct msghdr mess = {
+            .msg_name = dest,
+            .msg_namelen = quicly_get_socklen(dest),
+            .msg_iov = &packets[i],
+            .msg_iovlen = 1,
+            .msg_control = cmsgbuf,
+        };
+        set_ecn(&mess, ecn);
+        assert(mess.msg_controllen <= sizeof(cmsgbuf));
+        if (mess.msg_controllen == 0)
+            mess.msg_control = NULL;
         if (verbosity >= 2)
             hexdump("sendmsg", packets[i].iov_base, packets[i].iov_len);
         int ret;
@@ -441,29 +509,27 @@ static void send_packets_default(int fd, struct sockaddr *dest, struct iovec *pa
 #define UDP_SEGMENT 103
 #endif
 
-static void send_packets_gso(int fd, struct sockaddr *dest, struct iovec *packets, size_t num_packets)
+static void send_packets_gso(int fd, struct sockaddr *dest, struct iovec *packets, size_t num_packets, uint8_t ecn)
 {
     struct iovec vec = {.iov_base = (void *)packets[0].iov_base,
                         .iov_len = packets[num_packets - 1].iov_base + packets[num_packets - 1].iov_len - packets[0].iov_base};
+    char cmsgbuf[CMSG_SPACE(sizeof(uint16_t)) + CMSG_SPACE(sizeof(int))]; /* UDP_SEGMENT and IP_TOS */
     struct msghdr mess = {
         .msg_name = dest,
         .msg_namelen = quicly_get_socklen(dest),
         .msg_iov = &vec,
         .msg_iovlen = 1,
+        .msg_control = cmsgbuf,
     };
-
-    union {
-        struct cmsghdr hdr;
-        char buf[CMSG_SPACE(sizeof(uint16_t))];
-    } cmsg;
     if (num_packets != 1) {
-        cmsg.hdr.cmsg_level = SOL_UDP;
-        cmsg.hdr.cmsg_type = UDP_SEGMENT;
-        cmsg.hdr.cmsg_len = CMSG_LEN(sizeof(uint16_t));
-        *(uint16_t *)CMSG_DATA(&cmsg.hdr) = packets[0].iov_len;
-        mess.msg_control = &cmsg;
-        mess.msg_controllen = (socklen_t)CMSG_SPACE(sizeof(uint16_t));
+        struct cmsghdr *cmsg = mess.msg_control;
+        cmsg->cmsg_level = SOL_UDP;
+        cmsg->cmsg_type = UDP_SEGMENT;
+        cmsg->cmsg_len = CMSG_LEN(sizeof(uint16_t));
+        *(uint16_t *)CMSG_DATA(cmsg) = packets[0].iov_len;
+        mess.msg_controllen = CMSG_SPACE(sizeof(uint16_t));
     }
+    set_ecn(&mess, ecn);
 
     int ret;
     while ((ret = sendmsg(fd, &mess, 0)) == -1 && errno == EINTR)
@@ -474,12 +540,12 @@ static void send_packets_gso(int fd, struct sockaddr *dest, struct iovec *packet
 
 #endif
 
-static void (*send_packets)(int, struct sockaddr *, struct iovec *, size_t) = send_packets_default;
+static void (*send_packets)(int, struct sockaddr *, struct iovec *, size_t, uint8_t ecn) = send_packets_default;
 
 static void send_one_packet(int fd, struct sockaddr *dest, const void *payload, size_t payload_len)
 {
     struct iovec vec = {.iov_base = (void *)payload, .iov_len = payload_len};
-    send_packets(fd, dest, &vec, 1);
+    send_packets(fd, dest, &vec, 1, 0);
 }
 
 static int send_pending(int fd, quicly_conn_t *conn)
@@ -491,7 +557,7 @@ static int send_pending(int fd, quicly_conn_t *conn)
     int ret;
 
     if ((ret = quicly_send(conn, &dest, &src, packets, &num_packets, buf, sizeof(buf))) == 0 && num_packets != 0)
-        send_packets(fd, &dest.sa, packets, num_packets);
+        send_packets(fd, &dest.sa, packets, num_packets, quicly_send_get_ecn_bits(conn));
 
     return ret;
 }
@@ -577,20 +643,9 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
             enqueue_requests(conn);
         if (FD_ISSET(fd, &readfds)) {
             while (1) {
-                uint8_t buf[ctx.transport_params.max_udp_payload_size];
-                struct msghdr mess;
-                struct sockaddr sa;
-                struct iovec vec;
-                memset(&mess, 0, sizeof(mess));
-                mess.msg_name = &sa;
-                mess.msg_namelen = sizeof(sa);
-                vec.iov_base = buf;
-                vec.iov_len = sizeof(buf);
-                mess.msg_iov = &vec;
-                mess.msg_iovlen = 1;
-                ssize_t rret;
-                while ((rret = recvmsg(fd, &mess, 0)) == -1 && errno == EINTR)
-                    ;
+                uint8_t buf[ctx.transport_params.max_udp_payload_size], ecn;
+                quicly_address_t src;
+                ssize_t rret = receive_datagram(fd, buf, &src, &ecn);
                 if (rret <= 0)
                     break;
                 if (verbosity >= 2)
@@ -600,7 +655,8 @@ static int run_client(int fd, struct sockaddr *sa, const char *host)
                     quicly_decoded_packet_t packet;
                     if (quicly_decode_packet(&ctx, &packet, buf, rret, &off) == SIZE_MAX)
                         break;
-                    quicly_receive(conn, NULL, &sa, &packet);
+                    packet.ecn = ecn;
+                    quicly_receive(conn, NULL, &src.sa, &packet);
                     if (send_datagram_frame && quicly_connection_is_ready(conn)) {
                         const char *message = "hello datagram!";
                         ptls_iovec_t datagram = ptls_iovec_init(message, strlen(message));
@@ -751,20 +807,9 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
         } while (select(fd + 1, &readfds, NULL, NULL, tv) == -1 && errno == EINTR);
         if (FD_ISSET(fd, &readfds)) {
             while (1) {
-                uint8_t buf[ctx.transport_params.max_udp_payload_size];
-                struct msghdr mess;
+                uint8_t buf[ctx.transport_params.max_udp_payload_size], ecn;
                 quicly_address_t remote;
-                struct iovec vec;
-                memset(&mess, 0, sizeof(mess));
-                mess.msg_name = &remote.sa;
-                mess.msg_namelen = sizeof(remote);
-                vec.iov_base = buf;
-                vec.iov_len = sizeof(buf);
-                mess.msg_iov = &vec;
-                mess.msg_iovlen = 1;
-                ssize_t rret;
-                while ((rret = recvmsg(fd, &mess, 0)) == -1 && errno == EINTR)
-                    ;
+                ssize_t rret = receive_datagram(fd, buf, &remote, &ecn);
                 if (rret == -1)
                     break;
                 if (verbosity >= 2)
@@ -774,6 +819,7 @@ static int run_server(int fd, struct sockaddr *sa, socklen_t salen)
                     quicly_decoded_packet_t packet;
                     if (quicly_decode_packet(&ctx, &packet, buf, rret, &off) == SIZE_MAX)
                         break;
+                    packet.ecn = ecn;
                     if (QUICLY_PACKET_IS_LONG_HEADER(packet.octets.base[0])) {
                         if (packet.version != 0 && !quicly_is_supported_version(packet.version)) {
                             uint8_t payload[ctx.transport_params.max_udp_payload_size];
@@ -1113,8 +1159,10 @@ int main(int argc, char **argv)
         address_token_aead.dec = ptls_aead_new(&ptls_openssl_aes128gcm, &ptls_openssl_sha256, 0, secret, "");
     }
 
-    static const struct option longopts[] = {
-        {"ech-key", required_argument, NULL, 0}, {"ech-configs", required_argument, NULL, 0}, {NULL}};
+    static const struct option longopts[] = {{"ech-key", required_argument, NULL, 0},
+                                             {"ech-configs", required_argument, NULL, 0},
+                                             {"disable-ecn", no_argument, NULL, 0},
+                                             {NULL}};
     while ((ch = getopt_long(argc, argv, "a:b:B:c:C:Dd:k:Ee:f:Gi:I:K:l:M:m:NnOp:P:Rr:S:s:u:U:Vvw:W:x:X:y:h", longopts,
                              &opt_index)) != -1) {
         switch (ch) {
@@ -1123,6 +1171,8 @@ int main(int argc, char **argv)
                 ech_setup_key(&tlsctx, optarg);
             } else if (strcmp(longopts[opt_index].name, "ech-configs") == 0) {
                 ech_setup_configs(optarg);
+            } else if (strcmp(longopts[opt_index].name, "disable-ecn") == 0) {
+                ctx.enable_ecn = 0;
             } else {
                 assert(!"unexpected longname");
             }
@@ -1480,6 +1530,13 @@ int main(int argc, char **argv)
         int opt = IP_PMTUDISC_DO;
         if (setsockopt(fd, IPPROTO_IP, IP_MTU_DISCOVER, &opt, sizeof(opt)) != 0)
             perror("Warning: setsockopt(IP_MTU_DISCOVER) failed");
+    }
+#endif
+#ifdef IP_RECVTOS
+    {
+        int on = 1;
+        if (setsockopt(fd, IPPROTO_IP, IP_RECVTOS, &on, sizeof(on)) != 0)
+            perror("Warning: setsockopt(IP_RECVTOS) failed");
     }
 #endif
 

--- a/deps/quicly/t/test.c
+++ b/deps/quicly/t/test.c
@@ -716,6 +716,13 @@ static void test_set_cc(void)
     ok(strcmp(stats.cc.type->name, "reno") == 0);
 }
 
+void test_ecn_index_from_bits(void)
+{
+    ok(get_ecn_index_from_bits(1) == 1);
+    ok(get_ecn_index_from_bits(2) == 0);
+    ok(get_ecn_index_from_bits(3) == 2);
+}
+
 int main(int argc, char **argv)
 {
     static ptls_iovec_t cert;
@@ -791,6 +798,7 @@ int main(int argc, char **argv)
     subtest("lossy", test_lossy);
     subtest("test-nondecryptable-initial", test_nondecryptable_initial);
     subtest("set_cc", test_set_cc);
+    subtest("ecn-index-from-bits", test_ecn_index_from_bits);
 
     return done_testing();
 }

--- a/deps/quicly/t/test.c
+++ b/deps/quicly/t/test.c
@@ -515,20 +515,20 @@ static void do_test_record_receipt(size_t epoch)
 {
     struct st_quicly_pn_space_t *space =
         alloc_pn_space(sizeof(*space), epoch == QUICLY_EPOCH_1RTT ? QUICLY_DEFAULT_PACKET_TOLERANCE : 1);
-    uint64_t pn = 0;
+    uint64_t pn = 0, out_of_order_cnt = 0;
     int64_t now = 12345, send_ack_at = INT64_MAX;
 
     if (epoch == QUICLY_EPOCH_1RTT) {
         /* 2nd packet triggers an ack */
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now + QUICLY_DELAYED_ACK_TIMEOUT);
         now += 1;
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     } else {
         /* every packet triggers an ack */
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     }
@@ -538,23 +538,23 @@ static void do_test_record_receipt(size_t epoch)
     send_ack_at = INT64_MAX;
 
     /* ack-only packets do not elicit an ack */
-    ok(record_receipt(space, pn++, 1, now, &send_ack_at) == 0);
+    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
-    ok(record_receipt(space, pn++, 1, now, &send_ack_at) == 0);
+    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
     pn++; /* gap */
-    ok(record_receipt(space, pn++, 1, now, &send_ack_at) == 0);
+    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
-    ok(record_receipt(space, pn++, 1, now, &send_ack_at) == 0);
+    ok(record_receipt(space, pn++, 0, 1, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == INT64_MAX);
     now += 1;
 
     /* gap triggers an ack */
     pn += 1; /* gap */
-    ok(record_receipt(space, pn++, 0, now, &send_ack_at) == 0);
+    ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
     ok(send_ack_at == now);
     now += 1;
 
@@ -566,10 +566,10 @@ static void do_test_record_receipt(size_t epoch)
     if (epoch == QUICLY_EPOCH_1RTT) {
         space->ignore_order = 1;
         pn++; /* gap */
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now + QUICLY_DELAYED_ACK_TIMEOUT);
         now += 1;
-        ok(record_receipt(space, pn++, 0, now, &send_ack_at) == 0);
+        ok(record_receipt(space, pn++, 0, 0, now, &send_ack_at, &out_of_order_cnt) == 0);
         ok(send_ack_at == now);
         now += 1;
     }

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -725,9 +725,10 @@ Redo:
     buf = h2o_mem_alloc_pool(&req->pool, char, bufsize);
     len = snprintf(
         buf, bufsize,
-        "packets-received=%" PRIu64 ",packets-decryption-failed=%" PRIu64 ",packets-sent=%" PRIu64 ",packets-lost=%" PRIu64
-        ",packets-lost-time-threshold=%" PRIu64 ",packets-ack-received=%" PRIu64 ",packets-ack-ecn-ect0=%" PRIu64
-        ",packets-ack-ecn-ect1=%" PRIu64 ",packets-ack-ecn-ce=%" PRIu64 ",late-acked=%" PRIu64 ",bytes-received=%" PRIu64
+        "packets-received=%" PRIu64 ",packets-received-ecn-ect0=%" PRIu64 ",packets-received-ecn-ect1=%" PRIu64
+        ",packets-received-ecn-ce=%" PRIu64 ",packets-decryption-failed=%" PRIu64 ",packets-sent=%" PRIu64 ",packets-lost=%" PRIu64
+        ",packets-lost-time-threshold=%" PRIu64 ",packets-ack-received=%" PRIu64 ",packets-acked-ecn-ect0=%" PRIu64
+        ",packets-acked-ecn-ect1=%" PRIu64 ",packets-acked-ecn-ce=%" PRIu64 ",late-acked=%" PRIu64 ",bytes-received=%" PRIu64
         ",bytes-sent=%" PRIu64 ",bytes-lost=%" PRIu64 ",bytes-ack-received=%" PRIu64 ",bytes-stream-data-sent=%" PRIu64
         ",bytes-stream-data-resent=%" PRIu64 ",rtt-minimum=%" PRIu32 ",rtt-smoothed=%" PRIu32 ",rtt-variance=%" PRIu32
         ",rtt-latest=%" PRIu32 ",cwnd=%" PRIu32 ",ssthresh=%" PRIu32 ",cwnd-initial=%" PRIu32 ",cwnd-exiting-slow-start=%" PRIu32
@@ -735,12 +736,13 @@ Redo:
         ",num-ptos=%" PRIu64 ",delivery-rate-latest=%" PRIu64 ",delivery-rate-smoothed=%" PRIu64
         ",delivery-rate-stdev=%" PRIu64 APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, received)
             APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, sent) ",num-sentmap-packets-largest=%zu",
-        stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
-        stats.num_packets.lost_time_threshold, stats.num_packets.ack_received, stats.num_packets.ack_ecn_counts[0],
-        stats.num_packets.ack_ecn_counts[1], stats.num_packets.ack_ecn_counts[2], stats.num_packets.late_acked,
-        stats.num_bytes.received, stats.num_bytes.sent, stats.num_bytes.lost, stats.num_bytes.ack_received,
-        stats.num_bytes.stream_data_sent, stats.num_bytes.stream_data_resent, stats.rtt.minimum, stats.rtt.smoothed,
-        stats.rtt.variance, stats.rtt.latest, stats.cc.cwnd, stats.cc.ssthresh, stats.cc.cwnd_initial,
+        stats.num_packets.received, stats.num_packets.received_ecn_counts[0], stats.num_packets.received_ecn_counts[1],
+        stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed, stats.num_packets.sent,
+        stats.num_packets.lost, stats.num_packets.lost_time_threshold, stats.num_packets.ack_received,
+        stats.num_packets.acked_ecn_counts[0], stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2],
+        stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent, stats.num_bytes.lost,
+        stats.num_bytes.ack_received, stats.num_bytes.stream_data_sent, stats.num_bytes.stream_data_resent, stats.rtt.minimum,
+        stats.rtt.smoothed, stats.rtt.variance, stats.rtt.latest, stats.cc.cwnd, stats.cc.ssthresh, stats.cc.cwnd_initial,
         stats.cc.cwnd_exiting_slow_start, stats.cc.cwnd_minimum, stats.cc.cwnd_maximum, stats.cc.num_loss_episodes,
         stats.cc.num_ecn_loss_episodes, stats.num_ptos, stats.delivery_rate.latest, stats.delivery_rate.smoothed,
         stats.delivery_rate.stdev APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, received) APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, sent),

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -726,21 +726,23 @@ Redo:
     len = snprintf(
         buf, bufsize,
         "packets-received=%" PRIu64 ",packets-decryption-failed=%" PRIu64 ",packets-sent=%" PRIu64 ",packets-lost=%" PRIu64
-        ",packets-lost-time-threshold=%" PRIu64 ",packets-ack-received=%" PRIu64 ",late-acked=%" PRIu64 ",bytes-received=%" PRIu64
+        ",packets-lost-time-threshold=%" PRIu64 ",packets-ack-received=%" PRIu64 ",packets-ack-ecn-ect0=%" PRIu64
+        ",packets-ack-ecn-ect1=%" PRIu64 ",packets-ack-ecn-ce=%" PRIu64 ",late-acked=%" PRIu64 ",bytes-received=%" PRIu64
         ",bytes-sent=%" PRIu64 ",bytes-lost=%" PRIu64 ",bytes-ack-received=%" PRIu64 ",bytes-stream-data-sent=%" PRIu64
         ",bytes-stream-data-resent=%" PRIu64 ",rtt-minimum=%" PRIu32 ",rtt-smoothed=%" PRIu32 ",rtt-variance=%" PRIu32
         ",rtt-latest=%" PRIu32 ",cwnd=%" PRIu32 ",ssthresh=%" PRIu32 ",cwnd-initial=%" PRIu32 ",cwnd-exiting-slow-start=%" PRIu32
-        ",cwnd-minimum=%" PRIu32 ",cwnd-maximum=%" PRIu32 ",num-loss-episodes=%" PRIu32 ",num-ptos=%" PRIu64
-        ",delivery-rate-latest=%" PRIu64 ",delivery-rate-smoothed=%" PRIu64
+        ",cwnd-minimum=%" PRIu32 ",cwnd-maximum=%" PRIu32 ",num-loss-episodes=%" PRIu32 ",num-ecn-loss-episodes=%" PRIu32
+        ",num-ptos=%" PRIu64 ",delivery-rate-latest=%" PRIu64 ",delivery-rate-smoothed=%" PRIu64
         ",delivery-rate-stdev=%" PRIu64 APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, received)
             APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, sent) ",num-sentmap-packets-largest=%zu",
         stats.num_packets.received, stats.num_packets.decryption_failed, stats.num_packets.sent, stats.num_packets.lost,
-        stats.num_packets.lost_time_threshold, stats.num_packets.ack_received, stats.num_packets.late_acked,
+        stats.num_packets.lost_time_threshold, stats.num_packets.ack_received, stats.num_packets.ack_ecn_counts[0],
+        stats.num_packets.ack_ecn_counts[1], stats.num_packets.ack_ecn_counts[2], stats.num_packets.late_acked,
         stats.num_bytes.received, stats.num_bytes.sent, stats.num_bytes.lost, stats.num_bytes.ack_received,
         stats.num_bytes.stream_data_sent, stats.num_bytes.stream_data_resent, stats.rtt.minimum, stats.rtt.smoothed,
         stats.rtt.variance, stats.rtt.latest, stats.cc.cwnd, stats.cc.ssthresh, stats.cc.cwnd_initial,
-        stats.cc.cwnd_exiting_slow_start, stats.cc.cwnd_minimum, stats.cc.cwnd_maximum, stats.cc.num_loss_episodes, stats.num_ptos,
-        stats.delivery_rate.latest, stats.delivery_rate.smoothed,
+        stats.cc.cwnd_exiting_slow_start, stats.cc.cwnd_minimum, stats.cc.cwnd_maximum, stats.cc.num_loss_episodes,
+        stats.cc.num_ecn_loss_episodes, stats.num_ptos, stats.delivery_rate.latest, stats.delivery_rate.smoothed,
         stats.delivery_rate.stdev APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, received) APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, sent),
         stats.num_sentmap_packets_largest);
     if (len + 1 > bufsize) {

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -730,21 +730,22 @@ Redo:
         ",packets-lost-time-threshold=%" PRIu64 ",packets-ack-received=%" PRIu64 ",packets-acked-ecn-ect0=%" PRIu64
         ",packets-acked-ecn-ect1=%" PRIu64 ",packets-acked-ecn-ce=%" PRIu64 ",late-acked=%" PRIu64 ",bytes-received=%" PRIu64
         ",bytes-sent=%" PRIu64 ",bytes-lost=%" PRIu64 ",bytes-ack-received=%" PRIu64 ",bytes-stream-data-sent=%" PRIu64
-        ",bytes-stream-data-resent=%" PRIu64 ",rtt-minimum=%" PRIu32 ",rtt-smoothed=%" PRIu32 ",rtt-variance=%" PRIu32
-        ",rtt-latest=%" PRIu32 ",cwnd=%" PRIu32 ",ssthresh=%" PRIu32 ",cwnd-initial=%" PRIu32 ",cwnd-exiting-slow-start=%" PRIu32
-        ",cwnd-minimum=%" PRIu32 ",cwnd-maximum=%" PRIu32 ",num-loss-episodes=%" PRIu32 ",num-ecn-loss-episodes=%" PRIu32
-        ",num-ptos=%" PRIu64 ",delivery-rate-latest=%" PRIu64 ",delivery-rate-smoothed=%" PRIu64
-        ",delivery-rate-stdev=%" PRIu64 APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, received)
+        ",bytes-stream-data-resent=%" PRIu64 ",paths-ecn-validated=%" PRIu64 ",paths-ecn-failed=%" PRIu64 ",rtt-minimum=%" PRIu32
+        ",rtt-smoothed=%" PRIu32 ",rtt-variance=%" PRIu32 ",rtt-latest=%" PRIu32 ",cwnd=%" PRIu32 ",ssthresh=%" PRIu32
+        ",cwnd-initial=%" PRIu32 ",cwnd-exiting-slow-start=%" PRIu32 ",cwnd-minimum=%" PRIu32 ",cwnd-maximum=%" PRIu32
+        ",num-loss-episodes=%" PRIu32 ",num-ecn-loss-episodes=%" PRIu32 ",num-ptos=%" PRIu64 ",delivery-rate-latest=%" PRIu64
+        ",delivery-rate-smoothed=%" PRIu64 ",delivery-rate-stdev=%" PRIu64 APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, received)
             APPLY_NUM_FRAMES(FORMAT_OF_NUM_FRAMES, sent) ",num-sentmap-packets-largest=%zu",
         stats.num_packets.received, stats.num_packets.received_ecn_counts[0], stats.num_packets.received_ecn_counts[1],
         stats.num_packets.received_ecn_counts[2], stats.num_packets.decryption_failed, stats.num_packets.sent,
         stats.num_packets.lost, stats.num_packets.lost_time_threshold, stats.num_packets.ack_received,
         stats.num_packets.acked_ecn_counts[0], stats.num_packets.acked_ecn_counts[1], stats.num_packets.acked_ecn_counts[2],
         stats.num_packets.late_acked, stats.num_bytes.received, stats.num_bytes.sent, stats.num_bytes.lost,
-        stats.num_bytes.ack_received, stats.num_bytes.stream_data_sent, stats.num_bytes.stream_data_resent, stats.rtt.minimum,
-        stats.rtt.smoothed, stats.rtt.variance, stats.rtt.latest, stats.cc.cwnd, stats.cc.ssthresh, stats.cc.cwnd_initial,
-        stats.cc.cwnd_exiting_slow_start, stats.cc.cwnd_minimum, stats.cc.cwnd_maximum, stats.cc.num_loss_episodes,
-        stats.cc.num_ecn_loss_episodes, stats.num_ptos, stats.delivery_rate.latest, stats.delivery_rate.smoothed,
+        stats.num_bytes.ack_received, stats.num_bytes.stream_data_sent, stats.num_bytes.stream_data_resent,
+        stats.num_paths.ecn_validated, stats.num_paths.ecn_failed, stats.rtt.minimum, stats.rtt.smoothed, stats.rtt.variance,
+        stats.rtt.latest, stats.cc.cwnd, stats.cc.ssthresh, stats.cc.cwnd_initial, stats.cc.cwnd_exiting_slow_start,
+        stats.cc.cwnd_minimum, stats.cc.cwnd_maximum, stats.cc.num_loss_episodes, stats.cc.num_ecn_loss_episodes, stats.num_ptos,
+        stats.delivery_rate.latest, stats.delivery_rate.smoothed,
         stats.delivery_rate.stdev APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, received) APPLY_NUM_FRAMES(VALUE_OF_NUM_FRAMES, sent),
         stats.num_sentmap_packets_largest);
     if (len + 1 > bufsize) {

--- a/src/h2olog/generated_raw_tracer.cc
+++ b/src/h2olog/generated_raw_tracer.cc
@@ -157,6 +157,8 @@ enum h2olog_event_id_t {
   H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_RECEIVE,
   H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_SEND,
   H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_RECEIVE,
+  H2OLOG_EVENT_ID_QUICLY_ECN_VALIDATION,
+  H2OLOG_EVENT_ID_QUICLY_ECN_CONGESTION,
   H2OLOG_EVENT_ID_QUICLY_DATAGRAM_SEND,
   H2OLOG_EVENT_ID_QUICLY_DATAGRAM_RECEIVE,
   H2OLOG_EVENT_ID_QUICLY_ACK_FREQUENCY_RECEIVE,
@@ -589,6 +591,16 @@ struct h2olog_event_t {
       int64_t stream_id;
       uint64_t maximum;
     } stream_data_blocked_receive;
+    struct { // quicly:ecn_validation
+      typeof_st_quicly_conn_t__master_id conn_master_id;
+      int64_t at;
+      int ecn_state;
+    } ecn_validation;
+    struct { // quicly:ecn_congestion
+      typeof_st_quicly_conn_t__master_id conn_master_id;
+      int64_t at;
+      uint64_t ce_count;
+    } ecn_congestion;
     struct { // quicly:datagram_send
       typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
@@ -938,6 +950,8 @@ void h2o_raw_tracer::initialize() {
     h2o_tracer::usdt("quicly", "data_blocked_receive", "trace_quicly__data_blocked_receive"),
     h2o_tracer::usdt("quicly", "stream_data_blocked_send", "trace_quicly__stream_data_blocked_send"),
     h2o_tracer::usdt("quicly", "stream_data_blocked_receive", "trace_quicly__stream_data_blocked_receive"),
+    h2o_tracer::usdt("quicly", "ecn_validation", "trace_quicly__ecn_validation"),
+    h2o_tracer::usdt("quicly", "ecn_congestion", "trace_quicly__ecn_congestion"),
     h2o_tracer::usdt("quicly", "datagram_send", "trace_quicly__datagram_send"),
     h2o_tracer::usdt("quicly", "datagram_receive", "trace_quicly__datagram_receive"),
     h2o_tracer::usdt("quicly", "ack_frequency_receive", "trace_quicly__ack_frequency_receive"),
@@ -1642,6 +1656,24 @@ void h2o_raw_tracer::do_handle_event(const void *data, int data_len) {
     json_write_pair_c(out_, STR_LIT("maximum"), event.stream_data_blocked_receive.maximum);
     break;
   }
+  case H2OLOG_EVENT_ID_QUICLY_ECN_VALIDATION: { // quicly:ecn_validation
+    json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ecn-validation"));
+    json_write_pair_c(out_, STR_LIT("tid"), event.tid);
+    json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("conn"), event.ecn_validation.conn_master_id);
+    json_write_pair_c(out_, STR_LIT("time"), event.ecn_validation.at);
+    json_write_pair_c(out_, STR_LIT("ecn-state"), event.ecn_validation.ecn_state);
+    break;
+  }
+  case H2OLOG_EVENT_ID_QUICLY_ECN_CONGESTION: { // quicly:ecn_congestion
+    json_write_pair_n(out_, STR_LIT("type"), STR_LIT("ecn-congestion"));
+    json_write_pair_c(out_, STR_LIT("tid"), event.tid);
+    json_write_pair_c(out_, STR_LIT("seq"), seq_);
+    json_write_pair_c(out_, STR_LIT("conn"), event.ecn_congestion.conn_master_id);
+    json_write_pair_c(out_, STR_LIT("time"), event.ecn_congestion.at);
+    json_write_pair_c(out_, STR_LIT("ce-count"), event.ecn_congestion.ce_count);
+    break;
+  }
   case H2OLOG_EVENT_ID_QUICLY_DATAGRAM_SEND: { // quicly:datagram_send
     json_write_pair_n(out_, STR_LIT("type"), STR_LIT("datagram-send"));
     json_write_pair_c(out_, STR_LIT("tid"), event.tid);
@@ -2248,6 +2280,8 @@ enum h2olog_event_id_t {
   H2OLOG_EVENT_ID_QUICLY_DATA_BLOCKED_RECEIVE,
   H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_SEND,
   H2OLOG_EVENT_ID_QUICLY_STREAM_DATA_BLOCKED_RECEIVE,
+  H2OLOG_EVENT_ID_QUICLY_ECN_VALIDATION,
+  H2OLOG_EVENT_ID_QUICLY_ECN_CONGESTION,
   H2OLOG_EVENT_ID_QUICLY_DATAGRAM_SEND,
   H2OLOG_EVENT_ID_QUICLY_DATAGRAM_RECEIVE,
   H2OLOG_EVENT_ID_QUICLY_ACK_FREQUENCY_RECEIVE,
@@ -2680,6 +2714,16 @@ struct h2olog_event_t {
       int64_t stream_id;
       uint64_t maximum;
     } stream_data_blocked_receive;
+    struct { // quicly:ecn_validation
+      typeof_st_quicly_conn_t__master_id conn_master_id;
+      int64_t at;
+      int ecn_state;
+    } ecn_validation;
+    struct { // quicly:ecn_congestion
+      typeof_st_quicly_conn_t__master_id conn_master_id;
+      int64_t at;
+      uint64_t ce_count;
+    } ecn_congestion;
     struct { // quicly:datagram_send
       typeof_st_quicly_conn_t__master_id conn_master_id;
       int64_t at;
@@ -4643,6 +4687,52 @@ int trace_quicly__stream_data_blocked_receive(struct pt_regs *ctx) {
 
   if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
     bpf_trace_printk("failed to perf_submit in trace_quicly__stream_data_blocked_receive\n");
+
+  return 0;
+}
+// quicly:ecn_validation
+int trace_quicly__ecn_validation(struct pt_regs *ctx) {
+  const void *buf = NULL;
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ECN_VALIDATION, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
+
+  { // struct st_quicly_conn_t * conn
+    uint8_t conn[sizeof_st_quicly_conn_t] = {};
+    bpf_usdt_readarg(1, ctx, &buf);
+    bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
+    event.ecn_validation.conn_master_id = get_st_quicly_conn_t__master_id(conn);
+  }
+  { // int64_t at
+    bpf_usdt_readarg(2, ctx, &event.ecn_validation.at);
+  }
+  { // int ecn_state
+    bpf_usdt_readarg(3, ctx, &event.ecn_validation.ecn_state);
+  }
+
+  if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
+    bpf_trace_printk("failed to perf_submit in trace_quicly__ecn_validation\n");
+
+  return 0;
+}
+// quicly:ecn_congestion
+int trace_quicly__ecn_congestion(struct pt_regs *ctx) {
+  const void *buf = NULL;
+  struct h2olog_event_t event = { .id = H2OLOG_EVENT_ID_QUICLY_ECN_CONGESTION, .tid = (uint32_t)bpf_get_current_pid_tgid(), };
+
+  { // struct st_quicly_conn_t * conn
+    uint8_t conn[sizeof_st_quicly_conn_t] = {};
+    bpf_usdt_readarg(1, ctx, &buf);
+    bpf_probe_read(&conn, sizeof_st_quicly_conn_t, buf);
+    event.ecn_congestion.conn_master_id = get_st_quicly_conn_t__master_id(conn);
+  }
+  { // int64_t at
+    bpf_usdt_readarg(2, ctx, &event.ecn_congestion.at);
+  }
+  { // uint64_t ce_count
+    bpf_usdt_readarg(3, ctx, &event.ecn_congestion.ce_count);
+  }
+
+  if (events.perf_submit(ctx, &event, sizeof(event)) != 0)
+    bpf_trace_printk("failed to perf_submit in trace_quicly__ecn_congestion\n");
 
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2778,14 +2778,14 @@ static int on_config_listen_element(h2o_configurator_command_t *cmd, h2o_configu
                 listener->quic.ctx = quic;
                 if (quic_node != NULL) {
                     yoml_t **retry_node, **sndbuf, **rcvbuf, **amp_limit, **qpack_encoder_table_capacity, **max_streams_bidi,
-                        **max_udp_payload_size, **handshake_timeout_rtt_multiplier, **max_initial_handshake_packets;
+                        **max_udp_payload_size, **handshake_timeout_rtt_multiplier, **max_initial_handshake_packets, **ecn;
                     if (h2o_configurator_parse_mapping(cmd, *quic_node, NULL,
                                                        "retry:s,sndbuf:s,rcvbuf:s,amp-limit:s,qpack-encoder-table-capacity:s,max-"
                                                        "streams-bidi:s,max-udp-payload-size:s,handshake-timeout-rtt-multiplier:s,"
-                                                       "max-initial-handshake-packets:s",
+                                                       "max-initial-handshake-packets:s,ecn:s",
                                                        &retry_node, &sndbuf, &rcvbuf, &amp_limit, &qpack_encoder_table_capacity,
                                                        &max_streams_bidi, &max_udp_payload_size, &handshake_timeout_rtt_multiplier,
-                                                       &max_initial_handshake_packets) != 0)
+                                                       &max_initial_handshake_packets, &ecn) != 0)
                         return -1;
                     if (retry_node != NULL) {
                         ssize_t on = h2o_configurator_get_one_of(cmd, *retry_node, "OFF,ON");
@@ -2837,6 +2837,12 @@ static int on_config_listen_element(h2o_configurator_command_t *cmd, h2o_configu
                             return -1;
                         }
                         listener->quic.ctx->max_initial_handshake_packets = v;
+                    }
+                    if (ecn != NULL) {
+                        ssize_t on = h2o_configurator_get_one_of(cmd, *ecn, "OFF,ON");
+                        if (on == -1)
+                            return -1;
+                        listener->quic.ctx->enable_ecn = !!on;
                     }
                 }
                 if (conf.run_mode == RUN_MODE_WORKER)


### PR DESCRIPTION
Incorporates https://github.com/h2o/quicly/pull/561.

New fields added to `quicly_stats_t` are logged as part of `%{http3.quic-stats}x` logging directive.

Use of ECN as a sender can be turned off by setting the `ecn` parameter of `listen` -> `quic` to `OFF` (default: `ON`).