### PR TITLE
lock the logfiles for read/write to wait for the timestamp appender

### DIFF
--- a/t/run-tests
+++ b/t/run-tests
@@ -63,6 +63,7 @@ sub spawn_script {
     my $logfn = get_logfn($script);
     open my $logfh, ">", $logfn
         or die "failed to create log file:$logfn:$!";
+    flock($logfh, LOCK_EX) or die "failed to lock the file $logfn:$!";
     autoflush $logfh 1;
 
     my $pid = fork;
@@ -110,6 +111,7 @@ sub commit_test {
     my $logfn = get_logfn($script);
     open my $logfh, "<", $logfn
         or die "failed to open script:$logfn:$!";
+    flock($logfh, LOCK_SH) or die "failed to obtain shared lock on $logfn:$!";
     unlink $logfn;
     print do { local $/; <$logfh> };
 


### PR DESCRIPTION
In our CI environment, we occasionally see the log files of each `.t` file to be incomplete. I suspect that this is due to the `fork` in the `log_add_timestamp` sub, because the main test runner only waits for the parent process which writes to the pipe, and does not wait for the child process that reads from the pipe, to finish.

This patch adds an flock to the reader/writer of the output log file, making sure that the reader of the log file would wait for the child process to finish. I've also tried to swap the parent/child process relationship, but the flock approach is a smaller change and is more generic.