### PR TITLE
Updated H2O to support the newly added KEMs in PicoTLS.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1329,6 +1329,16 @@ static const char *listener_setup_ssl_picotls(struct listener_config_t *listener
 #else
             &ptls_minicrypto_x25519,
 #endif
+#if PTLS_OPENSSL_HAVE_X25519MLKEM768
+            &ptls_openssl_x25519mlkem768,
+#endif
+#if PTLS_OPENSSL_HAVE_MLKEM
+            &ptls_openssl_mlkem512,
+            &ptls_openssl_mlkem768,
+            &ptls_openssl_mlkem1024,
+            &ptls_openssl_secp256r1mlkem768,
+            &ptls_openssl_secp384r1mlkem1024,
+#endif
             &ptls_openssl_secp256r1,
             &ptls_openssl_secp384r1, NULL};
         key_exchanges = default_key_exchanges;

--- a/t/40tls-kem.t
+++ b/t/40tls-kem.t
@@ -1,0 +1,96 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use Test::More;
+use Time::HiRes qw(sleep);
+use t::Util;
+
+my $tempdir = tempdir(CLEANUP => 1);
+my $tls_port = empty_port();
+
+my $ossl_version = server_features()->{OpenSSL};
+# plan skip_all => "KEM is not be supported by $ossl_version"
+#     unless $ossl_version =~ /OpenSSL ([0-9]+\.[0-9]+)/ and $1 >= 3.5;
+plan skip_all => "KEM is not be supported by $ossl_version"
+    unless $ossl_version =~ /CiscoSSL ([0-9]+\.[0-9]+)/ and $1 >= 3.5;
+
+my $conf = <<"EOT";
+num-threads: 1
+listen:
+  port: $tls_port
+  ssl: &ssl
+    certificate-file: examples/h2o/server.crt
+    key-file: examples/h2o/server.key
+
+listen:
+  port: $tls_port
+  type: quic
+  ssl:
+    <<: *ssl
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: t/assets/doc_root
+EOT
+
+my $server = spawn_h2o_raw($conf, [ $tls_port ]);
+
+subtest "tcp" => sub {
+    my $fetch = sub {
+        my $kem = shift;
+
+        my $cmd = "@{[bindir()]}/picotls/cli -I -N $kem -j /dev/stdout localhost.examp1e.net $tls_port 2>&1";
+        open my $fh, "-|", $cmd
+            or die "failed to invoke command:$cmd:$!";
+        my $output = do { local $/; <$fh> };
+        $output;
+    };
+
+    my $doit = sub {
+        my $kem = shift;
+
+        my $resp = $fetch->($kem);
+        like $resp, qr([{,]"type":"receive_message");
+    };
+
+    subtest "tcp_kems" => sub {
+        $doit->("MLKEM512");
+        $doit->("MLKEM768");
+        $doit->("MLKEM1024");
+        $doit->("SecP256r1MLKEM768");
+        $doit->("SecP384r1MLKEM1024");
+        $doit->("X25519MLKEM768");
+    };
+
+};
+
+subtest "quic" => sub {
+    my $fetch = sub {
+        my $kem = shift;
+        my $cmd = "@{[bindir()]}/quicly/cli -a h3 -e /dev/stdout -x $kem localhost.examp1e.net $tls_port < /dev/null 2>&1";
+        open my $fh, "-|", $cmd
+            or die "failed to invoke command:$cmd:$!";
+        my $output = do { local $/; <$fh> };
+        $output;
+    };
+
+    my $doit = sub {
+        my $kem = shift;
+
+        # first connection is grease ECH
+        my $resp = $fetch->($kem);
+        like $resp, qr([{,]"type":"application_close_receive");
+    };
+
+    subtest "quic_kems" => sub {
+        $doit->("MLKEM512");
+        $doit->("MLKEM768");
+        $doit->("MLKEM1024");
+        $doit->("SecP256r1MLKEM768");
+        $doit->("SecP384r1MLKEM1024");
+        $doit->("X25519MLKEM768");
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Updating H2O to use the new ML_KEM algorithms provided by PicoTLS.

I wrote up a automation test. Though I could not get it to run on the Docker CI container since it did not have OpenSSL 3.5+. Therefore I ran the tests on my development machine.