### PR TITLE
[t/50connect-eyeballs.t] I/O error is expected under the current architecture

### DIFF
--- a/t/50connect-eyeballs.t
+++ b/t/50connect-eyeballs.t
@@ -90,7 +90,8 @@ foreach_http(sub {
             die "failed to launch $client_prog:$!";
         }
         close $wfh;
-        like do { local $/; <$rfh> }, qr{^HTTP/[0-9\.]+ 200.*\n\n$expected_resp$}s;
+        # the tunnel can be closed either by FIN or STOP_SENDING, and in the case of the latter, I/O error is reported; see #3521
+        like do { local $/; <$rfh> }, qr{^HTTP/[0-9\.]+ 200.*\n\n$expected_resp(?:|[^\n]*h2o-httpclient: I/O error\n)$}s;
         my $elapsed = time - $start_at;
         note "elapsed: $elapsed";
         cmp_ok $elapsed, ">=", $expected_time->[0];


### PR DESCRIPTION
As stated in #3521, when a tunnel is closed, the client might notice that either by observing a FIN or a STOP_SENDING, though it is worth noting that in either case, no data downstream will be lost.

While it is arguable that all the components should support half-close correctly, it is known that intermediaries often do not provide such support, and knowing that, we have intentionally avoided the hassle of implementing proper support.

Therefore, under the premise that we would not revisit that decision, we should either:
* in h2o-httpclient or lib/common/http3client.c, stop reporting STOP_SENDING as errors, or
* in the tests, ignore error messages emitted due to STOP_SENDING.

This PR adopts the latter appoarch, because, generally speaking, it is better to ignore errors (or this exact error is more of a warning) than suppressing them.