### PR TITLE
[h2olog] ensure uniqueness of connection id

### DIFF
--- a/fuzz/driver_h3.cc
+++ b/fuzz/driver_h3.cc
@@ -42,6 +42,7 @@
 static h2o_globalconf_t config;
 static h2o_context_t ctx;
 static h2o_accept_ctx_t accept_ctx;
+static quicly_cid_plaintext_t next_cid;
 static h2o_http3_server_ctx_t server_ctx;
 static quicly_context_t qctx = quicly_spec_context;
 static ptls_context_t ptls_ctx = {
@@ -141,6 +142,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
         accept_ctx.ctx = &ctx;
         accept_ctx.hosts = config.hosts;
 
+        server_ctx.super.next_cid = &next_cid;
         server_ctx.accept_ctx = &accept_ctx;
         server_ctx.send_retry = 0;
         server_ctx.qpack.encoder_table_capacity = 4096;

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -1737,8 +1737,7 @@ h2o_logger_t *h2o_create_logger(h2o_pathconf_t *conf, size_t sz);
 /**
  * initializes the context
  */
-void h2o_context_init(h2o_context_t *context, h2o_loop_t *loop, h2o_globalconf_t *config, uint32_t quic_thread_id,
-                      uint64_t quic_node_id);
+void h2o_context_init(h2o_context_t *context, h2o_loop_t *loop, h2o_globalconf_t *config);
 /**
  * disposes of the resources allocated for the context
  */

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -742,6 +742,13 @@ struct st_h2o_context_t {
     } http2;
 
     struct {
+        /**
+         * thread-local variable shared by multiple instances of `h2o_quic_ctx_t::next_cid`
+         */
+        quicly_cid_plaintext_t next_cid;
+        /**
+         *
+         */
         struct {
             /**
              * number of packets forwarded to another node in a cluster
@@ -1730,7 +1737,8 @@ h2o_logger_t *h2o_create_logger(h2o_pathconf_t *conf, size_t sz);
 /**
  * initializes the context
  */
-void h2o_context_init(h2o_context_t *context, h2o_loop_t *loop, h2o_globalconf_t *config);
+void h2o_context_init(h2o_context_t *context, h2o_loop_t *loop, h2o_globalconf_t *config, uint32_t quic_thread_id,
+                      uint64_t quic_node_id);
 /**
  * disposes of the resources allocated for the context
  */

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -266,9 +266,10 @@ struct st_h2o_quic_ctx_t {
      */
     quicly_context_t *quic;
     /**
-     *
+     * Retains the next CID to be used for a connection being associated to this context. Also, `thread_id` and `node_id` are
+     * constants that contain the identity of the current thread / node; packets targetted to other theads / nodes are forwarded.
      */
-    quicly_cid_plaintext_t next_cid;
+    quicly_cid_plaintext_t *next_cid;
     /**
      * hashmap of connections by quicly_cid_plaintext_t::master_id.
      */
@@ -451,7 +452,7 @@ void h2o_quic_dispose_context(h2o_quic_ctx_t *ctx);
 /**
  *
  */
-void h2o_quic_set_context_identifier(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, uint32_t thread_id, uint64_t node_id,
+void h2o_quic_set_context_identifier(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, quicly_cid_plaintext_t *next_cid,
                                      uint8_t ttl, h2o_quic_forward_packets_cb forward_cb,
                                      h2o_quic_preprocess_packet_cb preprocess_cb);
 /**

--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -442,19 +442,24 @@ void h2o_http3_on_create_unidirectional_stream(quicly_stream_t *qs);
 int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t stream_type, size_t max_frame_payload_size,
                          const uint8_t **src, const uint8_t *src_end, const char **err_desc);
 
+/**
+ * Initializes the QUIC context, binding the event loop, socket, quic, and other properties. `next_cid` should be a thread-local
+ * that contains the CID seed to be used; see `h2o_quic_ctx_t::next_cid` for more information.
+ */
 void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
-                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update, uint8_t use_gso,
-                           h2o_quic_stats_t *quic_stats);
+                           quicly_cid_plaintext_t *next_cid, h2o_quic_accept_cb acceptor,
+                           h2o_quic_notify_connection_update_cb notify_conn_update, uint8_t use_gso, h2o_quic_stats_t *quic_stats);
 /**
  *
  */
 void h2o_quic_dispose_context(h2o_quic_ctx_t *ctx);
 /**
- *
+ * When running QUIC on multiple threads / nodes, it becomes necessary to forward incoming packets between those threads / nodes
+ * with encapsulation. This function makes adjustments to the context initialized by `h2o_quic_init_context` and registers the
+ * callbacks necessary for forwarding with en(de)capsulation.
  */
-void h2o_quic_set_context_identifier(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, quicly_cid_plaintext_t *next_cid,
-                                     uint8_t ttl, h2o_quic_forward_packets_cb forward_cb,
-                                     h2o_quic_preprocess_packet_cb preprocess_cb);
+void h2o_quic_set_forwarding_context(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, uint8_t ttl,
+                                     h2o_quic_forward_packets_cb forward_cb, h2o_quic_preprocess_packet_cb preprocess_cb);
 /**
  *
  */

--- a/include/h2o/http3_server.h
+++ b/include/h2o/http3_server.h
@@ -44,7 +44,7 @@ extern const h2o_http3_conn_callbacks_t H2O_HTTP3_CONN_CALLBACKS;
  * initializes the context
  */
 void h2o_http3_server_init_context(h2o_context_t *h2o, h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock,
-                                   quicly_context_t *quic, h2o_quic_accept_cb acceptor,
+                                   quicly_context_t *quic, quicly_cid_plaintext_t *next_cid, h2o_quic_accept_cb acceptor,
                                    h2o_quic_notify_connection_update_cb notify_conn_update, uint8_t use_gso);
 
 /**

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -269,6 +269,7 @@ static void start_connect(struct st_h2o_httpclient__h3_conn_t *conn, struct sock
                                             &conn->handshake_properties.client.session_ticket, &resumed_tp))
             goto Fail;
     }
+    assert(conn->ctx->http3->h3.next_cid != NULL && "to identify connections, next_cid must be set");
     if ((ret = quicly_connect(&qconn, &conn->ctx->http3->quic, conn->server.origin_url.host.base, sa, NULL,
                               conn->ctx->http3->h3.next_cid, address_token, &conn->handshake_properties,
                               conn->handshake_properties.client.session_ticket.base != NULL ? &resumed_tp : NULL, NULL)) != 0) {

--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -270,12 +270,12 @@ static void start_connect(struct st_h2o_httpclient__h3_conn_t *conn, struct sock
             goto Fail;
     }
     if ((ret = quicly_connect(&qconn, &conn->ctx->http3->quic, conn->server.origin_url.host.base, sa, NULL,
-                              &conn->ctx->http3->h3.next_cid, address_token, &conn->handshake_properties,
+                              conn->ctx->http3->h3.next_cid, address_token, &conn->handshake_properties,
                               conn->handshake_properties.client.session_ticket.base != NULL ? &resumed_tp : NULL, NULL)) != 0) {
         conn->super.super.quic = NULL; /* just in case */
         goto Fail;
     }
-    ++conn->ctx->http3->h3.next_cid.master_id; /* FIXME check overlap */
+    ++conn->ctx->http3->h3.next_cid->master_id; /* FIXME check overlap */
     if ((ret = h2o_http3_setup(&conn->super, qconn)) != 0)
         goto Fail;
 

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -81,7 +81,8 @@ void h2o_context_dispose_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pa
 #undef DOIT
 }
 
-void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *config)
+void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *config, uint32_t quic_thread_id,
+                      uint64_t quic_node_id)
 {
     size_t i, j;
 
@@ -97,6 +98,8 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     h2o_linklist_init_anchor(&ctx->_conns.active);
     h2o_linklist_init_anchor(&ctx->_conns.idle);
     h2o_linklist_init_anchor(&ctx->_conns.shutdown);
+    ctx->http3.next_cid.thread_id = quic_thread_id;
+    ctx->http3.next_cid.node_id = quic_node_id;
     ctx->proxy.client_ctx.loop = loop;
     ctx->proxy.client_ctx.io_timeout = ctx->globalconf->proxy.io_timeout;
     ctx->proxy.client_ctx.connect_timeout = ctx->globalconf->proxy.connect_timeout;

--- a/lib/core/context.c
+++ b/lib/core/context.c
@@ -81,8 +81,7 @@ void h2o_context_dispose_pathconf_context(h2o_context_t *ctx, h2o_pathconf_t *pa
 #undef DOIT
 }
 
-void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *config, uint32_t quic_thread_id,
-                      uint64_t quic_node_id)
+void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *config)
 {
     size_t i, j;
 
@@ -98,8 +97,6 @@ void h2o_context_init(h2o_context_t *ctx, h2o_loop_t *loop, h2o_globalconf_t *co
     h2o_linklist_init_anchor(&ctx->_conns.active);
     h2o_linklist_init_anchor(&ctx->_conns.idle);
     h2o_linklist_init_anchor(&ctx->_conns.shutdown);
-    ctx->http3.next_cid.thread_id = quic_thread_id;
-    ctx->http3.next_cid.node_id = quic_node_id;
     ctx->proxy.client_ctx.loop = loop;
     ctx->proxy.client_ctx.io_timeout = ctx->globalconf->proxy.io_timeout;
     ctx->proxy.client_ctx.connect_timeout = ctx->globalconf->proxy.connect_timeout;

--- a/lib/handler/proxy.c
+++ b/lib/handler/proxy.c
@@ -107,7 +107,7 @@ static h2o_http3client_ctx_t *create_http3_context(h2o_context_t *ctx, int use_g
         h2o_fatal("failed to bind default address to UDP socket: %s", h2o_strerror_r(errno, buf, sizeof(buf)));
     }
     h2o_socket_t *sock = h2o_evloop_socket_create(ctx->loop, sockfd, H2O_SOCKET_FLAG_DONT_READ);
-    h2o_http3_server_init_context(ctx, &h3ctx->h3, ctx->loop, sock, &h3ctx->quic, NULL,
+    h2o_http3_server_init_context(ctx, &h3ctx->h3, ctx->loop, sock, &h3ctx->quic, &ctx->http3.next_cid, NULL,
                                   h2o_httpclient_http3_notify_connection_update, use_gso);
 
     h3ctx->load_session = NULL; /* TODO reuse session? */

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -989,8 +989,8 @@ Validation_Success:;
 }
 
 void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock, quicly_context_t *quic,
-                           h2o_quic_accept_cb acceptor, h2o_quic_notify_connection_update_cb notify_conn_update, uint8_t use_gso,
-                           h2o_quic_stats_t *quic_stats)
+                           quicly_cid_plaintext_t *next_cid, h2o_quic_accept_cb acceptor,
+                           h2o_quic_notify_connection_update_cb notify_conn_update, uint8_t use_gso, h2o_quic_stats_t *quic_stats)
 {
     assert(quic->stream_open != NULL);
 
@@ -998,7 +998,7 @@ void h2o_quic_init_context(h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *
         .loop = loop,
         .sock = {.sock = sock},
         .quic = quic,
-        .next_cid = NULL /* set by h2o_http3_set_context_identifier */,
+        .next_cid = next_cid,
         .conns_by_id = kh_init_h2o_quic_idmap(),
         .conns_accepting = kh_init_h2o_quic_acceptmap(),
         .notify_conn_update = notify_conn_update,
@@ -1034,12 +1034,10 @@ void h2o_quic_dispose_context(h2o_quic_ctx_t *ctx)
     kh_destroy_h2o_quic_acceptmap(ctx->conns_accepting);
 }
 
-void h2o_quic_set_context_identifier(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, quicly_cid_plaintext_t *next_cid,
-                                     uint8_t ttl, h2o_quic_forward_packets_cb forward_cb,
-                                     h2o_quic_preprocess_packet_cb preprocess_cb)
+void h2o_quic_set_forwarding_context(h2o_quic_ctx_t *ctx, uint32_t accept_thread_divisor, uint8_t ttl,
+                                     h2o_quic_forward_packets_cb forward_cb, h2o_quic_preprocess_packet_cb preprocess_cb)
 {
     ctx->accept_thread_divisor = accept_thread_divisor;
-    ctx->next_cid = next_cid;
     ctx->forward_packets = forward_cb;
     ctx->default_ttl = ttl;
     ctx->preprocess_packet = preprocess_cb;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -2167,7 +2167,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
 #endif
     quicly_conn_t *qconn;
     int accept_ret = quicly_accept(
-        &qconn, ctx->super.quic, &destaddr->sa, &srcaddr->sa, packet, address_token, &ctx->super.next_cid,
+        &qconn, ctx->super.quic, &destaddr->sa, &srcaddr->sa, packet, address_token, ctx->super.next_cid,
         &conn->handshake_properties,
         &conn->h3 /* back pointer is set up here so that callbacks being called while parsing ClientHello can refer to `conn` */);
 #if PICOTLS_USE_DTRACE
@@ -2185,7 +2185,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
     if (ctx->super.quic_stats != NULL) {
         ++ctx->super.quic_stats->packet_processed;
     }
-    ++ctx->super.next_cid.master_id; /* FIXME check overlap */
+    ++ctx->super.next_cid->master_id; /* FIXME check overlap */
     h2o_http3_setup(&conn->h3, qconn);
 
     H2O_PROBE_CONN(H3S_ACCEPT, &conn->super, &conn->super, conn->h3.super.quic, h2o_conn_get_uuid(&conn->super));

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -2161,6 +2161,7 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
     conn->datagram_flows = kh_init(stream);
 
     /* accept connection */
+    assert(ctx->super.next_cid != NULL && "to set next_cid, h2o_quic_set_context_identifier must be called");
 #if PICOTLS_USE_DTRACE
     unsigned orig_skip_tracing = ptls_default_skip_tracing;
     ptls_default_skip_tracing = skip_tracing;

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -2089,10 +2089,10 @@ static void on_h3_destroy(h2o_quic_conn_t *h3_)
 }
 
 void h2o_http3_server_init_context(h2o_context_t *h2o, h2o_quic_ctx_t *ctx, h2o_loop_t *loop, h2o_socket_t *sock,
-                                   quicly_context_t *quic, h2o_quic_accept_cb acceptor,
+                                   quicly_context_t *quic, quicly_cid_plaintext_t *next_cid, h2o_quic_accept_cb acceptor,
                                    h2o_quic_notify_connection_update_cb notify_conn_update, uint8_t use_gso)
 {
-    return h2o_quic_init_context(ctx, loop, sock, quic, acceptor, notify_conn_update, use_gso, &h2o->quic_stats);
+    return h2o_quic_init_context(ctx, loop, sock, quic, next_cid, acceptor, notify_conn_update, use_gso, &h2o->quic_stats);
 }
 
 h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_address_t *destaddr, quicly_address_t *srcaddr,

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -94,6 +94,7 @@ static h2o_http3client_ctx_t h3ctx = {
         },
     .max_frame_payload_size = 16384,
 };
