### PR TITLE
Only forward a RST_STREAM as REFUSED_STREAM if the error code is actually REFUSED_STREAM

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1337,7 +1337,7 @@ struct st_h2o_req_t {
      */
     unsigned char reprocess_if_too_early : 1;
     /**
-     * set by the prxy handler if the http2 upstream refused the stream so the client can retry the request
+     * set by the proxy handler if the http2 upstream refused the stream so the client can retry the request
      */
     unsigned char upstream_refused : 1;
     /**

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -669,7 +669,8 @@ static int handle_rst_stream_frame(struct st_h2o_http2client_conn_t *conn, h2o_h
     stream = get_stream(conn, frame->stream_id);
     if (stream != NULL) {
         /* reset the stream */
-        call_callback_with_error(stream, h2o_httpclient_error_refused_stream);
+        call_callback_with_error(stream, payload.error_code == -H2O_HTTP2_ERROR_REFUSED_STREAM ? h2o_httpclient_error_refused_stream
+                                                                                               : h2o_httpclient_error_io);
         close_stream(stream);
     }
 


### PR DESCRIPTION
Before this commit, we would erroneously imply that the request could be safely retried.