### PR TITLE
[h2o-httpclient] add `-s` option for resumption

### DIFF
--- a/t/40http3-reconnect.t
+++ b/t/40http3-reconnect.t
@@ -49,7 +49,8 @@ subtest "idle-timeout-reconnect" => sub {
         unless prog_exists('curl');
 
     # spawn client that fetches twice with an interval greater than the idle timeout
-    open my $client_fh, "-|", "$client_prog -3 100 -d 6000 -t 2 https://127.0.0.1:$quic_port/ 2> /dev/null"
+    unlink("$tempdir/session");
+    open my $client_fh, "-|", "$client_prog -3 100 -d 6000 -t 2 -s $tempdir/session https://127.0.0.1:$quic_port/ 2> /dev/null"
         or die "failed to spawn $client_prog:$!";
 
     sleep 1;
@@ -69,7 +70,8 @@ subtest "too-early" => sub {
         ],
         is_ready => sub { !! -e "$tempdir/upstream.sock" },
     );
-    open my $client_fh, "-|", "$client_prog -3 100 -d 5000 -t 2 https://127.0.0.1:$quic_port/proxy/425 2>&1"
+    unlink("$tempdir/session");
+    open my $client_fh, "-|", "$client_prog -3 100 -d 5000 -t 2 -s $tempdir/session https://127.0.0.1:$quic_port/proxy/425 2>&1"
         or die "failed to spawn $client_prog:$!";
     like do {local $/; join "", <$client_fh>}, qr{^HTTP/[0-9\.]+ 200.*\nhello\nHTTP/[0-9\.]+ 425}s, "2nd response is 425";
 };


### PR DESCRIPTION
At the moment, the flag works only when H3 is used.

Also, this PR incorporates a mitigation against broken logic that perpetually set a zero-timeout. As of d327485, h2o will continue to process events even if something starts doing that (at the cost of consuming 100% CPU cycles), rather than ceasing to work due to missing I/O events or updates to the internal clock.

Full fix for the issues is https://github.com/h2o/quicly/pull/587.