### PR TITLE
Update CI image (ubuntu 22.04) to contain curl with support for H3

### DIFF
--- a/misc/docker-ci/Dockerfile.ubuntu2204
+++ b/misc/docker-ci/Dockerfile.ubuntu2204
@@ -5,13 +5,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get --yes update
 RUN apt-get install --yes \
 	apache2-utils \
+	autoconf \
 	bison \
 	bpftrace \
 	brotli \
 	clang \
 	cmake \
 	cmake-data \
-	curl \
 	dnsutils \
 	flex \
 	git \
@@ -25,7 +25,10 @@ RUN apt-get install --yes \
 	libedit-dev \
 	libelf-dev \
 	libev-dev \
+	libnghttp2-dev \
+	libpsl-dev \
 	libssl-dev \
+	libtool \
 	liburing-dev \
 	libuv1-dev \
 	llvm \
@@ -64,6 +67,31 @@ RUN apt-get install --yes \
 ENV PERL_CPANM_OPT="--mirror https://cpan.metacpan.org/"
 RUN cpanm -n Test::More Starlet Protocol::HTTP2 Test::TCP
 RUN cpanm -n NLNETLABS/Net-DNS-1.36.tar.gz # Net-DNS 1.39 has issues around use of alarm, fork, etc.
+
+# curl with ngtcp2
+RUN mkdir -p /opt/src \
+	&& git clone --depth 1 --branch openssl-3.0.10+quic https://github.com/quictls/openssl /opt/src/quictls \
+	&& cd /opt/src/quictls \
+	&& ./config enable-tls1_3 no-shared --prefix=/usr/local/quictls \
+	&& make install clean
+RUN mkdir -p /opt/src \
+	&& git clone --depth 1 --branch v1.1.0 https://github.com/ngtcp2/nghttp3 /opt/src/nghttp3 \
+	&& cd /opt/src/nghttp3 \
+	&& autoreconf -fi \
+	&& PKG_CONFIG_PATH=/usr/local/quictls/lib64/pkgconfig ./configure --enable-lib-only --disable-shared \
+	&& make install clean
+RUN mkdir -p /opt/src \
+	&& git clone --depth 1 --branch v1.2.0 https://github.com/ngtcp2/ngtcp2 /opt/src/ngtcp2 \
+	&& cd /opt/src/ngtcp2 \
+	&& autoreconf -fi \
+	&& PKG_CONFIG_PATH=/usr/local/quictls/lib64/pkgconfig ./configure --enable-lib-only --disable-shared \
+	&& make install clean
+RUN mkdir -p /opt/src \
+	&& cd /opt/src \
+	&& wget --quiet -O - https://curl.se/download/curl-8.6.0.tar.bz2 | tar xjf - \
+	&& cd curl-8.6.0 \
+	&& USE_CURL_SSLKEYLOGFILE=true ./configure --disable-shared --with-nghttp2 --with-ngtcp2 --with-nghttp3 --with-openssl=/usr/local/quictls \
+	&& make install clean
 
 # boringssl
 RUN apt-get install --yes golang-go

--- a/t/50connect.t
+++ b/t/50connect.t
@@ -78,34 +78,39 @@ EOS
 };
 
 subtest "curl-h1" => sub {
+    my $re_success = qr{Proxy replied 200 to CONNECT request|CONNECT tunnel established, response 200}m;
+    my $re_fail = sub {
+        my $code = shift;
+        qr{Received HTTP code $code from proxy after CONNECT|CONNECT tunnel failed, response $code}m;
+    };
     subtest "basic", sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://127.0.0.1:$origin_port/echo 2>&1`;
-        like $content, qr{Proxy replied 200 to CONNECT request}m, "Connect got a 200 response to CONNECT";
+        like $content, $re_success, "Connect got a 200 response to CONNECT";
         my @c = $content =~ /$ok_resp/g;
         is @c, 2, "Got two 200 responses";
         unlike $content, qr{proxy-status:}i;
     };
     subtest "timeout", sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://127.0.0.1:$origin_port/sleep-and-respond?sleep=1 2>&1`;
-        like $content, qr{Proxy replied 200 to CONNECT request}m, "Connect got a 200";
+        like $content, $re_success, "Connect got a 200";
         my @c = $content =~ /$ok_resp/g;
         is @c, 2, "Got two 200 responses, no timeout";
         unlike $content, qr{proxy-status:}i;
 
         $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://127.0.0.1:$origin_port/sleep-and-respond?sleep=10 2>&1`;
-        like $content, qr{Proxy replied 200 to CONNECT request}m, "Connect got a 200";
+        like $content, $re_success, "Connect got a 200";
         @c = $content =~ /$ok_resp/g;
         is @c, 1, "Only got one 200 response";
         unlike $content, qr{proxy-status:}i;
     };
     subtest "acl" => sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error https://8.8.8.8/ 2>&1 2>&1`;
-        like $content, qr{Received HTTP code 403 from proxy after CONNECT};
+        like $content, $re_fail->(403);
         unlike $content, qr{proxy-status:}i;
     };
     subtest "immediate connect failure" => sub {
         my $content = `curl --http1.1 -p -x 127.0.0.1:$server->{port} --silent -v --show-error http://255.255.255.255:$origin_port/ 2>&1 2>&1`;
-        like $content, qr{Received HTTP code 502 from proxy after CONNECT};
+        like $content, $re_fail->(502);
     };
 };
 


### PR DESCRIPTION
Based on https://github.com/h2o/h2o/pull/2990. This PR just updates the image without making any changes to the tests to actually use it. Follow-on PRs will address that.