### PR TITLE
[h2olog] Add NULL check for h3_frame_receive.payload

### DIFF
--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -937,7 +937,11 @@ int h2o_http3_read_frame(h2o_http3_read_frame_t *frame, int is_client, uint64_t 
     H2O_PROBE(H3_FRAME_RECEIVE, frame->type, frame->payload, frame->length);
     PTLS_LOG(h2o, h3_frame_receive, {
         PTLS_LOG_ELEMENT_UNSIGNED(frame_type, frame->type);
-        PTLS_LOG_ELEMENT_HEXDUMP(payload, frame->payload, frame->length);
+        if (frame->payload != NULL) {
+            PTLS_LOG_APPDATA_ELEMENT_HEXDUMP(payload, frame->payload, frame->length);
+        } else {
+            PTLS_LOG_ELEMENT_UNSIGNED(payload_len, frame->length);
+        }
     });
 
     /* validate frame type */


### PR DESCRIPTION
In #3430, PTLS_LOG was added for consistency with H2O_PROBE, but we need a null check here.