### PR TITLE
correctly route 2nd flight of QUIC Initial packets

### DIFF
--- a/h2o.xcodeproj/project.pbxproj
+++ b/h2o.xcodeproj/project.pbxproj
@@ -706,6 +706,7 @@
 		0829879326E1F3530053638F /* rate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rate.h; sourceTree = "<group>"; };
 		0829879526E1F3700053638F /* rate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rate.c; sourceTree = "<group>"; };
 		082B0FF52AAAE83A0091B1D5 /* 80resume-context.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "80resume-context.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
+		082BAC4D2E5F2EE300881E91 /* 40http3-hrr.t */ = {isa = PBXFileReference; lastKnownFileType = text; path = "40http3-hrr.t"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.perl; };
 		082E148C2692F51000603AED /* driver.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = driver.cc; sourceTree = "<group>"; };
 		082E1B402692F52100603AED /* driver_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = driver_common.h; sourceTree = "<group>"; };
 		082E1B412692F52100603AED /* quicly_mock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = quicly_mock.h; sourceTree = "<group>"; };
@@ -2270,6 +2271,7 @@
 				E90BB43B24F38937006507EA /* 40http3-concurrency.t */,
 				E90BB43C24F4834D006507EA /* 40http3-forward.t */,
 				E9D49A5025FB561A00F4A80D /* 40http3-forward-initial.t */,
