### PR TITLE
validate h2o_send (do_send) is called when progress can be made

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -857,9 +857,10 @@ struct st_h2o_ostream_t {
      */
     struct st_h2o_ostream_t *next;
     /**
-     * called by the core to send output.
-     * Intermediary output streams should process the given output and call the h2o_ostream_send_next function if any data can be
-     * sent.
+     * Called by the core to send output.
+     * Intermediary output streams should process the given output and call the h2o_ostream_send_next function either immediately or
+     * at some time in the future.
+     * Note: this callback is invoked only when progress can be made; For details, see `h2o_send`.
      */
     void (*do_send)(struct st_h2o_ostream_t *self, h2o_req_t *req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t state);
     /**
@@ -1620,8 +1621,13 @@ void h2o_req_bind_conf(h2o_req_t *req, h2o_hostconf_t *hostconf, h2o_pathconf_t 
  */
 static int h2o_send_state_is_in_progress(h2o_send_state_t s);
 /**
- * called by the generators to send output
- * note: generators should free itself after sending the final chunk (i.e. calling the function with is_final set to true)
+ * Called by the generators to send output.
+ * When supplying a partial response (i.e., `state` being set to `H2O_SEND_STATE_IN_PROGRESS`), the caller should wait for the
+ * invocation of its `proceed` callback, then invoke `h2o_send` again to supply more data.
+ * Note `h2o_send` cannot be called to supply just an empty body in the middle of the stream. It is valid to invoke this callback
+ * with an empty body with the intent to supply response headers or the closure of the response.
+ * After supplying the full response (i.e., `state` being set to something other than `H2O_SEND_STATE_IN_PROGRESS`), generators
+ * should free itself.
  * @param req the request
  * @param bufs an array of buffers
  * @param bufcnt length of the buffers array

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1661,6 +1661,8 @@ static void finalize_do_send(struct st_h2o_http3_server_stream_t *stream)
 static void do_send(h2o_ostream_t *_ostr, h2o_req_t *_req, h2o_sendvec_t *bufs, size_t bufcnt, h2o_send_state_t send_state)
 {
     struct st_h2o_http3_server_stream_t *stream = H2O_STRUCT_FROM_MEMBER(struct st_h2o_http3_server_stream_t, ostr_final, _ostr);
+    int empty_payload_allowed =
+        stream->state == H2O_HTTP3_SERVER_STREAM_STATE_SEND_HEADERS || send_state != H2O_SEND_STATE_IN_PROGRESS;
 
     assert(&stream->req == _req);
 
@@ -1702,23 +1704,28 @@ static void do_send(h2o_ostream_t *_ostr, h2o_req_t *_req, h2o_sendvec_t *bufs, 
 
     /* If vectors carrying response body are being provided, copy them, incrementing the reference count if possible (for future
      * retransmissions), as well as prepending a DATA frame header */
-    if (bufcnt != 0) {
-        h2o_vector_reserve(&stream->req.pool, &stream->sendbuf.vecs, stream->sendbuf.vecs.size + 1 + bufcnt);
-        uint64_t prev_body_size = stream->sendbuf.final_body_size;
-        for (size_t i = 0; i != bufcnt; ++i) {
-            /* copy one body vector */
-            struct st_h2o_http3_server_sendvec_t *dst = stream->sendbuf.vecs.entries + stream->sendbuf.vecs.size + i + 1;
-            dst->vec = bufs[i];
-            dst->entity_offset = stream->sendbuf.final_body_size;
-            stream->sendbuf.final_body_size += bufs[i].len;
-        }
-        uint64_t payload_size = stream->sendbuf.final_body_size - prev_body_size;
+    h2o_vector_reserve(&stream->req.pool, &stream->sendbuf.vecs, stream->sendbuf.vecs.size + 1 + bufcnt);
+    size_t dst_slot = stream->sendbuf.vecs.size + 1 /* reserve slot for DATA frame header */, payload_size = 0;
+    for (size_t i = 0; i != bufcnt; ++i) {
+        if (bufs[i].len == 0)
+            continue;
+        /* copy one body vector */
+        payload_size += bufs[i].len;
+        stream->sendbuf.vecs.entries[dst_slot++] = (struct st_h2o_http3_server_sendvec_t){
+            .vec = bufs[i],
+            .entity_offset = stream->sendbuf.final_body_size,
+        };
+    }
+    if (payload_size != 0) {
         /* build DATA frame header */
         size_t header_size =
             flatten_data_frame_header(stream, stream->sendbuf.vecs.entries + stream->sendbuf.vecs.size, payload_size);
         /* update properties */
-        stream->sendbuf.vecs.size += 1 + bufcnt;
+        stream->sendbuf.vecs.size = dst_slot;
+        stream->sendbuf.final_body_size += payload_size;
         stream->sendbuf.final_size += header_size + payload_size;
+    } else {
+        assert(empty_payload_allowed || !"h2o_data must only be called when there is progress");
     }
 
     switch (send_state) {


### PR DESCRIPTION
This PR adds assertions that detect improper invocations `h2o_send` that do provide no data to make progress.

Rather than adding the assertions to `h2o_send`, the checks are added to the `do_send` callbacks found in the http server-side implementations due to the following reasons:
* `h2o_send` does not know if it is invoked for the first time (invocation with zero-byte body is permitted for the first time only),
* output filters (e.g., on-the-fly compression) might modify the data then call `h2o_ostream_send_next` that call the `do_send` callbacks; it is better to have the check where the data is actually used