### PR TITLE
doc: document 'client-ca-file' SSL option for client certificate veri…

### DIFF
--- a/doc/h2o.conf.5
+++ b/doc/h2o.conf.5
@@ -705,6 +705,13 @@ neverbleed:
 unless set to OFF, H2O isolates SSL private key operations to a different process by using Neverbleed.
 Default is ON.
 
+client-ca-file:
+
+path to a file of Certificate Authority (CA) certificates used to verify client certificates (optional).
+If set, H2O will request a client certificate from connecting clients and validate it against these CAs.
+Connections lacking a valid client certificate (either not provided or not signed by one of the given CAs) will be rejected.
+This enables mutual TLS (mTLS) authentication.
+
 
 ssl-session-resumption directive is provided for tuning parameters related to session resumption and session tickets.
 


### PR DESCRIPTION
…fication

Adds documentation for the SSL configuration option 'client-ca-file', which allows H2O to verify client certificates against a given CA file, enabling mutual TLS (mTLS) authentication.

This option was implemented but never documented in the h2o.conf(5) man page, causing user confusion about how to enable client certificate verification.

Fixes #3475