### PR TITLE
[http3] when streamed request is reset, continue sending response if possible

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -520,10 +520,8 @@ static void shutdown_stream(struct st_h2o_http3_server_stream_t *stream, int sto
                             int reset_only_if_open)
 {
     assert(stream->state < H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT);
-    if (quicly_stream_has_receive_side(0, stream->quic->stream_id)) {
+    if (quicly_stream_has_receive_side(0, stream->quic->stream_id))
         quicly_request_stop(stream->quic, stop_sending_code);
-        h2o_buffer_consume(&stream->recvbuf.buf, stream->recvbuf.buf->size);
-    }
     if (reset_only_if_open && quicly_stream_has_send_side(0, stream->quic->stream_id) &&
         !quicly_sendstate_is_open(&stream->quic->sendstate)) {
         if (stream->state < H2O_HTTP3_SERVER_STREAM_STATE_SEND_BODY)

--- a/t/80issues3388.t
+++ b/t/80issues3388.t
@@ -1,0 +1,63 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use Net::EmptyPort qw(check_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => "curl not found"
+    unless prog_exists("curl");
+plan skip_all => "curl does not support HTTP/3"
+    unless curl_supports_http3();
+plan skip_all => "h2get not found"
+    unless h2get_exists();
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+my $backend = spawn_h2get_backend(<< 'EOT');
+if f.type == 'HEADERS'
+  resp = {
+    ":status" => "401",
+    "hello" => "world",
+  }
+  conn.send_headers(resp, f.stream_id, END_HEADERS | END_STREAM)
+  # sleep 5
+  conn.send_rst_stream(f.stream_id, 5)
+end
+EOT
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: https://127.0.0.1:$backend->{tls_port}/
+        proxy.http2.ratio: 100
+        proxy.ssl.verify-peer: OFF
+access-log: /dev/stdout
+EOT
+
+subtest "tiny-req" => sub {
+    doit(10);
+} if 1;
+
+subtest "huge-req" => sub {
+    doit(2_000_000);
+};
+
+undef $server;
+undef $backend;
+
+done_testing;
+
+sub doit {
+    my $reqsize = shift;
+
+    open my $fh, '>', "$tempdir/req"
+        or die "failed to open file $tempdir/req:$!";
+    print $fh 'A' x $reqsize;
+    close $fh;
+
+    my $resp = `curl --silent --insecure --http3 --include --data \@$tempdir/req https://127.0.0.1:$server->{quic_port} 2>&1`;
+   like $resp, qr{^HTTP/3 401.*\nhello: world}s;
+}


### PR DESCRIPTION
#3388 is an attempt to continue forwarding a response even when the request side that is streamed is reset (i.e., `h2o_req_t::proceed_req` callback is invoked with a non-NULL error string). But as stated in https://github.com/h2o/h2o/pull/3388#issuecomment-2174642752, as the callback error signals termination of both the request and the response, it is not always possible to forward a response under such situation; the only possible case is when the entire response is provided prior to the callback error.

Therefore, this PR adjusts #3388 in the following ways:
* refactor the provided test as a unit test case
* do not reset the response if the entire response is available, unless the client asks h2o to stop.

While this PR does not address the case where a request streaming error is delivered prior to the response, the proposed change increases the probability of the client obtaining the response without excess amount of additional complexity.