### PR TITLE
[http3] knobs for tuning and evaluating parameters of QUIC

### DIFF
--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -155,7 +155,7 @@ QUICLY_CALLBACK_TYPE(quicly_error_t, generate_resumption_token, quicly_conn_t *c
  * called to initialize a congestion controller for a new connection.
  * should in turn call one of the quicly_cc_*_init functions from cc.h with customized parameters.
  */
-QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now);
+QUICLY_CALLBACK_TYPE(void, init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now, uint16_t slow_start_increase);
 /**
  * reference counting.
  * delta must be either 1 or -1.
@@ -344,6 +344,11 @@ struct st_quicly_context_t {
      */
     uint64_t max_path_validation_failures;
     /**
+     * If set to non-zero, CWND is be increased by `slow_start_increase / 256` bytes for each byte acked. If set to zero, CWND
+     * increase is 1 byte per byte acked.
+     */
+    uint32_t slow_start_increase;
+    /**
      * Jumpstart CWND to be used when there is no previous information. If set to zero, slow start is used. Note jumpstart is
      * possible only when the use_pacing flag is set.
      */
@@ -354,21 +359,31 @@ struct st_quicly_context_t {
      */
     uint32_t max_jumpstart_cwnd_packets;
     /**
+     * Probabilities for enabling features when they are configured, multiplied by 255. 0 means never, 255 (default) means always.
+     */
+    struct {
+        uint8_t scaled_slow_start;
+        struct {
+            uint8_t non_resume;
+            uint8_t resume;
+        } jumpstart;
+        /**
+         * whether to use ECN on the send side; ECN is always on on the receive side
+         */
+        uint8_t ecn;
+        /**
+         * if pacing should be used
+         */
+        uint8_t pacing;
+        /**
+         * if CC should take app-limited into consideration
+         */
+        uint8_t respect_app_limited;
+    } enable_ratio;
+    /**
      * expand client hello so that it does not fit into one datagram
      */
     unsigned expand_client_hello : 1;
-    /**
-     * whether to use ECN on the send side; ECN is always on on the receive side
-     */
-    unsigned enable_ecn : 1;
-    /**
-     * if pacing should be used
-     */
-    unsigned use_pacing : 1;
-    /**
-     * if CC should take app-limited into consideration
-     */
-    unsigned respect_app_limited : 1;
     /**
      *
      */
@@ -610,7 +625,23 @@ struct st_quicly_conn_streamgroup_state_t {
     /**                                                                                                                            \
      * Total number of events where `initial_handshake_sent` exceeds limit.                                                        \
      */                                                                                                                            \
-    uint64_t num_initial_handshake_exceeded
+    uint64_t num_initial_handshake_exceeded;                                                                                       \
+    /**                                                                                                                            \
+     * Number of connections that used scaled slow start.                                                                          \
+     */                                                                                                                            \
+    uint64_t num_scaled_slow_start;                                                                                                \
+    /**                                                                                                                            \
+     * Number of connections for which jumpstart is or could have been used.                                                       \
+     */                                                                                                                            \
+    uint64_t num_jumpstart_applicable;                                                                                             \
+    /**                                                                                                                            \
+     * Total number of connections that were paced.                                                                                \
+     */                                                                                                                            \
+    uint64_t num_paced;                                                                                                            \
+    /**                                                                                                                            \
+     * Total number of connections where app-limited state was respected by CC.                                                    \
+     */                                                                                                                            \
+    uint64_t num_respected_app_limited
 
 /**
  * Stats that do not need to be gathered upon the invocation of `quicly_get_stats`. This macro is used to define the same fields in
@@ -740,17 +771,21 @@ typedef struct st_quicly_stats_t {
     QUICLY_STATS__DO_FOREACH_NUM_FRAMES(ack_frequency, dir, apply)
 
 #define QUICLY_STATS_FOREACH_TRANSPORT_COUNTERS(apply)                                                                             \
-        apply(num_paths.created, "num-paths.created")                                                                                  \
-        apply(num_paths.validated, "num-paths.validated")                                                                              \
-        apply(num_paths.validation_failed, "num-paths.validation-failed")                                                              \
-        apply(num_paths.migration_elicited, "num-paths.migration-elicited")                                                            \
-        apply(num_paths.promoted, "num-paths.promoted")                                                                                \
-        apply(num_paths.closed_no_dcid, "num-paths.closed-no-dcid")                                                                    \
-        apply(num_paths.ecn_validated, "num-paths.ecn-validated")                                                                      \
-        apply(num_paths.ecn_failed, "num-paths.ecn-failed")                                                                            \
-        apply(num_ptos, "num-ptos")                                                                                                    \
-        apply(num_handshake_timeouts, "num-handshake-timeouts")                                                                        \
-        apply(num_initial_handshake_exceeded, "num-initial-handshake-exceeded")
+    apply(num_paths.created, "num-paths.created")                                                                                  \
+    apply(num_paths.validated, "num-paths.validated")                                                                              \
+    apply(num_paths.validation_failed, "num-paths.validation-failed")                                                              \
+    apply(num_paths.migration_elicited, "num-paths.migration-elicited")                                                            \
+    apply(num_paths.promoted, "num-paths.promoted")                                                                                \
+    apply(num_paths.closed_no_dcid, "num-paths.closed-no-dcid")                                                                    \
+    apply(num_paths.ecn_validated, "num-paths.ecn-validated")                                                                      \
+    apply(num_paths.ecn_failed, "num-paths.ecn-failed")                                                                            \
+    apply(num_ptos, "num-ptos")                                                                                                    \
+    apply(num_handshake_timeouts, "num-handshake-timeouts")                                                                        \
+    apply(num_initial_handshake_exceeded, "num-initial-handshake-exceeded")                                                        \
+    apply(num_scaled_slow_start, "num-scaled-slow-start")                                                                          \
+    apply(num_jumpstart_applicable, "num-jumpstart-applicable")                                                                    \
+    apply(num_paced, "num-paced")                                                                                                  \
+    apply(num_respected_app_limited, "num-respected-app-limited")
 
 /**
  * Macro for iterating QUICLY_STATS_PREBUILT_COUNTERS.
@@ -769,7 +804,7 @@ typedef struct st_quicly_stats_t {
     apply(handshake_confirmed_msec, "handshake-confirmed-msec")                                                                    \
     apply(jumpstart.prev_rate, "jumpstart.prev-rate")                                                                              \
     apply(jumpstart.prev_rtt, "jumpstart.prev-rtt")                                                                                \
-    apply(jumpstart.new_rtt, "jumpstart.new-rtt")                                                                                 \
+    apply(jumpstart.new_rtt, "jumpstart.new-rtt")                                                                                  \
     apply(jumpstart.cwnd, "jumpstart.cwnd")                                                                                        \
     apply(token_sent.at, "token-sent.at")                                                                                          \
     apply(token_sent.rate, "token-sent.rate")                                                                                      \

--- a/deps/quicly/include/quicly/cc.h
+++ b/deps/quicly/include/quicly/cc.h
@@ -39,6 +39,7 @@ extern "C" {
 
 #define QUICLY_MIN_CWND 2
 #define QUICLY_RENO_BETA 0.7
+#define QUICLY_STANDARD_SLOW_START_INCREASE 256 /* +1x */
 
 /**
  * Holds pointers to concrete congestion control implementation functions.
@@ -62,6 +63,10 @@ typedef struct st_quicly_cc_t {
      * Packet number indicating end of recovery period, if in recovery.
      */
     uint64_t recovery_end;
+    /**
+     * Bytes to add to CWND for each byte being acked, multiplied by 256 (default is QUICLY_STANDARD_SLOW_START_INCREASE)
+     */
+    uint16_t slow_start_increase;
     /**
      * If the most recent loss episode was signalled by ECN only (i.e., no packet loss).
      */

--- a/deps/quicly/lib/cc-cubic.c
+++ b/deps/quicly/lib/cc-cubic.c
@@ -77,7 +77,7 @@ static void cubic_on_acked(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t 
 
     /* Slow start. */
     if (cc->cwnd < cc->ssthresh) {
-        cc->cwnd = quicly_u32_add_saturating(cc->cwnd, bytes);
+        cc->cwnd = quicly_u32_add_saturating(cc->cwnd, (uint32_t)((uint64_t)bytes * cc->slow_start_increase / 256));
         if (cc->cwnd_maximum < cc->cwnd)
             cc->cwnd_maximum = cc->cwnd;
         return;
@@ -172,11 +172,12 @@ static void cubic_on_sent(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t b
     cc->state.cubic.last_sent_time = now;
 }
 
-static void cubic_reset(quicly_cc_t *cc, uint32_t initcwnd)
+static void cubic_reset(quicly_cc_t *cc, uint32_t initcwnd, uint16_t slow_start_increase)
 {
     memset(cc, 0, sizeof(quicly_cc_t));
     cc->type = &quicly_cc_type_cubic;
     cc->cwnd = cc->cwnd_initial = cc->cwnd_maximum = initcwnd;
+    cc->slow_start_increase = slow_start_increase;
     cc->ssthresh = cc->cwnd_minimum = UINT32_MAX;
     cc->exit_slow_start_at = INT64_MAX;
 
@@ -193,7 +194,7 @@ static int cubic_on_switch(quicly_cc_t *cc)
         if (cc->cwnd_exiting_slow_start == 0) {
             cc->type = &quicly_cc_type_cubic;
         } else {
-            cubic_reset(cc, cc->cwnd_initial);
+            cubic_reset(cc, cc->cwnd_initial, cc->slow_start_increase);
         }
         return 1;
     }
@@ -201,9 +202,9 @@ static int cubic_on_switch(quicly_cc_t *cc)
     return 0;
 }
 
-static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
+static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd, int64_t now, uint16_t slow_start_add_ratio)
 {
-    cubic_reset(cc, initcwnd);
+    cubic_reset(cc, initcwnd, slow_start_add_ratio);
 }
 
 quicly_cc_type_t quicly_cc_type_cubic = {"cubic",         &quicly_cc_cubic_init,          cubic_on_acked,

--- a/deps/quicly/lib/defaults.c
+++ b/deps/quicly/lib/defaults.c
@@ -34,78 +34,82 @@
 #define DEFAULT_MAX_PATH_VALIDATION_FAILURES 100
 
 /* profile that employs IETF specified values */
-const quicly_context_t quicly_spec_context = {NULL,                                                 /* tls */
-                                              DEFAULT_INITIAL_EGRESS_MAX_UDP_PAYLOAD_SIZE,          /* client_initial_size */
-                                              QUICLY_LOSS_SPEC_CONF,                                /* loss */
-                                              {{1 * 1024 * 1024, 1 * 1024 * 1024, 1 * 1024 * 1024}, /* max_stream_data */
-                                               16 * 1024 * 1024,                                    /* max_data */
-                                               30 * 1000,                                           /* idle_timeout (30 seconds) */
-                                               100, /* max_concurrent_streams_bidi */
-                                               0,   /* max_concurrent_streams_uni */
-                                               DEFAULT_MAX_UDP_PAYLOAD_SIZE},
-                                              DEFAULT_MAX_PACKETS_PER_KEY,
-                                              DEFAULT_MAX_CRYPTO_BYTES,
-                                              DEFAULT_INITCWND_PACKETS,
-                                              QUICLY_PROTOCOL_VERSION_1,
-                                              DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
-                                              0, /* ack_frequency */
-                                              DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
-                                              DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
-                                              DEFAULT_MAX_PROBE_PACKETS,
-                                              DEFAULT_MAX_PATH_VALIDATION_FAILURES,
-                                              0, /* default_jumpstart_cwnd_bytes */
-                                              0, /* max_jumpstart_cwnd_bytes */
-                                              0, /* enlarge_client_hello */
-                                              1, /* enable_ecn */
-                                              0, /* use_pacing */
-                                              1, /* cc_recognize_app_limited */
-                                              NULL,
-                                              NULL, /* on_stream_open */
-                                              &quicly_default_stream_scheduler,
-                                              NULL, /* receive_datagram_frame */
-                                              NULL, /* on_conn_close */
-                                              &quicly_default_now,
-                                              NULL,
-                                              NULL,
-                                              &quicly_default_crypto_engine,
-                                              &quicly_default_init_cc};
+const quicly_context_t quicly_spec_context = {
+    .initial_egress_max_udp_payload_size = DEFAULT_INITIAL_EGRESS_MAX_UDP_PAYLOAD_SIZE,
+    .loss = QUICLY_LOSS_SPEC_CONF,
+    .transport_params =
+        {
+            .max_stream_data.bidi_local = 1 * 1024 * 1024,
+            .max_stream_data.bidi_remote = 11 * 1024 * 1024,
+            .max_stream_data.uni = 1 * 1024 * 1024,
+            .max_data = 16 * 1024 * 1024,
+            .max_idle_timeout = 30 * 1000,
+            .max_streams_bidi = 100,
+            .max_streams_uni = 0,
+            .max_udp_payload_size = DEFAULT_MAX_UDP_PAYLOAD_SIZE,
+        },
+    .max_packets_per_key = DEFAULT_MAX_PACKETS_PER_KEY,
+    .max_crypto_bytes = DEFAULT_MAX_CRYPTO_BYTES,
+    .initcwnd_packets = DEFAULT_INITCWND_PACKETS,
+    .initial_version = QUICLY_PROTOCOL_VERSION_1,
+    .pre_validation_amplification_limit = DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
+    .handshake_timeout_rtt_multiplier = DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
+    .max_initial_handshake_packets = DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
+    .max_probe_packets = DEFAULT_MAX_PROBE_PACKETS,
+    .max_path_validation_failures = DEFAULT_MAX_PATH_VALIDATION_FAILURES,
+    .enable_ratio =
+        {
+            .scaled_slow_start = 255,
+            .jumpstart.non_resume = 255,
+            .jumpstart.resume = 255,
+            .ecn = 255,
+            .pacing = 0, /* off by default */
+            .respect_app_limited = 255,
+        },
+    .stream_scheduler = &quicly_default_stream_scheduler,
+    .now = &quicly_default_now,
+    .crypto_engine = &quicly_default_crypto_engine,
+    .init_cc = &quicly_default_init_cc,
+};
 
 /* profile with a focus on reducing latency for the HTTP use case */
-const quicly_context_t quicly_performant_context = {NULL,                                                 /* tls */
-                                                    DEFAULT_INITIAL_EGRESS_MAX_UDP_PAYLOAD_SIZE,          /* client_initial_size */
-                                                    QUICLY_LOSS_PERFORMANT_CONF,                          /* loss */
-                                                    {{1 * 1024 * 1024, 1 * 1024 * 1024, 1 * 1024 * 1024}, /* max_stream_data */
-                                                     16 * 1024 * 1024,                                    /* max_data */
-                                                     30 * 1000, /* idle_timeout (30 seconds) */
-                                                     100,       /* max_concurrent_streams_bidi */
-                                                     0,         /* max_concurrent_streams_uni */
-                                                     DEFAULT_MAX_UDP_PAYLOAD_SIZE},
-                                                    DEFAULT_MAX_PACKETS_PER_KEY,
-                                                    DEFAULT_MAX_CRYPTO_BYTES,
-                                                    DEFAULT_INITCWND_PACKETS,
-                                                    QUICLY_PROTOCOL_VERSION_1,
-                                                    DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
-                                                    0, /* ack_frequency */
-                                                    DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
-                                                    DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
-                                                    DEFAULT_MAX_PROBE_PACKETS,
-                                                    DEFAULT_MAX_PATH_VALIDATION_FAILURES,
-                                                    0, /* default_jumpstart_cwnd_bytes */
-                                                    0, /* max_jumpstart_cwnd_bytes */
-                                                    0, /* enlarge_client_hello */
-                                                    1, /* enable_ecn */
-                                                    0, /* use_pacing */
-                                                    1, /* cc_recognize_app_limited */
-                                                    NULL,
-                                                    NULL, /* on_stream_open */
-                                                    &quicly_default_stream_scheduler,
-                                                    NULL, /* receive_datagram_frame */
-                                                    NULL, /* on_conn_close */
-                                                    &quicly_default_now,
-                                                    NULL,
-                                                    NULL,
-                                                    &quicly_default_crypto_engine,
-                                                    &quicly_default_init_cc};
+const quicly_context_t quicly_performant_context = {
+    .initial_egress_max_udp_payload_size = DEFAULT_INITIAL_EGRESS_MAX_UDP_PAYLOAD_SIZE,
+    .loss = QUICLY_LOSS_PERFORMANT_CONF,
+    .transport_params =
+        {
+            .max_stream_data.bidi_local = 1 * 1024 * 1024,
+            .max_stream_data.bidi_remote = 11 * 1024 * 1024,
+            .max_stream_data.uni = 1 * 1024 * 1024,
+            .max_data = 16 * 1024 * 1024,
+            .max_idle_timeout = 30 * 1000,
+            .max_streams_bidi = 100,
+            .max_streams_uni = 0,
+            .max_udp_payload_size = DEFAULT_MAX_UDP_PAYLOAD_SIZE,
+        },
+    .max_packets_per_key = DEFAULT_MAX_PACKETS_PER_KEY,
+    .max_crypto_bytes = DEFAULT_MAX_CRYPTO_BYTES,
+    .initcwnd_packets = DEFAULT_INITCWND_PACKETS,
+    .initial_version = QUICLY_PROTOCOL_VERSION_1,
+    .pre_validation_amplification_limit = DEFAULT_PRE_VALIDATION_AMPLIFICATION_LIMIT,
+    .handshake_timeout_rtt_multiplier = DEFAULT_HANDSHAKE_TIMEOUT_RTT_MULTIPLIER,
+    .max_initial_handshake_packets = DEFAULT_MAX_INITIAL_HANDSHAKE_PACKETS,
+    .max_probe_packets = DEFAULT_MAX_PROBE_PACKETS,
+    .max_path_validation_failures = DEFAULT_MAX_PATH_VALIDATION_FAILURES,
+    .enable_ratio =
+        {
+            .scaled_slow_start = 255,
+            .jumpstart.non_resume = 255,
+            .jumpstart.resume = 255,
+            .ecn = 255,
+            .pacing = 0, /* off by default */
+            .respect_app_limited = 255,
+        },
+    .stream_scheduler = &quicly_default_stream_scheduler,
+    .now = &quicly_default_now,
+    .crypto_engine = &quicly_default_crypto_engine,
+    .init_cc = &quicly_default_init_cc,
+};
 
 /**
  * The context of the default CID encryptor.  All the contexts being used here are ECB ciphers and therefore stateless - they can be

--- a/deps/quicly/quicly-probes.d
+++ b/deps/quicly/quicly-probes.d
@@ -166,6 +166,9 @@ provider quicly {
     probe enter_cc_limited(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
     probe exit_cc_limited(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn);
 
+    probe enter_jumpstart(struct st_quicly_conn_t *conn, int64_t at, uint64_t pn, uint32_t rtt, uint32_t cwnd,
+                          uint32_t jumpstart_cwnd);
+
     probe debug_message(struct st_quicly_conn_t *conn, const char *function, int line, const char *message);
 
     probe conn_stats(struct st_quicly_conn_t *conn, int64_t at, struct st_quicly_stats_t *stats, size_t size);

--- a/deps/quicly/t/jumpstart.c
+++ b/deps/quicly/t/jumpstart.c
@@ -37,7 +37,7 @@ static void test_jumpstart_pattern(quicly_init_cc_t *init, const struct test_jum
     uint32_t packets_acked = 0, packets_inflight = 0;
     size_t ackcnt = 0;
 
-    init->cb(init, &cc, 10 * mtu, now);
+    init->cb(init, &cc, 10 * mtu, now, QUICLY_STANDARD_SLOW_START_INCREASE);
     ok(cc.cwnd == 10 * mtu);
     ok(cc.num_loss_episodes == 0);
 

--- a/deps/quicly/t/test.c
+++ b/deps/quicly/t/test.c
@@ -155,6 +155,32 @@ static void test_error_codes(void)
     ok(!QUICLY_ERROR_IS_QUIC_APPLICATION(a));
 }
 
+static uint16_t test_enable_with_ratio255_random_value;
+
+static void test_enable_with_ratio255_get_random(void *p, size_t len)
+{
+    assert(len == sizeof(test_enable_with_ratio255_random_value));
+    memcpy(p, &test_enable_with_ratio255_random_value, sizeof(test_enable_with_ratio255_random_value));
+}
+
+static void test_enable_with_ratio255(void)
+{
+    test_enable_with_ratio255_random_value = 0;
+    ok(!enable_with_ratio255(0, test_enable_with_ratio255_get_random));
+    ok(enable_with_ratio255(255, test_enable_with_ratio255_get_random));
+
+    test_enable_with_ratio255_random_value = 255;
+    ok(!enable_with_ratio255(0, test_enable_with_ratio255_get_random));
+    ok(enable_with_ratio255(255, test_enable_with_ratio255_get_random));
+
+    size_t num_enabled = 0;
+    for (test_enable_with_ratio255_random_value = 0; test_enable_with_ratio255_random_value < 0xffff;
+         ++test_enable_with_ratio255_random_value)
+        if (enable_with_ratio255(63, test_enable_with_ratio255_get_random))
+            ++num_enabled;
+    ok(num_enabled == 63 * (65535 / 255));
+}
+
 static void test_adjust_stream_frame_layout(void)
 {
 #define TEST(_is_crypto, _capacity, check)                                                                                         \
@@ -1124,6 +1150,7 @@ int main(int argc, char **argv)
     quicly_amend_ptls_context(quic_ctx.tls);
 
     subtest("error-codes", test_error_codes);
+    subtest("enable_with_ratio255", test_enable_with_ratio255);
     subtest("next-packet-number", test_next_packet_number);
     subtest("address-token-codec", test_address_token_codec);
     subtest("ranges", test_ranges);

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -832,6 +832,33 @@ static int retain_sendvecs(struct st_h2o_http3_server_stream_t *stream)
     return 1;
 }
 
+static void collect_quic_performance_metrics(struct st_h2o_http3_server_stream_t *stream)
+{
+    struct st_h2o_http3_server_conn_t *conn = get_conn(stream);
+
+    /* If the request is the first request, log method, content-length, and ttlb so that the performance of HTTP/3 can be evaluated.
+     * Note, to compare the performance of connections using different CC parameters, only the numbers from connections that served
+     * requests capable of fulfilling the CWND regardless of CC behavior (i.e, pre-built local objects) can be used. To extract such
+     * connections, properties other than method and content-length might be needed. */
+    if (stream->quic->stream_id == 0) {
+#define EMIT_STATS_FIELD(fld, lit) PTLS_LOG__DO_ELEMENT_UNSIGNED(lit, stats.fld);
+        H2O_LOG_CONN(h3s_stream0_ttlb, &conn->super, {
+            PTLS_LOG_ELEMENT_UNSAFESTR(method, stream->req.method.base, stream->req.method.len);
+            PTLS_LOG_ELEMENT_UNSIGNED(content_length, stream->req.res.content_length);
+            struct timeval now = h2o_gettimeofday(conn->super.ctx->loop);
+            int64_t ttlb = (h2o_timeval_subtract(&stream->req.timestamps.request_begin_at, &now) + 500) / 1000;
+            if (ttlb < 0)
+                ttlb = 0;
+            PTLS_LOG_ELEMENT_SIGNED(ttlb, ttlb);
+            quicly_stats_t stats;
+            if (quicly_get_stats(conn->h3.super.quic, &stats) == 0) {
+                QUICLY_STATS_FOREACH(EMIT_STATS_FIELD); /* if this is too heavyweight, we can hexdump `stats` instead */
+            }
+        });
+#undef EMIT_STATS_FIELD
+    }
+}
+
 static void on_send_shift(quicly_stream_t *qs, size_t delta)
 {
     struct st_h2o_http3_server_stream_t *stream = qs->data;
@@ -875,6 +902,7 @@ static void on_send_shift(quicly_stream_t *qs, size_t delta)
                     stream->state <= H2O_HTTP3_SERVER_STREAM_STATE_SEND_HEADERS) ||
                    stream->proceed_requested);
         } else {
+            collect_quic_performance_metrics(stream);
             if (quicly_stream_has_receive_side(0, stream->quic->stream_id))
                 quicly_request_stop(stream->quic, H2O_HTTP3_ERROR_EARLY_RESPONSE);
             set_state(stream, H2O_HTTP3_SERVER_STREAM_STATE_CLOSE_WAIT, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -2962,6 +2962,22 @@ static void on_http3_conn_destroy(h2o_quic_conn_t *conn)
     H2O_HTTP3_CONN_CALLBACKS.super.destroy_connection(conn);
 }
 
+static int parse_quic_enable_ratio(h2o_configurator_command_t *cmd, yoml_t *node, uint8_t *ratio)
+{
+    assert(node->type == YOML_TYPE_SCALAR);
+
+    if (strcasecmp(node->data.scalar, "ON") == 0) {
+        *ratio = 255;
+    } else if (strcasecmp(node->data.scalar, "OFF") == 0) {
+        *ratio = 0;
+    } else if (sscanf(node->data.scalar, "%" SCNu8, ratio) != 1) {
+        h2o_configurator_errprintf(cmd, node, "argument must be `ON`, `OFF`, or an integer between 0 (never) and 255 (always)");
+        return -1;
+    }
+
+    return 0;
+}
+
 static int on_config_listen_element(h2o_configurator_command_t *cmd, h2o_configurator_context_t *ctx, yoml_t *node)
 {
     const char *hostname = NULL, *servname, *type = "tcp";
@@ -3163,16 +3179,19 @@ static int on_config_listen_element(h2o_configurator_command_t *cmd, h2o_configu
                 if (quic_node != NULL) {
                     yoml_t **retry_node, **sndbuf, **rcvbuf, **amp_limit, **qpack_encoder_table_capacity, **max_streams_bidi,
                         **max_udp_payload_size, **handshake_timeout_rtt_multiplier, **max_initial_handshake_packets, **ecn,
-                        **pacing, **respect_app_limited, **jumpstart_default, **jumpstart_max;
+                        **pacing, **respect_app_limited, **slow_start_increase, **jumpstart_default, **jumpstart_max,
+                        **scaled_slow_start_ratio, **non_resume_jumpstart_ratio, **resume_jumpstart_ratio;
                     if (h2o_configurator_parse_mapping(
                             cmd, *quic_node, NULL,
                             "retry:s,sndbuf:s,rcvbuf:s,amp-limit:s,qpack-encoder-table-capacity:s,max-"
                             "streams-bidi:s,max-udp-payload-size:s,handshake-timeout-rtt-multiplier:s,"
-                            "max-initial-handshake-packets:s,ecn:s,pacing:s,respect-app-limited:s,jumpstart-default:s,"
-                            "jumpstart-max:s",
+                            "max-initial-handshake-packets:s,ecn:s,pacing:s,respect-app-limited:s,slow-start-increase:s,"
+                            "jumpstart-default:s,jumpstart-max:s,slow-start-ratio:s,non-resume-jumpstart-ratio:s,"
+                            "resume-jumpstart-ratio:s",
                             &retry_node, &sndbuf, &rcvbuf, &amp_limit, &qpack_encoder_table_capacity, &max_streams_bidi,
                             &max_udp_payload_size, &handshake_timeout_rtt_multiplier, &max_initial_handshake_packets, &ecn, &pacing,
-                            &respect_app_limited, &jumpstart_default, &jumpstart_max) != 0)
+                            &respect_app_limited, &slow_start_increase, &jumpstart_default, &jumpstart_max, &scaled_slow_start_ratio,
+                            &non_resume_jumpstart_ratio, &resume_jumpstart_ratio) != 0)
                         return -1;
                     if (retry_node != NULL) {
                         ssize_t on = h2o_configurator_get_one_of(cmd, *retry_node, "OFF,ON");
@@ -3225,23 +3244,16 @@ static int on_config_listen_element(h2o_configurator_command_t *cmd, h2o_configu
                         }
                         listener->quic.ctx->max_initial_handshake_packets = v;
                     }
-                    if (ecn != NULL) {
-                        ssize_t on = h2o_configurator_get_one_of(cmd, *ecn, "OFF,ON");
-                        if (on == -1)
+                    if (slow_start_increase != NULL) {
+                        double v;
+                        if (h2o_configurator_scanf(cmd, *slow_start_increase, "%lf", &v) != 0)
                             return -1;
-                        listener->quic.ctx->enable_ecn = !!on;
-                    }
-                    if (pacing != NULL) {
-                        ssize_t on = h2o_configurator_get_one_of(cmd, *pacing, "OFF,ON");
-                        if (on == -1)
+                        if (!(1 <= v && v <= 10)) {
+                            h2o_configurator_errprintf(cmd, *slow_start_increase,
+                                                       "slow start increase must be a number between 1 and 10");
                             return -1;
-                        listener->quic.ctx->use_pacing = (unsigned)on;
-                    }
-                    if (respect_app_limited != NULL) {
-                        ssize_t on = h2o_configurator_get_one_of(cmd, *respect_app_limited, "OFF,ON");
-                        if (on == -1)
-                            return -1;
-                        listener->quic.ctx->respect_app_limited = (unsigned)on;
+                        }
+                        listener->quic.ctx->slow_start_increase = (v * 512 + 1) / 2;
                     }
                     if (jumpstart_default != NULL &&
                         h2o_configurator_scanf(cmd, *jumpstart_default, "%" SCNu32,
@@ -3250,6 +3262,18 @@ static int on_config_listen_element(h2o_configurator_command_t *cmd, h2o_configu
                     if (jumpstart_max != NULL && h2o_configurator_scanf(cmd, *jumpstart_max, "%" SCNu32,
                                                                         &listener->quic.ctx->max_jumpstart_cwnd_packets) != 0)
                         return -1;
+#define APPLY_RATIO(node, fld)                                                                                                     \
+    do {                                                                                                                           \
+        if (node != NULL && parse_quic_enable_ratio(cmd, *node, &listener->quic.ctx->enable_ratio.fld) != 0)                       \
+            return -1;                                                                                                             \
+    } while (0)
+                    APPLY_RATIO(scaled_slow_start_ratio, scaled_slow_start);
+                    APPLY_RATIO(non_resume_jumpstart_ratio, jumpstart.non_resume);
+                    APPLY_RATIO(resume_jumpstart_ratio, jumpstart.resume);
+                    APPLY_RATIO(ecn, ecn);
+                    APPLY_RATIO(pacing, pacing);
+                    APPLY_RATIO(respect_app_limited, respect_app_limited);
+#undef APPLY_RATIO
                 }
                 if (conf.run_mode == RUN_MODE_WORKER)
                     set_quic_sockopts(fd, ai->ai_family, listener->sndbuf, listener->rcvbuf);


### PR DESCRIPTION
This pull request builds on top of https://github.com/h2o/quicly/pull/620 and https://github.com/h2o/quicly/pull/621, providing the following features:

Introduces the capability to turn a feature on for a QUIC connection at a given probability between 0 (never) and 255 (always).

Adds knobs `non-resume-jumpstart-ratio`, `resume-jumpstart-ratio` for controlling the probability of connections that use jumpstart.

Extends knobs `ecn`, `pacing`, `respect-app-limited` to accept the probability ratios, in addition to `ON` and `OFF` that they already support. With this change, the effect of these parameters can be also A/B tested.

Adds a knob named `slow-start-increase` that changes the scale of Slow Start (see https://github.com/h2o/quicly/pull/621), alongsite `scaled-slow-start-ratio` that controls the ratio of connections using scaled Slow Start.

The `h2o:h3s_stream0_ttlb` probe point for collecting the performance of each HTTP/3 connection. This probe is called when the last ACK for the first request is received, and records the method, content-length, TTLB, and quicly stats at that moment.

The probe point provides visibility to the performance characteristics of HTTP/3 connections that would have never been application-limited from the beginning of the connection (IOW only use the results for connections that must have served local, pre-built objects as the first request; hopefully they can be extracted by looking at the method and content-length).

Then, it would be possible to look at the attached quicly stats to see if each feature was on for that connection, and group them into two based on that.