### PR TITLE
[mruby] add support for request streaming

### DIFF
--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -174,6 +174,10 @@ struct st_h2o_mruby_generator_t {
         mrb_value generator;
         mrb_value error_stream;
     } refs;
+    /**
+     * request streaming: set to non-NULL to retains context from when mruby asks for more until a new chunk is fed; within that
+     * period, `proceed_req` and `write_req` callbacks will be called
+     */
     struct st_h2o_mruby_req_streaming_ctx_t *req_streaming;
 };
 

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -174,12 +174,7 @@ struct st_h2o_mruby_generator_t {
         mrb_value generator;
         mrb_value error_stream;
     } refs;
-    struct {
-        h2o_mruby_context_t *ctx;
-        mrb_value receiver;
-        h2o_timer_t delay_slot;
-        int is_end_stream;
-    } req_streaming_callback;
+    struct st_h2o_mruby_req_streaming_ctx_t *req_streaming;
 };
 
 #define h2o_mruby_assert(mrb)                                                                                                      \

--- a/include/h2o/mruby_.h
+++ b/include/h2o/mruby_.h
@@ -174,6 +174,12 @@ struct st_h2o_mruby_generator_t {
         mrb_value generator;
         mrb_value error_stream;
     } refs;
+    struct {
+        h2o_mruby_context_t *ctx;
+        mrb_value receiver;
+        h2o_timer_t delay_slot;
+        int is_end_stream;
+    } req_streaming_callback;
 };
 
 #define h2o_mruby_assert(mrb)                                                                                                      \

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -143,22 +143,31 @@
     "  end\n"                                                                                                                      \
     "\n"                                                                                                                           \
     "  class StreamingInputStream\n"                                                                                               \
+    "\n"                                                                                                                           \
     "    def initialize(generator, chunk)\n"                                                                                       \
     "      @generator = generator\n"                                                                                               \
     "      @chunk = chunk\n"                                                                                                       \
     "      @eos = false\n"                                                                                                         \
     "    end\n"                                                                                                                    \
-    "    def fetch\n"                                                                                                              \
+    "\n"                                                                                                                           \
+    "    def gets\n"                                                                                                               \
     "      while @chunk.empty? and !@eos\n"                                                                                        \
     "        @chunk, @eos = _h2o__fetch_req_chunk(@generator)\n"                                                                   \
     "      end\n"                                                                                                                  \
     "      if @chunk.empty?\n"                                                                                                     \
-    "        return nil\n"                                                                                                         \
+    "        return nil # eos\n"                                                                                                   \
     "      end\n"                                                                                                                  \
-    "      ret = @chunk\n"                                                                                                         \
+    "      c = @chunk\n"                                                                                                           \
     "      @chunk = \"\"\n"                                                                                                        \
-    "      return ret\n"                                                                                                           \
+    "      return c\n"                                                                                                             \
     "    end\n"                                                                                                                    \
+    "\n"                                                                                                                           \
+    "    def each\n"                                                                                                               \
+    "      while c = gets\n"                                                                                                       \
+    "        yield c\n"                                                                                                            \
+    "      end\n"                                                                                                                  \
+    "    end\n"                                                                                                                    \
+    "\n"                                                                                                                           \
     "  end\n"                                                                                                                      \
     "\n"                                                                                                                           \
     "end\n"

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -168,6 +168,25 @@
     "      end\n"                                                                                                                  \
     "    end\n"                                                                                                                    \
     "\n"                                                                                                                           \
+    "    def read(len = nil, outbuf = \"\")\n"                                                                                     \
+    "      outbuf.clear\n"                                                                                                         \
+    "      while len.nil? or outbuf.length < len\n"                                                                                \
+    "        c = gets\n"                                                                                                           \
+    "        if !c\n"                                                                                                              \
+    "          break\n"                                                                                                            \
+    "        end\n"                                                                                                                \
+    "        outbuf << c\n"                                                                                                        \
+    "        if !len.nil? and outbuf.length > len\n"                                                                               \
+    "          @chunk = outbuf.slice!(len, outbuf.length - len)\n"                                                                 \
+    "          break\n"                                                                                                            \
+    "        end\n"                                                                                                                \
+    "      end\n"                                                                                                                  \
+    "      if outbuf.empty? and len\n"                                                                                             \
+    "        outbuf = nil\n"                                                                                                       \
+    "      end\n"                                                                                                                  \
+    "      outbuf\n"                                                                                                               \
+    "    end\n"                                                                                                                    \
+    "\n"                                                                                                                           \
     "  end\n"                                                                                                                      \
     "\n"                                                                                                                           \
     "end\n"

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -262,6 +262,12 @@
     "    def initialize(reprocess)\n"                                                                                              \
     "      @reprocess = reprocess\n"                                                                                               \
     "    end\n"                                                                                                                    \
+    "    def request(env)\n"                                                                                                       \
+    "      if !(env[\"rack.input\"].nil? or env[\"rack.input\"].is_a?(InputStream))\n"                                             \
+    "        env[\"rack.input\"] = InputStream.new(env[\"rack.input\"].read)\n"                                                    \
+    "      end\n"                                                                                                                  \
+    "      _h2o_request(env)\n"                                                                                                    \
+    "    end\n"                                                                                                                    \
     "    def call(env)\n"                                                                                                          \
     "      request(env).join\n"                                                                                                    \
     "    end\n"                                                                                                                    \

--- a/lib/handler/mruby/embedded.c.h
+++ b/lib/handler/mruby/embedded.c.h
@@ -72,6 +72,9 @@
     "        while 1\n"                                                                                                            \
     "          begin\n"                                                                                                            \
     "            while 1\n"                                                                                                        \
