### PR TITLE
fix h3 CI issues with t/50mruby-http-request.t

### DIFF
--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -117,6 +117,7 @@ hosts:
           end
           Proc.new do |env|
             resp = http_request("http://$upstream_hostport/esi.html").join
+            resp[1].delete("content-length")
             resp[2] = ESIResponse.new(resp[2].join)
             resp
           end
@@ -224,7 +225,6 @@ EOT
             };
         };
         subtest "esi" => sub {
-            local $TODO = "HTTP/3 is not yet supported" if $curl_cmd =~ /--http3/;
             my ($headers, $body) = run_prog("$curl_cmd $proto://127.0.0.1:$port/esi/");
             like $headers, qr{HTTP/[^ ]+ 200\s}is;
             is $body, "Hello to the world, from H2O!\n";

--- a/t/50mruby-http-request.t
+++ b/t/50mruby-http-request.t
@@ -87,6 +87,7 @@ hosts:
                 end
                 def each(&b)
                   \@a.each(&b)
+                  sleep 0.1
                 end
               end
               body = T.new(body)
@@ -212,7 +213,6 @@ EOT
                 };
             };
             subtest "chunked" => sub {
-                local $TODO = "HTTP/3 is not yet supported" if $curl_cmd =~ /--http3/;
                 for my $i (0..30) {
                     subtest "cl=$i" => sub {
                         my ($headers, $body) = run_prog("$curl_cmd $proto://127.0.0.1:$port/cl/$i/chunked");


### PR DESCRIPTION
Closes one of the TODOs in #3346.

Two issues were both due to abrupt close leading to total loss of response, likely due to curl-ngtcp2 not reporting any byte (even the headers) as received when the stream is reset without delay.