### PR TITLE
 When h2c is disabled, ignore the upgrade: header

### DIFF
--- a/lib/http1.c
+++ b/lib/http1.c
@@ -513,8 +513,11 @@ static const char *fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_he
                 if (upgrade.base != NULL && h2o_contains_token(connection.base, connection.len, H2O_STRLIT("upgrade"), ',') &&
                     *entity_header_index == -1) {
                     /* early return if upgrading to h2 */
-                    if (upgrade_is_h2(upgrade) && conn->sock->ssl == NULL && conn->super.ctx->globalconf->http1.upgrade_to_http2)
-                        return fixup_request_is_h2_upgrade;
+                    if (upgrade_is_h2(upgrade) && conn->sock->ssl == NULL) {
+                        if (conn->super.ctx->globalconf->http1.upgrade_to_http2)
+                            return fixup_request_is_h2_upgrade;
+                        return NULL;
+                    }
                     conn->req.upgrade = upgrade;
                     conn->req.is_tunnel_req = 1;
                     conn->req.http1_is_persistent = 0;

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -516,11 +516,11 @@ static const char *fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_he
                     if (upgrade_is_h2(upgrade) && conn->sock->ssl == NULL) {
                         if (conn->super.ctx->globalconf->http1.upgrade_to_http2)
                             return fixup_request_is_h2_upgrade;
-                        return NULL;
+                    } else {
+                        conn->req.upgrade = upgrade;
+                        conn->req.is_tunnel_req = 1;
+                        conn->req.http1_is_persistent = 0;
                     }
-                    conn->req.upgrade = upgrade;
-                    conn->req.is_tunnel_req = 1;
-                    conn->req.http1_is_persistent = 0;
                 }
             } else if (conn->req.version >= 0x101) {
                 /* defaults to keep-alive if >= HTTP/1.1 */

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -513,8 +513,8 @@ static const char *fixup_request(struct st_h2o_http1_conn_t *conn, struct phr_he
                 if (upgrade.base != NULL && h2o_contains_token(connection.base, connection.len, H2O_STRLIT("upgrade"), ',') &&
                     *entity_header_index == -1) {
                     /* early return if upgrading to h2 */
-                    if (upgrade_is_h2(upgrade) && conn->sock->ssl == NULL) {
-                        if (conn->super.ctx->globalconf->http1.upgrade_to_http2)
+                    if (upgrade_is_h2(upgrade)) {
+                        if (conn->sock->ssl == NULL && conn->super.ctx->globalconf->http1.upgrade_to_http2)
                             return fixup_request_is_h2_upgrade;
                     } else {
                         conn->req.upgrade = upgrade;

--- a/t/40no-h2c.t
+++ b/t/40no-h2c.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Net::EmptyPort qw(check_port);
+use Test::More;
+use t::Util;
+
+plan skip_all => 'plackup not found'
+    unless prog_exists('plackup');
+plan skip_all => 'Starlet not found'
+    unless system('perl -MStarlet /dev/null > /dev/null 2>&1') == 0;
+
+my $upstream_port = empty_port();
+my $upstream = spawn_server(
+    argv     => [
+        qw(plackup -s Starlet --access-log /dev/null --listen), "127.0.0.1:$upstream_port", ASSETS_DIR . "/upstream.psgi",
+    ],
+    is_ready => sub {
+        check_port($upstream_port);
+    },
+);
+
+my $server = spawn_h2o(sub {
+        my ($port, $tls_port) = @_;
+        return << "EOT";
+http1-upgrade-to-http2: OFF
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://127.0.0.1:$upstream_port
+        proxy.tunnel: OFF
+EOT
+});
+
+my ($head, $body) = run_prog("curl --http2 -sv http://127.0.0.1:$server->{port}/echo-headers");
+like $head, qr{HTTP/1.1 200 OK}, "Status code is 200, protocol is 1.1";
+like $body, qr{connection: keep-alive}, "connection: keep-alive";
+unlike $body, qr{upgrade:}, "No upgrade: header";
+
+done_testing;


### PR DESCRIPTION
The current behavior lets the request through and depending on whether the handler lets an `upgrade:` request through or not, might forward the request and attempt an upgrade or return a 403.

This PR makes h2o forward the request to the backend.