### PR TITLE
introduce container type of parse_request arguments

### DIFF
--- a/include/h2o/hpack.h
+++ b/include/h2o/hpack.h
@@ -85,14 +85,26 @@ typedef int (*h2o_hpack_decode_header_cb)(h2o_mem_pool_t *pool, void *ctx, h2o_i
  */
 int h2o_hpack_decode_header(h2o_mem_pool_t *pool, void *_hpack_header_table, h2o_iovec_t **name, h2o_iovec_t *_value,
                             const uint8_t **const src, const uint8_t *src_end, const char **err_desc);
+
+typedef struct {
+    h2o_iovec_t *method;
+    const h2o_url_scheme_t **scheme;
+    h2o_iovec_t *authority;
+    h2o_iovec_t *path;
+    h2o_iovec_t *protocol;
+    h2o_headers_t *headers;
+    int *pseudo_header_exists_map;
+    size_t *content_length;
+    h2o_iovec_t *expect;
+    h2o_cache_digests_t **digests;
+    h2o_iovec_t *datagram_flow_id;
+} h2o_hpack_request_t;
+
 /**
  * Request parser that uses given callback as the decoder.
  */
-int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb decode_cb, void *decode_ctx, h2o_iovec_t *method,
-                            const h2o_url_scheme_t **scheme, h2o_iovec_t *authority, h2o_iovec_t *path, h2o_iovec_t *protocol,
-                            h2o_headers_t *headers, int *pseudo_header_exists_map, size_t *content_length, h2o_iovec_t *expect,
-                            h2o_cache_digests_t **digests, h2o_iovec_t *datagram_flow_id, const uint8_t *src, size_t len,
-                            const char **err_desc);
+int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb decode_cb, void *decode_ctx,
+                            h2o_hpack_request_t result, const uint8_t *src, size_t len, const char **err_desc);
 /**
  * Response parser that uses given callback as the decoder.
  */

