### PR TITLE
guard DHE cipher constants for BoringSSL compatibility

### DIFF
--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -1601,13 +1601,17 @@ static void on_handshake_complete(h2o_socket_t *sock, const char *err)
             uint32_t cipher_id = SSL_CIPHER_get_id(cipher);
             switch (cipher_id) {
             case TLS1_CK_RSA_WITH_AES_128_GCM_SHA256:
+#if defined(TLS1_CK_DHE_RSA_WITH_AES_128_GCM_SHA256)
             case TLS1_CK_DHE_RSA_WITH_AES_128_GCM_SHA256:
+#endif
             case TLS1_CK_ECDHE_RSA_WITH_AES_128_GCM_SHA256:
             case TLS1_CK_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:
                 sock->ssl->record_overhead = 5 /* header */ + 8 /* iv (RFC 5288 3) */ + 16 /* tag (RFC 5116 5.1) */;
                 break;
             case TLS1_CK_RSA_WITH_AES_256_GCM_SHA384:
+#if defined(TLS1_CK_DHE_RSA_WITH_AES_256_GCM_SHA384)
             case TLS1_CK_DHE_RSA_WITH_AES_256_GCM_SHA384:
+#endif
             case TLS1_CK_ECDHE_RSA_WITH_AES_256_GCM_SHA384:
             case TLS1_CK_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:
                 sock->ssl->record_overhead = 5 /* header */ + 8 /* iv (RFC 5288 3) */ + 16 /* tag (RFC 5116 5.1) */;


### PR DESCRIPTION
This patch guards the DHE cipher suites behind a flag.

DHE was functionally removed from boringssl in 2017, but the header constants lingered until late 2025.

1. March 2017 ([cedc6f18](https://github.com/google/boringssl/commit/cedc6f1824ddc116872f762f28df3146889209be)): DHE cipher suites were disabled by default, with a compile flag -DBORINGSSL_ENABLE_DHE_TLS to restore them
2. April 2017 ([7e06de5d2](https://github.com/google/boringssl/commit/7e06de5d2d1b53c57c0c81e8d6ba4122b64cf626)): The compile flag and all DHE support code was completely removed (448 lines deleted)
3. September 2025 ([8aa95db78](https://github.com/google/boringssl/commit/8aa95db78a068ee9b964828dc3d45e5599114180)): The TLS1_CK_* constants for unimplemented cipher suites (including TLS1_CK_DHE_RSA_WITH_AES_128_GCM_SHA256 and TLS1_CK_DHE_RSA_WITH_AES_256_GCM_SHA384) were finally removed from the headers

