### PR TITLE
Use `sh -c` for shell commands in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,7 +655,7 @@ ENDIF ()
 
 ADD_CUSTOM_COMMAND(
     OUTPUT quicly-tracer.h
-    COMMAND ${PROJECT_SOURCE_DIR}/deps/quicly/misc/probe2trace.pl -a tracer < ${PROJECT_SOURCE_DIR}/deps/quicly/quicly-probes.d > ${CMAKE_CURRENT_BINARY_DIR}/quicly-tracer.h
+    COMMAND sh -c "'${PROJECT_SOURCE_DIR}'/deps/quicly/misc/probe2trace.pl -a tracer < '${PROJECT_SOURCE_DIR}'/deps/quicly/quicly-probes.d > '${CMAKE_CURRENT_BINARY_DIR}'/quicly-tracer.h"
     DEPENDS deps/quicly/quicly-probes.d deps/quicly/misc/probe2trace.pl
     VERBATIM)
 


### PR DESCRIPTION
`ADD_CUSTOM_COMMAND()` in `CMakeLists.txt` might not support shell commands in some environments and `sh -c` forces it to be interpreted as a shell command. I encountered this issue when building `h2o` nested inside `meson`. Related:

- https://stackoverflow.com/questions/66656004/shell-commands-using-cmake-add-custom-command-on-linux
- https://cmake.org/cmake/help/latest/command/add_custom_command.html

`h2o` does not seem to support Windows so `sh` should be available.