### PR TITLE
add support for ticket-requests (RFC 9149)

### DIFF
--- a/deps/picotls/include/picotls.h
+++ b/deps/picotls/include/picotls.h
@@ -308,6 +308,11 @@ extern "C" {
 #define PTLS_TO__STR(n) #n
 #define PTLS_TO_STR(n) PTLS_TO__STR(n)
 
+/**
+ * default maximum of tickets to send (see ptls_context_t::ticket_requests.server.max_count)
+ */
+#define PTLS_DEFAULT_MAX_TICKETS_TO_SERVE 4
+
 typedef struct st_ptls_t ptls_t;
 typedef struct st_ptls_context_t ptls_context_t;
 typedef struct st_ptls_key_schedule_t ptls_key_schedule_t;
@@ -1021,6 +1026,26 @@ struct st_ptls_context_t {
         const ptls_iovec_t *list;
         size_t count;
     } client_ca_names;
+    /**
+     * (optional)
+     */
+    struct {
+        /**
+         * if set to non-zero and if the save_ticket callback is provided, a ticket_request extension containing the specified
+         * values is sent
+         */
+        struct {
+            uint8_t new_session_count;
+            uint8_t resumption_count;
+        } client;
+        /**
+         * if set to non-zero, the maximum number of tickets being sent is capped to the specifed value; if set to zero, the maximum
+         * adopted is PTLS_DEFAULT_MAX_TICKETS_TO_SERVE.
+         */
+        struct {
+            uint8_t max_count;
+        } server;
+    } ticket_requests;
 };
 
 typedef struct st_ptls_raw_extension_t {

--- a/deps/picotls/picotls.xcodeproj/project.pbxproj
+++ b/deps/picotls/picotls.xcodeproj/project.pbxproj
@@ -976,10 +976,10 @@
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = (
-					/usr/local/opt/openssl/include,
-					include,
+					"$(inherited)",
+					/opt/homebrew/opt/openssl/include,
 				);
-				LIBRARY_SEARCH_PATHS = /usr/local/opt/openssl/lib;
+				LIBRARY_SEARCH_PATHS = /opt/homebrew/opt/openssl/lib;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -990,10 +990,10 @@
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = (
-					/usr/local/opt/openssl/include,
-					include,
+					"$(inherited)",
+					/opt/homebrew/opt/openssl/include,
 				);
-				LIBRARY_SEARCH_PATHS = /usr/local/opt/openssl/lib;
+				LIBRARY_SEARCH_PATHS = /opt/homebrew/opt/openssl/lib;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -1041,8 +1041,9 @@
 				HEADER_SEARCH_PATHS = (
 					include,
 					/usr/local/include,
+					/opt/homebrew/opt/brotli/include,
 				);
-				LIBRARY_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = /opt/homebrew/opt/brotli/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1087,8 +1088,9 @@
 				HEADER_SEARCH_PATHS = (
 					include,
 					/usr/local/include,
+					/opt/homebrew/opt/brotli/include,
 				);
-				LIBRARY_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = /opt/homebrew/opt/brotli/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
@@ -1100,10 +1102,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = (
-					/usr/local/opt/openssl/include,
-					include,
+					"$(inherited)",
+					/opt/homebrew/opt/openssl/include,
 				);
-				LIBRARY_SEARCH_PATHS = /usr/local/opt/openssl/lib;
+				LIBRARY_SEARCH_PATHS = /opt/homebrew/opt/openssl/lib;
 				OTHER_LDFLAGS = "-lcrypto";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1114,10 +1116,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = (
-					/usr/local/opt/openssl/include,
-					include,
+					"$(inherited)",
+					/opt/homebrew/opt/openssl/include,
 				);
-				LIBRARY_SEARCH_PATHS = /usr/local/opt/openssl/lib;
+				LIBRARY_SEARCH_PATHS = /opt/homebrew/opt/openssl/lib;
 				OTHER_LDFLAGS = "-lcrypto";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1149,13 +1151,12 @@
 					"$(inherited)",
 				);
 				HEADER_SEARCH_PATHS = (
-					include,
-					/usr/local/opt/openssl/include,
-					/usr/local/include,
+					"$(inherited)",
+					/opt/homebrew/opt/openssl/include,
 				);
 				LIBRARY_SEARCH_PATHS = (
-					/usr/local/opt/openssl/lib,
-					/usr/local/lib,
+					"$(inherited)",
+					/opt/homebrew/opt/openssl/lib,
 				);
 				OTHER_LDFLAGS = (
 					"-lcrypto",
@@ -1175,13 +1176,12 @@
 					"$(inherited)",
 				);
 				HEADER_SEARCH_PATHS = (
-					include,
-					/usr/local/opt/openssl/include,
-					/usr/local/include,
+					"$(inherited)",
+					/opt/homebrew/opt/openssl/include,
 				);
 				LIBRARY_SEARCH_PATHS = (
-					/usr/local/opt/openssl/lib,
-					/usr/local/lib,
+					"$(inherited)",
+					/opt/homebrew/opt/openssl/lib,
 				);
 				OTHER_LDFLAGS = (
 					"-lcrypto",

--- a/deps/picotls/picotlsvs/bcrypt-test/bcrypt-test.vcxproj
+++ b/deps/picotls/picotlsvs/bcrypt-test/bcrypt-test.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{7A04A2BF-03BF-4C3A-9E44-A53B0E90036B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bcrypttest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/fusiontest/fusiontest.vcxproj
+++ b/deps/picotls/picotlsvs/fusiontest/fusiontest.vcxproj
@@ -27,7 +27,7 @@
     <ProjectGuid>{513DC1C9-2CD4-437C-B8EC-168924EB5AAC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>fusiontest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/picotls-bcrypt/picotls-bcrypt.vcxproj
+++ b/deps/picotls/picotlsvs/picotls-bcrypt/picotls-bcrypt.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{0A0E7AF2-05C8-488B-867C-D83B776B8BF4}</ProjectGuid>
     <RootNamespace>picotlsbcrypt</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/picotls-core/picotls-core.vcxproj
+++ b/deps/picotls/picotlsvs/picotls-core/picotls-core.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{497433FE-B252-4985-A504-54EB791F57F4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>picotlscore</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/picotls-fusion/picotls-fusion.vcxproj
+++ b/deps/picotls/picotlsvs/picotls-fusion/picotls-fusion.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{55F22DE6-EAAE-4279-97B7-84FAAB7F29BB}</ProjectGuid>
     <RootNamespace>picotlsfusion</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/picotls-minicrypto-deps/picotls-minicrypto-deps.vcxproj
+++ b/deps/picotls/picotlsvs/picotls-minicrypto-deps/picotls-minicrypto-deps.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{499B82B3-F5A5-4C2E-91EF-A2F77CBC33F5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>picotlsminicryptodeps</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/picotls-minicrypto/picotls-minicrypto.vcxproj
+++ b/deps/picotls/picotlsvs/picotls-minicrypto/picotls-minicrypto.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{559AC085-1BEF-450A-A62D-0D370561D596}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>picotlsminicrypto</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/picotls-openssl/picotls-openssl.vcxproj
+++ b/deps/picotls/picotlsvs/picotls-openssl/picotls-openssl.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{56C264BF-822B-4F29-B512-5B26157CA2EC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>picotlsopenssl</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/picotlsvs/picotlsvs.vcxproj
+++ b/deps/picotls/picotlsvs/picotlsvs/picotlsvs.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{D0265367-FCCF-47A4-95FD-C33BECAB3486}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>picotlsvs</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/ptlsbench/ptlsbench.vcxproj
+++ b/deps/picotls/picotlsvs/ptlsbench/ptlsbench.vcxproj
@@ -26,7 +26,7 @@
     <ProjectGuid>{15D7D32F-3B62-4B10-A06A-BA1ADD591D7F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ptlsbench</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/deps/picotls/picotlsvs/testopenssl/testopenssl.vcxproj
+++ b/deps/picotls/picotlsvs/testopenssl/testopenssl.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{8750EE3B-9440-48BF-8D83-7274E94B06A7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>testopenssl</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/doc/configure/base_directives.html
+++ b/doc/configure/base_directives.html
@@ -443,6 +443,11 @@ Default is <code>14400</code> (4 hours).
 number of consecutive OCSP query failures before stopping to send OCSP stapling data to the client.
 Default is 3.
 </dd>
+<dt id="max-tickets">max-tickets:</dt>
+<dd>
+maximum number of TLS/1.3 session tickets to send, when the client requests for them using the ticket_request extension.
+Default is 4.
+</dd>
 <dt id="ech">ech:</dt>
 <dd>
 This experimental attribute controls the use of <a href="https://datatracker.ietf.org/doc/draft-ietf-tls-esni/">TLS Encrypted Client Hello extension (draft-15)</a>.

--- a/srcdoc/configure/base_directives.mt
+++ b/srcdoc/configure/base_directives.mt
@@ -242,6 +242,11 @@ Default is <code>14400</code> (4 hours).
 number of consecutive OCSP query failures before stopping to send OCSP stapling data to the client.
 Default is 3.
 </dd>
+<dt id="max-tickets">max-tickets:</dt>
+<dd>
+maximum number of TLS/1.3 session tickets to send, when the client requests for them using the ticket_request extension.
+Default is 4.
+</dd>
 <dt id="ech">ech:</dt>
 <dd>
 This experimental attribute controls the use of <a href="https://datatracker.ietf.org/doc/draft-ietf-tls-esni/">TLS Encrypted Client Hello extension (draft-15)</a>.


### PR DESCRIPTION
Integrates https://github.com/h2o/picotls/pull/548 and adds `max-tickets` property to `listen` -> `ssl`.