### PR TITLE
Detect and reject excess overhead in chunked encoding

### DIFF
--- a/deps/picohttpparser/.github/workflows/ci.yml
+++ b/deps/picohttpparser/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        cc:
+        - gcc
+        - clang
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: make test
+      run: make test CC=${{ matrix.cc }}

--- a/deps/picohttpparser/.travis.yml
+++ b/deps/picohttpparser/.travis.yml
@@ -1,6 +1,0 @@
-language: c
-compiler:
-  - gcc
-  - clang
-script:
-  - make test

--- a/deps/picohttpparser/Makefile
+++ b/deps/picohttpparser/Makefile
@@ -25,14 +25,16 @@
 
 CC?=gcc
 PROVE?=prove
+CFLAGS=-Wall -fsanitize=address,undefined
+TEST_ENV="UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1"
 
 all:
 
 test: test-bin
-	$(PROVE) -v ./test-bin
+	env $(TEST_ENV) $(PROVE) -v ./test-bin
 
 test-bin: picohttpparser.c picotest/picotest.c test.c
-	$(CC) -Wall $(CFLAGS) $(LDFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 clean:
 	rm -f test-bin

--- a/deps/picohttpparser/picohttpparser.h
+++ b/deps/picohttpparser/picohttpparser.h
@@ -27,6 +27,7 @@
 #ifndef picohttpparser_h
 #define picohttpparser_h
 
+#include <stdint.h>
 #include <sys/types.h>
 
 #ifdef _MSC_VER
@@ -64,6 +65,8 @@ struct phr_chunked_decoder {
     char consume_trailer;       /* if trailing headers should be consumed */
     char _hex_count;
     char _state;
+    uint64_t _total_read;
+    uint64_t _total_overhead;
 };
 
 /* the function rewrites the buffer given as (buf, bufsz) removing the chunked-

--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 		08CEA9D6267AF0EB00B4BB6B /* self_trace.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = self_trace.c; sourceTree = "<group>"; };
 		08CEA9DA267B0E3B00B4BB6B /* self_trace.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = self_trace.c; sourceTree = "<group>"; };
 		08DAFA07289763FC00364143 /* memory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = memory.c; sourceTree = "<group>"; };
+		08E86F462B60D94400F7211C /* 80http1-chunk-overhead.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "80http1-chunk-overhead.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		08E8FBF32A84DB5B00CF8FF3 /* 50reverse-proxy-http2-trailers.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50reverse-proxy-http2-trailers.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		08E9CC4D1E41F6660049DD26 /* embedded.c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = embedded.c.h; sourceTree = "<group>"; };
 		08EFC4CF27FD8FAA004C532C /* 50file-shrink.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "50file-shrink.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
@@ -2380,6 +2381,7 @@
 				E9D497C625E4DE1E00F4A80D /* 80chunked.t */,
 				109EEFE11D77B350001F11D1 /* 80dup-host-headers.t */,
 				E9BC76C51EE4AB6C00EB7A09 /* 80graceful-shutdown.t */,
+				08E86F462B60D94400F7211C /* 80http1-chunk-overhead.t */,
 				08529A932AD4F6FF00A2C76B /* 80http2-reset-flood.t */,
 				E9AFBF2C212A985E000F5DB8 /* 80http2-idle-timeout-for-zero-window.t */,
 				08CEA9CF2662136B00B4BB6B /* 80http3-header-linefeed.t */,

--- a/t/80http1-chunk-overhead.t
+++ b/t/80http1-chunk-overhead.t
@@ -1,0 +1,68 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use IO::Socket::IP;
+use Net::EmptyPort qw(check_port);
+use Socket qw(SOCK_STREAM);
+use Test::More;
+use Time::HiRes qw(sleep);
+use t::Util;
+
+local $SIG{PIPE} = sub {};
+
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $tempdir = tempdir(CLEANUP => 1);
+my $upstream_port = empty_port();
+
+my $upstream = spawn_server(
+    argv     => [
+        qw(plackup -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port", ASSETS_DIR . "/upstream.psgi",
+    ],
+    is_ready => sub {
+        check_port($upstream_port);
+    },
+);
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+EOT
+
+like send_request(0, 0, ""), qr{^HTTP/1\.1 200 }s, "zero chunks";
+
+like send_request(1000, 1000, ""), qr{^HTTP/1\.1 200 }s, "1000 x 1000B chunks => ok";
+like send_request(100, 10000, ""), qr{^HTTP/1\.1 200 }s, "10000 x 100B chunks => ok";
+like send_request(10, 100000, ""), qr{^HTTP/1\.1 200 }s, "100000 x 10B chunks => ok";
+like send_request(1, 1000000, ""), qr{^HTTP/1\.1 400 }s, "1000000 x 1B chunks => error";
+like send_request(1, 100000, ""), qr{^HTTP/1\.1 400 }s, "100000 x 1B chunks => ok"; # below our 100KB threshold
+
+like send_request(100, 10000, "; ext=small"), qr{^HTTP/1\.1 200 }s, "100B chunks with small ext => ok";
+like send_request(100, 10000, "; ext=" . "x" x 1000), qr{^HTTP/1\.1 400 }s, "100B chunks with 1KB ext => error";
+
+sub send_request {
+    my ($len, $count, $extra) = @_;
+
+    my $chunk = sprintf("%x%s\r\n", $len, $extra) . "x" x $len . "\r\n";
+
+    my $conn = IO::Socket::IP->new(
+        PeerHost => "127.0.0.1",
+        PeerPort => $server->{port},
+        Type     => SOCK_STREAM,
+    ) or die "failed to connect to 127.0.0.1:@{[$server->{port}]}:$!";
+    syswrite $conn, "POST /echo-headers HTTP/1.1\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n";
+    syswrite $conn, join "", map { $chunk } (0..($count - 1));
+    sleep 0.1; # chunk decoder detects attack only at the end of the bytes returned by `recv`, so add a sleep before sending the
+               # last chunk
+    syswrite $conn, "${chunk}0\r\n\r\n";
+    sysread $conn, my $resp, 65536;
+    $resp;
+}
+
+done_testing();


### PR DESCRIPTION
Adopts https://github.com/h2o/picohttpparser/pull/81; please refer to the PR for context.

In this PR, h2o's own tests are also added. They might not be strictly necessary, though they do assert that error responses are sent correctly upon detecting malicious behavior.