+    "              if req[\"rack.input\"].is_a?(String)\n"                                                                         \
+    "                req[\"rack.input\"] = H2O::StreamingInputStream.new(generator, req[\"rack.input\"])\n"                        \
+    "              end\n"                                                                                                          \
     "              resp = app.call(req)\n"                                                                                         \
     "              cached = self_fiber\n"                                                                                          \
     "              (req, generator) = Fiber.yield(resp, generator)\n"                                                              \
@@ -137,6 +140,25 @@
     "      self\n"                                                                                                                 \
     "    end\n"                                                                                                                    \
     "\n"                                                                                                                           \
+    "  end\n"                                                                                                                      \
+    "\n"                                                                                                                           \
+    "  class StreamingInputStream\n"                                                                                               \
+    "    def initialize(generator, chunk)\n"                                                                                       \
+    "      @generator = generator\n"                                                                                               \
+    "      @chunk = chunk\n"                                                                                                       \
+    "      @eos = false\n"                                                                                                         \
+    "    end\n"                                                                                                                    \
+    "    def fetch\n"                                                                                                              \
+    "      while @chunk.empty? and !@eos\n"                                                                                        \
+    "        @chunk, @eos = _h2o__fetch_req_chunk(@generator)\n"                                                                   \
+    "      end\n"                                                                                                                  \
+    "      if @chunk.empty?\n"                                                                                                     \
+    "        return nil\n"                                                                                                         \
+    "      end\n"                                                                                                                  \
+    "      ret = @chunk\n"                                                                                                         \
+    "      @chunk = \"\"\n"                                                                                                        \
+    "      return ret\n"                                                                                                           \
+    "    end\n"                                                                                                                    \
     "  end\n"                                                                                                                      \
     "\n"                                                                                                                           \
     "end\n"

--- a/lib/handler/mruby/embedded/core.rb
+++ b/lib/handler/mruby/embedded/core.rb
@@ -136,22 +136,31 @@ module H2O
   end
 
   class StreamingInputStream
+
     def initialize(generator, chunk)
       @generator = generator
       @chunk = chunk
       @eos = false
     end
-    def fetch
+
+    def gets
       while @chunk.empty? and !@eos
         @chunk, @eos = _h2o__fetch_req_chunk(@generator)
       end
       if @chunk.empty?
-        return nil
+        return nil # eos
       end
-      ret = @chunk
+      c = @chunk
       @chunk = ""
-      return ret
+      return c
     end
+
+    def each
+      while c = gets
+        yield c
+      end
+    end
+
   end
 
 end

--- a/lib/handler/mruby/embedded/core.rb
+++ b/lib/handler/mruby/embedded/core.rb
@@ -161,6 +161,10 @@ module H2O
       end
     end
 
+    def read
+      raise RuntimeError.new('InputStream#read not implemented')
+    end
+
   end
 
 end

--- a/lib/handler/mruby/embedded/core.rb
+++ b/lib/handler/mruby/embedded/core.rb
@@ -161,8 +161,23 @@ module H2O
       end
     end
 
-    def read
-      raise RuntimeError.new('InputStream#read not implemented')
+    def read(len = nil, outbuf = "")
+      outbuf.clear
+      while len.nil? or outbuf.length < len
+        c = gets
+        if !c
+          break
+        end
+        outbuf << c
+        if !len.nil? and outbuf.length > len
+          @chunk = outbuf.slice!(len, outbuf.length - len)
+          break
+        end
+      end
+      if outbuf.empty? and len
+        outbuf = nil
+      end
+      outbuf
     end
 
   end

--- a/lib/handler/mruby/embedded/middleware.rb
+++ b/lib/handler/mruby/embedded/middleware.rb
@@ -24,6 +24,13 @@ module H2O
     def initialize(reprocess)
       @reprocess = reprocess
     end
+    def request(env)
+      # `_h2o_request` reads all input synchronously, so convert streaming input here to avoid fiber error
+      if !(env["rack.input"].nil? or env["rack.input"].is_a?(InputStream))
+        env["rack.input"] = InputStream.new(env["rack.input"].read)
+      end
+      _h2o_request(env)
+    end
     def call(env)
       request(env).join
     end

--- a/lib/handler/mruby/middleware.c
+++ b/lib/handler/mruby/middleware.c
@@ -932,7 +932,7 @@ void h2o_mruby_middleware_init_context(h2o_mruby_shared_context_t *shared_ctx)
     struct RClass *module = mrb_define_module(mrb, "H2O");
 
     struct RClass *app_klass = mrb_class_get_under(shared_ctx->mrb, module, "App");
-    mrb_define_method(mrb, app_klass, "request", middleware_request_method, MRB_ARGS_ARG(1, 0));
+    mrb_define_method(mrb, app_klass, "_h2o_request", middleware_request_method, MRB_ARGS_ARG(1, 0));
 
     struct RClass *app_request_klass = mrb_class_get_under(shared_ctx->mrb, module, "AppRequest");
     mrb_ary_set(shared_ctx->mrb, shared_ctx->constants, H2O_MRUBY_APP_REQUEST_CLASS, mrb_obj_value(app_request_klass));

--- a/t/40http3-forward.t
+++ b/t/40http3-forward.t
@@ -93,6 +93,9 @@ hosts:
       "/":
         mruby.handler: |
           Proc.new do |env|
+            if env["rack.input"]
+              env["rack.input"].read
+            end
             [200, {}, ["server=$server_id"]]
           end
       "/server-status":


### PR DESCRIPTION
For long time, proxy handler has been the only one to support request streaming. This PR adds support for that to mruby.

Part of the intent of this PR is to use the it as a basis for writing origin servers that speak webtransport, which would be helpful for writing tests.