### PR TITLE
[http1client] do not opt-in the pipe reader if the client is using ssl

### DIFF
--- a/lib/common/http1client.c
+++ b/lib/common/http1client.c
@@ -549,7 +549,8 @@ static void on_head(h2o_socket_t *sock, const char *err)
      * transferring the content zero-copy. As switching to pipe involves the cost of creating a pipe (and disposing it when the
      * request is complete), we adopt this margin of 64KB, which offers clear improvement (5%) on 9th-gen Intel Core. */
     if (client->_app_prefers_pipe_reader && reader == on_body_content_length &&
-        client->sock->input->size + 65536 <= client->_body_decoder.content_length.bytesleft)
+        client->sock->input->size + 65536 <= client->_body_decoder.content_length.bytesleft &&
+        client->sock->ssl == NULL)
         on_head.pipe_reader = &client->pipe_reader;
 #endif
 


### PR DESCRIPTION
the optimization doesn't make sense in this case since it would result in encrypted bytes being fed to the pipe.