### PR TITLE
Fix leak in socket.c

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1156,6 +1156,8 @@ h2o_iovec_t h2o_socket_log_tcp_congestion_controller(h2o_socket_t *sock, h2o_mem
             buf[CC_BUFSIZE - 1] = '\0';
             return h2o_iovec_init(buf, strlen(buf));
         }
+        if (pool == NULL)
+            free(buf);
 #undef CC_BUFSIZE
     }
 #endif


### PR DESCRIPTION
Hi,
I am a new contributor looking forward to contribute to the h2o project :).

Fixes #3354. The leak occurs because buf is allocated within `h2o_socket_log_tcp_congestion_controller` but not freed if `getsockopt` fails. 

The patch in this case checks if pool is NULL. If so the allocated memory `buf` is not referenced by `pool`. Therefore  we are free to deallocate `buf` after `getsockopt` branch in this case.

Let me know if this is a good patch! If not let me know what changes need be done. I am eager to contribute more to this repository :)