### PR TITLE
Stabilize early response H2 assertion

### DIFF
--- a/t/50reverse-proxy-early-response.t
+++ b/t/50reverse-proxy-early-response.t
@@ -240,8 +240,12 @@ EOS
                     h2g.read_loop(500)
 EOS
 
-                like $output, qr/':status' => '500'.*?half close.*?RST_STREAM frame <length=4, flags=0x00, stream_id=1>\n\s+error_code => 0/s,
-                    "Proxy forwarded headers, the complete body, and then RST_STREAM (NO_ERROR) in strict order";
+                like $output,
+                    qr/':status' => '500'.*?DATA frame <length=10, flags=0x01, stream_id=1>.*?RST_STREAM frame <length=4, flags=0x00, stream_id=1>\n\s+error_code => 0/s,
+                    "Proxy forwarded headers, END_STREAM DATA, and then RST_STREAM (NO_ERROR) in strict order";
+                # h2get's DATA renderer writes the payload hexdump with printf rather than appending it to Frame#to_s, so the payload
+                # dump can be reordered against subsequent "puts f.to_s" output. Check DATA frame ordering and content separately.
+                like $output, qr/half close/, "Proxy forwarded the complete response body";
             };
 
             subtest "rst-delay=0" => sub {
@@ -567,4 +571,3 @@ sub close {
     $self->{sock}->close if $self->{sock};
     $self->{sock} = undef;
 }
-


### PR DESCRIPTION
## Summary

This stabilizes the H2 early-response test that checks forwarding of an upstream RST_STREAM(NO_ERROR) after an early response body.

The previous assertion treated the h2get textual dump as a single ordered stream containing both frame metadata and DATA payload content. h2get DATA rendering writes the payload hexdump through printf rather than appending it to Frame#to_s, so the payload text can appear after later frame output even when the frames arrived in the correct order.

## Changes

- Assert strict frame order using frame metadata: HEADERS 500 -> DATA END_STREAM -> RST_STREAM(NO_ERROR).
- Assert the half close response body separately.
- Add a test comment explaining why frame order and body content need separate checks.

## Validation

- make -C build/default h2o
- BINARY_DIR=build/default perl -I. t/50reverse-proxy-early-response.t
- git diff --check

Note: the local h2get target cannot be rebuilt with this CMake version because the vendored h2get external project uses an old cmake_minimum_required; therefore local h2-down subtests were skipped here.