### PR TITLE
[http3] send server-timing header

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1641,6 +1641,9 @@ static void do_send(h2o_ostream_t *_ostr, h2o_req_t *_req, h2o_sendvec_t *bufs, 
     case H2O_HTTP3_SERVER_STREAM_STATE_SEND_HEADERS: {
         h2o_iovec_t datagram_flow_id;
         ssize_t priority_header_index;
+        if (stream->req.send_server_timing != 0)
+            h2o_add_server_timing_header(&stream->req, 0 /* TODO add support for trailers; it's going to be a little complex as we
+                                                          * need to build trailers the moment they are emitted onto wire */);
         if (!finalize_do_send_setup_udp_tunnel(stream, send_state, &datagram_flow_id))
             return;
         stream->req.timestamps.response_start_at = h2o_gettimeofday(get_conn(stream)->super.ctx->loop);

--- a/t/50reverse-proxy-timings.t
+++ b/t/50reverse-proxy-timings.t
@@ -95,8 +95,12 @@ run_with_curl($server, sub {
         within_eps($st, 'proxy.connect', 0, 10);
         within_eps($st, 'proxy.request', 0);
         within_eps($st, 'proxy.process', 100);
-        within_eps($st, 'proxy.response', 100);
-        within_eps($st, 'proxy.total', 200);
+        subtest "trailer" => sub {
+            plan skip_all => "no support for trailers with server-timing in h3 (yet)"
+                if $curl =~ /--http3/;
+            within_eps($st, 'proxy.response', 100);
+            within_eps($st, 'proxy.total', 200);
+        };
     };
 });
 

--- a/t/50reverse-proxy-timings.t
+++ b/t/50reverse-proxy-timings.t
@@ -64,8 +64,6 @@ EOT
 run_with_curl($server, sub {
     my ($proto, $port, $curl) = @_;
 
-    local $TODO = "HTTP/3 is not yet supported" if $curl =~ /--http3/;
-
     open(CURL, "$curl --silent --dump-header /dev/stdout $proto://127.0.0.1:$port/ |");
 
     do_upstream($upstream);


### PR DESCRIPTION
Partially resolves one of the TODOs in #3346.

Trailer support is still missing as we need a complex logic to obtain the moment the final byte of the response body is emitted onto the wire. To observe that moment and then build trailers, we need to keep the stream open after all the response body becomes ready.