### PR TITLE
[http3] relax limits applied to the header section

### DIFF
--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -416,6 +416,8 @@ typedef struct st_h2o_http3_read_frame_t {
     uint64_t length;
 } h2o_http3_read_frame_t;
 
+extern const char h2o_http3_err_frame_too_large[];
+
 extern const ptls_iovec_t h2o_http3_alpn[3];
 
 /**

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -77,13 +77,6 @@
 #define H2O_HTTP3_ERROR_TRANSPORT -2
 #define H2O_HTTP3_ERROR_USER1 -256
 
-/**
- * maximum payload size excluding DATA frame; stream receive window MUST be at least as big as this + 16 bytes to hold the type and
- * the length
- */
-#define H2O_HTTP3_MAX_FRAME_PAYLOAD_SIZE 16384
-#define H2O_HTTP3_INITIAL_REQUEST_STREAM_WINDOW_SIZE (H2O_HTTP3_MAX_FRAME_PAYLOAD_SIZE * 2)
-
 typedef struct st_h2o_quic_ctx_t h2o_quic_ctx_t;
 typedef struct st_h2o_quic_conn_t h2o_quic_conn_t;
 typedef struct st_h2o_http3_conn_t h2o_http3_conn_t;
@@ -401,6 +394,13 @@ struct st_h2o_http3_conn_t {
             struct st_h2o_http3_egress_unistream_t *qpack_decoder;
         } egress;
     } _control_streams;
+    /**
+     * Maximum frame payload size (excluding DATA); this property essentially limits the maximum size of HEADERS frame.
+     * As `h2o_http3_read_frame` parses the frame inside the receive buffer, stream-level flow control credits specified in
+     * `quicly_context_t::transport_params.max_stream_data` MUST be no less than
+     * `h2o_http3_calc_min_flow_control_size(max_frame_payload_size)`.
+     */
+    size_t max_frame_payload_size;
 };
 
 #define H2O_HTTP3_CHECK_SUCCESS(expr)                                                                                              \
@@ -433,8 +433,8 @@ void h2o_http3_on_create_unidirectional_stream(quicly_stream_t *qs);
 /**
  * returns a frame header (if BODY frame) or an entire frame
  */
-int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t stream_type, const uint8_t **src,
-                         const uint8_t *src_end, const char **err_desc);
+int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t stream_type, size_t max_frame_payload_size,
+                         const uint8_t **src, const uint8_t *src_end, const char **err_desc);
 
 void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
                            h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update, uint8_t use_gso,
@@ -481,7 +481,7 @@ void h2o_quic_setup(h2o_quic_conn_t *conn, quicly_conn_t *quic);
  * initializes a http3 connection
  */
 void h2o_http3_init_conn(h2o_http3_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_http3_conn_callbacks_t *callbacks,
-                         const h2o_http3_qpack_context_t *qpack_ctx);
+                         const h2o_http3_qpack_context_t *qpack_ctx, size_t max_frame_payload_size);
 /**
  *
  */
