### PR TITLE
Suppression of SIGPIPE Error for libh2o

### DIFF
--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -175,7 +175,7 @@ static size_t write_vecs(struct st_h2o_evloop_socket_t *sock, h2o_iovec_t **bufs
         struct msghdr msg;
         do {
             msg = (struct msghdr){.msg_iov = (struct iovec *)*bufs, .msg_iovlen = iovcnt};
-        } while ((wret = sendmsg(sock->fd, &msg, sendmsg_flags)) == -1 && errno == EINTR);
+        } while ((wret = sendmsg(sock->fd, &msg, sendmsg_flags | MSG_NOSIGNAL)) == -1 && errno == EINTR);
         SOCKET_PROBE(WRITEV, &sock->super, wret);
 
         if (wret == -1)


### PR DESCRIPTION
Usually I use `h2o` and not have so problem, but I have crashing when I use `libh2o-evloop`.
For example I will use `examples-simple-evloop` (`examples/libh2o/simple.c`) application and I will connecting to this server, send some data and close connection

![image](https://github.com/user-attachments/assets/a59bce04-ce46-47db-a59d-ebe5b574fb7e)

after execute I have this debug information for `examples-simple-evloop` application:

```
Process finished with exit code 141 (interrupted by signal 13:SIGPIPE)


Program received signal SIGPIPE, Broken pipe.
0x00007ffff789c930 in __libc_sendmsg (fd=7, msg=0x7fffffffd3a0, flags=0) at ../sysdeps/unix/sysv/linux/sendmsg.c:28
warning: 28	../sysdeps/unix/sysv/linux/sendmsg.c: No such file or directory
The target architecture is set to "auto" (currently "i386:x86-64").
(gdb) bt
#0  0x00007ffff789c930 in __libc_sendmsg (fd=7, msg=0x7fffffffd3a0, flags=0) at ../sysdeps/unix/sysv/linux/sendmsg.c:28
#1  0x00005555555748fe in write_vecs (sock=0x55555570db80, bufs=0x7fffffffd428, bufcnt=0x7fffffffd420, sendmsg_flags=0) at lib/common/socket/evloop.c.h:178
#2  0x0000555555574c2a in write_core (sock=0x55555570db80, bufs=0x7fffffffd490, bufcnt=0x7fffffffd488) at lib/common/socket/evloop.c.h:245
#3  0x000055555557531c in do_write (_sock=0x55555570db80, bufs=0x7fffffffd4e0, bufcnt=0) at lib/common/socket/evloop.c.h:418
#4  0x0000555555578388 in h2o_socket_sendvec (sock=0x55555570db80, vecs=0x7fffffffd550, cnt=2, cb=0x55555559d1dc <on_send_complete>) at lib/common/socket.c:975
#5  0x000055555559dfaf in finalostream_send (_self=0x55555571fbc8, _req=0x55555571fc48, inbufs=0x7fffffffd6b0, inbufcnt=1, send_state=H2O_SEND_STATE_FINAL) at lib/http1.c:1064
#6  0x000055555558ca4a in do_sendvec (req=0x55555571fc48, bufs=0x7fffffffd6b0, bufcnt=1, state=H2O_SEND_STATE_FINAL) at lib/core/request.c:532
#7  0x000055555558cb1b in h2o_send (req=0x55555571fc48, bufs=0x7fffffffd740, bufcnt=1, state=H2O_SEND_STATE_FINAL) at lib/core/request.c:543
#8  0x000055555558d06e in h2o_send_inline (req=0x55555571fc48, body=0x55555565dcd8 "Bad Request", len=18446744073709551615) at lib/core/request.c:643
#9  0x000055555558d1a4 in h2o_send_error_generic (req=0x55555571fc48, status=400, reason=0x55555565dcd8 "Bad Request", body=0x55555565dcd8 "Bad Request", flags=5) at lib/core/request.c:670
#10 0x000055555559975d in h2o_send_error_400 (req=0x55555571fc48, reason=0x55555565dcd8 "Bad Request", body=0x55555565dcd8 "Bad Request", flags=5) at include/h2o.h:1849
#11 0x000055555559c419 in send_bad_request (conn=0x55555571faf0, body=0x55555565dcd8 "Bad Request") at lib/http1.c:559
#12 0x000055555559cec4 in handle_incoming_request (conn=0x55555571faf0) at lib/http1.c:743
#13 0x000055555559cf4c in reqread_on_read (sock=0x55555570db80, err=0x0) at lib/http1.c:760
#14 0x000055555557513f in read_on_ready (sock=0x55555570db80) at lib/common/socket/evloop.c.h:366
#15 0x0000555555575dfa in run_socket (sock=0x55555570db80) at lib/common/socket/evloop.c.h:834
#16 0x0000555555576032 in run_pending (loop=0x5555556ac280) at lib/common/socket/evloop.c.h:876
#17 0x00005555555761ce in h2o_evloop_run (loop=0x5555556ac280, max_wait=2147483647) at lib/common/socket/evloop.c.h:925
#18 0x0000555555572f6f in main (argc=1, argv=0x7fffffffe788) at examples/libh2o/simple.c:282
#19 0x00007ffff77b91ca in __libc_start_call_main (main=main@entry=0x555555572d1a <main>, argc=argc@entry=1, argv=argv@entry=0x7fffffffe788) at ../sysdeps/nptl/libc_start_call_main.h:58
#20 0x00007ffff77b9285 in __libc_start_main_impl (main=0x555555572d1a <main>, argc=1, argv=0x7fffffffe788, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffe778) at ../csu/libc-start.c:360
#21 0x00005555555725c1 in _start ()
```

How we can fix that? I sure that should work, because `h2o` web server have not so problem and I not receive SIGPIPE for same code