### PR TITLE
kill timed out tests

### DIFF
--- a/t/run-tests
+++ b/t/run-tests
@@ -40,6 +40,7 @@ while (@scripts or %pids) {
     if ($@) {
         for my $kid (keys %pids) {
             my $script = delete $pids{$kid};
+            kill 'TERM', $kid or kill 'KILL', $kid;
             commit_test($script, 0, 'timeout');
         }
     } elsif ($pids{$kid}) {


### PR DESCRIPTION
in #3324 flock is introduced so `run-tests` will wait for the test to actually finish before reading the log file. With that change, when a test actually times out (after 600s), the parent cannot acquire the lock because the child process (test) is never terminated.

This PR adds a `kill` to reap the timed out tests.