### PR TITLE
http/3 quic: fix inter node forwarding for mismatched address families

### DIFF
--- a/t/40http3-forward.t
+++ b/t/40http3-forward.t
@@ -30,7 +30,7 @@ plan skip_all => "macOS has issues https://twitter.com/kazuho/status/12980731105
 my $quic_port = empty_port({ host  => "0.0.0.0", proto => "udp" });
 
 # start server1 at 0.0.0.0, check that it is up
-my $server1 = spawn("0.0.0.0", 1);
+my $server1 = spawn("*", 1);
 is do {my $fh = fetch(""); local $/; join "", <$fh> }, "server=1", "server1 is up";
 
 # initiate the slow request
@@ -66,11 +66,14 @@ done_testing;
 
 sub spawn {
     my ($listen_ip, $server_id) = @_;
+    my $host_directive = "";
+    if ($listen_ip ne "*") {
+        $host_directive = "\n  host: $listen_ip";
+    }
     my $conf = {opts => [qw(-m worker)], conf => <<"EOT"};
 num-threads: 1
 listen:
-  type: quic
-  host: $listen_ip
+  type: quic$host_directive
   port: $quic_port
   ssl:
     key-file: examples/h2o/server.key
@@ -78,7 +81,7 @@ listen:
 quic-nodes:
   self: $server_id
   mapping:
-    1: "127.0.0.2:$quic_port" # server1 can be reached at 127.0.0.2 too
+    1: "[::1]:$quic_port" # server1 can be reached over ipv6 as well
     2: "127.0.0.1:$quic_port"
 ssl-session-resumption:
   mode: ticket


### PR DESCRIPTION
Current inter-node forwarding doesn't work for for mismatching address
families: if the internode address is ipv4, it cannot process forwarded
ipv6 packets and vice versa.

This fix instruments the listener creation logic by marking which
listeners are each other's 'siblings', meaning they come from the same
configuration directive, which resolved to one ipv4 listener on one hand
and ipv6 on the other.

The forwarding logic then uses that sibling fd in order to reach the
worker thread with the context matching the address family.