### PR TITLE
fix race in t/90h2olog-socket.t

### DIFF
--- a/src/h2olog/h2olog.cc
+++ b/src/h2olog/h2olog.cc
@@ -296,9 +296,6 @@ static int read_from_unix_socket(const char *unix_socket_path, FILE *outfp, bool
         (void)write(fd, req, sizeof(req) - 1);
     }
 
-    if (debug)
-        infof("Attaching %s", unix_socket_path);
-
     /* read and process */
     while (1) {
         ssize_t rret;
@@ -335,6 +332,8 @@ static int read_from_unix_socket(const char *unix_socket_path, FILE *outfp, bool
             }
             /* success */
             ret = EXIT_SUCCESS;
+            if (debug)
+                infof("Attaching %s", unix_socket_path);
             memmove(buf, buf + http_headers_len, buflen - http_headers_len);
             buflen -= http_headers_len;
         }


### PR DESCRIPTION
t/90h2olot-socket.t uses debug message "Attaching..." as an indication that h2olog has started receiving events from h2o. But when the socket mode is used, the message is emitted immediately after h2olog sends the HTTP request, which could be earlier than when h2o recognizes the request and start sending the events, leading to a race.

This PR fixes the issue by changing the moment the message is emitted to when h2olog receives the HTTP response headers indicating that h2o has accepted the request to forward events.