### PR TITLE
Repro and possible fix for HTTP3 stream reset bug

### DIFF
--- a/examples/h2o/h2o.conf
+++ b/examples/h2o/h2o.conf
@@ -1,29 +1,27 @@
 # to find out the configuration commands, run: h2o --help
-
 listen: 8080
 listen: &ssl_listen
   port: 8081
   ssl:
-    certificate-file: examples/h2o/server.crt
-    key-file: examples/h2o/server.key
+    certificate-file: /examples/h2o/server.crt
+    key-file: /examples/h2o/server.key
     minimum-version: TLSv1.2
     cipher-preference: server
     cipher-suite: "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
     # Oldest compatible clients: Firefox 27, Chrome 30, IE 11 on Windows 7, Edge, Opera 17, Safari 9, Android 5.0, and Java 8
     # see: https://wiki.mozilla.org/Security/Server_Side_TLS
 # The following three lines enable HTTP/3
-#listen:
-#  <<: *ssl_listen
-#  type: quic
-#header.set: "Alt-Svc: h3-25=\":8081\""
+listen:
+ <<: *ssl_listen
+ type: quic
+header.set: "Alt-Svc: h3-27=\":8081\""
 hosts:
-  "localhost.examp1e.net:8080":
+  "*":
     paths:
       /:
-        file.dir: examples/doc_root
-    access-log: /dev/stdout
-  "alternate.localhost.examp1e.net:8081":
-    paths:
-      /:
-        file.dir: examples/doc_root.alternate
+        proxy.reverse.url: https://127.0.0.1:1443/
+        proxy.http2.ratio: 100
+        proxy.ssl.verify-peer: OFF
+      /s:
+        status: ON
     access-log: /dev/stdout

--- a/examples/h2o/send401s.rb
+++ b/examples/h2o/send401s.rb
@@ -1,0 +1,45 @@
+STDOUT.sync = true
+h2g = H2.server({
+    'cert_path' => '/fst-h2o/examples/h2o/server.crt',
+    'key_path' => '/fst-h2o/examples/h2o/server.key',
+});
+h2g.listen("https://127.0.0.1:1443")
+
+loop do
+  conn = h2g.accept(-1)
+  puts "recv conn = #{conn}"
+
+  conn.expect_prefix
+  conn.send_settings([])
+
+  loop do
+    f = conn.read(-1)
+    puts "recv f = #{f}"
+    if f.type == 'SETTINGS'
+      unless f.flags == ACK then
+        conn.send_settings_ack()
+        break
+      end
+    else
+      raise 'oops'
+    end
+  end
+
+  f = nil
+  loop do
+    f = conn.read(-1)
+    puts "recv f = #{f}"
+    if f.type == 'HEADERS'
+      break
+    end
+  end
+  puts "stream_id = #{f.stream_id}"
+  resp = {
+        ":status" => "401",
+        "hello" => "world",
+  }
+  conn.send_headers(resp, f.stream_id, END_HEADERS | END_STREAM)
+  # sleep(5);
+  conn.send_rst_stream(f.stream_id, 5)
+
+end

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1173,10 +1173,10 @@ static void proceed_request_streaming(h2o_req_t *_req, const char *errstr)
             --conn->num_streams_req_streaming;
         check_run_blocked(conn);
         /* close the stream if an error occurred */
-        if (errstr != NULL) {
-            shutdown_stream(stream, H2O_HTTP3_ERROR_INTERNAL, H2O_HTTP3_ERROR_INTERNAL, 1);
-            return;
-        }
+        // if (errstr != NULL) {
+        //     shutdown_stream(stream, H2O_HTTP3_ERROR_INTERNAL, H2O_HTTP3_ERROR_INTERNAL, 1);
+        //     return;
+        // }
     }
 
     /* remove the bytes from the request body buffer */


### PR DESCRIPTION
When a large-body request using HTTP3 receives a stream reset from a backend, the headers frame is lost in H2O. To reproduce the stream reset locally, un-comment the changed lines in /lib/http3/server.c and then

1. run `build/h2get_bin/h2get examples/h2o/send401s.rb`
2. in a separate window, run `build/h2o -c examples/h2o/h2o.conf`
3. in a separate window, run `curl -sSi -k https://127.0.0.1:8081/ --http3-only`. You should see a 401 as the response. 
4. Now make a big garbage file, >1MB. Mine has a million 'A's. 
5. Run `curl -sSi -k https://127.0.0.1:8081/ --http3-only -d million_As.txt`. You should see something like `curl: (95) HTTP/3 stream 0 reset by server`
6. The bug is the response's lack of a headers frame when a request with a large body gets a stream reset.

You can repeat this, but preserving the change in /lib/http3/server.c, and see how the 401 goes through even with a large body.

I am not sure what other bugs commenting out this call to shutdown_stream may cause, and am looking for suggested scenarios to test out.