### PR TITLE
When h2c is disabled, redirect to https

### DIFF
--- a/t/40no-h2c.t
+++ b/t/40no-h2c.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port);
+use Test::More;
+use t::Util;
+
+my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        return << "EOT";
+http1-upgrade-to-http2: OFF
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: t/assets/doc_root
+EOT
+});
+
+my ($head, $body) = run_prog("curl --http2 -sv http://127.0.0.1:$server->{port}/");
+like $head, qr{HTTP/1.1 301 Moved Permanently}, "Status code is 301";
+like $head, qr{location: https://127.0.0.1:$server->{port}/}, "location header contains expected value";
+is $body, '<!DOCTYPE html><TITLE>Moved</TITLE><P>The document has moved <A HREF="https://127.0.0.1:'.$server->{port}.'/">here</A>', "Body contains rewritten destination";
+
+done_testing;


### PR DESCRIPTION
The current behavior lets the request through and depending on whether the handler lets an `upgrade:` request through or not, might forward the request and attempt an upgrade or return a 403.

This PR makes h2o redirect to https instead.