+static quicly_cid_plaintext_t h3_next_cid;
 static const char *progname; /* refers to argv[0] */
 
 static h2o_httpclient_head_cb on_connect(h2o_httpclient_t *client, const char *errstr, h2o_iovec_t *method, h2o_url_t *url,
@@ -704,6 +705,7 @@ int main(int argc, char **argv)
         h2o_socket_t *sock = h2o_evloop_socket_create(ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
         h2o_quic_init_context(&h3ctx.h3, ctx.loop, sock, &h3ctx.quic, NULL, h2o_httpclient_http3_notify_connection_update,
                               1 /* use_gso */, NULL);
+        h3ctx.h3.next_cid = &h3_next_cid;
     }
 #endif
 

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -703,9 +703,8 @@ int main(int argc, char **argv)
             exit(EXIT_FAILURE);
         }
         h2o_socket_t *sock = h2o_evloop_socket_create(ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
-        h2o_quic_init_context(&h3ctx.h3, ctx.loop, sock, &h3ctx.quic, NULL, h2o_httpclient_http3_notify_connection_update,
-                              1 /* use_gso */, NULL);
-        h3ctx.h3.next_cid = &h3_next_cid;
+        h2o_quic_init_context(&h3ctx.h3, ctx.loop, sock, &h3ctx.quic, &h3_next_cid, NULL,
+                              h2o_httpclient_http3_notify_connection_update, 1 /* use_gso */, NULL);
     }
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -4072,8 +4072,9 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     struct listener_ctx_t *listeners = alloca(sizeof(*listeners) * conf.num_listeners);
     size_t i;
 