@@ -535,12 +535,22 @@ void h2o_http3_send_h3_datagrams(h2o_http3_conn_t *conn, uint64_t flow_id, h2o_i
  * Decodes an H3 datagram. Returns the flow id if successful, or UINT64_MAX if not.
  */
 uint64_t h2o_http3_decode_h3_datagram(h2o_iovec_t *payload, const void *_src, size_t len);
+/**
+ * Given maximum payload size of headers block (e.g., `H2O_MAX_REQLEN`), returns the mimimum stream-level flow control credit that
+ * have to be guaranteed.
+ */
+static uint64_t h2o_http3_calc_min_flow_control_size(size_t max_headers_length);
 
 /* inline definitions */
 
 inline int h2o_http3_has_received_settings(h2o_http3_conn_t *conn)
 {
     return conn->qpack.enc != NULL;
+}
+
+inline uint64_t h2o_http3_calc_min_flow_control_size(size_t max_headers_length)
+{
+    return 8 /* max. type field */ + 8 /* max. length field */ + max_headers_length;
 }
 
 #endif

--- a/include/h2o/httpclient.h
+++ b/include/h2o/httpclient.h
@@ -184,6 +184,7 @@ struct st_h2o_http3client_ctx_t {
     ptls_context_t tls;
     quicly_context_t quic;
     h2o_quic_ctx_t h3;
+    uint64_t max_frame_payload_size;
     /**
      * Optional callback invoked by the HTTP/3 client implementation to obtain information used for resuming a connection. When the
      * connection is to be resumed, the callback should set `*address_token` and `*session_ticket` to a vector that can be freed by

--- a/include/h2o/qpack.h
+++ b/include/h2o/qpack.h
@@ -38,6 +38,12 @@ extern const char *h2o_qpack_err_invalid_pseudo_header;
 
 h2o_qpack_decoder_t *h2o_qpack_create_decoder(uint32_t header_table_size, uint16_t max_blocked);
 void h2o_qpack_destroy_decoder(h2o_qpack_decoder_t *qpack);
+/**
+ * This function processes a stream of QPACK encoder instructions provided in [*src, src_end), and updates `*src` to point to the
+ * beginning of the first partial instruction being found.
+ * This decoder does not enforce its own limits to the instruction size. Instead, it relies on the caller's flow control to block
+ * encoder instructions that exceed the flow control size. That is how we protect us from memory exhaustion attacks.
+ */
 int h2o_qpack_decoder_handle_input(h2o_qpack_decoder_t *qpack, int64_t **unblocked_stream_ids, size_t *num_unblocked,
                                    const uint8_t **src, const uint8_t *src_end, const char **err_desc);
 size_t h2o_qpack_decoder_send_state_sync(h2o_qpack_decoder_t *qpack, uint8_t *outbuf);

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -358,9 +358,7 @@ struct st_h2o_httpclient__h3_conn_t *create_connection(h2o_httpclient_ctx_t *ctx
 
     struct st_h2o_httpclient__h3_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
-    h2o_http3_init_conn(&conn->super, &ctx->http3->h3, &callbacks, &qpack_ctx,
-                        16384 /* max frame size (excl. DATA) is set to the old 16KB, capping max HEADERS size to that. Do we want
-                               * to raise or provide a knob? */);
+    h2o_http3_init_conn(&conn->super, &ctx->http3->h3, &callbacks, &qpack_ctx, ctx->http3->max_frame_payload_size);
     memset((char *)conn + sizeof(conn->super), 0, sizeof(*conn) - sizeof(conn->super));
     conn->ctx = ctx;
     h2o_url_copy(NULL, &conn->server.origin_url, origin);

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -358,7 +358,9 @@ struct st_h2o_httpclient__h3_conn_t *create_connection(h2o_httpclient_ctx_t *ctx
 
     struct st_h2o_httpclient__h3_conn_t *conn = h2o_mem_alloc(sizeof(*conn));
 
-    h2o_http3_init_conn(&conn->super, &ctx->http3->h3, &callbacks, &qpack_ctx);
+    h2o_http3_init_conn(&conn->super, &ctx->http3->h3, &callbacks, &qpack_ctx,
+                        16384 /* max frame size (excl. DATA) is set to the old 16KB, capping max HEADERS size to that. Do we want
+                               * to raise or provide a knob? */);
     memset((char *)conn + sizeof(conn->super), 0, sizeof(*conn) - sizeof(conn->super));
     conn->ctx = ctx;
     h2o_url_copy(NULL, &conn->server.origin_url, origin);
@@ -445,7 +447,8 @@ int handle_input_expect_data_frame(struct st_h2o_http3client_req_t *req, const u
         /* otherwise, read the frame */
         h2o_http3_read_frame_t frame;
         int ret;
-        if ((ret = h2o_http3_read_frame(&frame, 1, H2O_HTTP3_STREAM_TYPE_REQUEST, src, src_end, err_desc)) != 0) {
+        if ((ret = h2o_http3_read_frame(&frame, 1, H2O_HTTP3_STREAM_TYPE_REQUEST, req->conn->super.max_frame_payload_size, src,
+                                        src_end, err_desc)) != 0) {
             /* incomplete */
             if (ret == H2O_HTTP3_ERROR_INCOMPLETE && err == 0)
                 return ret;
@@ -484,7 +487,8 @@ static int handle_input_expect_headers(struct st_h2o_http3client_req_t *req, con
     int ret, frame_is_eos;
 
     /* read HEADERS frame */
-    if ((ret = h2o_http3_read_frame(&frame, 1, H2O_HTTP3_STREAM_TYPE_REQUEST, src, src_end, err_desc)) != 0) {
+    if ((ret = h2o_http3_read_frame(&frame, 1, H2O_HTTP3_STREAM_TYPE_REQUEST, req->conn->super.max_frame_payload_size, src, src_end,
+                                    err_desc)) != 0) {
         if (ret == H2O_HTTP3_ERROR_INCOMPLETE) {
             if (err != 0) {
                 notify_response_error(req, h2o_httpclient_error_io);

--- a/lib/core/configurator.c
+++ b/lib/core/configurator.c
@@ -595,9 +595,9 @@ static int on_config_http3_input_window_size(h2o_configurator_command_t *cmd, h2
     uint32_t v;
     if (h2o_configurator_scanf(cmd, node, "%" SCNu32, &v) != 0)
         return -1;
-    if (v < H2O_HTTP3_INITIAL_REQUEST_STREAM_WINDOW_SIZE) {
-        h2o_configurator_errprintf(cmd, node, "window size must be no less than %u",
-                                   (unsigned)H2O_HTTP3_INITIAL_REQUEST_STREAM_WINDOW_SIZE);
+    if (v < h2o_http3_calc_min_flow_control_size(H2O_MAX_REQLEN)) {
+        h2o_configurator_errprintf(cmd, node, "window size must be no less than %" PRIu64,
+                                   h2o_http3_calc_min_flow_control_size(H2O_MAX_REQLEN));
         return -1;
     }
     ctx->globalconf->http3.active_stream_window_size = v;

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -91,7 +91,11 @@ static h2o_http3client_ctx_t *create_http3_context(h2o_context_t *ctx, int use_g
     ptls_clear_memory(cid_key, sizeof(cid_key));
     h3ctx->quic.stream_open = &h2o_httpclient_http3_on_stream_open;
 
-    /* http3 */
+    /* http3 client-specific fields */
+    h3ctx->max_frame_payload_size = h2o_http3_calc_min_flow_control_size(H2O_MAX_REQLEN); /* same maximum for HEADERS frame in both
+                                                                                           directions */
+
+    /* h2o server http3 integration */
     int sockfd;
     if ((sockfd = socket(PF_INET, SOCK_DGRAM, 0)) < 0) {
         perror("failed to open UDP socket");

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -298,8 +298,8 @@ static void control_stream_handle_input(h2o_http3_conn_t *conn, struct st_h2o_ht
         int ret;
         const char *err_desc = NULL;
 
-        if ((ret = h2o_http3_read_frame(&frame, quicly_is_client(conn->super.quic), H2O_HTTP3_STREAM_TYPE_CONTROL, src, src_end,
-                                        &err_desc)) != 0) {
+        if ((ret = h2o_http3_read_frame(&frame, quicly_is_client(conn->super.quic), H2O_HTTP3_STREAM_TYPE_CONTROL,
+                                        conn->max_frame_payload_size, src, src_end, &err_desc)) != 0) {
             if (ret != H2O_HTTP3_ERROR_INCOMPLETE)
                 h2o_quic_close_connection(&conn->super, ret, err_desc);
             break;
@@ -907,8 +907,8 @@ static void on_timeout(h2o_timer_t *timeout)
     h2o_quic_send(conn);
 }
 
-int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t stream_type, const uint8_t **_src,
-                         const uint8_t *src_end, const char **err_desc)
+int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t stream_type, size_t max_frame_payload_size,
+                         const uint8_t **_src, const uint8_t *src_end, const char **err_desc)
 {
     const uint8_t *src = *_src;
 
@@ -921,7 +921,7 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
     /* read the content of the frame (unless it's a DATA frame) */
     frame->payload = NULL;
     if (frame->type != H2O_HTTP3_FRAME_TYPE_DATA) {
-        if (frame->length > H2O_HTTP3_MAX_FRAME_PAYLOAD_SIZE) {
+        if (frame->length > max_frame_payload_size) {
             H2O_PROBE(H3_FRAME_RECEIVE, frame->type, NULL, frame->length);
             *err_desc = "H3 frame too large";
             return H2O_HTTP3_ERROR_GENERAL_PROTOCOL; /* FIXME is this the correct code? */
@@ -1116,11 +1116,12 @@ void h2o_quic_setup(h2o_quic_conn_t *conn, quicly_conn_t *quic)
 }
 
 void h2o_http3_init_conn(h2o_http3_conn_t *conn, h2o_quic_ctx_t *ctx, const h2o_http3_conn_callbacks_t *callbacks,
-                         const h2o_http3_qpack_context_t *qpack_ctx)
+                         const h2o_http3_qpack_context_t *qpack_ctx, size_t max_frame_payload_size)
 {
     h2o_quic_init_conn(&conn->super, ctx, &callbacks->super);
     memset((char *)conn + sizeof(conn->super), 0, sizeof(*conn) - sizeof(conn->super));
     conn->qpack.ctx = qpack_ctx;
+    conn->max_frame_payload_size = max_frame_payload_size;
 }
 
 void h2o_http3_dispose_conn(h2o_http3_conn_t *conn)

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -55,6 +55,8 @@ struct st_h2o_http3_ingress_unistream_t {
                          const uint8_t *src_end, int is_eos);
 };
 
+const char h2o_http3_err_frame_too_large[] = "HTTP/3 frame is too large";
+
 const ptls_iovec_t h2o_http3_alpn[3] = {{(void *)H2O_STRLIT("h3")}, {(void *)H2O_STRLIT("h3-29")}, {(void *)H2O_STRLIT("h3-27")}};
 
 static void report_sendmsg_errors(h2o_error_reporter_t *reporter, uint64_t total_successes, uint64_t cur_successes)
@@ -923,7 +925,7 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
     if (frame->type != H2O_HTTP3_FRAME_TYPE_DATA) {
         if (frame->length > max_frame_payload_size) {
             H2O_PROBE(H3_FRAME_RECEIVE, frame->type, NULL, frame->length);
-            *err_desc = "H3 frame too large";
+            *err_desc = h2o_http3_err_frame_too_large;
             return H2O_HTTP3_ERROR_GENERAL_PROTOCOL; /* FIXME is this the correct code? */
         }
         if (src_end - src < frame->length)

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1232,7 +1232,8 @@ int handle_input_post_trailers(struct st_h2o_http3_server_stream_t *stream, cons
     int ret;
 
     /* read and ignore unknown frames */
-    if ((ret = h2o_http3_read_frame(&frame, 0, H2O_HTTP3_STREAM_TYPE_REQUEST, src, src_end, err_desc)) != 0)
+    if ((ret = h2o_http3_read_frame(&frame, 0, H2O_HTTP3_STREAM_TYPE_REQUEST, get_conn(stream)->h3.max_frame_payload_size, src,
+                                    src_end, err_desc)) != 0)
         return ret;
     switch (frame.type) {
     case H2O_HTTP3_FRAME_TYPE_HEADERS:
@@ -1275,7 +1276,8 @@ int handle_input_expect_data(struct st_h2o_http3_server_stream_t *stream, const 
     int ret;
 
     /* read frame */
-    if ((ret = h2o_http3_read_frame(&frame, 0, H2O_HTTP3_STREAM_TYPE_REQUEST, src, src_end, err_desc)) != 0)
+    if ((ret = h2o_http3_read_frame(&frame, 0, H2O_HTTP3_STREAM_TYPE_REQUEST, get_conn(stream)->h3.max_frame_payload_size, src,
+                                    src_end, err_desc)) != 0)
         return ret;
     switch (frame.type) {
     case H2O_HTTP3_FRAME_TYPE_HEADERS:
@@ -1379,7 +1381,8 @@ static int handle_input_expect_headers(struct st_h2o_http3_server_stream_t *stre
     size_t header_ack_len;
 
     /* read the HEADERS frame (or a frame that precedes that) */
-    if ((ret = h2o_http3_read_frame(&frame, 0, H2O_HTTP3_STREAM_TYPE_REQUEST, src, src_end, err_desc)) != 0)
+    if ((ret = h2o_http3_read_frame(&frame, 0, H2O_HTTP3_STREAM_TYPE_REQUEST, get_conn(stream)->h3.max_frame_payload_size, src,
+                                    src_end, err_desc)) != 0)
         return ret;
     if (frame.type != H2O_HTTP3_FRAME_TYPE_HEADERS) {
         switch (frame.type) {
@@ -2072,7 +2075,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
         sizeof(*conn), ctx->accept_ctx->ctx, ctx->accept_ctx->hosts, h2o_gettimeofday(ctx->accept_ctx->ctx->loop), &conn_callbacks);
     memset((char *)conn + sizeof(conn->super), 0, sizeof(*conn) - sizeof(conn->super));
 
-    h2o_http3_init_conn(&conn->h3, &ctx->super, h3_callbacks, &ctx->qpack);
+    h2o_http3_init_conn(&conn->h3, &ctx->super, h3_callbacks, &ctx->qpack, H2O_MAX_REQLEN);
     conn->handshake_properties = (ptls_handshake_properties_t){{{{NULL}}}};
     h2o_linklist_init_anchor(&conn->delayed_streams.recv_body_blocked);
     h2o_linklist_init_anchor(&conn->delayed_streams.req_streaming);
@@ -2130,7 +2133,8 @@ void h2o_http3_server_amend_quicly_context(h2o_globalconf_t *conf, quicly_contex
     quic->transport_params.max_data =
         conf->http3.active_stream_window_size; /* set to a size that does not block the unblocked request stream */
     quic->transport_params.max_streams_uni = 10;
-    quic->transport_params.max_stream_data.bidi_remote = H2O_HTTP3_INITIAL_REQUEST_STREAM_WINDOW_SIZE;
+    quic->transport_params.max_stream_data.bidi_remote = h2o_http3_calc_min_flow_control_size(H2O_MAX_REQLEN);
+    quic->transport_params.max_stream_data.uni = h2o_http3_calc_min_flow_control_size(H2O_MAX_REQLEN);
     quic->transport_params.max_idle_timeout = conf->http3.idle_timeout;
     quic->transport_params.min_ack_delay_usec = conf->http3.allow_delayed_ack ? 0 : UINT64_MAX;
     quic->ack_frequency = conf->http3.ack_frequency;

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -90,6 +90,7 @@ static h2o_http3client_ctx_t h3ctx = {
             .cipher_suites = ptls_openssl_cipher_suites,
             .save_ticket = &save_http3_ticket,
         },
+    .max_frame_payload_size = 16384,
 };
 static const char *progname; /* refers to argv[0] */
 
@@ -650,12 +651,14 @@ int main(int argc, char **argv)
         OPT_DISALLOW_DELAYED_ACK,
         OPT_ACK_FREQUENCY,
         OPT_IO_TIMEOUT,
+        OPT_HTTP3_MAX_FRAME_PAYLOAD_SIZE,
     };
     struct option longopts[] = {{"initial-udp-payload-size", required_argument, NULL, OPT_INITIAL_UDP_PAYLOAD_SIZE},
                                 {"max-udp-payload-size", required_argument, NULL, OPT_MAX_UDP_PAYLOAD_SIZE},
                                 {"disallow-delayed-ack", no_argument, NULL, OPT_DISALLOW_DELAYED_ACK},
                                 {"ack-frequency", required_argument, NULL, OPT_ACK_FREQUENCY},
                                 {"io-timeout", required_argument, NULL, OPT_IO_TIMEOUT},
+                                {"http3-max-frame-payload-size", required_argument, NULL, OPT_HTTP3_MAX_FRAME_PAYLOAD_SIZE},
                                 {"help", no_argument, NULL, 'h'},
                                 {NULL}};
     const char *optstring = "t:m:o:b:x:X:C:c:d:H:i:fk2:W:h3:"
@@ -828,6 +831,12 @@ int main(int argc, char **argv)
         case OPT_IO_TIMEOUT:
             if (sscanf(optarg, "%" SCNu64, &io_timeout) != 1) {
                 fprintf(stderr, "failed to parse --io-timeout\n");
+                exit(EXIT_FAILURE);
+            }
+            break;
+        case OPT_HTTP3_MAX_FRAME_PAYLOAD_SIZE:
+            if (sscanf(optarg, "%" SCNu64, &h3ctx.max_frame_payload_size) != -1) {
+                fprintf(stderr, "failed to parse --http3-max-frame-payload-size\n");
                 exit(EXIT_FAILURE);
             }
             break;

--- a/t/40http3.t
+++ b/t/40http3.t
@@ -147,4 +147,45 @@ EOT
     like $fetch->("?delay-fin"), qr{^HTTP/3 200\n.*\n\nx$}s;
 };
 
+subtest "large-headers" => sub {
+    my $server = spawn_h2o(<< "EOT");
+listen:
+  type: quic
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: t/assets/doc_root
+EOT
+
+    my $fetch = sub {
+        my ($query, $opts) = @_;
+        open my $fh, "-|", "$client_prog -3 100 $opts https://127.0.0.1:$quic_port/$query 2>&1"
+            or die "failed to spawn $client_prog:$!";
+        local $/;
+        join "", <$fh>;
+    };
+
+    like $fetch->(""), qr{^HTTP/3 200\n.*\n\nhello\n$}s, "no headers";
+
+    # When generating headers, 'X' is used, as it is 8 bits in cleartext and also in static huffman.
+    # TODO: can we check that the error is stream-level?
+    subtest "single header" => sub {
+        like $fetch->("", "-H a:" . "X" x 409600), qr{^HTTP/3 200\n.*\n\nhello\n$}s, "slightly below limit";
+        unlike $fetch->("", "-H a:" . "X" x 512000), qr{^HTTP/3 200\n.*\n\nhello\n$}s, "slightly above limit";
+    };
+    subtest "multiple headers" => sub {
+        like $fetch->("", join " ", map { "-H a:" . "X" x 4096 } (0..90)), qr{^HTTP/3 200\n.*\n\nhello\n$}s, "slightly below limit";
+        unlike $fetch->("", join " ", map { "-H a:" . "X" x 4096 } (0..110)), qr{^HTTP/3 200\n.*\n\nhello\n$}s, "slightly above limit";
+    };
+    subtest "URI" => sub {
+        like $fetch->("?q=" . "X" x 409600, ""), qr{^HTTP/3 200\n.*\n\nhello\n$}s, "slightly below limit";
+        unlike $fetch->("?q=" . "X" x 512000, ""), qr{^HTTP/3 200\n.*\n\nhello\n$}s, "slightly below limit";
+    };
+};
+
 done_testing;


### PR DESCRIPTION
At the moment, limits that are applied to the H3 headers are too strict:
* total size of the header section (prior to decompression) is limited to 16KB
* length of field names is limited to 100 bytes
* length of field values is limited to 4096 bytes

This PR removes these limits and aligns the size of any of these to `H2O_MAX_REQLEN`. With these changes, the limits would essentially be equivalents to that we apply on the HTTP/2 side.