### PR TITLE
fill response_start_at stamp at response_end if empty

### DIFF
--- a/include/h2o/http2_internal.h
+++ b/include/h2o/http2_internal.h
@@ -398,6 +398,9 @@ inline void h2o_http2_stream_set_state(h2o_http2_conn_t *conn, h2o_http2_stream_
         }
         stream->state = new_state;
         stream->req.timestamps.response_end_at = h2o_gettimeofday(conn->super.ctx->loop);
+        if (h2o_timeval_is_null(&stream->req.timestamps.response_start_at)) {
+            stream->req.timestamps.response_start_at = stream->req.timestamps.response_end_at;
+        }
         --stream->_num_streams_slot->open;
         stream->_num_streams_slot = NULL;
         if (stream->blocked_by_server)

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -867,6 +867,9 @@ static void on_send_complete(h2o_socket_t *sock, const char *err)
         } else {
             /* success */
             conn->req.timestamps.response_end_at = h2o_gettimeofday(conn->super.ctx->loop);
+            if (h2o_timeval_is_null(&conn->req.timestamps.response_start_at)) {
+                conn->req.timestamps.response_start_at = conn->req.timestamps.response_end_at;
+            }
         }
     }
 

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -1991,8 +1991,12 @@ static quicly_error_t scheduler_do_send(quicly_stream_scheduler_t *sched, quicly
                 goto Exit;
             ++stream->scheduler.call_cnt;
             if (stream->quic->sendstate.size_inflight == stream->quic->sendstate.final_size &&
-                h2o_timeval_is_null(&stream->req.timestamps.response_end_at))
+                h2o_timeval_is_null(&stream->req.timestamps.response_end_at)) {
                 stream->req.timestamps.response_end_at = h2o_gettimeofday(stream->req.conn->ctx->loop);
+                if (h2o_timeval_is_null(&stream->req.timestamps.response_start_at)) {
+                    stream->req.timestamps.response_start_at = stream->req.timestamps.response_end_at;
+                }
+            }
             /* 4. invoke h2o_proceed_request synchronously, so that we could obtain additional data for the current (i.e. highest)
              *    stream. */
             if (stream->proceed_while_sending) {


### PR DESCRIPTION
The `response_start_at` stamp is sometimes not set, leading to odd values if the stamp is used to compute things like ttfb.

This pr fills it in at the same as `response_end_at` if it had not been previously set.