### PR TITLE
When logging QUIC stats, use the iterator defined by quicly

### DIFF
--- a/include/h2o/http3_common.h
+++ b/include/h2o/http3_common.h
@@ -152,14 +152,6 @@ typedef int (*h2o_quic_forward_packets_cb)(h2o_quic_ctx_t *ctx, const uint64_t *
 typedef int (*h2o_quic_preprocess_packet_cb)(h2o_quic_ctx_t *ctx, struct msghdr *msghdr, quicly_address_t *destaddr,
                                              quicly_address_t *srcaddr, uint8_t *ttl);
 
-/**
- * Holds the counters. It is mere coincident that the members are equivalent with QUICLY_STATS_PREBUILT_FIELDS. The macro below can
- * be used for generating expression that take all the members equally.
- */
-struct st_h2o_quic_aggregated_stats_t {
-    QUICLY_STATS_PREBUILT_COUNTERS;
-};
-
 typedef struct st_h2o_quic_stats_t {
     /**
      * number of quic packets received
@@ -177,99 +169,10 @@ typedef struct st_h2o_quic_stats_t {
     /**
      * aggregated quicly stats
      */
-    struct st_h2o_quic_aggregated_stats_t quicly;
+    struct {
+        QUICLY_STATS_PREBUILT_COUNTERS;
+    } quicly;
 } h2o_quic_stats_t;
-
-/* clang-format off */
-#define H2O_QUIC_AGGREGATED_STATS_APPLY(func) \
-    func(num_packets.received, "num-packets.received") \
-    func(num_packets.decryption_failed, "num-packets.decryption-failed") \
-    func(num_packets.sent, "num-packets.sent") \
-    func(num_packets.lost, "num-packets.lost") \
-    func(num_packets.lost_time_threshold, "num-packets.lost-time-threshold") \
-    func(num_packets.ack_received, "num-packets.ack-received") \
-    func(num_packets.late_acked, "num-packets.late-acked") \
-    func(num_packets.initial_received, "num-packets.initial-received") \
-    func(num_packets.zero_rtt_received, "num-packets.zero-rtt-received") \
-    func(num_packets.handshake_received, "num-packets.handshake-received") \
-    func(num_packets.initial_sent, "num-packets.initial-sent") \
-    func(num_packets.zero_rtt_sent, "num-packets.zero-rtt-sent") \
-    func(num_packets.handshake_sent, "num-packets.handshake-sent") \
-    func(num_packets.received_out_of_order, "num-packets.received-out-of-order") \
-    func(num_packets.received_ecn_counts[0], "num-packets.received-ecn-ect0") \
-    func(num_packets.received_ecn_counts[1], "num-packets.received-ecn-ect1") \
-    func(num_packets.received_ecn_counts[2], "num-packets.received-ecn-ce") \
-    func(num_packets.acked_ecn_counts[0], "num-packets.acked-ecn-ect0") \
-    func(num_packets.acked_ecn_counts[1], "num-packets.acked-ecn-ect1") \
-    func(num_packets.acked_ecn_counts[2], "num-packets.acked-ecn-ce") \
-    func(num_packets.sent_promoted_paths, "num-packets.sent-promoted-paths") \
-    func(num_packets.ack_received_promoted_paths, "num-packets.ack-received-promoted-paths") \
-    func(num_bytes.received, "num-bytes.received") \
-    func(num_bytes.sent, "num-bytes.sent") \
-    func(num_bytes.lost, "num-bytes.lost") \
-    func(num_bytes.ack_received, "num-bytes.ack-received") \
-    func(num_bytes.stream_data_sent, "num-bytes.stream-data-sent") \
-    func(num_bytes.stream_data_resent, "num-bytes.stream-data-resent") \
-    func(num_paths.created, "num-paths.created") \
-    func(num_paths.validated, "num-paths.validated") \
-    func(num_paths.validation_failed, "num-paths.validation-failed") \
-    func(num_paths.migration_elicited, "num-paths.migration-elicited") \
-    func(num_paths.promoted, "num-paths.promoted") \
-    func(num_paths.closed_no_dcid, "num-paths.closed-no-dcid") \
-    func(num_paths.ecn_validated, "num-paths.ecn-validated") \
-    func(num_paths.ecn_failed, "num-paths.ecn_failed") \
-    func(num_frames_sent.padding, "num-frames-sent.padding") \
-    func(num_frames_sent.ping, "num-frames-sent.ping") \
-    func(num_frames_sent.ack, "num-frames-sent.ack") \
-    func(num_frames_sent.reset_stream, "num-frames-sent.reset_stream") \
-    func(num_frames_sent.stop_sending, "num-frames-sent.stop_sending") \
-    func(num_frames_sent.crypto, "num-frames-sent.crypto") \
-    func(num_frames_sent.new_token, "num-frames-sent.new_token") \
-    func(num_frames_sent.stream, "num-frames-sent.stream") \
-    func(num_frames_sent.max_data, "num-frames-sent.max_data") \
-    func(num_frames_sent.max_stream_data, "num-frames-sent.max_stream_data") \
-    func(num_frames_sent.max_streams_bidi, "num-frames-sent.max_streams_bidi") \
-    func(num_frames_sent.max_streams_uni, "num-frames-sent.max_streams_uni") \
-    func(num_frames_sent.data_blocked, "num-frames-sent.data_blocked") \
-    func(num_frames_sent.stream_data_blocked, "num-frames-sent.stream_data_blocked") \
-    func(num_frames_sent.streams_blocked, "num-frames-sent.streams_blocked") \
-    func(num_frames_sent.new_connection_id, "num-frames-sent.new_connection_id") \
-    func(num_frames_sent.retire_connection_id, "num-frames-sent.retire_connection_id") \
-    func(num_frames_sent.path_challenge, "num-frames-sent.path_challenge") \
-    func(num_frames_sent.path_response, "num-frames-sent.path_response") \
-    func(num_frames_sent.transport_close, "num-frames-sent.transport_close") \
-    func(num_frames_sent.application_close, "num-frames-sent.application_close") \
-    func(num_frames_sent.handshake_done, "num-frames-sent.handshake_done") \
-    func(num_frames_sent.datagram, "num-frames-sent.datagram") \
-    func(num_frames_sent.ack_frequency, "num-frames-sent.ack_frequency") \
-    func(num_frames_received.padding, "num-frames-received.padding") \
-    func(num_frames_received.ping, "num-frames-received.ping") \
-    func(num_frames_received.ack, "num-frames-received.ack") \
-    func(num_frames_received.reset_stream, "num-frames-received.reset_stream") \
-    func(num_frames_received.stop_sending, "num-frames-received.stop_sending") \
-    func(num_frames_received.crypto, "num-frames-received.crypto") \
-    func(num_frames_received.new_token, "num-frames-received.new_token") \
-    func(num_frames_received.stream, "num-frames-received.stream") \
-    func(num_frames_received.max_data, "num-frames-received.max_data") \
-    func(num_frames_received.max_stream_data, "num-frames-received.max_stream_data") \
-    func(num_frames_received.max_streams_bidi, "num-frames-received.max_streams_bidi") \
-    func(num_frames_received.max_streams_uni, "num-frames-received.max_streams_uni") \
-    func(num_frames_received.data_blocked, "num-frames-received.data_blocked") \
-    func(num_frames_received.stream_data_blocked, "num-frames-received.stream_data_blocked") \
-    func(num_frames_received.streams_blocked, "num-frames-received.streams_blocked") \
-    func(num_frames_received.new_connection_id, "num-frames-received.new_connection_id") \
-    func(num_frames_received.retire_connection_id, "num-frames-received.retire_connection_id") \
-    func(num_frames_received.path_challenge, "num-frames-received.path_challenge") \
-    func(num_frames_received.path_response, "num-frames-received.path_response") \
-    func(num_frames_received.transport_close, "num-frames-received.transport_close") \
-    func(num_frames_received.application_close, "num-frames-received.application_close") \
-    func(num_frames_received.handshake_done, "num-frames-received.handshake_done") \
-    func(num_frames_received.datagram, "num-frames-received.datagram") \
-    func(num_frames_received.ack_frequency, "num-frames-received.ack_frequency") \
-    func(num_ptos, "num-ptos") \
-    func(num_handshake_timeouts, "num-handshake-timeouts") \
-    func(num_initial_handshake_exceeded, "num-initial-handshake-exceeded")
-/* clang-format on */
 
 struct st_h2o_quic_ctx_t {
     /**

--- a/lib/handler/status/events.c
+++ b/lib/handler/status/events.c
@@ -78,7 +78,7 @@ static void events_status_per_thread(void *priv, h2o_context_t *ctx)
     if (esc->quic_stats.num_sentmap_packets_largest < ctx->quic_stats.num_sentmap_packets_largest)
         esc->quic_stats.num_sentmap_packets_largest = ctx->quic_stats.num_sentmap_packets_largest;
 #define ACC(fld, _unused) esc->quic_stats.quicly.fld += ctx->quic_stats.quicly.fld;
-    H2O_QUIC_AGGREGATED_STATS_APPLY(ACC);
+    QUICLY_STATS_FOREACH_COUNTERS(ACC);
 #undef ACC
 
     pthread_mutex_unlock(&esc->mutex);
@@ -146,7 +146,7 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                                           " \"quic.packet-received\": %" PRIu64 ",\n"
                                           " \"quic.packet-processed\": %" PRIu64 ",\n"
                                           " \"quic.num-sentmap-packets-largest\": %zu"
-                                          ",\n" H2O_QUIC_AGGREGATED_STATS_APPLY(QUIC_FMT)
+                                          ",\n" QUICLY_STATS_FOREACH_COUNTERS(QUIC_FMT)
                                           " \"ssl.errors\": %" PRIu64 ",\n"
                                           " \"memory.mmap_errors\": %zu,\n"
                                           " \"h2olog.lost\": %zu\n",
@@ -161,7 +161,7 @@ static h2o_iovec_t events_status_final(void *priv, h2o_globalconf_t *gconf, h2o_
                        esc->connection_stats.idle_closed, esc->connection_stats.num_idle, esc->connection_stats.num_active,
                        esc->connection_stats.num_shutdown, esc->quic_stats.packet_received, esc->quic_stats.packet_processed,
                        esc->quic_stats.num_sentmap_packets_largest
-                       H2O_QUIC_AGGREGATED_STATS_APPLY(QUIC_VAL),
+                       QUICLY_STATS_FOREACH_COUNTERS(QUIC_VAL),
                        esc->ssl_errors, h2o_mmap_errors, ptls_log_num_lost());
     /* clang-format on */
     assert(ret.len < BUFSIZE);


### PR DESCRIPTION
See https://github.com/h2o/quicly/pull/619.

Up until now, h2o had two different ways of serializing the QUIC stats (using different naming schemes!), while quicly had none.

#619 added one two quicly, adopting the naming scheme of the event handler. This PR adopts the change to quicly, and uses the iterator defined in quicly for serializing the stats inside h2o.

Therefore, the side effect is that the field names used by `%{http3.quic-stats}x` changes to that was used by the event handler. Hopefully, people will not care (or easy to adapt).