### PR TITLE
make h2o_fatal use h2o__fatal_redirect function pointer #3244

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -182,11 +182,14 @@ typedef struct st_h2o_doublebuffer_t {
 extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 
 /**
- * prints an error message and aborts
+ * prints an error message and aborts. h2o_fatal can be modified by
+ * setting the function pointer it expands to, which is
+ * h2o__fatal_redirect.
  */
 H2O_NORETURN void h2o__fatal(const char *file, int line, const char *msg, ...) __attribute__((format(printf, 3, 4)));
+extern H2O_NORETURN void (*h2o__fatal_redirect)(const char *file, int line, const char *msg, ...);
 #ifndef h2o_fatal
-#define h2o_fatal(...) h2o__fatal(__FILE__, __LINE__, __VA_ARGS__)
+#define h2o_fatal(...) h2o__fatal_redirect(__FILE__, __LINE__, __VA_ARGS__)
 #endif
 
 void h2o_perror(const char *msg);

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -184,12 +184,12 @@ extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 /**
  * prints an error message and aborts. h2o_fatal can be modified by
  * setting the function pointer it expands to, which is
- * h2o__fatal_redirect.
+ * h2o___fatal.
  */
 H2O_NORETURN void h2o__fatal(const char *file, int line, const char *msg, ...) __attribute__((format(printf, 3, 4)));
-extern H2O_NORETURN void (*h2o__fatal_redirect)(const char *file, int line, const char *msg, ...);
+extern H2O_NORETURN void (*h2o___fatal)(const char *file, int line, const char *msg, ...);
 #ifndef h2o_fatal
-#define h2o_fatal(...) h2o__fatal_redirect(__FILE__, __LINE__, __VA_ARGS__)
+#define h2o_fatal(...) h2o__fatal(__FILE__, __LINE__, __VA_ARGS__)
 #endif
 
 void h2o_perror(const char *msg);

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -78,7 +78,7 @@ struct st_h2o_mem_pool_shared_ref_t {
 };
 
 void *(*volatile h2o_mem__set_secure)(void *, int, size_t) = memset;
-H2O_NORETURN void (*h2o__fatal_redirect)(const char *, int, const char *, ...) = h2o__fatal;
+H2O_NORETURN void (*h2o___fatal)(const char *, int, const char *, ...) = h2o__fatal;
 
 static const h2o_mem_recycle_conf_t mem_pool_allocator_conf = {.memsize = sizeof(union un_h2o_mem_pool_chunk_t)};
 __thread h2o_mem_recycle_t h2o_mem_pool_allocator = {&mem_pool_allocator_conf};

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -78,6 +78,7 @@ struct st_h2o_mem_pool_shared_ref_t {
 };
 
 void *(*volatile h2o_mem__set_secure)(void *, int, size_t) = memset;
+H2O_NORETURN void (*h2o__fatal_redirect)(const char *, int, const char *, ...) = h2o__fatal;
 
 static const h2o_mem_recycle_conf_t mem_pool_allocator_conf = {.memsize = sizeof(union un_h2o_mem_pool_chunk_t)};
 __thread h2o_mem_recycle_t h2o_mem_pool_allocator = {&mem_pool_allocator_conf};


### PR DESCRIPTION
Follows the suggestion of @yrashk in #3244 to make the `h2o_fatal` macro call through a function pointer call whose default is the current `h2o__fatal` function. This makes it possible to configure and reset `h2o_fatal` at runtime.