--- a/include/h2o/qpack.h
+++ b/include/h2o/qpack.h
@@ -52,11 +52,8 @@ size_t h2o_qpack_decoder_send_stream_cancel(h2o_qpack_decoder_t *qpack, uint8_t 
 /**
  * Parses a QPACK request. The input should be the *payload* of the HTTP/3 HEADERS frame.
  */
-int h2o_qpack_parse_request(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, int64_t stream_id, h2o_iovec_t *method,
-                            const h2o_url_scheme_t **scheme, h2o_iovec_t *authority, h2o_iovec_t *path, h2o_iovec_t *protocol,
-                            h2o_headers_t *headers, int *pseudo_header_exists_map, size_t *content_length, h2o_iovec_t *expect,
-                            h2o_cache_digests_t **digests, h2o_iovec_t *datagram_flow_id, uint8_t *outbuf, size_t *outbufsize,
-                            const uint8_t *src, size_t len, const char **err_desc);
+int h2o_qpack_parse_request(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, int64_t stream_id, h2o_hpack_request_t result,
+                            uint8_t *outbuf, size_t *outbufsize, const uint8_t *src, size_t len, const char **err_desc);
 /**
  * Parses a QPACK response. The input should be the *payload* of the HTTP/3 HEADERS frame. `outbuf` should be at least
  * H2O_HPACK_ENCODE_INT_MAX_LENGTH long.

--- a/lib/http2/connection.c
+++ b/lib/http2/connection.c
@@ -617,10 +617,20 @@ static int handle_incoming_request(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     assert(stream->state == H2O_HTTP2_STREAM_STATE_RECV_HEADERS);
 
     if ((ret = h2o_hpack_parse_request(&stream->req.pool, h2o_hpack_decode_header, &conn->_input_header_table,
-                                       &stream->req.input.method, &stream->req.input.scheme, &stream->req.input.authority,
-                                       &stream->req.input.path, &stream->req.upgrade, &stream->req.headers, &header_exists_map,
-                                       &stream->req.content_length, &expect, &stream->cache_digests, NULL, src, len, err_desc)) !=
-        0) {
+                                       (h2o_hpack_request_t){
+                                           .method = &stream->req.input.method,
+                                           .scheme = &stream->req.input.scheme,
+                                           .authority = &stream->req.input.authority,
+                                           .path = &stream->req.input.path,
+                                           .protocol = &stream->req.upgrade,
+                                           .headers = &stream->req.headers,
+                                           .pseudo_header_exists_map = &header_exists_map,
+                                           .content_length = &stream->req.content_length,
+                                           .expect = &expect,
+                                           .digests = &stream->cache_digests,
+                                           .datagram_flow_id = NULL,
+                                       },
+                                       src, len, err_desc)) != 0) {
         /* all errors except invalid-header-char are connection errors */
         if (ret != H2O_HTTP2_ERROR_INVALID_HEADER_CHAR)
             return ret;
@@ -729,8 +739,12 @@ static int handle_trailing_headers(h2o_http2_conn_t *conn, h2o_http2_stream_t *s
     h2o_iovec_t dummy_expect = h2o_iovec_init(NULL, 0);
     int ret;
 
-    if ((ret = h2o_hpack_parse_request(&stream->req.pool, h2o_hpack_decode_header, &conn->_input_header_table, NULL, NULL, NULL,
-                                       NULL, NULL, &stream->req.headers, NULL, &dummy_content_length, &dummy_expect, NULL, NULL,
+    if ((ret = h2o_hpack_parse_request(&stream->req.pool, h2o_hpack_decode_header, &conn->_input_header_table,
+                                       (h2o_hpack_request_t){
+                                           .headers = &stream->req.headers,
+                                           .content_length = &dummy_content_length,
+                                           .expect = &dummy_expect,
+                                       },
                                        src, len, err_desc)) != 0)
         return ret;
     handle_request_body_chunk(conn, stream, h2o_iovec_init(NULL, 0), 1);

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -500,15 +500,12 @@ void h2o_hpack_dispose_header_table(h2o_hpack_header_table_t *header_table)
     free(header_table->entries);
 }
 
-int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb decode_cb, void *decode_ctx, h2o_iovec_t *method,
-                            const h2o_url_scheme_t **scheme, h2o_iovec_t *authority, h2o_iovec_t *path, h2o_iovec_t *protocol,
-                            h2o_headers_t *headers, int *pseudo_header_exists_map, size_t *content_length, h2o_iovec_t *expect,
-                            h2o_cache_digests_t **digests, h2o_iovec_t *datagram_flow_id, const uint8_t *src, size_t len,
-                            const char **err_desc)
+int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb decode_cb, void *decode_ctx,
+                            h2o_hpack_request_t result, const uint8_t *src, size_t len, const char **err_desc)
 {
     const uint8_t *src_end = src + len;
 
-    *content_length = SIZE_MAX;
+    *result.content_length = SIZE_MAX;
 
     while (src != src_end) {
         h2o_iovec_t *name, value;
@@ -526,29 +523,29 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
             }
         }
         if (name->base[0] == ':') {
-            if (pseudo_header_exists_map != NULL) {
+            if (result.pseudo_header_exists_map != NULL) {
                 /* FIXME validate the chars in the value (e.g. reject SP in path) */
                 if (name == &H2O_TOKEN_AUTHORITY->buf) {
-                    if (authority->base != NULL) {
+                    if (result.authority->base != NULL) {
                         *err_desc = h2o_hpack_err_invalid_pseudo_header;
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     }
-                    *authority = value;
-                    *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS;
+                    *result.authority = value;
+                    *result.pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS;
                 } else if (name == &H2O_TOKEN_METHOD->buf) {
-                    if (method->base != NULL) {
+                    if (result.method->base != NULL) {
                         *err_desc = h2o_hpack_err_invalid_pseudo_header;
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     }
-                    *method = value;
-                    *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS;
+                    *result.method = value;
+                    *result.pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS;
                 } else if (name == &H2O_TOKEN_PROTOCOL->buf) {
-                    if (protocol->base != NULL)
+                    if (result.protocol->base != NULL)
                         return H2O_HTTP2_ERROR_PROTOCOL;
-                    *protocol = value;
-                    *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_PROTOCOL_EXISTS;
+                    *result.protocol = value;
+                    *result.pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_PROTOCOL_EXISTS;
                 } else if (name == &H2O_TOKEN_PATH->buf) {
-                    if (path->base != NULL) {
+                    if (result.path->base != NULL) {
                         *err_desc = h2o_hpack_err_invalid_pseudo_header;
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     }
@@ -556,22 +553,22 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                         *err_desc = h2o_hpack_err_invalid_pseudo_header;
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     }
-                    *path = value;
-                    *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_PATH_EXISTS;
+                    *result.path = value;
+                    *result.pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_PATH_EXISTS;
                 } else if (name == &H2O_TOKEN_SCHEME->buf) {
-                    if (*scheme != NULL) {
+                    if (*result.scheme != NULL) {
                         *err_desc = h2o_hpack_err_invalid_pseudo_header;
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     }
                     if (h2o_memis(value.base, value.len, H2O_STRLIT("https"))) {
-                        *scheme = &H2O_URL_SCHEME_HTTPS;
+                        *result.scheme = &H2O_URL_SCHEME_HTTPS;
                     } else if (h2o_memis(value.base, value.len, H2O_STRLIT("masque"))) {
-                        *scheme = &H2O_URL_SCHEME_MASQUE;
+                        *result.scheme = &H2O_URL_SCHEME_MASQUE;
                     } else {
                         /* draft-16 8.1.2.3 suggests quote: ":scheme is not restricted to http and https schemed URIs" */
-                        *scheme = &H2O_URL_SCHEME_HTTP;
+                        *result.scheme = &H2O_URL_SCHEME_HTTP;
                     }
-                    *pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS;
+                    *result.pseudo_header_exists_map |= H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS;
                 } else {
                     return H2O_HTTP2_ERROR_PROTOCOL;
                 }
@@ -580,32 +577,32 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                 return H2O_HTTP2_ERROR_PROTOCOL;
             }
         } else {
-            pseudo_header_exists_map = NULL;
+            result.pseudo_header_exists_map = NULL;
             if (h2o_iovec_is_token(name)) {
                 h2o_token_t *token = H2O_STRUCT_FROM_MEMBER(h2o_token_t, buf, name);
                 if (token->flags.is_hpack_special) {
                     if (token == H2O_TOKEN_CONTENT_LENGTH) {
-                        if ((*content_length = h2o_strtosize(value.base, value.len)) == SIZE_MAX) {
+                        if ((*result.content_length = h2o_strtosize(value.base, value.len)) == SIZE_MAX) {
                             *err_desc = h2o_hpack_err_invalid_content_length_header;
                             return H2O_HTTP2_ERROR_PROTOCOL;
                         }
                         goto Next;
                     } else if (token == H2O_TOKEN_EXPECT) {
-                        *expect = value;
+                        *result.expect = value;
                         goto Next;
-                    } else if (token == H2O_TOKEN_HOST && authority != NULL) {
+                    } else if (token == H2O_TOKEN_HOST && result.authority != NULL) {
                         /* HTTP2 allows the use of host header (in place of :authority) */
-                        if (authority->base == NULL)
-                            *authority = value;
+                        if (result.authority->base == NULL)
+                            *result.authority = value;
                         goto Next;
                     } else if (token == H2O_TOKEN_TE && h2o_lcstris(value.base, value.len, H2O_STRLIT("trailers"))) {
                         /* do not reject */
-                    } else if (token == H2O_TOKEN_CACHE_DIGEST && digests != NULL) {
+                    } else if (token == H2O_TOKEN_CACHE_DIGEST && result.digests != NULL) {
                         /* TODO cache the decoded result in HPACK, as well as delay the decoding of the digest until being used */
-                        h2o_cache_digests_load_header(digests, value.base, value.len);
+                        h2o_cache_digests_load_header(result.digests, value.base, value.len);
                     } else if (token == H2O_TOKEN_DATAGRAM_FLOW_ID) {
-                        if (datagram_flow_id != NULL)
-                            *datagram_flow_id = value;
+                        if (result.datagram_flow_id != NULL)
+                            *result.datagram_flow_id = value;
                         goto Next;
                     } else {
                         /* rest of the header fields that are marked as special are rejected */
@@ -613,9 +610,9 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     }
                 }
-                h2o_add_header(pool, headers, token, NULL, value.base, value.len);
+                h2o_add_header(pool, result.headers, token, NULL, value.base, value.len);
             } else {
-                h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
+                h2o_add_header_by_str(pool, result.headers, name->base, name->len, 0, NULL, value.base, value.len);
             }
         }
     Next:;

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -809,11 +809,8 @@ static int normalize_error_code(int err)
     return err;
 }
 
-int h2o_qpack_parse_request(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, int64_t stream_id, h2o_iovec_t *method,
-                            const h2o_url_scheme_t **scheme, h2o_iovec_t *authority, h2o_iovec_t *path, h2o_iovec_t *protocol,
-                            h2o_headers_t *headers, int *pseudo_header_exists_map, size_t *content_length, h2o_iovec_t *expect,
-                            h2o_cache_digests_t **digests, h2o_iovec_t *datagram_flow_id, uint8_t *outbuf, size_t *outbufsize,
-                            const uint8_t *_src, size_t len, const char **err_desc)
+int h2o_qpack_parse_request(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, int64_t stream_id, h2o_hpack_request_t result,
+                            uint8_t *outbuf, size_t *outbufsize, const uint8_t *_src, size_t len, const char **err_desc)
 {
     struct st_h2o_qpack_decode_header_ctx_t ctx;
     const uint8_t *src = _src, *src_end = src + len;
@@ -821,9 +818,7 @@ int h2o_qpack_parse_request(h2o_mem_pool_t *pool, h2o_qpack_decoder_t *qpack, in
 
     if ((ret = parse_decode_context(qpack, &ctx, stream_id, &src, src_end)) != 0)
         return ret;
-    if ((ret = h2o_hpack_parse_request(pool, decode_header, &ctx, method, scheme, authority, path, protocol, headers,
-                                       pseudo_header_exists_map, content_length, expect, digests, datagram_flow_id, src,
-                                       src_end - src, err_desc)) != 0) {
+    if ((ret = h2o_hpack_parse_request(pool, decode_header, &ctx, result, src, src_end - src, err_desc)) != 0) {
         /* bail out if the error is a hard error, otherwise build header ack then return */
         if (ret != H2O_HTTP2_ERROR_INVALID_HEADER_CHAR)
             return normalize_error_code(ret);

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1408,9 +1408,19 @@ static int handle_input_expect_headers(struct st_h2o_http3_server_stream_t *stre
 
     /* parse the headers, and ack */
     if ((ret = h2o_qpack_parse_request(&stream->req.pool, get_conn(stream)->h3.qpack.dec, stream->quic->stream_id,
-                                       &stream->req.input.method, &stream->req.input.scheme, &stream->req.input.authority,
-                                       &stream->req.input.path, &stream->req.upgrade, &stream->req.headers, &header_exists_map,
-                                       &stream->req.content_length, &expect, NULL /* TODO cache-digests */, &datagram_flow_id_field,
+                                       (h2o_hpack_request_t){
+                                           .method = &stream->req.input.method,
+                                           .scheme = &stream->req.input.scheme,
+                                           .authority = &stream->req.input.authority,
+                                           .path = &stream->req.input.path,
+                                           .protocol = &stream->req.upgrade,
+                                           .headers = &stream->req.headers,
+                                           .pseudo_header_exists_map = &header_exists_map,
+                                           .content_length = &stream->req.content_length,
+                                           .expect = &expect,
+                                           .digests = NULL /* TODO cache-digests */,
+                                           .datagram_flow_id = &datagram_flow_id_field,
+                                       },
                                        header_ack, &header_ack_len, frame.payload, frame.length, err_desc)) != 0 &&
         ret != H2O_HTTP2_ERROR_INVALID_HEADER_CHAR)
         return ret;


### PR DESCRIPTION
`h2o_hpack_parse_request` and `h2o_qpack_parse_request` has too many *output* arguments. It's especially hard to maintain since we added several fork-only arguments in our fork, and that makes the merge harder. This PR introduces `h2o_hpack_request_t` which contains all of those output arguments.