### PR TITLE
rework pipe_sender_send

### DIFF
--- a/include/h2o/pipe_sender.h
+++ b/include/h2o/pipe_sender.h
@@ -71,7 +71,7 @@ static void h2o_pipe_sender_update(h2o_pipe_sender_t *sender, size_t read_bytes)
 /**
  * wrapper function of `h2o_sendvec` that submits the contents of the pipe
  */
-void h2o_pipe_sender_send(h2o_req_t *req, h2o_pipe_sender_t *sender, h2o_send_state_t send_state);
+void h2o_pipe_sender_send(h2o_req_t *req, h2o_pipe_sender_t *sender, size_t len, h2o_send_state_t send_state);
 
 /* inline definitions */
 

--- a/include/h2o/pipe_sender.h
+++ b/include/h2o/pipe_sender.h
@@ -34,12 +34,7 @@ typedef struct st_h2o_pipe_sender_t {
      */
     int inflight;
     /**
-     * cumulative bytes being read
-     */
-    size_t bytes_read;
-    /**
-     * cumulative bytes being sent; when `h2o_pipe_sender_send` is called, `bytes_read - bytes_sent` is the amount of data assumed
-     * to be in the pipe
+     * cumulative bytes being sent
      */
     size_t bytes_sent;
 } h2o_pipe_sender_t;
@@ -57,17 +52,9 @@ void h2o_pipe_sender_dispose(h2o_pipe_sender_t *sender, h2o_context_t *ctx);
  */
 static int h2o_pipe_sender_in_use(h2o_pipe_sender_t *sender);
 /**
- * if there is any data to be sent
- */
-static int h2o_pipe_sender_is_empty(h2o_pipe_sender_t *sender);
-/**
  * starts a pipe sender and returns a boolean indicating success
  */
 int h2o_pipe_sender_start(h2o_context_t *ctx, h2o_pipe_sender_t *sender);
-/**
- * notifies the pipe sender that new data has become available
- */
-static void h2o_pipe_sender_update(h2o_pipe_sender_t *sender, size_t read_bytes);
 /**
  * wrapper function of `h2o_sendvec` that submits the contents of the pipe
  */
@@ -83,16 +70,6 @@ inline void h2o_pipe_sender_init(h2o_pipe_sender_t *sender)
 inline int h2o_pipe_sender_in_use(h2o_pipe_sender_t *sender)
 {
     return sender->fds[0] != -1;
-}
-
-inline int h2o_pipe_sender_is_empty(h2o_pipe_sender_t *sender)
-{
-    return sender->bytes_read == sender->bytes_sent;
-}
-
-inline void h2o_pipe_sender_update(h2o_pipe_sender_t *sender, size_t read_bytes)
-{
-    sender->bytes_read = read_bytes;
 }
 
 #endif

--- a/lib/core/pipe_sender.c
+++ b/lib/core/pipe_sender.c
@@ -126,12 +126,11 @@ static size_t from_pipe_send(h2o_sendvec_t *vec, int sockfd, size_t len)
 #endif
 }
 
-void h2o_pipe_sender_send(h2o_req_t *req, h2o_pipe_sender_t *sender, h2o_send_state_t send_state)
+void h2o_pipe_sender_send(h2o_req_t *req, h2o_pipe_sender_t *sender, size_t len, h2o_send_state_t send_state)
 {
     static const h2o_sendvec_callbacks_t callbacks = {.read_ = from_pipe_read, .send_ = from_pipe_send};
-    h2o_sendvec_t vec = {.callbacks = &callbacks};
-    if ((vec.len = sender->bytes_read - sender->bytes_sent) > H2O_PULL_SENDVEC_MAX_SIZE)
-        vec.len = H2O_PULL_SENDVEC_MAX_SIZE;
+    assert(len <= H2O_PULL_SENDVEC_MAX_SIZE);
+    h2o_sendvec_t vec = {.callbacks = &callbacks, .len = len};
     vec.cb_arg[0] = (uint64_t)sender;
     vec.cb_arg[1] = 0; /* unused */
 

--- a/lib/core/proxy.c
+++ b/lib/core/proxy.c
@@ -375,7 +375,13 @@ static void do_send_from_pipe(struct rp_generator_t *self)
         return;
     }
 
-    h2o_pipe_sender_send(self->src_req, &self->pipe_sender, send_state);
+   size_t len;
+    if ((len = self->pipe_sender.bytes_read - self->pipe_sender.bytes_sent) > H2O_PULL_SENDVEC_MAX_SIZE) {
+        if (send_state == H2O_SEND_STATE_FINAL)
+            send_state = H2O_SEND_STATE_IN_PROGRESS;
+        len = H2O_PULL_SENDVEC_MAX_SIZE;
+    }
+    h2o_pipe_sender_send(self->src_req, &self->pipe_sender, len, send_state);
 }
 
 static void do_proceed(h2o_generator_t *generator, h2o_req_t *req)

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -167,7 +167,6 @@ static void do_proceed_on_splice_complete(h2o_io_uring_cmd_t *cmd)
     self->file.off += cmd->result;
     self->bytesleft -= cmd->result;
 
-    h2o_pipe_sender_update(&self->pipe_sender, self->pipe_sender.bytes_read + cmd->result);
     h2o_send_state_t send_state = self->bytesleft != 0 ? H2O_SEND_STATE_IN_PROGRESS : H2O_SEND_STATE_FINAL;
 
     h2o_pipe_sender_send(self->src_req, &self->pipe_sender, cmd->result, send_state);

--- a/lib/handler/file.c
+++ b/lib/handler/file.c
@@ -168,8 +168,9 @@ static void do_proceed_on_splice_complete(h2o_io_uring_cmd_t *cmd)
     self->bytesleft -= cmd->result;
 
     h2o_pipe_sender_update(&self->pipe_sender, self->pipe_sender.bytes_read + cmd->result);
-    h2o_pipe_sender_send(self->src_req, &self->pipe_sender,
-                         self->bytesleft != 0 ? H2O_SEND_STATE_IN_PROGRESS : H2O_SEND_STATE_FINAL);
+    h2o_send_state_t send_state = self->bytesleft != 0 ? H2O_SEND_STATE_IN_PROGRESS : H2O_SEND_STATE_FINAL;
+
+    h2o_pipe_sender_send(self->src_req, &self->pipe_sender, cmd->result, send_state);
 }
 
 #endif


### PR DESCRIPTION
The callers should be responsible for making sure h2o_pipe_sender_send will not send more than H2O_PULL_SENDVEC_MAX_SIZE and h2o_pipe_sender_send should assert if its asked to send more than that.

