### PR TITLE
Fix CONNECT datagram handler null pointer access

### DIFF
--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -2109,10 +2109,9 @@ static void datagram_frame_receive_cb(quicly_receive_datagram_frame_t *self, qui
     struct st_h2o_http3_server_stream_t *stream = kh_val(conn->datagram_flows, iter);
     assert(stream->req.forward_datagram.write_ != NULL);
 
-    if (stream->req.forward_datagram.write_ == NULL) {
-        // Drop this datagram if req.forward_datagram.write_ has been reset
+    /* drop this datagram if req.forward_datagram.write_ has been reset */
+    if (stream->req.forward_datagram.write_ == NULL)
         return;
-    }
 
     /* forward */
     stream->req.forward_datagram.write_(&stream->req, &payload, 1);


### PR DESCRIPTION
## Current Issue
Currently, if a client sends an HTTP/3 HEADERS frame with the FIN bit set and then continues to send a datagram with that associated stream id, the h2o CONNECT handler doesn't correctly clean up the stream and the datagram handler attempts to access a null context pointer.

## Proposed Fix
When receiving a FIN in the course of http3 CONNECT request streaming handling, we reset `stream->req.forward_datagram.write_`

We can then check for that in the `datagram_frame_receive_cb` handler and if it is NULL we can just drop the datagram, preventing us from attempting to access a NULL `ctx` pointer later in the handler logic.