### PR TITLE
fix `make checkdepends` failure on alpine linux

### DIFF
--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -7031,6 +7031,11 @@ int quicly_receive(quicly_conn_t *conn, struct sockaddr *dest_addr, struct socka
     for (path_index = 0; path_index < PTLS_ELEMENTSOF(conn->paths); ++path_index)
         if (conn->paths[path_index] != NULL && compare_socket_address(src_addr, &conn->paths[path_index]->address.remote.sa) == 0)
             break;
+    if (path_index != 0 && !quicly_is_client(conn) &&
+        (QUICLY_PACKET_IS_LONG_HEADER(packet->octets.base[0]) || !conn->super.remote.address_validation.validated)) {
+        ret = QUICLY_ERROR_PACKET_IGNORED;
+        goto Exit;
+    }
     if (path_index == PTLS_ELEMENTSOF(conn->paths) &&
         conn->super.stats.num_paths.validation_failed >= conn->super.ctx->max_path_validation_failures) {
         ret = QUICLY_ERROR_PACKET_IGNORED;

--- a/deps/quicly/src/cli.c
+++ b/deps/quicly/src/cli.c
@@ -33,6 +33,7 @@
 #include <netinet/udp.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <picotls.h>

--- a/deps/quicly/t/test.c
+++ b/deps/quicly/t/test.c
@@ -740,6 +740,90 @@ static void test_jumpstart_cwnd(void)
     ok(derive_jumpstart_cwnd(&bounded_max, 250, 1000000, 250) == 80000);
 }
 
+static void do_test_migration_during_handshake(int second_flight_from_orig_address)
+{
+    quicly_conn_t *client, *server;
+    const struct sockaddr_in serveraddr = {.sin_family = AF_INET, .sin_addr.s_addr = htonl(0x7f000001), .sin_port = htons(12345)},
+                             clientaddr1 = {.sin_family = AF_INET, .sin_addr.s_addr = htonl(0x7f000002), .sin_port = htons(12345)},
+                             clientaddr2 = {.sin_family = AF_INET, .sin_addr.s_addr = htonl(0x7f000003), .sin_port = htons(12345)};
+    quicly_address_t destaddr, srcaddr;
+    struct iovec datagrams[10];
+    uint8_t buf[quic_ctx.transport_params.max_udp_payload_size * 10];
+    quicly_decoded_packet_t packets[40];
+    size_t num_datagrams, num_packets;
+    int ret;
+
+    /* client send first flight */
+    ret = quicly_connect(&client, &quic_ctx, "example.com", (void *)&serveraddr, NULL, new_master_id(), ptls_iovec_init(NULL, 0),
+                         NULL, NULL, NULL);
+    ok(ret == 0);
+    num_datagrams = 10;
+    ret = quicly_send(client, &destaddr, &srcaddr, datagrams, &num_datagrams, buf, sizeof(buf));
+    ok(ret == 0);
+    ok(num_datagrams > 0);
+
+    /* server accepts and responds, but the packets are dropped */
+    num_packets = decode_packets(packets, datagrams, num_datagrams);
+    ok(num_packets == 1);
+    ret = quicly_accept(&server, &quic_ctx, &destaddr.sa, (void *)&clientaddr1, packets, NULL, new_master_id(), NULL, NULL);
+    ok(ret == 0);
+    num_datagrams = 10;
+    ret = quicly_send(server, &destaddr, &srcaddr, datagrams, &num_datagrams, buf, sizeof(buf));
+    ok(ret == 0);
+    ok(num_datagrams > 0);
+
+    /* loop until timeout */
+    const struct sockaddr_in *clientaddr = second_flight_from_orig_address ? &clientaddr1 : &clientaddr2;
+    while (1) {
+        int64_t client_timeout = quicly_get_first_timeout(client), server_timeout = quicly_get_first_timeout(server),
+                smaller_timeout = client_timeout < server_timeout ? client_timeout : server_timeout;
+        if (quic_now < smaller_timeout)
+            quic_now = smaller_timeout;
+
+        /* when client times out, it resends Initials but from a different address and the server drops them */
+        if (quic_now >= client_timeout) {
+            num_datagrams = 10;
+            ret = quicly_send(client, &destaddr, &srcaddr, datagrams, &num_datagrams, buf, sizeof(buf));
+            if (ret == QUICLY_ERROR_FREE_CONNECTION)
+                break;
+            ok(ret == 0);
+            ok(num_datagrams > 0);
+            num_packets = decode_packets(packets, datagrams, num_datagrams);
+            ok(num_packets > 0);
+            for (size_t i = 0; i < num_packets; ++i) {
+                ret = quicly_receive(server, (void *)&serveraddr, (void *)clientaddr, &packets[i]);
+                if (clientaddr == &clientaddr1) {
+                    ok(ret == 0);
+                } else {
+                    ok(ret == QUICLY_ERROR_PACKET_IGNORED);
+                }
+            }
+            clientaddr = &clientaddr2;
+        }
+
+        /* when server times out it resends packets to the old client address */
+        if (quic_now >= server_timeout) {
+            num_datagrams = 10;
+            ret = quicly_send(server, &destaddr, &srcaddr, datagrams, &num_datagrams, buf, sizeof(buf));
+            if (ret == QUICLY_ERROR_FREE_CONNECTION)
+                break;
+            ok(ret == 0);
+            ok(num_datagrams > 0);
+            ok(destaddr.sin.sin_family == AF_INET);
+            ok(destaddr.sin.sin_addr.s_addr == clientaddr1.sin_addr.s_addr);
+        }
+    }
+
+    quicly_free(client);
+    quicly_free(server);
+}
+
+static void test_migration_during_handshake(void)
+{
+    subtest("migrate-before-2nd", do_test_migration_during_handshake, 0);
+    subtest("migrate-before-3nd", do_test_migration_during_handshake, 1);
+}
+
 int main(int argc, char **argv)
 {
     static ptls_iovec_t cert;
@@ -811,6 +895,8 @@ int main(int argc, char **argv)
     subtest("ecn-index-from-bits", test_ecn_index_from_bits);
     subtest("jumpstart-cwnd", test_jumpstart_cwnd);
     subtest("jumpstart", test_jumpstart);
+
+    subtest("migration-during-handshake", test_migration_during_handshake);
 
     return done_testing();
 }

--- a/t/40http2-header-softerror.t
+++ b/t/40http2-header-softerror.t
@@ -42,6 +42,8 @@ subtest "header-values-with-surronding-space" => sub {
     is get_status(), 400;
 };
 
+undef $server;
+
 done_testing;
 
 # connect, send (broken) request, read something

--- a/t/40session-ticket.t
+++ b/t/40session-ticket.t
@@ -110,8 +110,6 @@ EOT
     $doit->("ascii");
 };
 
