### PR TITLE
apply filters and loggers at host and path level, when file.custom-handler at global level is applied

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1595,6 +1595,10 @@ h2o_ostream_t *h2o_add_ostream(h2o_req_t *req, size_t alignment, size_t sz, h2o_
  */
 h2o_hostconf_t *h2o_req_setup(h2o_req_t *req);
 /**
+ * applies given environment configuration to the request
+ */
+void h2o_req_apply_env(h2o_req_t *req, h2o_envconf_t *env);
+/**
  * binds configurations to the request
  */
 void h2o_req_bind_conf(h2o_req_t *req, h2o_hostconf_t *hostconf, h2o_pathconf_t *pathconf);

--- a/include/h2o/configurator.h
+++ b/include/h2o/configurator.h
@@ -143,6 +143,10 @@ int h2o_configurator_apply(h2o_globalconf_t *config, yoml_t *node, int dry_run);
  */
 int h2o_configurator_apply_commands(h2o_configurator_context_t *ctx, yoml_t *node, int flags_mask, const char **ignore_commands);
 /**
+ *
+ */
+static int h2o_configurator_at_extension_level(h2o_configurator_context_t *ctx);
+/**
  * emits configuration error
  */
 void h2o_configurator_errprintf(h2o_configurator_command_t *cmd, yoml_t *node, const char *reason, ...)
@@ -192,5 +196,12 @@ void h2o_configurator_define_headers_commands(h2o_globalconf_t *global_conf, h2o
 
 void h2o_configurator__init_core(h2o_globalconf_t *conf);
 void h2o_configurator__dispose_configurators(h2o_globalconf_t *conf);
+
+/* inline definitions */
+
+inline int h2o_configurator_at_extension_level(h2o_configurator_context_t *ctx)
+{
+    return ctx->pathconf != NULL && ctx->pathconf->path.base == NULL && ctx->pathconf != &ctx->hostconf->fallback_path;
+}
 
 #endif

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -334,6 +334,8 @@ h2o_handler_t *h2o_create_handler(h2o_pathconf_t *conf, size_t sz)
 
 h2o_filter_t *h2o_create_filter(h2o_pathconf_t *conf, size_t sz)
 {
+    assert(conf->path.base != NULL && "filters cannot be added at the extension level");
+
     h2o_filter_t *filter = h2o_mem_alloc(sz);
 
     memset(filter, 0, sz);
@@ -349,6 +351,8 @@ h2o_filter_t *h2o_create_filter(h2o_pathconf_t *conf, size_t sz)
 
 h2o_logger_t *h2o_create_logger(h2o_pathconf_t *conf, size_t sz)
 {
+    assert(conf->path.base != NULL && "loggers cannot be added at the extension level");
+
     h2o_logger_t *logger = h2o_mem_alloc(sz);
 
     memset(logger, 0, sz);

--- a/lib/core/config.c
+++ b/lib/core/config.c
@@ -334,8 +334,6 @@ h2o_handler_t *h2o_create_handler(h2o_pathconf_t *conf, size_t sz)
 
 h2o_filter_t *h2o_create_filter(h2o_pathconf_t *conf, size_t sz)
 {
-    assert(conf->path.base != NULL && "filters cannot be added at the extension level");
-
     h2o_filter_t *filter = h2o_mem_alloc(sz);
 
     memset(filter, 0, sz);
@@ -351,8 +349,6 @@ h2o_filter_t *h2o_create_filter(h2o_pathconf_t *conf, size_t sz)
 
 h2o_logger_t *h2o_create_logger(h2o_pathconf_t *conf, size_t sz)
 {
-    assert(conf->path.base != NULL && "loggers cannot be added at the extension level");
-
     h2o_logger_t *logger = h2o_mem_alloc(sz);
 
     memset(logger, 0, sz);

--- a/lib/core/request.c
+++ b/lib/core/request.c
@@ -570,12 +570,12 @@ h2o_ostream_t *h2o_add_ostream(h2o_req_t *req, size_t alignment, size_t sz, h2o_
     return ostr;
 }
 
-static void apply_env(h2o_req_t *req, h2o_envconf_t *env)
+void h2o_req_apply_env(h2o_req_t *req, h2o_envconf_t *env)
 {
     size_t i;
 
     if (env->parent != NULL)
-        apply_env(req, env->parent);
+        h2o_req_apply_env(req, env->parent);
     for (i = 0; i != env->unsets.size; ++i)
         h2o_req_unsetenv(req, env->unsets.entries[i].base, env->unsets.entries[i].len);
     for (i = 0; i != env->sets.size; i += 2)
@@ -594,7 +594,7 @@ void h2o_req_bind_conf(h2o_req_t *req, h2o_hostconf_t *hostconf, h2o_pathconf_t 
     req->num_loggers = pathconf->_loggers.size;
 
     if (pathconf->env != NULL)
-        apply_env(req, pathconf->env);
+        h2o_req_apply_env(req, pathconf->env);
 }
 
 void h2o_proceed_response_deferred(h2o_req_t *req)

--- a/lib/handler/configurator/access_log.c
+++ b/lib/handler/configurator/access_log.c
@@ -101,7 +101,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
     /* register all handles, and decref them */
     for (i = 0; i != self->handles->size; ++i) {
         h2o_access_log_filehandle_t *fh = self->handles->entries[i];
-        if (ctx->pathconf != NULL)
+        if (ctx->pathconf != NULL && !h2o_configurator_at_extension_level(ctx))
             h2o_access_log_register(ctx->pathconf, fh);
         h2o_mem_release_shared(fh);
     }
@@ -122,5 +122,7 @@ void h2o_access_log_register_configurator(h2o_globalconf_t *conf)
     self->super.exit = on_config_exit;
     self->handles = self->_handles_stack;
 
-    h2o_configurator_define_command(&self->super, "access-log", H2O_CONFIGURATOR_FLAG_ALL_LEVELS, on_config);
+    h2o_configurator_define_command(&self->super, "access-log",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH,
+                                    on_config);
 }

--- a/lib/handler/configurator/compress.c
+++ b/lib/handler/configurator/compress.c
@@ -140,7 +140,8 @@ static int on_config_exit(h2o_configurator_t *configurator, h2o_configurator_con
 {
     struct compress_configurator_t *self = (void *)configurator;
 
-    if (ctx->pathconf != NULL && (self->vars->gzip.quality != -1 || self->vars->brotli.quality != -1))
+    if (ctx->pathconf != NULL && !h2o_configurator_at_extension_level(ctx) &&
+        (self->vars->gzip.quality != -1 || self->vars->brotli.quality != -1))
         h2o_compress_register(ctx->pathconf, self->vars);
 
     --self->vars;
@@ -153,11 +154,16 @@ void h2o_compress_register_configurator(h2o_globalconf_t *conf)
 
     c->super.enter = on_config_enter;
     c->super.exit = on_config_exit;
-    h2o_configurator_define_command(&c->super, "compress", H2O_CONFIGURATOR_FLAG_ALL_LEVELS, on_config_compress);
+    h2o_configurator_define_command(&c->super, "compress",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH,
+                                    on_config_compress);
     h2o_configurator_define_command(&c->super, "compress-minimum-size",
-                                    H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_compress_min_size);
-    h2o_configurator_define_command(&c->super, "gzip", H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+    h2o_configurator_define_command(&c->super, "gzip",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_gzip);
     c->vars = c->_vars_stack;
     c->vars->gzip.quality = -1;

--- a/lib/handler/configurator/errordoc.c
+++ b/lib/handler/configurator/errordoc.c
@@ -133,7 +133,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 {
     struct errordoc_configurator_t *self = (void *)_self;
 
-    if (ctx->pathconf != NULL && self->vars->size != 0)
+    if (ctx->pathconf != NULL && !h2o_configurator_at_extension_level(ctx) && self->vars->size != 0)
         h2o_errordoc_register(ctx->pathconf, self->vars->entries, self->vars->size);
 
     --self->vars;
@@ -157,5 +157,7 @@ void h2o_errordoc_register_configurator(h2o_globalconf_t *conf)
     c->super.exit = on_config_exit;
 
     /* reproxy: ON | OFF */
-    h2o_configurator_define_command(&c->super, "error-doc", H2O_CONFIGURATOR_FLAG_ALL_LEVELS, on_config_errordoc);
+    h2o_configurator_define_command(&c->super, "error-doc",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH,
+                                    on_config_errordoc);
 }

--- a/lib/handler/configurator/expires.c
+++ b/lib/handler/configurator/expires.c
@@ -95,9 +95,8 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 
     if (*self->args != NULL) {
         /* setup */
-        if (ctx->pathconf != NULL) {
+        if (ctx->pathconf != NULL && !h2o_configurator_at_extension_level(ctx))
             h2o_expires_register(ctx->pathconf, *self->args);
-        }
         /* destruct */
         assert((*self->args)->mode == H2O_EXPIRES_MODE_MAX_AGE);
         free(*self->args);
@@ -118,6 +117,8 @@ void h2o_expires_register_configurator(h2o_globalconf_t *conf)
     /* setup handlers */
     c->super.enter = on_config_enter;
     c->super.exit = on_config_exit;
-    h2o_configurator_define_command(&c->super, "expires", H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+    h2o_configurator_define_command(&c->super, "expires",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_expires);
 }

--- a/lib/handler/configurator/headers.c
+++ b/lib/handler/configurator/headers.c
@@ -44,7 +44,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 {
     struct headers_configurator_t *self = (void *)_self;
 
-    if (ctx->pathconf != NULL && *self->cmds != NULL) {
+    if (ctx->pathconf != NULL && !h2o_configurator_at_extension_level(ctx) && *self->cmds != NULL) {
         if (*self->cmds != NULL)
             h2o_mem_addref_shared(*self->cmds);
         h2o_headers_register(ctx->pathconf, *self->cmds);

--- a/lib/handler/configurator/headers_util.c
+++ b/lib/handler/configurator/headers_util.c
@@ -255,8 +255,9 @@ void h2o_configurator_define_headers_commands(h2o_globalconf_t *global_conf, h2o
 
 #define DEFINE_CMD(name, cb)                                                                                                       \
     h2o_configurator_define_command(&c->super, name,                                                                               \
-                                    H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR |                       \
-                                        H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE | H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,              \
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |       \
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR | H2O_CONFIGURATOR_FLAG_EXPECT_SEQUENCE |              \
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_MAPPING,                                                      \
                                     cb)
     DEFINE_CMD(add_directive, on_config_header_add);
     DEFINE_CMD(append_directive, on_config_header_append);

--- a/lib/handler/configurator/reproxy.c
+++ b/lib/handler/configurator/reproxy.c
@@ -57,7 +57,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 {
     struct reproxy_configurator_t *self = (void *)_self;
 
-    if (ctx->pathconf != NULL && self->vars->enabled != 0)
+    if (ctx->pathconf != NULL && !h2o_configurator_at_extension_level(ctx) && self->vars->enabled != 0)
         h2o_reproxy_register(ctx->pathconf);
 
     --self->vars;
@@ -76,6 +76,8 @@ void h2o_reproxy_register_configurator(h2o_globalconf_t *conf)
     c->super.exit = on_config_exit;
 
     /* reproxy: ON | OFF */
-    h2o_configurator_define_command(&c->super, "reproxy", H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+    h2o_configurator_define_command(&c->super, "reproxy",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_reproxy);
 }

--- a/lib/handler/configurator/server_timing.c
+++ b/lib/handler/configurator/server_timing.c
@@ -59,7 +59,7 @@ static int on_config_exit(h2o_configurator_t *_self, h2o_configurator_context_t 
 {
     struct server_timing_configurator_t *self = (void *)_self;
 
-    if (ctx->pathconf != NULL && self->vars->mode != SERVER_TIMING_MODE_OFF)
+    if (ctx->pathconf != NULL && !h2o_configurator_at_extension_level(ctx) && self->vars->mode != SERVER_TIMING_MODE_OFF)
         h2o_server_timing_register(ctx->pathconf, self->vars->mode == SERVER_TIMING_MODE_ENFORCE);
 
     --self->vars;
@@ -78,5 +78,7 @@ void h2o_server_timing_register_configurator(h2o_globalconf_t *conf)
     c->super.exit = on_config_exit;
 
     /* server_timing: ON | OFF */
-    h2o_configurator_define_command(&c->super, "server-timing", H2O_CONFIGURATOR_FLAG_ALL_LEVELS, on_config_server_timing);
+    h2o_configurator_define_command(&c->super, "server-timing",
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH,
+                                    on_config_server_timing);
 }

--- a/lib/handler/configurator/throttle_resp.c
+++ b/lib/handler/configurator/throttle_resp.c
@@ -53,7 +53,7 @@ static int on_config_exit(h2o_configurator_t *configurator, h2o_configurator_con
 {
     struct throttle_resp_configurator_t *self = (void *)configurator;
 
-    if (ctx->pathconf != NULL && self->vars->on)
+    if (ctx->pathconf != NULL && !h2o_configurator_at_extension_level(ctx) && self->vars->on)
         h2o_throttle_resp_register(ctx->pathconf);
 
     --self->vars;
@@ -67,7 +67,8 @@ void h2o_throttle_resp_register_configurator(h2o_globalconf_t *conf)
     c->super.enter = on_config_enter;
     c->super.exit = on_config_exit;
     h2o_configurator_define_command(&c->super, "throttle-response",
-                                    H2O_CONFIGURATOR_FLAG_ALL_LEVELS | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    H2O_CONFIGURATOR_FLAG_GLOBAL | H2O_CONFIGURATOR_FLAG_HOST | H2O_CONFIGURATOR_FLAG_PATH |
+                                        H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
                                     on_config_throttle_resp);
     c->vars = c->_vars_stack;
 }

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -600,6 +600,8 @@ static int delegate_dynamic_request(h2o_req_t *req, h2o_iovec_t script_name, h2o
     h2o_filereq_t *filereq;
 
     assert(mime_type->data.dynamic.pathconf.handlers.size == 1);
+    assert(mime_type->data.dynamic.pathconf._filters.size == 0);
+    assert(mime_type->data.dynamic.pathconf._loggers.size == 0);
 
     /* setup CGI attributes (e.g., PATH_INFO) */
     filereq = h2o_mem_alloc_pool(&req->pool, *filereq, 1);

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -608,6 +608,10 @@ static int delegate_dynamic_request(h2o_req_t *req, h2o_iovec_t script_name, h2o
     filereq->local_path = h2o_strdup(&req->pool, local_path, local_path_len);
     req->filereq = filereq;
 
+    /* apply environment */
+    if (mime_type->data.dynamic.pathconf.env != NULL)
+        h2o_req_apply_env(req, mime_type->data.dynamic.pathconf.env);
+
     /* call the dynamic handler while retaining current hostconf or pathconf; in other words, filters and loggers of current
      * path level is applied, rather than of the extension level */
     h2o_handler_t *handler = mime_type->data.dynamic.pathconf.handlers.entries[0];

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -598,19 +598,19 @@ static int delegate_dynamic_request(h2o_req_t *req, h2o_iovec_t script_name, h2o
                                     size_t local_path_len, h2o_mimemap_type_t *mime_type)
 {
     h2o_filereq_t *filereq;
-    h2o_handler_t *handler;
 
     assert(mime_type->data.dynamic.pathconf.handlers.size == 1);
 
+    /* setup CGI attributes (e.g., PATH_INFO) */
     filereq = h2o_mem_alloc_pool(&req->pool, *filereq, 1);
     filereq->script_name = script_name;
     filereq->path_info = path_info;
     filereq->local_path = h2o_strdup(&req->pool, local_path, local_path_len);
-
-    h2o_req_bind_conf(req, req->hostconf, &mime_type->data.dynamic.pathconf);
     req->filereq = filereq;
 
-    handler = mime_type->data.dynamic.pathconf.handlers.entries[0];
+    /* call the dynamic handler while retaining current hostconf or pathconf; in other words, filters and loggers of current
+     * path level is applied, rather than of the extension level */
+    h2o_handler_t *handler = mime_type->data.dynamic.pathconf.handlers.entries[0];
     return handler->on_req(handler, req);
 }
 

--- a/t/50file-custom-handler.t
+++ b/t/50file-custom-handler.t
@@ -123,11 +123,14 @@ EOT
     my $doit = sub {
         my ($path, $expected) = @_;
         subtest $path => sub {
-            my $resp = `curl --silent http://127.0.0.1:$server->{port}$path`;
-            my $env = +{ map { split(':', $_, 2) } split(/\n/, $resp) };
-            for my $key (sort keys %$expected) {
-                is $env->{$key}, $expected->{$key}, $key;
-            }
+            run_with_curl($server, sub {
+                my ($proto, $port, $cmd) = @_;
+                my $resp = `$cmd --silent $proto://127.0.0.1:$port$path`;
+                my $env = +{ map { split(':', $_, 2) } split(/\n/, $resp) };
+                for my $key (sort keys %$expected) {
+                    is $env->{$key}, $expected->{$key}, $key;
+                }
+            });
         };
     };
 


### PR DESCRIPTION
The configuration file of h2o uses a lexical structure.

In the example below, a response to `example.com/` will include headers not only "p" but also "g" and "h", because they are defined at "global" or "host" level.

```yaml
header.add: "g: 1"
hosts:
  example.com:
    paths:
      "/":
        ...
        header.add: "p: 3"
    header.add: "h: 2"
```

Up until now, `file.custom-handler` has worked the same way, but that has caused confusion. In the following example, when processing a request to `example.com/index.php`, the access will not be logged in `/path/to/log`. This is because the custom handler for extension `.php` is defined at the global level, rather than within the lexical scope of the path that has the `access-log` directive being used.

```yaml
file.custom-handler:
  extension: .php
  fastcgi.spawn: "PHP_FCGI_CHILDREN=10 exec /usr/local/bin/php-cgi"
hosts:
  example.com:
    paths:
      "/":
        ...
        access-log: /path/to/log
```

This pull request changes the behavior.

Now, even when `file.custom-handler` in an outer scope is applied, filters (handlers that modify the response; e.g., headers, compress) and loggers down to the path level is applied.

The side effect of this PR is that  filters and loggers can no longer be defined within `file.custom-handler`, as the ones defined in the global -> host -> path chain are applied.

Reported by @utrenkner.