### PR TITLE
Latest BoringSSL to support TLS1.0 and TLS1.1

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2103,6 +2103,10 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
 
         /* initialize OpenSSL context */
         identity->ossl = SSL_CTX_new(SSLv23_server_method());
+#ifdef OPENSSL_IS_BORINGSSL
+        /* unlock TLS1.0 for min version */
+        SSL_CTX_set_min_proto_version(identity->ossl, TLS1_VERSION);
+#endif
         SSL_CTX_set_options(identity->ossl, ssl_options);
 #if H2O_CAN_OSSL_ASYNC
         if (use_neverbleed)


### PR DESCRIPTION
https://boringssl.googlesource.com/boringssl/+/e95b0cad901abd49755d2a2a2f1f6c3e87d12b94 made calling `SSL_CTX_set_min_proto_version()` mandatory to support lower (than 1.2) versions of TLS.

Verified that options via min-version is still honored as expected. 
I believe `t/50status.t` enforces that the configured minimum version (`min-version`) is still honored.