### PR TITLE
correctly error-exit when given invalid key exchange names

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2115,7 +2115,7 @@ static int listener_setup_ssl(h2o_configurator_command_t *cmd, h2o_configurator_
                 for (named = ptls_openssl_key_exchanges_all; *named != NULL; ++named)
                     if (strcasecmp((*named)->name, element->data.scalar) == 0)
                         break;
-                if (named != NULL) {
+                if (*named != NULL) {
                     key_exchange_tls13[slot] = *named;
 #if !PTLS_OPENSSL_HAVE_X25519
                 } else if (strcasecmp(ptls_minicrypto_x25519.name, element->data.scalar) == 0) {


### PR DESCRIPTION
In #3433, we introduced a new configuration knob called `key-exchange-tls13` for specifying the key exchange algorithms to be used.

Unfortunately, the knob did not correctly handle invalid names. Rather than printing an error message and refusing to start up, the server starts running with an invalid configuration.

This PR fixes the bug.