### PR TITLE
Fix H2O_NORETURN for fn pointers on clang

### DIFF
--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -63,6 +63,17 @@ extern "C" {
 #define H2O_NORETURN
 #endif
 
+#if defined(__clang__) && H2O_GNUC_VERSION >= 0x20500
+#define H2O_NORETURN_PTR __attribute__((noreturn))
+#elif __STDC_VERSION__ >= 201112L
+#define H2O_NORETURN_PTR _Noreturn
+#elif defined(__GNUC__) && H2O_GNUC_VERSION >= 0x20500
+// noreturn was not defined before gcc 2.5
+#define H2O_NORETURN_PTR __attribute__((noreturn))
+#else
+#define H2O_NORETURN_PTR
+#endif
+
 #if !defined(__clang__) && defined(__GNUC__) && H2O_GNUC_VERSION >= 0x40900
 // returns_nonnull was seemingly not defined before gcc 4.9 (exists in 4.9.1 but not in 4.8.2)
 #define H2O_RETURNS_NONNULL __attribute__((returns_nonnull))
@@ -184,7 +195,7 @@ extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 /**
  * prints an error message and aborts. h2o_fatal can be modified by setting the function pointer it expands to, which is h2o__fatal.
  */
-extern H2O_NORETURN void (*h2o__fatal)(const char *file, int line, const char *msg, ...) __attribute__((format(printf, 3, 4)));
+extern H2O_NORETURN_PTR void (*h2o__fatal)(const char *file, int line, const char *msg, ...) __attribute__((format(printf, 3, 4)));
 #ifndef h2o_fatal
 #define h2o_fatal(...) h2o__fatal(__FILE__, __LINE__, __VA_ARGS__)
 #endif

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -54,24 +54,11 @@ extern "C" {
 #define H2O_GNUC_VERSION 0
 #endif
 
-#if __STDC_VERSION__ >= 201112L
-#define H2O_NORETURN _Noreturn
-#elif defined(__clang__) || defined(__GNUC__) && H2O_GNUC_VERSION >= 0x20500
 // noreturn was not defined before gcc 2.5
+#if __STDC_VERSION__ >= 201112L || defined(__clang__) || (defined(__GNUC__) && H2O_GNUC_VERSION >= 0x20500)
 #define H2O_NORETURN __attribute__((noreturn))
 #else
 #define H2O_NORETURN
-#endif
-
-#if defined(__clang__) && H2O_GNUC_VERSION >= 0x20500
-#define H2O_NORETURN_PTR __attribute__((noreturn))
-#elif __STDC_VERSION__ >= 201112L
-#define H2O_NORETURN_PTR _Noreturn
-#elif defined(__GNUC__) && H2O_GNUC_VERSION >= 0x20500
-// noreturn was not defined before gcc 2.5
-#define H2O_NORETURN_PTR __attribute__((noreturn))
-#else
-#define H2O_NORETURN_PTR
 #endif
 
 #if !defined(__clang__) && defined(__GNUC__) && H2O_GNUC_VERSION >= 0x40900
@@ -195,7 +182,7 @@ extern void *(*volatile h2o_mem__set_secure)(void *, int, size_t);
 /**
  * prints an error message and aborts. h2o_fatal can be modified by setting the function pointer it expands to, which is h2o__fatal.
  */
-extern H2O_NORETURN_PTR void (*h2o__fatal)(const char *file, int line, const char *msg, ...) __attribute__((format(printf, 3, 4)));
+extern H2O_NORETURN void (*h2o__fatal)(const char *file, int line, const char *msg, ...) __attribute__((format(printf, 3, 4)));
 #ifndef h2o_fatal
 #define h2o_fatal(...) h2o__fatal(__FILE__, __LINE__, __VA_ARGS__)
 #endif

--- a/include/h2o/memory.h
+++ b/include/h2o/memory.h
@@ -55,8 +55,10 @@ extern "C" {
 #endif
 
 // noreturn was not defined before gcc 2.5
-#if __STDC_VERSION__ >= 201112L || defined(__clang__) || (defined(__GNUC__) && H2O_GNUC_VERSION >= 0x20500)
+#if defined(__clang__) || (defined(__GNUC__) && H2O_GNUC_VERSION >= 0x20500)
 #define H2O_NORETURN __attribute__((noreturn))
+#elif __STDC_VERSION__ >= 201112L
+#define H2O_NORETURN _Noreturn
 #else
 #define H2O_NORETURN
 #endif

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -97,7 +97,7 @@ static H2O_NORETURN void default_h2o_fatal(const char *file, int line, const cha
     abort();
 }
 
-H2O_NORETURN void (*h2o__fatal)(const char *, int, const char *, ...) = default_h2o_fatal;
+H2O_NORETURN_PTR void (*h2o__fatal)(const char *, int, const char *, ...) = default_h2o_fatal;
 
 void *h2o_mem_alloc_recycle(h2o_mem_recycle_t *allocator)
 {

--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -97,7 +97,7 @@ static H2O_NORETURN void default_h2o_fatal(const char *file, int line, const cha
     abort();
 }
 
-H2O_NORETURN_PTR void (*h2o__fatal)(const char *, int, const char *, ...) = default_h2o_fatal;
+H2O_NORETURN void (*h2o__fatal)(const char *, int, const char *, ...) = default_h2o_fatal;
 
 void *h2o_mem_alloc_recycle(h2o_mem_recycle_t *allocator)
 {


### PR DESCRIPTION
in gcc, it seems unclear if the compiler should generate an error: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80495

in clang, I get the following error:
```
error: '_Noreturn' can only appear on functions
```
see https://clang.llvm.org/docs/AttributeReference.html#noreturn