### PR TITLE
[ipv6] fix address token validation failures

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1350,7 +1350,6 @@ int h2o_socket_compare_address(struct sockaddr *x, struct sockaddr *y, int check
             return r;
         if (check_port)
             CMP(ntohs(xin6->sin6_port), ntohs(yin6->sin6_port));
-        CMP(xin6->sin6_flowinfo, yin6->sin6_flowinfo);
         CMP(xin6->sin6_scope_id, yin6->sin6_scope_id);
     } else {
         assert(!"unknown sa_family");


### PR DESCRIPTION
Builds on top of https://github.com/h2o/quicly/pull/563.

As reported in #3298, h2o fails to accept HTTP/3 connections when it it configured to send Retries (i.e., when having `retry: ON` in the configuration file).

This PR fixes the issue. For more information, please refer to the quicly PR.

Closes #3298.