### PR TITLE
fix build issue on CI

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1299,7 +1299,7 @@ static const char *listener_setup_ssl_picotls(struct listener_config_t *listener
                                               ptls_ech_create_opener_t *ech_create_opener, ptls_iovec_t ech_retry_configs)
 {
     static const ptls_key_exchange_algorithm_t *key_exchanges[] = {
-#ifdef PTLS_OPENSSL_HAVE_X25519
+#if PTLS_OPENSSL_HAVE_X25519
         &ptls_openssl_x25519,
 #else
         &ptls_minicrypto_x25519,


### PR DESCRIPTION
Due to h2o using the PTLS_HAVE_ macros incorrectly, the change introduced in https://github.com/h2o/picotls/pull/532 has caused CI errors on flavors that use OpenSSL 1.0.2 (i.e., ones without X25519).

It might be time to get rid of flavors that use versions of Ubuntu no longer maintained. But regardless, this PR changes h2o to use the macro correctly.