### PR TITLE
libh2o/libuv: Fix crash when an ssl socket closes mid-write

### DIFF
--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -223,6 +223,8 @@ void report_early_write_error(h2o_socket_t *_sock)
 static void on_ssl_write_complete(uv_write_t *wreq, int status)
 {
     struct st_h2o_uv_socket_t *sock = H2O_STRUCT_FROM_MEMBER(struct st_h2o_uv_socket_t, stream._wreq, wreq);
+    if (uv_is_closing(sock->handle))
+        return;
 
     assert(has_pending_ssl_bytes(sock->super.ssl));
     dispose_ssl_output_buffer(sock->super.ssl);


### PR DESCRIPTION
I've been running into an issue that looks very similar to #1249 in that it seems to have to do with an HTTP2 socket being closed abruptly, specifically while in the middle of a write - but this time it's on SSL reads/writes.

Like #1249, it's difficult to reproduce - I haven't been able to reproduce it "in isolation", but it does inevitably happen if I keep hammering my own libh2o application (which uses a lot of libuv-based parallelism) with enough activity.

I slapped a few printf's into h2o to try and give some context to what's happening, and this seems to consistently be the order of operations (for a particular `h2o_socket_t`) when the crash happens:
```
[thread:29562] do_read_start sock 0x5555559baf10
[thread:29562] do_ssl_write sock 0x5555559baf10
[thread:29562] on_read_ssl: EOF sock 0x5555559baf10
[thread:29562] do_dispose_socket sock 0x5555559baf10
[thread:29562] on_ssl_write_complete sock 0x5555559baf10
/path/to/h2o/lib/common/socket/uv-binding.c.h:238(*): on_ssl_write_complete: Assertion `has_pending_ssl_bytes(sock->super.ssl)' failed.
```
In other words, what seems to be happening is:
- The socket starts reading
- The socket starts writing
- The socket is closed, causing the read callback (`on_read_ssl`) to be called with a status of `UV_EOF` (-4095)
- We dispose the socket, including killing its SSL context and calling `uv_close` on the tcp handle
- The write callback (`on_ssl_write_complete`) is called (before the close callback), which finds that the SSL context is gone and barfs

The backtrace from the crash site itself is somewhat unhelpful as `on_ssl_write_complete` is the entry point back into h2o land from libuv, but here it is anyway, for completeness:
```
#0  0x00007ffff72a636c in ?? () from /usr/lib64/libc.so.6
#1  0x00007ffff724efc6 in raise () from /usr/lib64/libc.so.6
#2  0x00007ffff723734b in abort () from /usr/lib64/libc.so.6
#3  0x00007ffff72372b5 in ?? () from /usr/lib64/libc.so.6
#4  0x0000555555616d90 in on_ssl_write_complete (wreq=0x7fffec020480, status=0) at /path/to/h2o/lib/common/socket/uv-binding.c.h:238
#5  0x00007ffff7f703d9 in ?? () from /usr/lib64/libuv.so.1
#6  0x00007ffff7f70e85 in ?? () from /usr/lib64/libuv.so.1
#7  0x00007ffff7f653d8 in uv_run () from /usr/lib64/libuv.so.1
```
However, if I put an `assert(sock->stream._wreq.cb != on_ssl_write_complete);` into `do_dispose_socket` (and clear `_wreq.cb` in the write callback), we can see the backtrace immediately preceding the crash, where we're disposing a socket that's in its read callback and planning to call `on_ssl_write_complete`:
```
#0  0x00007ffff72a636c in ?? () from /usr/lib64/libc.so.6
#1  0x00007ffff724efc6 in raise () from /usr/lib64/libc.so.6
#2  0x00007ffff723734b in abort () from /usr/lib64/libc.so.6
#3  0x00007ffff72372b5 in ?? () from /usr/lib64/libc.so.6
#4  0x00005555556169db in do_dispose_socket (_sock=0x5555559af090) at /path/to/h2o/lib/common/socket/uv-binding.c.h:150
#5  0x0000555555618825 in dispose_socket (sock=0x5555559af090, err=0x0) at /path/to/h2o/lib/common/socket.c:524
#6  0x000055555561899e in shutdown_ssl (sock=0x5555559af090, err=0x0) at /path/to/h2o/lib/common/socket.c:570
#7  0x0000555555618d1a in h2o_socket_close (sock=0x5555559af090) at/path/to/h2o/lib/common/socket.c:635
#8  0x000055555564034c in close_connection (conn=0x5555559b73a0, close_socket=1) at /path/to/h2o/lib/http1.c:146
#9  0x0000555555642921 in reqread_on_read (sock=0x5555559af090, err=0x5555557e06a8 <h2o_socket_error_io> "I/O error") at /path/to/h2o/lib/http1.c:784
#10 0x0000555555616780 in on_read_ssl (stream=0x555555a01fb0, nread=-4095, _unused=0x7fffffff62b0) at /path/to/h2o/lib/common/socket/uv-binding.c.h:99
#11 0x00007ffff7f701fb in ?? () from /usr/lib64/libuv.so.1
#12 0x00007ffff7f708f4 in ?? () from /usr/lib64/libuv.so.1
#13 0x00007ffff7f785fb in ?? () from /usr/lib64/libuv.so.1
#14 0x00007ffff7f652d3 in uv_run () from /usr/lib64/libuv.so.1
```
I took inspiration from #1250 - just as it fixes #1249 by clearing a write callback, I figured we want to not execute `on_ssl_write_complete` if we've disposed the socket previously.

We can't just directly clear `_wreq.cb` in practice though as it's not a documented public member.  We do, however, close `sock->handle` here - so, by checking if `sock->handle` is closing at the beginning of `on_ssl_write_complete`, we achieve the same thing.

With this change I can hit my application as long as I want and no longer see this crash, and if I put a log line here I see us skipping this call occasionally.

I can't think of a situation where this is the _wrong_ thing to do; the only place we `uv_close` the handle is in `do_dispose_socket`, and the only time we do _that_ is after we've killed the SSL context - so if the handle is closing, this call is doomed no matter what.  Would be interested to be proven wrong, though.

If there are any tests to add/update for this, or additional checks elsewhere (or if I'm just straight up wrong about the change), I'm open to suggestions.

(*) note that line numbers are slightly off from master here due to additional debugging code not included in this PR