### PR TITLE
http3client: socket pool DNS resolution must only return addresses corresponding to the address family of `st_h2o_quic_ctx_t`

### DIFF
--- a/lib/common/http3client.c
+++ b/lib/common/http3client.c
@@ -371,8 +371,9 @@ struct st_h2o_httpclient__h3_conn_t *create_connection(h2o_httpclient_ctx_t *ctx
     h2o_linklist_init_anchor(&conn->pending_requests);
 
     conn->getaddr_req = h2o_hostinfo_getaddr(conn->ctx->getaddr_receiver, conn->server.origin_url.host,
-                                             h2o_iovec_init(conn->server.named_serv, strlen(conn->server.named_serv)), AF_UNSPEC,
-                                             SOCK_DGRAM, IPPROTO_UDP, AI_ADDRCONFIG | AI_NUMERICSERV, on_getaddr, conn);
+                                             h2o_iovec_init(conn->server.named_serv, strlen(conn->server.named_serv)),
+                                             ctx->http3->h3.sock.addr.ss_family, SOCK_DGRAM, IPPROTO_UDP,
+                                             AI_ADDRCONFIG | AI_NUMERICSERV, on_getaddr, conn);
     h2o_timer_link(conn->ctx->loop, conn->ctx->connect_timeout, &conn->timeout);
     conn->timeout.cb = on_connect_timeout;
 


### PR DESCRIPTION


Before this fix, if name resolution was used by the http3 client, it might have returned a result that didn't correspond to the socket used in `st_h2o_quic_ctx_t`.