### PR TITLE
Add support for proxy-expect: for http2client

### DIFF
--- a/include/h2o/http2_common.h
+++ b/include/h2o/http2_common.h
@@ -111,7 +111,7 @@ size_t h2o_hpack_flatten_response(h2o_buffer_t **buf, h2o_hpack_header_table_t *
                                   size_t num_headers, const h2o_iovec_t *server_name, size_t content_length, int is_end_stream);
 void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
                                uint32_t stream_id, size_t max_frame_size, h2o_iovec_t method, h2o_url_t *url, h2o_iovec_t protocol,
-                               const h2o_header_t *headers, size_t num_headers, int is_end_stream);
+                               const h2o_header_t *headers, size_t num_headers, int is_end_stream, int use_expect);
 void h2o_hpack_flatten_trailers(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
                                 uint32_t stream_id, size_t max_frame_size, const h2o_header_t *headers, size_t num_headers);
 

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -1173,8 +1173,10 @@ static void on_write_complete(h2o_socket_t *sock, const char *err)
             H2O_STRUCT_FROM_MEMBER(struct st_h2o_http2client_stream_t, output.sending_link, link);
         h2o_linklist_unlink(link);
 
-        if (stream->_use_expect && stream->state.req == STREAM_STATE_BODY)
+        if (stream->_use_expect && stream->state.req == STREAM_STATE_BODY) {
+            h2o_timer_link(stream->super.ctx->loop, stream->super.ctx->first_byte_timeout, &stream->super._timeout);
             continue;
+        }
 
         /* request the app to send more, unless the stream is already closed (note: invocation of `proceed_req` might invoke
          * `do_write_req` synchronously) */

--- a/lib/common/http2client.c
+++ b/lib/common/http2client.c
@@ -346,9 +346,9 @@ static int on_head(struct st_h2o_http2client_conn_t *conn, struct st_h2o_http2cl
             ret = H2O_HTTP2_ERROR_PROTOCOL; // TODO is this alright?
             goto Failed;
         }