-    h2o_context_init(&conf.threads[thread_index].ctx, h2o_evloop_create(), &conf.globalconf, (uint32_t)thread_index,
-                     conf.quic.node_id);
+    h2o_context_init(&conf.threads[thread_index].ctx, h2o_evloop_create(), &conf.globalconf);
+    conf.threads[thread_index].ctx.http3.next_cid.thread_id = (uint32_t)conf.quic.node_id;
+    conf.threads[thread_index].ctx.http3.next_cid.thread_id = (uint32_t)thread_index;
     h2o_multithread_register_receiver(conf.threads[thread_index].ctx.queue, &conf.threads[thread_index].server_notifications,
                                       on_server_notification);
     h2o_multithread_register_receiver(conf.threads[thread_index].ctx.queue, &conf.threads[thread_index].memcached,

--- a/src/main.c
+++ b/src/main.c
@@ -4135,9 +4135,10 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
         if (thread_index < conf.quic.num_threads && listener_config->quic.ctx != NULL) {
             h2o_http3_server_init_context(listeners[i].accept_ctx.ctx, &listeners[i].http3.ctx.super,
                                           conf.threads[thread_index].ctx.loop, listeners[i].sock, listener_config->quic.ctx,
-                                          on_http3_accept, NULL, conf.globalconf.http3.use_gso);
-            h2o_quic_set_context_identifier(&listeners[i].http3.ctx.super, 0, &conf.threads[thread_index].ctx.http3.next_cid, 4,
-                                            forward_quic_packets, rewrite_forwarded_quic_datagram);
+                                          &conf.threads[thread_index].ctx.http3.next_cid, on_http3_accept, NULL,
+                                          conf.globalconf.http3.use_gso);
+            h2o_quic_set_forwarding_context(&listeners[i].http3.ctx.super, 0, 4, forward_quic_packets,
+                                            rewrite_forwarded_quic_datagram);
             listeners[i].http3.ctx.accept_ctx = &listeners[i].accept_ctx;
             listeners[i].http3.ctx.send_retry = listener_config->quic.send_retry;
             listeners[i].http3.ctx.qpack = listener_config->quic.qpack;

--- a/src/main.c
+++ b/src/main.c
@@ -4073,7 +4073,7 @@ H2O_NORETURN static void *run_loop(void *_thread_index)
     size_t i;
 
     h2o_context_init(&conf.threads[thread_index].ctx, h2o_evloop_create(), &conf.globalconf);
-    conf.threads[thread_index].ctx.http3.next_cid.thread_id = (uint32_t)conf.quic.node_id;
+    conf.threads[thread_index].ctx.http3.next_cid.node_id = (uint32_t)conf.quic.node_id;
     conf.threads[thread_index].ctx.http3.next_cid.thread_id = (uint32_t)thread_index;
     h2o_multithread_register_receiver(conf.threads[thread_index].ctx.queue, &conf.threads[thread_index].server_notifications,
                                       on_server_notification);

--- a/src/main.c
+++ b/src/main.c
@@ -3798,7 +3798,7 @@ static int rewrite_forwarded_quic_datagram(h2o_quic_ctx_t *h3ctx, struct msghdr 
     if (encapsulated.destaddr.sa.sa_family != h3ctx->sock.addr.ss_family) {
         struct listener_config_t *listener_config = conf.listeners[lctx->listener_index];
         if (listener_config->quic.sibling != NULL) {
-            int fd = listener_config->quic.sibling->quic.thread_fds[h3ctx->next_cid.thread_id];
+            int fd = listener_config->quic.sibling->quic.thread_fds[h3ctx->next_cid->thread_id];
             write(fd, msg->msg_iov[0].iov_base, msg->msg_iov[0].iov_len);
         } else {
             /* drop packet */


### PR DESCRIPTION
When creating a new QUIC connection, CIDs are cloned from `h2o_quic_ctx_t::next_cid`, and `h2o_quic_ctx_t::next_cid.master_cid` is incremented.

If there are multiple accepting contexts (e.g., due to multiple `listen` directives in use, or due to one `listen` directive binding to both IPv4 and IPv6), there will be multiple instances of `h2o_quic_ctx_t` and therefore, there could be multiple QUIC connections sharing the same thread id and master id.

While this is behavior is fine in terms of operations, it causes confusion to the log collected by h2olog. This is because each log line of `h2olog` contains only the thread-id and conn-id (corresponds to master id).

This PR address the confusion by changing the code so that all instances of `h2o_quic_ctx_t::next_cid` refer to one thread-local variable via a pointer.