### PR TITLE
[http3] if send-informational is set to NONE, suppress 1xx

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1792,7 +1792,9 @@ static int stream_open_cb(quicly_stream_open_t *self, quicly_stream_t *qs)
     stream->state = H2O_HTTP3_SERVER_STREAM_STATE_RECV_HEADERS;
     stream->link = (h2o_linklist_t){NULL};
     stream->link_resp_settings_blocked = (h2o_linklist_t){NULL};
-    stream->ostr_final = (h2o_ostream_t){NULL, do_send, NULL, do_send_informational};
+    stream->ostr_final = (h2o_ostream_t){
+        NULL, do_send, NULL,
+        conn->super.ctx->globalconf->send_informational_mode == H2O_SEND_INFORMATIONAL_MODE_NONE ? NULL : do_send_informational};
     stream->scheduler.link = (h2o_linklist_t){NULL};
     stream->scheduler.priority = h2o_absprio_default;
     stream->scheduler.call_cnt = 0;


### PR DESCRIPTION
This check has been missing in the h3 side.