-        if (stream->input.status == 100 && stream->_use_expect) {
+        if (stream->input.status == 100 && stream->use_expect) {
             stream->input.status = 0;
-            stream->_use_expect = 0;
+            stream->use_expect = 0;
             if (stream->output.buf != NULL && !h2o_linklist_is_linked(&stream->output.sending_link)) {
                 h2o_linklist_insert(&stream->conn->output.sending_streams, &stream->output.sending_link);
                 request_write(stream->conn);
@@ -1116,7 +1116,7 @@ static void on_connection_ready(struct st_h2o_http2client_stream_t *stream, stru
     }
 
     if (props.use_expect && (stream->output.proceed_req != NULL || body.len != 0))
-        stream->_use_expect = 1;
+        stream->use_expect = 1;
 
     /* send headers */
     h2o_hpack_flatten_request(&conn->output.buf, &conn->output.header_table, conn->peer_settings.header_table_size,
@@ -1124,7 +1124,7 @@ static void on_connection_ready(struct st_h2o_http2client_stream_t *stream, stru
                               stream->super.upgrade_to != NULL && stream->super.upgrade_to != h2o_httpclient_upgrade_to_connect
                                   ? h2o_iovec_init(stream->super.upgrade_to, strlen(stream->super.upgrade_to))
                                   : h2o_iovec_init(NULL, 0),
-                              headers, num_headers, stream->state.req == STREAM_STATE_CLOSED, stream->_use_expect);
+                              headers, num_headers, stream->state.req == STREAM_STATE_CLOSED, stream->use_expect);
 
     if (stream->state.req == STREAM_STATE_BODY) {
         h2o_buffer_init(&stream->output.buf, &h2o_socket_buffer_prototype);
@@ -1173,7 +1173,7 @@ static void on_write_complete(h2o_socket_t *sock, const char *err)
             H2O_STRUCT_FROM_MEMBER(struct st_h2o_http2client_stream_t, output.sending_link, link);
         h2o_linklist_unlink(link);
 
-        if (stream->_use_expect && stream->state.req == STREAM_STATE_BODY) {
+        if (stream->use_expect && stream->state.req == STREAM_STATE_BODY) {
             h2o_timer_link(stream->super.ctx->loop, stream->super.ctx->first_byte_timeout, &stream->super._timeout);
             continue;
         }
@@ -1265,12 +1265,12 @@ static void do_emit_writereq(struct st_h2o_http2client_conn_t *conn)
             H2O_STRUCT_FROM_MEMBER(struct st_h2o_http2client_stream_t, output.sending_link, pending.next);
         h2o_linklist_unlink(&stream->output.sending_link);
 
-        if (stream->output.buf != NULL && !stream->_use_expect)
+        if (stream->output.buf != NULL && !stream->use_expect)
             stream_emit_pending_data(stream);
 
         if (stream->output.buf == NULL || stream->output.buf->size == 0) {
             h2o_linklist_insert(&conn->output.sent_streams, &stream->output.sending_link);
-        } else if (h2o_http2_window_get_avail(&stream->output.window) > 0 && !stream->_use_expect) {
+        } else if (h2o_http2_window_get_avail(&stream->output.window) > 0 && !stream->use_expect) {
             /* re-insert to tail so that streams would be sent round-robin */
             h2o_linklist_insert(&conn->output.sending_streams, &stream->output.sending_link);
         } else {

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -1016,8 +1016,9 @@ static void fixup_frame_headers(h2o_buffer_t **buf, size_t start_at, uint8_t typ
 
 void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *header_table, uint32_t hpack_capacity,
                                uint32_t stream_id, size_t max_frame_size, h2o_iovec_t method, h2o_url_t *url, h2o_iovec_t protocol,
-                               const h2o_header_t *headers, size_t num_headers, int is_end_stream)
+                               const h2o_header_t *headers, size_t num_headers, int is_end_stream, int use_expect)
 {
+    h2o_iovec_t hundred_continue = h2o_iovec_init(H2O_STRLIT("100-continue"));
     int old_style_connect = h2o_memis(method.base, method.len, H2O_STRLIT("CONNECT")) && protocol.base == NULL;
 
     size_t capacity = calc_headers_capacity(headers, num_headers);
@@ -1030,6 +1031,8 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
     if (!old_style_connect)
         capacity += calc_capacity(H2O_TOKEN_PATH->buf.len, url->path.len);
     capacity += calc_capacity(H2O_TOKEN_PROTOCOL->buf.len, protocol.len);
+    if (use_expect)
+        capacity += calc_capacity(H2O_TOKEN_EXPECT->buf.len, hundred_continue.len);
 
     size_t start_at = (*buf)->size;
     uint8_t *dst = (void *)(h2o_buffer_reserve(buf, capacity).base + H2O_HTTP2_FRAME_HEADER_SIZE);
@@ -1046,6 +1049,9 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
         h2o_header_t h = {&H2O_TOKEN_PROTOCOL->buf, NULL, protocol};
         dst = encode_header(header_table, dst, &h);
     }
+    if (use_expect)
+        dst = encode_header_token(header_table, dst, H2O_TOKEN_EXPECT, &hundred_continue);
+
     for (size_t i = 0; i != num_headers; ++i) {
         const h2o_header_t *header = headers + i;
         if (header->name == &H2O_TOKEN_ACCEPT_ENCODING->buf &&

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -1018,7 +1018,7 @@ void h2o_hpack_flatten_request(h2o_buffer_t **buf, h2o_hpack_header_table_t *hea
                                uint32_t stream_id, size_t max_frame_size, h2o_iovec_t method, h2o_url_t *url, h2o_iovec_t protocol,
                                const h2o_header_t *headers, size_t num_headers, int is_end_stream, int use_expect)
 {
-    static const h2o_iovec_t hundred_continue = h2o_iovec_init(H2O_STRLIT("100-continue"));
+    static const h2o_iovec_t hundred_continue = (h2o_iovec_t){H2O_STRLIT("100-continue")};
     int old_style_connect = h2o_memis(method.base, method.len, H2O_STRLIT("CONNECT")) && protocol.base == NULL;
 
     size_t capacity = calc_headers_capacity(headers, num_headers);

--- a/t/50reverse-proxy-expect-100-continue.t
+++ b/t/50reverse-proxy-expect-100-continue.t
@@ -6,12 +6,16 @@ use t::Util;
 use IO::Select;
 use IO::Socket::INET;
 
+plan skip_all => "h2get not found"
+    unless h2get_exists();
+
 plan skip_all => "nc not found"
     unless prog_exists("nc");
 
-my $h1_upstream_port = empty_port();
+subtest 'h1 upstream' => sub {
+    my $h1_upstream_port = empty_port();
 
-my $server = spawn_h2o(<< "EOT");
+    my $server = spawn_h2o(<< "EOT");
 hosts:
   default:
     paths:
@@ -20,7 +24,6 @@ hosts:
         proxy.reverse.url: http://127.0.0.1:$h1_upstream_port
 EOT
 
-subtest 'h1 upstream' => sub {
     my $upstream = IO::Socket::INET->new(
         LocalHost => '127.0.0.1',
         LocalPort => $h1_upstream_port,
@@ -32,10 +35,10 @@ subtest 'h1 upstream' => sub {
         my $c = spawn_forked(sub {
             print `curl --http2 -s -X POST --data-binary xxxxx http://127.0.0.1:$server->{port}/h1`;
         });
-        
+
         my $client = $upstream->accept;
         my $chunk;
-        
+
         note 'read header';
         my $header = '';
         while ($client->sysread($chunk, 1) > 0) {
@@ -43,30 +46,30 @@ subtest 'h1 upstream' => sub {
             last if $header =~ /\r\n\r\n$/;
         }
         like $header, qr/expect: *100-continue/i;
-        
+
         note 'test that h2o never send req body before this server respond with 100 continue';
         ok(! IO::Select->new([ $client ])->can_read(1));
-        
+
         note 'send 100 continue';
         $client->syswrite("HTTP/1.1 100 Continue\r\n\r\n");
-        
+
         note 'then h2o should have sent the body';
         ok(IO::Select->new([ $client ])->can_read(1));
-        
+
         note 'read body';
         my $body;
         is $client->sysread($body, 5), 5;
         is $body, 'xxxxx';
-        
+
         my $content = "Good waiting! You're awesome!";
         $client->syswrite(join("\r\n", (
             "HTTP/1.1 200 OK",
             "Content-Length: @{[length($content)]}",
             "", ""
         )) . $content);
-        
+
         my ($cout) = $c->{wait}->();
-        
+
         is $cout, $content;
     };
 
@@ -74,10 +77,10 @@ subtest 'h1 upstream' => sub {
         my $c = spawn_forked(sub {
             print `curl --http2 -s -X POST --data-binary xxxxx http://127.0.0.1:$server->{port}/h1`;
         });
-        
+
         my $client = $upstream->accept;
         my $chunk;
-        
+
         note 'read header';
         my $header = '';
         while ($client->sysread($chunk, 1) > 0) {
@@ -95,17 +98,17 @@ subtest 'h1 upstream' => sub {
             "Content-Length: @{[length($content)]}",
             "", ""
         )) . $content);
-        
+
         note 'then h2o should have sent the body';
         ok(IO::Select->new([ $client ])->can_read(1));
-        
+
         note 'read body';
         my $body;
         is $client->sysread($body, 5), 5;
         is $body, 'xxxxx';
-        
+
         my ($cout) = $c->{wait}->();
-        
+
         is $cout, $content;
     };
 
@@ -140,7 +143,51 @@ subtest 'h1 upstream' => sub {
 };
 
 subtest 'h2 upstream' => sub {
-    plan skip_all => 'TODO';
+    my $backend = spawn_h2get_backend(<< 'EOT');
+if f.type == 'HEADERS'
+  exit 1 unless f.to_s.include? "'expect' => '100-continue'"
+  # make sure no DATA frame is seen
+  while true do
+    should_be_nil = conn.read(2000)
+    # there might be a SETTINGS ack frame in flight, ignore
+    next if should_be_nil != nil and should_be_nil.type == 'SETTINGS'
+    exit 1 if should_be_nil != nil
+    break
+  end
+  # Send 100
+  resp = {
+    ":status" => "100",
+  }
+  conn.send_headers(resp, f.stream_id, END_HEADERS)
+  # Expect a DATA frame now
+  should_be_data_frame = conn.read(2000)
+  exit 1 if should_be_data_frame == nil or should_be_data_frame.type != 'DATA'
+  resp = {
+    ":status" => "200",
+  }
+  conn.send_headers(resp, f.stream_id, END_HEADERS | END_STREAM)
+  puts "OK"
+end
+EOT
+    my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      /:
+        proxy.expect: ON
+        proxy.reverse.url: https://127.0.0.1:$backend->{tls_port}/
+        proxy.http2.ratio: 100
+        proxy.ssl.verify-peer: OFF
+access-log: /dev/stdout
+EOT
+    run_with_curl($server, sub {
+        my ($proto, $port, $curl) = @_;
+        my ($headers, $body) = run_prog("$curl --data 'request body' --silent --dump-header /dev/stderr $proto://127.0.0.1:$port/");
+        like $headers, qr{^HTTP/[0-9.]+ 200}is, '200 status';
+    });
+    my ($out, $err) = $backend->{kill}->();
+    like $out, qr/OK\nOK\nOK\n/, "server side tests successful";
+    like $err, qr/^$/, "server stderr is empty";
 };
 
 subtest 'h3 upstream' => sub {


### PR DESCRIPTION
This is a follow up to https://github.com/h2o/h2o/pull/3316/ -- adding support for the same configuration knob for the http2 client.