-done_testing;
-
 my $server;
 
 sub spawn_with {
@@ -136,3 +134,7 @@ sub test {
         or die "failed to parse the output of s_client:{{{$lines}}}";
     $1;
 }
+
+undef $server;
+
+done_testing;

--- a/t/40tunnel.t
+++ b/t/40tunnel.t
@@ -285,4 +285,6 @@ subtest "connect" => sub {
     while (waitpid($upstream_pid, 0) != $upstream_pid) {}
 };
 
+undef $server;
+
 done_testing;

--- a/t/50chunked-encoding-proxying.t
+++ b/t/50chunked-encoding-proxying.t
@@ -78,4 +78,6 @@ for my $w (1 .. 5) {
 doit("5\r\nHello\r\n5\r\nThere\r\n", "HelloThere", 14);
 
 $socket->close();
+undef $server;
+
 done_testing();

--- a/t/50compress-hint.t
+++ b/t/50compress-hint.t
@@ -100,4 +100,6 @@ subtest "forcing gzip or br also works" => sub {
 };
 
 $socket->close();
+undef $server;
+
 done_testing();

--- a/t/50compress-wetag.t
+++ b/t/50compress-wetag.t
@@ -68,4 +68,6 @@ subtest "gzip + weak" => sub {
 };
 
 $upstream_listener->close();
+undef $server;
+
 done_testing();

--- a/t/50proxy-max-buffer-size.t
+++ b/t/50proxy-max-buffer-size.t
@@ -149,4 +149,7 @@ subtest 'http1' => sub {
 #     };
 # };
 
+undef $http1_upstream;
+undef $http2_upstream;
+
 done_testing();

--- a/t/50reverse-proxy-chunk-sizes.t
+++ b/t/50reverse-proxy-chunk-sizes.t
@@ -52,5 +52,7 @@ foreach my $cl (@clopts) {
     }
 }
 
-done_testing();
+undef $upstream;
+undef $server;
 
+done_testing();

--- a/t/50reverse-proxy-chunk-trailing-headers.t
+++ b/t/50reverse-proxy-chunk-trailing-headers.t
@@ -77,5 +77,8 @@ EOR
 
 test(0);
 test(1);
-done_testing();
 
+undef $upstream;
+undef $server;
+
+done_testing();

--- a/t/50reverse-proxy-request-bytes.t
+++ b/t/50reverse-proxy-request-bytes.t
@@ -86,5 +86,7 @@ subtest 'streaming' => sub {
     doit(1);
 };
 
-done_testing();
+undef $upstream;
+undef $server;
 
+done_testing();

--- a/t/50reverse-proxy-round-robin-weighted.t
+++ b/t/50reverse-proxy-round-robin-weighted.t
@@ -68,4 +68,9 @@ for my $i (1..30) {
 
 isnt $unexpected, 1;
 is((2 * $access_count1), $access_count2, "load balanced");
+
+undef $guard1;
+undef $guard2;
+undef $server;
+
 done_testing();

--- a/t/50too-much-data.t
+++ b/t/50too-much-data.t
@@ -62,5 +62,8 @@ foreach my $iter ((1, 10, 100)) {
         }
     }
 }
-done_testing();
 
+undef $upstream;
+undef $server;
+
+done_testing();

--- a/t/50too-much-headers.t
+++ b/t/50too-much-headers.t
@@ -68,5 +68,8 @@ foreach my $iter ((1, 10, 100)) {
         }
     }
 }
-done_testing();
 
+undef $upstream;
+undef $server;
+
+done_testing();

--- a/t/80http1-chunk-overhead.t
+++ b/t/80http1-chunk-overhead.t
@@ -65,4 +65,7 @@ sub send_request {
     $resp;
 }
 
+undef $upstream;
+undef $server;
+
 done_testing();

--- a/t/80reverse-proxy-truncated-chunked.t
+++ b/t/80reverse-proxy-truncated-chunked.t
@@ -91,4 +91,6 @@ subtest "HTTP/2" => sub {
 };
 
 $socket->close();
+undef $server;
+
 done_testing();


### PR DESCRIPTION
Adopts https://github.com/h2o/quicly/pull/599. Also fixes deadlocks found in tests.

Note one test (t/80chunked.t) still gets stuck on Alpine. This is due to it having a different version of `nc` that does not listen to the specified host:port when given auguments of `-l host port`. At the moment, we use this form so that the tests run as expected on ordinary linux, FreeBSD, macOS.