### PR TITLE
allow users pass options to docker build

### DIFF
--- a/misc/docker-ci/build.mk
+++ b/misc/docker-ci/build.mk
@@ -11,7 +11,7 @@ ALL:
 
 
 build:
-	cd misc/docker-ci/docker-root && docker build --tag "$(IMAGE_NAME):$(VARIANT)" -f "../Dockerfile.$(VARIANT)" .
+	cd misc/docker-ci/docker-root && docker build --network=host --tag "$(IMAGE_NAME):$(VARIANT)" -f "../Dockerfile.$(VARIANT)" .
 
 push: build
 	docker push "$(IMAGE_NAME):$(VARIANT)"

--- a/misc/docker-ci/build.mk
+++ b/misc/docker-ci/build.mk
@@ -1,5 +1,6 @@
 IMAGE_NAME=h2oserver/h2o-ci
 VARIANT=unknown
+DOCKER_OPTS=
 PROJECT_DIR=$(shell pwd)
 
 ALL:
@@ -8,10 +9,12 @@ ALL:
 	@echo 'Command is either `build` or `push`.'
 	@echo 'Variant might be ubuntu1604, ubuntu2004 (corresponds to misc/docker-ci/Dockerfile.$$variant).'
 	@echo ''
+	@echo 'DOCKER_OPTS can also be set; e.g., DOCKER_OPTS=--network=host'
+	@echo ''
 
 
 build:
-	cd misc/docker-ci/docker-root && docker build --network=host --tag "$(IMAGE_NAME):$(VARIANT)" -f "../Dockerfile.$(VARIANT)" .
+	cd misc/docker-ci/docker-root && docker build $(DOCKER_OPTS) --tag "$(IMAGE_NAME):$(VARIANT)" -f "../Dockerfile.$(VARIANT)" .
 
 push: build
 	docker push "$(IMAGE_NAME):$(VARIANT)"


### PR DESCRIPTION
When host supports IPv6 and the DNS is returning AAAA results, setting `--network=host` makes sense, because otherwise the guest might not have IPv6 support and fail to build.

But as the situation might depend on each environment, we stop by providing a knob for changing arguments, with the example suggesting the use of `--network=host`.