### PR TITLE
Problem: h2o_url_parse fails on http://example.com:8080?abc

### DIFF
--- a/lib/common/url.c
+++ b/lib/common/url.c
@@ -218,7 +218,8 @@ const char *h2o_url_parse_hostport(const char *s, size_t len, h2o_iovec_t *host,
     if (token_start != end && *token_start == ':') {
         size_t p;
         ++token_start;
-        if ((token_end = memchr(token_start, '/', end - token_start)) == NULL)
+        if (((token_end = memchr(token_start, '/', end - token_start)) == NULL) &&
+            ((token_end = memchr(token_start, '?', end - token_start)) == NULL))
             token_end = end;
         if ((p = h2o_strtosize(token_start, token_end - token_start)) >= 65535)
             return NULL;
@@ -238,7 +239,7 @@ static int parse_authority_and_path(const char *src, const char *url_end, h2o_ur
     if (p == url_end) {
         parsed->path = h2o_iovec_init(H2O_STRLIT("/"));
     } else {
-        if (*p != '/')
+        if (*p != '/' && *p != '?')
             return -1;
         parsed->path = h2o_iovec_init(p, url_end - p);
     }

--- a/t/00unit/lib/common/url.c
+++ b/t/00unit/lib/common/url.c
@@ -353,6 +353,11 @@ static void test_normalize_path(void)
     ok(q == SIZE_MAX);
     ok(norm_indexes == NULL);
 
+    input = h2o_iovec_init(H2O_STRLIT("?abc"));
+    b = h2o_url_normalize_path(&pool, input.base, input.len, &q, &norm_indexes);
+    ok(b.len == 1);
+    ok(memcmp(b.base, H2O_STRLIT("/")) == 0);
+
     h2o_mem_clear_pool(&pool);
 }
 
@@ -484,6 +489,11 @@ static void test_parse(void)
     ok(parsed._port == 111);
     ok(h2o_url_get_port(&parsed) == 111);
     ok(h2o_memis(parsed.path.base, parsed.path.len, H2O_STRLIT("/abc")));
+
+    ret = h2o_url_parse("http://example.com:8080?abc", SIZE_MAX, &parsed);
+    ok(ret == 0);
+    ok(h2o_memis(parsed.path.base, parsed.path.len, H2O_STRLIT("?abc")));
+
 }
 
 static void test_parse_relative(void)


### PR DESCRIPTION
However, according to RFC 3986, this is a valid URL as `path`/`path-abempty` part of the grammar allows for this (section 3.3):

 "If a URI contains an authority component, then the path component
 must either be empty or begin with a slash ("/") character."

 Solution: ensure h2o_url_parse accommodates this case