### PR TITLE
avoid NULL deref when `host` field appears in trailer (amends #3278)

### DIFF
--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -590,7 +590,7 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                             return H2O_HTTP2_ERROR_PROTOCOL;
                         }
                         goto Next;
-                    } else if (token == H2O_TOKEN_HOST) {
+                    } else if (token == H2O_TOKEN_HOST && authority != NULL) {
                         /* HTTP2 allows the use of host header (in place of :authority) */
                         if (authority->base == NULL)
                             *authority = value;


### PR DESCRIPTION
In #3278, specifically in commit de9c6af, we started passing NULLs to `h2o_hpack_parse_request` when parsing trailers, as pseudo headers are not expected to seen.

This almost worked, as the `pseudo_header_exists_map` is also set to NULL. Due to this argument set to NULL, pseudo headers are simply rejected.

But there was one regression, and that is that if a host field is found, the hpack decoder tries to store the value by dereferencing a pointer that points to the storage of the `:authority` pseudo heaoder, without NULL-checking the pointer, hence leading to a crash.