### PR TITLE
test setup with a misbehaving handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/headers_util.c
     lib/handler/http2_debug_state.c
     lib/handler/mimemap.c
+    lib/handler/mishandler.c
     lib/handler/proxy.c
     lib/handler/connect.c
     lib/handler/redirect.c
@@ -453,6 +454,7 @@ SET(LIB_SOURCE_FILES
     lib/handler/configurator/headers.c
     lib/handler/configurator/headers_util.c
     lib/handler/configurator/http2_debug_state.c
+    lib/handler/configurator/mishandler.c
     lib/handler/configurator/proxy.c
     lib/handler/configurator/redirect.c
     lib/handler/configurator/reproxy.c

--- a/include/h2o.h
+++ b/include/h2o.h
@@ -2179,6 +2179,9 @@ h2o_mimemap_t *h2o_file_get_mimemap(h2o_file_handler_t *handler);
  */
 void h2o_file_register_configurator(h2o_globalconf_t *conf);
 
+void h2o_mishandler_register_configurator(h2o_globalconf_t *globalconf);
+h2o_handler_t *h2o_mishandler_register(h2o_pathconf_t *pathconf);
+
 /* lib/headers.c */
 
 enum {

--- a/lib/handler/configurator/mishandler.c
+++ b/lib/handler/configurator/mishandler.c
@@ -1,0 +1,15 @@
+#include "h2o.h"
+#include "h2o/configurator.h"
+
+static int on_config(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
+{
+    h2o_mishandler_register(ctx->pathconf);
+    return 0;
+}
+
+void h2o_mishandler_register_configurator(h2o_globalconf_t *globalconf)
+{
+    h2o_configurator_t *self = h2o_configurator_create(globalconf, sizeof(*self));
+    h2o_configurator_define_command(self, "mishandler", H2O_CONFIGURATOR_FLAG_PATH | H2O_CONFIGURATOR_FLAG_EXPECT_SCALAR,
+                                    on_config);
+}

--- a/lib/handler/mishandler.c
+++ b/lib/handler/mishandler.c
@@ -1,0 +1,45 @@
+#include "h2o.h"
+
+#include <stddef.h>
+
+struct my_generator {
+    h2o_generator_t super;
+    size_t counter;
+};
+
+static void on_generator_proceed(h2o_generator_t *opaque, h2o_req_t *req)
+{
+    struct my_generator *self = (void *)opaque;
+    if (self->counter++ != 0) {
+        h2o_iovec_t iov = h2o_iovec_init(H2O_STRLIT("world"));
+        h2o_send(req, &iov, 1, H2O_SEND_STATE_FINAL);
+    } else if (h2o_memis(req->input.path.base, req->input.path.len, H2O_STRLIT("/zero"))) {
+        h2o_send(req, NULL, 0, H2O_SEND_STATE_IN_PROGRESS);
+    } else if (h2o_memis(req->input.path.base, req->input.path.len, H2O_STRLIT("/empty"))) {
+        h2o_iovec_t iov = h2o_iovec_init(NULL, 0);
+        h2o_send(req, &iov, 1, H2O_SEND_STATE_IN_PROGRESS);
+    } else {
+        h2o_iovec_t iov = h2o_iovec_init(H2O_STRLIT("unknown path"));
+        h2o_send(req, &iov, 1, H2O_SEND_STATE_FINAL);
+    }
+}
+
+static int on_req(h2o_handler_t *_self, h2o_req_t *req)
+{
+    req->res.status = 200;
+    req->res.headers = (h2o_headers_t){};
+    req->res.content_length = SIZE_MAX;
+    struct my_generator *generator = h2o_mem_alloc_pool(&req->pool, struct my_generator, 1);
+    *generator = (struct my_generator){.super = {.proceed = on_generator_proceed}};
+    h2o_start_response(req, &generator->super);
+    h2o_iovec_t iov = h2o_iovec_init(H2O_STRLIT("hello "));
+    h2o_send(req, &iov, 1, H2O_SEND_STATE_IN_PROGRESS);
+    return 0;
+}
+
+h2o_handler_t *h2o_mishandler_register(h2o_pathconf_t *pathconf)
+{
+    h2o_handler_t *self = h2o_create_handler(pathconf, sizeof(*self));
+    self->on_req = on_req;
+    return self;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -4563,6 +4563,7 @@ static void setup_configurators(void)
 #if H2O_USE_MRUBY
     h2o_mruby_register_configurator(&conf.globalconf);
 #endif
+    h2o_mishandler_register_configurator(&conf.globalconf);
     h2o_self_trace_register_configurator(&conf.globalconf);
     h2o_log_register_configurator(&conf.globalconf);
 

--- a/t/40mishandler.t
+++ b/t/40mishandler.t
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(wait_port);
+use File::Temp qw(tempdir);
+use Test::More;
+use t::Util;
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+my $client_prog = bindir() . "/h2o-httpclient";
+plan skip_all => "$client_prog not found"
+    unless -e $client_prog;
+
+my $tls_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "tcp",
+});
+my $quic_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
+
+my $conf = << "EOT";
+listen:
+  port: $tls_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+listen:
+  type: quic
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+num-threads: 1
+hosts:
+  default:
+    paths:
+      /:
+        mishandler: ON
+EOT
+my $guard = spawn_h2o($conf);
+wait_port({port => $tls_port, proto => 'tcp'});
+wait_port({port => $quic_port, proto => 'udp'});
+
+subtest "h1 unknown path" => sub {
+    my $resp = `$client_prog -k -2 0 https://127.0.0.1:$tls_port/other 2>&1`;
+    like $resp, qr{^HTTP/.*\n\nhello unknown path$}s;
+};
+
+subtest "h1 and zero iovecs" => sub {
+    my $resp = `$client_prog -k -2 0 https://127.0.0.1:$tls_port/zero 2>&1`;
+    like $resp, qr{^HTTP/.*\n\nhello world$}s;
+};
+
+subtest "h1 and one zero-length iovec" => sub {
+    my $resp = `$client_prog -k -2 0 https://127.0.0.1:$tls_port/empty 2>&1`;
+    like $resp, qr{^HTTP/.*\n\nhello world$}s;
+};
+
+subtest "h2 and zero iovecs" => sub {
+    my $resp = `$client_prog -k -2 100 https://127.0.0.1:$tls_port/zero 2>&1`;
+    like $resp, qr{^HTTP/.*\n\nhello world$}s;
+};
+
+subtest "h2 and one zero-length iovec" => sub {
+    my $resp = `$client_prog -k -2 100 https://127.0.0.1:$tls_port/empty 2>&1`;
+    like $resp, qr{^HTTP/.*\n\nhello world$}s;
+};
+
+subtest "h3 and one zero-length iovec" => sub {
+    my $resp = `$client_prog -k -3 100 https://127.0.0.1:$quic_port/empty 2>&1`;
+    like $resp, qr{^HTTP/.*\n\nhello world$}s;
+};
+
+subtest "h3 and zero iovecs" => sub {
+    my $resp = `$client_prog -k -3 100 https://127.0.0.1:$quic_port/zero 2>&1`;
+    like $resp, qr{^HTTP/.*\n\nhello world$}s;
+};
+
+done_testing;


### PR DESCRIPTION
The "h2 and one zero-length iovec" test case hangs and times out.

The "h3 and zero iovecs" test case hits an assert:

```
lib/http3/server.c:983: on_send_emit: Assertion `vec_index < stream->sendbuf.vecs.size' failed.
```

<details>

```
# Subtest: h3 and zero iovecs                                                                  
h2o: …/lib/http3/server.c:983: on_send_emit: Assertion `vec_index < stream->sendbuf.vecs.size' failed.                                                             
received fatal signal 6                                                                        
[32796] …/build/h2o(+0x173089)[0x579754b36089] on_sigfatal at …/src/main.c:3584                                                        
[32796] /lib/x86_64-linux-gnu/libc.so.6(+0x45320)[0x6ffc80445320] __sigaction at ??:?          
[32796] /lib/x86_64-linux-gnu/libc.so.6(pthread_kill+0x11c)[0x6ffc8049eb1c] ?? ??:0            
[32796] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x1e)[0x6ffc8044526e] ?? ??:0
[32796] /lib/x86_64-linux-gnu/libc.so.6(abort+0xdf)[0x6ffc804288ff] ?? ??:0
[32796] /lib/x86_64-linux-gnu/libc.so.6(+0x2881b)[0x6ffc8042881b] ?? ??:0
[32796] /lib/x86_64-linux-gnu/libc.so.6(+0x3b507)[0x6ffc8043b507] __assert_fail at ??:?
[32796] …/build/h2o(+0x10ff88)[0x579754ad2f88] on_send_emit at …/lib/http3/server.c:968 (discriminator 1)
[32796] …/build/h2o(quicly_send_stream+0xf1)[0x579754a61941] ?? ??:0
[32796] …/build/h2o(+0x10ea6f)[0x579754ad1a6f] scheduler_do_send at …/lib/http3/server.c:1954 (discriminator 1)
[32796] …/build/h2o(quicly_send+0x1421)[0x579754a643a1] ?? ??:0
[32796] …/build/h2o(h2o_quic_send+0x8b)[0x579754ace3cb] ?? ??:0
[32796] …/build/h2o(h2o_evloop_run+0x93)[0x579754a82723] ?? ??:0
[32796] …/build/h2o(+0x175cf9)[0x579754b38cf9] run_loop at …/src/main.c:4206
[32796] …/build/h2o(main+0x14e1)[0x579754a20f61] ?? ??:0
[32796] /lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x6ffc8042a1ca] __libc_init_first at ??:?
[32796] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x6ffc8042a28b] ?? ??:0
[32796] …/build/h2o(_start+0x25)[0x579754a212d5] ?? ??:0
```

</details>