+				082BAC4D2E5F2EE300881E91 /* 40http3-hrr.t */,
 				0810E6AA286DACB600333FA4 /* 40http3-invalid-token.t */,
 				08B2EBF62DA09FD000715398 /* 40http3-io-batch10.t */,
 				085BDAE72B1DB4C2002851EA /* 40http3-priority.t */,

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -646,7 +646,7 @@ static void process_packets(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, qui
                 uint32_t offending_thread_id = packets[0].cid.dest.plaintext.thread_id;
                 if (offending_node_id != ctx->next_cid->node_id || offending_thread_id != ctx->next_cid->thread_id) {
                     /* accept key matches to a connection being established, but DCID doesn't -- likely a second (or later) Initial
-                     that is supposed to be handled by another node. forward it. */
+                     * that is supposed to be handled by another node. forward it. */
                     if (ttl == 0)
                         return;
                     if (ctx->forward_packets != NULL)

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -658,25 +658,20 @@ static void process_packets(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, qui
         }
     }
 
-    { /* receive packets to the found connection */
-        if (!quicly_is_destination(conn->quic, &destaddr->sa, &srcaddr->sa, packets))
-            return;
-        size_t i;
-    Receive:
-        for (i = 0; i != num_packets; ++i) {
-            if (i != accepted_packet_index) {
-                quicly_error_t ret = quicly_receive(conn->quic, &destaddr->sa, &srcaddr->sa, packets + i);
-                switch (ret) {
-                case QUICLY_ERROR_STATE_EXHAUSTION:
-                case PTLS_ERROR_NO_MEMORY:
-                    fprintf(stderr, "%s: `quicly_receive()` returned ret:%" PRId64 "\n", __func__, ret);
-                    conn->callbacks->destroy_connection(conn);
-                    return;
-                }
-                if (ret != QUICLY_ERROR_PACKET_IGNORED && ret != QUICLY_ERROR_DECRYPTION_FAILED) {
-                    if (ctx->quic_stats != NULL) {
-                        ++ctx->quic_stats->packet_processed;
-                    }
+Receive: /* receive packets to the found connection */
+    for (size_t i = 0; i != num_packets; ++i) {
+        if (i != accepted_packet_index) {
+            quicly_error_t ret = quicly_receive(conn->quic, &destaddr->sa, &srcaddr->sa, packets + i);
+            switch (ret) {
+            case QUICLY_ERROR_STATE_EXHAUSTION:
+            case PTLS_ERROR_NO_MEMORY:
+                fprintf(stderr, "%s: `quicly_receive()` returned ret:%" PRId64 "\n", __func__, ret);
+                conn->callbacks->destroy_connection(conn);
+                return;
+            }
+            if (ret != QUICLY_ERROR_PACKET_IGNORED && ret != QUICLY_ERROR_DECRYPTION_FAILED) {
+                if (ctx->quic_stats != NULL) {
+                    ++ctx->quic_stats->packet_processed;
                 }
             }
         }

--- a/lib/http3/common.c
+++ b/lib/http3/common.c
@@ -543,7 +543,7 @@ static void process_packets(h2o_quic_ctx_t *ctx, quicly_address_t *destaddr, qui
         if (iter != kh_end(ctx->conns_by_id)) {
             conn = kh_val(ctx->conns_by_id, iter);
             /* CID-based matching on Initial and 0-RTT packets should only be applied for clients */
-            if (!quicly_is_client(conn->quic) && packets[0].cid.dest.might_be_client_generated)
+            if (!quicly_is_destination(conn->quic, &destaddr->sa, &srcaddr->sa, packets))
                 conn = NULL;
         } else if (!packets[0].cid.dest.might_be_client_generated) {
             /* send stateless reset when we could not find a matching connection for a 1 RTT packet */

--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -78,11 +78,7 @@ static h2o_socket_t *udp_sock = NULL;
 static const char *upgrade_token = NULL;
 static h2o_httpclient_forward_datagram_cb udp_write;
 static struct sockaddr_in udp_sock_remote_addr;
-static const ptls_key_exchange_algorithm_t *h3_key_exchanges[] = {
-#if PTLS_OPENSSL_HAVE_X25519
-    &ptls_openssl_x25519,
-#endif
-    &ptls_openssl_secp256r1, NULL};
+static const ptls_key_exchange_algorithm_t *h3_key_exchanges[128];
 static h2o_http3client_ctx_t h3ctx = {
     .tls =
         {
@@ -698,6 +694,8 @@ static void usage(const char *progname)
             "               (default: %" PRIu64 ")\n"
             " --io-timeout <milliseconds>\n"
             "               specifies the timeout for I/O operations (default: 5000ms)\n"
+            " --http3-key-exchange <name>\n"
+            "               overrides the TLS/1.3 key exchanges to be used\n"
             "  -h, --help   prints this help\n"
             "\n",
             progname, quicly_spec_context.initial_egress_max_udp_payload_size,
@@ -818,6 +816,7 @@ int main(int argc, char **argv)
         OPT_ACK_FREQUENCY,
         OPT_IO_TIMEOUT,
         OPT_HTTP3_MAX_FRAME_PAYLOAD_SIZE,
+        OPT_HTTP3_KEY_EXCHANGE,
         OPT_UPGRADE,
     };
     struct option longopts[] = {{"initial-udp-payload-size", required_argument, NULL, OPT_INITIAL_UDP_PAYLOAD_SIZE},
@@ -826,6 +825,7 @@ int main(int argc, char **argv)
                                 {"ack-frequency", required_argument, NULL, OPT_ACK_FREQUENCY},
                                 {"io-timeout", required_argument, NULL, OPT_IO_TIMEOUT},
                                 {"http3-max-frame-payload-size", required_argument, NULL, OPT_HTTP3_MAX_FRAME_PAYLOAD_SIZE},
+                                {"http3-key-exchange", required_argument, NULL, OPT_HTTP3_KEY_EXCHANGE},
                                 {"upgrade", required_argument, NULL, OPT_UPGRADE},
                                 {"help", no_argument, NULL, 'h'},
                                 {NULL}};
@@ -1007,6 +1007,19 @@ int main(int argc, char **argv)
                 exit(EXIT_FAILURE);
             }
             break;
+        case OPT_HTTP3_KEY_EXCHANGE: {
+            ptls_key_exchange_algorithm_t **named, **slot;
+            for (named = ptls_openssl_key_exchanges_all; *named != NULL; ++named)
+                if (strcasecmp((*named)->name, optarg) == 0)
+                    break;
+            if (*named == NULL) {
+                fprintf(stderr, "unknown key exchange: %s\n", optarg);
+                exit(EXIT_FAILURE);
+            }
+            for (slot = h3_key_exchanges; *slot != NULL; ++slot)
+                ;
+            *slot = *named;
+        } break;
         case OPT_UPGRADE:
             upgrade_token = optarg;
             break;
@@ -1026,6 +1039,14 @@ int main(int argc, char **argv)
     if (ctx.protocol_selector.ratio.http2 + ctx.protocol_selector.ratio.http3 > 100) {
         fprintf(stderr, "sum of the use ratio of HTTP/2 and HTTP/3 is greater than 100\n");
         exit(EXIT_FAILURE);
+    }
+
+    if (h3_key_exchanges[0] == NULL) {
+        size_t i = 0;
+#if PTLS_OPENSSL_HAVE_X25519
+        h3_key_exchanges[i++] = &ptls_openssl_x25519;
+#endif
+        h3_key_exchanges[i++] = &ptls_openssl_secp256r1;
     }
 
     int is_connect = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -5065,6 +5065,10 @@ int main(int argc, char **argv)
 #if H2O_USE_IO_URING
                 printf("io_uring: YES\n");
 #endif
+                printf("key-exchanges: ");
+                for (size_t i = 0; ptls_openssl_key_exchanges_all[i] != NULL; ++i)
+                        printf("%s%s", ptls_openssl_key_exchanges_all[i]->name,
+                               ptls_openssl_key_exchanges_all[i + 1] != NULL ? ", " : "\n");
                 exit(0);
             case 'h':
                 printf("h2o version " H2O_VERSION "\n"

--- a/t/40http3-hrr.t
+++ b/t/40http3-hrr.t
@@ -1,0 +1,71 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use Net::EmptyPort qw(wait_port);
+use POSIX ":sys_wait_h";
+use Test::More;
+use t::Util;
+use JSON;
+
+# skip unless x25519 is supported, in addition to secp256r1 which is mandatory
+plan skip_all => "x25519 not supported"
+    unless server_features()->{"key-exchanges"} =~ /\s?x25519(,|$)/;
+my $h3client = bindir() . "/h2o-httpclient";
+plan skip_all => "h2o-httpclient not found"
+    unless -x $h3client;
+
+my $tempdir = tempdir(CLEANUP => 1);
+
+my $quic_port = empty_port({
+    host  => "127.0.0.1",
+    proto => "udp",
+});
+
+# spawn server that only supports secp256r1
+my $server = spawn_h2o(<< "EOT");
+listen:
+  type: quic
+  host: 127.0.0.1
+  port: $quic_port
+  ssl:
+    key-file: examples/h2o/server.key
+    certificate-file: examples/h2o/server.crt
+    key-exchange-tls1.3:
+    - secp256r1
+hosts:
+  default:
+    paths:
+      /:
+        file.dir: t/assets/doc_root
+EOT
+
+wait_port({port => $quic_port, proto => 'udp'});
+
+subtest "secp256r1 only" => sub {
+    doit("secp256r1");
+};
+subtest "secp256r1-then-secp256r1" => sub {
+    doit("secp256r1", "x25519");
+};
+subtest "x25519-then-secp256r1" => sub {
+    doit("x25519", "secp256r1");
+};
+
+undef $server;
+
+done_testing;
+
+sub doit {
+    my @keyex = @_;
+    my $cmd = "$h3client -3 100 -k" .
+        join("", map { " --http3-key-exchange $_" } @keyex) .
+        " https://127.0.0.1:$quic_port/";
+    open my $fh, "-|", "$cmd 2>&1"
+        or die "failed to run $cmd: $!";
+    my $resp = do { local $/; <$fh> };
+    close $fh;
+    ok $? == 0, "h2o-httpclient exited with 0";
+    like $resp, qr{^HTTP/3 200}, "response code is 200";
+    like $resp, qr{\nhello\n$}s, "response body is correct";
+}
+


### PR DESCRIPTION
As stated in #3505, h2o silently discards 2nd flight of QUIC initial packets sent by the client.

ToDo:
* [x] add tests

Closes #3505.