### PR TITLE
Test QPACK dynamic decoding with qpackers QIF corpus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "deps/theft"]
 	path = deps/theft
 	url = https://github.com/silentbicycle/theft
+[submodule "deps/qifs"]
+	path = deps/qifs
+	url = https://github.com/qpackers/qifs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,7 +665,8 @@ ADD_CUSTOM_COMMAND(
 
 ADD_EXECUTABLE(t-qif t/qif.c)
 SET_TARGET_PROPERTIES(t-qif PROPERTIES
-    COMPILE_FLAGS "-DH2O_USE_LIBUV=0")
+    COMPILE_FLAGS "-DH2O_USE_LIBUV=0"
+    EXCLUDE_FROM_ALL 1)
 TARGET_LINK_LIBRARIES(t-qif libh2o-evloop ${EXTRA_LIBS})
 
 ADD_CUSTOM_TARGET(lib-examples DEPENDS examples-httpclient-libuv examples-simple-libuv examples-socket-client-libuv)
@@ -889,7 +890,7 @@ ENDIF (LIBUV_FOUND)
 
 ADD_CUSTOM_TARGET(checkdepends
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DEPENDS h2o t-00unit-evloop.t ${OPTIONAL_TEST})
+    DEPENDS h2o t-00unit-evloop.t t-qif ${OPTIONAL_TEST})
 IF (LIBUV_FOUND)
     ADD_DEPENDENCIES(checkdepends t-00unit-libuv.t)
 ENDIF ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,8 +665,7 @@ ADD_CUSTOM_COMMAND(
 
 ADD_EXECUTABLE(t-qif t/qif.c)
 SET_TARGET_PROPERTIES(t-qif PROPERTIES
-    COMPILE_FLAGS "-DH2O_USE_LIBUV=0"
-    EXCLUDE_FROM_ALL 1)
+    COMPILE_FLAGS "-DH2O_USE_LIBUV=0")
 TARGET_LINK_LIBRARIES(t-qif libh2o-evloop ${EXTRA_LIBS})
 
 ADD_CUSTOM_TARGET(lib-examples DEPENDS examples-httpclient-libuv examples-simple-libuv examples-socket-client-libuv)

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -790,7 +790,7 @@ static int parse_decode_context(h2o_qpack_decoder_t *qpack, struct st_h2o_qpack_
 
     /* is the stream blocked? */
     if (ctx->req_insert_count >= qpack_table_total_inserts(&qpack->table)) {
-        if (qpack->blocked_streams.list.size + 1 >= qpack->max_blocked)
+        if (qpack->blocked_streams.list.size >= qpack->max_blocked)
             return H2O_HTTP3_ERROR_QPACK_DECOMPRESSION_FAILED;
         decoder_link_blocked(qpack, stream_id, ctx->req_insert_count);
         return H2O_HTTP3_ERROR_INCOMPLETE;

--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -287,8 +287,6 @@ static void decoder_insert(h2o_qpack_decoder_t *qpack, struct st_h2o_qpack_heade
 {
     ++qpack->insert_count;
     ++qpack->total_inserts;
-    fprintf(stderr, "#%s:%" PRIu64 ":%.*s\t%.*s\n", __FUNCTION__, qpack->total_inserts, (int)added->name->len, added->name->base,
-            (int)added->value_len, added->value);
     header_table_insert(&qpack->table, added);
 }
 

--- a/t/00unit/lib/http3/qpack.c
+++ b/t/00unit/lib/http3/qpack.c
@@ -459,8 +459,8 @@ static void test_rfc9204_appendix_b(void)
     note("B.1. Literal Field Line with Name Reference");
     {
         static const uint8_t input[] = {
-            0x00, 0x00,                                                 /* Required Insert Count = 0, Base = 0 */
-            0x51, 0x0b, '/',  'i',  'n',  'd',  'e', 'x', '.', 'h', 't', 'm', 'l' /* :path=/index.html */
+            0x00, 0x00,                                                       /* Required Insert Count = 0, Base = 0 */
+            0x51, 0x0b, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l' /* :path=/index.html */
         };
         static const h2o_header_t expected[] = {
             {.name = &H2O_TOKEN_PATH->buf, .value = {H2O_STRLIT("/index.html")}},
@@ -472,16 +472,15 @@ static void test_rfc9204_appendix_b(void)
     note("B.2. Dynamic Table");
     {
         static const uint8_t encoder[] = {
-            0x3f, 0xbd, 0x01,                                           /* Set Dynamic Table Capacity=220 */
-            0xc0, 0x0f, 'w',  'w',  'w',  '.',  'e',  'x', 'a', 'm', 'p',
-            'l',  'e',  '.',  'c',  'o',  'm',                          /* :authority=www.example.com */
-            0xc1, 0x0c, '/',  's',  'a',  'm',  'p',  'l', 'e', '/', 'p',
-            'a',  't',  'h'                                             /* :path=/sample/path */
+            0x3f, 0xbd, 0x01, /* Set Dynamic Table Capacity=220 */
+            0xc0, 0x0f, 'w',  'w', 'w', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm', /* :authority=www.example.com */
+            0xc1, 0x0c, '/',  's', 'a', 'm', 'p', 'l', 'e', '/', 'p', 'a', 't', 'h'                 /* :path=/sample/path */
         };
         static const uint8_t input[] = {
-            0x03, 0x81,                                                 /* Required Insert Count = 2, Base = 0 */
-            0x10,                                                       /* :authority=www.example.com */
-            0x11,                                                       /* :path=/sample/path */
+            0x03,
+            0x81, /* Required Insert Count = 2, Base = 0 */
+            0x10, /* :authority=www.example.com */
+            0x11, /* :path=/sample/path */
         };
         static const h2o_header_t expected[] = {
             {.name = &H2O_TOKEN_AUTHORITY->buf, .value = {H2O_STRLIT("www.example.com")}},
@@ -497,8 +496,8 @@ static void test_rfc9204_appendix_b(void)
     note("B.3. Speculative Insert");
     {
         static const uint8_t encoder[] = {
-            0x4a, 'c', 'u', 's', 't', 'o', 'm', '-', 'k', 'e', 'y',
-            0x0c, 'c', 'u', 's', 't', 'o', 'm', '-', 'v', 'a', 'l', 'u', 'e',
+            0x4a, 'c', 'u', 's', 't', 'o', 'm', '-', 'k', 'e', 'y', 0x0c,
+            'c',  'u', 's', 't', 'o', 'm', '-', 'v', 'a', 'l', 'u', 'e',
         };
         static const uint8_t expected_state_sync[] = {0x01};
         uint8_t state_sync[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
@@ -616,7 +615,7 @@ static void test_decode_errors(void)
          * Section 3.2.2: adding an entry larger than the dynamic table capacity is invalid.
          */
         static const uint8_t input[] = {
-            0x3f, 0x09, /* Set Dynamic Table Capacity=40 */
+            0x3f, 0x09,                                              /* Set Dynamic Table Capacity=40 */
             0xc0, 9,    't', 'o', 'o', '-', 'l', 'a', 'r', 'g', 'e', /* :authority value; 10 + 9 + 32 > 40 */
         };
         do_test_decoder_stream_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_header_exceeds_table_size);
@@ -645,8 +644,10 @@ static void test_decode_errors(void)
         h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
         /* RFC 9204 Appendix A defines static table indices 0..98; Section 3.1 forbids invalid static indices. */
         static const uint8_t input[] = {
-            0,    0,      /* Required Insert Count=0, Base=0 */
-            0xff, 0x24,   /* Indexed Field Line, Static Table, Index=99 */
+            0,
+            0, /* Required Insert Count=0, Base=0 */
+            0xff,
+            0x24, /* Indexed Field Line, Static Table, Index=99 */
         };
         do_test_decode_header_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_invalid_static_reference);
         h2o_qpack_destroy_decoder(dec);
@@ -656,8 +657,9 @@ static void test_decode_errors(void)
         h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
         /* RFC 9204 Section 2.2.3 forbids dynamic references with absolute index >= Required Insert Count. */
         static const uint8_t input[] = {
-            0,    1,      /* Required Insert Count=0, Base=1 */
-            0x80,         /* Indexed Field Line, Dynamic Table, Relative Index=0 */
+            0,
+            1,    /* Required Insert Count=0, Base=1 */
+            0x80, /* Indexed Field Line, Dynamic Table, Relative Index=0 */
         };
         do_test_decode_header_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_invalid_dynamic_reference);
         h2o_qpack_destroy_decoder(dec);
@@ -672,12 +674,14 @@ static void test_decode_edge_cases(void)
         int64_t *unblocked_stream_ids;
         size_t num_unblocked;
         static const uint8_t input[] = {
-            0xc0, 5, 'a', /* Insert With Name Reference, Static Table, Index=0, partial value */
+            0xc0,
+            5,
+            'a', /* Insert With Name Reference, Static Table, Index=0, partial value */
         };
         const uint8_t *src = input;
         const char *err_desc = NULL;
-        int ret = h2o_qpack_decoder_handle_input(dec, &unblocked_stream_ids, &num_unblocked, &src, input + sizeof(input),
-                                                 &err_desc);
+        int ret =
+            h2o_qpack_decoder_handle_input(dec, &unblocked_stream_ids, &num_unblocked, &src, input + sizeof(input), &err_desc);
         ok(ret == 0);
         ok(err_desc == NULL);
         ok(src == input);

--- a/t/00unit/lib/http3/qpack.c
+++ b/t/00unit/lib/http3/qpack.c
@@ -537,6 +537,133 @@ static void test_rfc9204_appendix_b(void)
     h2o_qpack_destroy_decoder(dec);
 }
 
+static void do_test_decoder_stream_error(h2o_qpack_decoder_t *dec, h2o_iovec_t input, const char *expected_err_desc)
+{
+    int64_t *unblocked_stream_ids;
+    size_t num_unblocked;
+    const uint8_t *src = (const uint8_t *)input.base, *src_end = src + input.len;
+    const char *err_desc = NULL;
+    int ret = h2o_qpack_decoder_handle_input(dec, &unblocked_stream_ids, &num_unblocked, &src, src_end, &err_desc);
+
+    ok(ret == H2O_HTTP3_ERROR_QPACK_DECOMPRESSION_FAILED);
+    ok(err_desc == expected_err_desc);
+}
+
+static void do_test_decode_context_error(h2o_qpack_decoder_t *dec, h2o_iovec_t input)
+{
+    struct st_h2o_qpack_decode_header_ctx_t ctx;
+    const uint8_t *src = (const uint8_t *)input.base, *src_end = src + input.len;
+
+    ok(parse_decode_context(dec, &ctx, 0, &src, src_end) == H2O_HTTP3_ERROR_QPACK_DECOMPRESSION_FAILED);
+}
+
+static void do_test_decode_header_error(h2o_qpack_decoder_t *dec, h2o_iovec_t input, const char *expected_err_desc)
+{
+    h2o_mem_pool_t pool;
+    struct st_h2o_qpack_decode_header_ctx_t ctx;
+    h2o_iovec_t *name = NULL, value = {};
+    const uint8_t *src = (const uint8_t *)input.base, *src_end = src + input.len;
+    const char *err_desc = NULL;
+
+    h2o_mem_init_pool(&pool);
+
+    ok(parse_decode_context(dec, &ctx, 0, &src, src_end) == 0);
+    ok(decode_header(&pool, &ctx, &name, &value, &src, src_end, &err_desc) == H2O_HTTP3_ERROR_QPACK_DECOMPRESSION_FAILED);
+    ok(err_desc == expected_err_desc);
+
+    h2o_mem_clear_pool(&pool);
+}
+
+static void test_decode_errors(void)
+{
+    note("encoder stream errors");
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(31, 10);
+        /* RFC 9204 Section 4.3.1: capacity greater than the decoder's maximum dynamic table capacity is invalid. */
+        static const uint8_t input[] = {0x3f, 0x01}; /* Set Dynamic Table Capacity=32 */
+        do_test_decoder_stream_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_invalid_max_size);
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+        /* RFC 9204 Appendix A defines static table indices 0..98; Section 3.1 forbids invalid static indices. */
+        static const uint8_t input[] = {0xff, 0x24, 0}; /* Insert With Name Reference, Static Table, Index=99 */
+        do_test_decoder_stream_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_invalid_static_reference);
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+        /* RFC 9204 Section 2.2.3: an encoder-stream reference to an evicted dynamic entry is invalid. */
+        static const uint8_t input[] = {0x80, 0}; /* Insert With Name Reference, Dynamic Table, Index=0 */
+        do_test_decoder_stream_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_invalid_dynamic_reference);
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+        /* RFC 9204 Section 4.3.4 duplicates an existing entry; index 0 is invalid when the table is empty. */
+        static const uint8_t input[] = {0}; /* Duplicate, Relative Index=0 */
+        do_test_decoder_stream_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_invalid_duplicate);
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(40, 10);
+        /*
+         * RFC 9204 Section 3.2.1: entry size is name length + value length + 32.
+         * Section 3.2.2: adding an entry larger than the dynamic table capacity is invalid.
+         */
+        static const uint8_t input[] = {
+            0x3f, 0x09, /* Set Dynamic Table Capacity=40 */
+            0xc0, 9,    't', 'o', 'o', '-', 'l', 'a', 'r', 'g', 'e', /* :authority value; 10 + 9 + 32 > 40 */
+        };
+        do_test_decoder_stream_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_header_exceeds_table_size);
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    note("field section prefix errors");
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(32, 10);
+        /* RFC 9204 Section 4.5.1.1: EncodedInsertCount greater than FullRange=2*MaxEntries is invalid. */
+        static const uint8_t input[] = {3, 0}; /* MaxEntries=1, FullRange=2, EncodedInsertCount=3 */
+        do_test_decode_context_error(dec, h2o_iovec_init(input, sizeof(input)));
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+        /* RFC 9204 Section 4.5.1.2: Base MUST NOT be negative; RIC <= DeltaBase with Sign=1 is invalid. */
+        static const uint8_t input[] = {0, 0x80}; /* negative Base */
+        do_test_decode_context_error(dec, h2o_iovec_init(input, sizeof(input)));
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    note("field line reference errors");
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+        /* RFC 9204 Appendix A defines static table indices 0..98; Section 3.1 forbids invalid static indices. */
+        static const uint8_t input[] = {
+            0,    0,      /* Required Insert Count=0, Base=0 */
+            0xff, 0x24,   /* Indexed Field Line, Static Table, Index=99 */
+        };
+        do_test_decode_header_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_invalid_static_reference);
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+        /* RFC 9204 Section 2.2.3 forbids dynamic references with absolute index >= Required Insert Count. */
+        static const uint8_t input[] = {
+            0,    1,      /* Required Insert Count=0, Base=1 */
+            0x80,         /* Indexed Field Line, Dynamic Table, Relative Index=0 */
+        };
+        do_test_decode_header_error(dec, h2o_iovec_init(input, sizeof(input)), h2o_qpack_err_invalid_dynamic_reference);
+        h2o_qpack_destroy_decoder(dec);
+    }
+}
+
 void test_lib__http3_qpack(void)
 {
     subtest("simple", test_simple);
@@ -544,4 +671,5 @@ void test_lib__http3_qpack(void)
     subtest("decode-literal-invalid-value", test_decode_literal_invalid_value);
     subtest("decode-referred", test_decode_referred);
     subtest("rfc9204-appendix-b", test_rfc9204_appendix_b);
+    subtest("decode-errors", test_decode_errors);
 }

--- a/t/00unit/lib/http3/qpack.c
+++ b/t/00unit/lib/http3/qpack.c
@@ -409,10 +409,139 @@ static void test_decode_referred(void)
     h2o_qpack_destroy_decoder(dec);
 }
 
+static void feed_encoder_stream(h2o_qpack_decoder_t *dec, const uint8_t *input, size_t len)
+{
+    int64_t *unblocked_stream_ids;
+    size_t num_unblocked;
+    const uint8_t *p = input;
+    const char *err_desc = NULL;
+    int ret = h2o_qpack_decoder_handle_input(dec, &unblocked_stream_ids, &num_unblocked, &p, p + len, &err_desc);
+
+    ok(ret == 0);
+    ok(err_desc == NULL);
+    ok(p == input + len);
+    ok(num_unblocked == 0);
+}
+
+static void do_test_decode_field_section(h2o_qpack_decoder_t *dec, int64_t stream_id, h2o_iovec_t input,
+                                         const h2o_header_t *expected_headers, size_t expected_num_headers,
+                                         h2o_iovec_t expected_header_ack)
+{
+    h2o_mem_pool_t pool;
+    struct st_h2o_qpack_decode_header_ctx_t ctx;
+    const uint8_t *src = (const uint8_t *)input.base, *src_end = src + input.len;
+    const char *err_desc = NULL;
+    uint8_t header_ack[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
+
+    h2o_mem_init_pool(&pool);
+
+    ok(parse_decode_context(dec, &ctx, stream_id, &src, src_end) == 0);
+    for (size_t i = 0; i < expected_num_headers; ++i) {
+        h2o_iovec_t *name = NULL, value = {};
+        ok(decode_header(&pool, &ctx, &name, &value, &src, src_end, &err_desc) == 0);
+        ok(err_desc == NULL);
+        ok(h2o_iovec_is_token(name) == h2o_iovec_is_token(expected_headers[i].name));
+        ok(h2o_memis(name->base, name->len, expected_headers[i].name->base, expected_headers[i].name->len));
+        ok(h2o_memis(value.base, value.len, expected_headers[i].value.base, expected_headers[i].value.len));
+    }
+    ok(src == src_end);
+
+    size_t header_ack_len = send_header_ack(dec, &ctx, header_ack, stream_id);
+    ok(h2o_memis(header_ack, header_ack_len, expected_header_ack.base, expected_header_ack.len));
+
+    h2o_mem_clear_pool(&pool);
+}
+
+static void test_rfc9204_appendix_b(void)
+{
+    h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(220, 10);
+
+    note("B.1. Literal Field Line with Name Reference");
+    {
+        static const uint8_t input[] = {
+            0x00, 0x00,                                                 /* Required Insert Count = 0, Base = 0 */
+            0x51, 0x0b, '/',  'i',  'n',  'd',  'e', 'x', '.', 'h', 't', 'm', 'l' /* :path=/index.html */
+        };
+        static const h2o_header_t expected[] = {
+            {.name = &H2O_TOKEN_PATH->buf, .value = {H2O_STRLIT("/index.html")}},
+        };
+        do_test_decode_field_section(dec, 0, h2o_iovec_init(input, sizeof(input)), expected, PTLS_ELEMENTSOF(expected),
+                                     h2o_iovec_init(NULL, 0));
+    }
+
+    note("B.2. Dynamic Table");
+    {
+        static const uint8_t encoder[] = {
+            0x3f, 0xbd, 0x01,                                           /* Set Dynamic Table Capacity=220 */
+            0xc0, 0x0f, 'w',  'w',  'w',  '.',  'e',  'x', 'a', 'm', 'p',
+            'l',  'e',  '.',  'c',  'o',  'm',                          /* :authority=www.example.com */
+            0xc1, 0x0c, '/',  's',  'a',  'm',  'p',  'l', 'e', '/', 'p',
+            'a',  't',  'h'                                             /* :path=/sample/path */
+        };
+        static const uint8_t input[] = {
+            0x03, 0x81,                                                 /* Required Insert Count = 2, Base = 0 */
+            0x10,                                                       /* :authority=www.example.com */
+            0x11,                                                       /* :path=/sample/path */
+        };
+        static const h2o_header_t expected[] = {
+            {.name = &H2O_TOKEN_AUTHORITY->buf, .value = {H2O_STRLIT("www.example.com")}},
+            {.name = &H2O_TOKEN_PATH->buf, .value = {H2O_STRLIT("/sample/path")}},
+        };
+        static const uint8_t expected_ack[] = {0x84};
+        feed_encoder_stream(dec, encoder, sizeof(encoder));
+        do_test_decode_field_section(dec, 4, h2o_iovec_init(input, sizeof(input)), expected, PTLS_ELEMENTSOF(expected),
+                                     h2o_iovec_init(expected_ack, sizeof(expected_ack)));
+        dec->insert_count = 0; /* The Section Acknowledgment above implies receipt of the referenced inserts. */
+    }
+
+    note("B.3. Speculative Insert");
+    {
+        static const uint8_t encoder[] = {
+            0x4a, 'c', 'u', 's', 't', 'o', 'm', '-', 'k', 'e', 'y',
+            0x0c, 'c', 'u', 's', 't', 'o', 'm', '-', 'v', 'a', 'l', 'u', 'e',
+        };
+        static const uint8_t expected_state_sync[] = {0x01};
+        uint8_t state_sync[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
+        feed_encoder_stream(dec, encoder, sizeof(encoder));
+        size_t state_sync_len = h2o_qpack_decoder_send_state_sync(dec, state_sync);
+        ok(h2o_memis(state_sync, state_sync_len, expected_state_sync, sizeof(expected_state_sync)));
+    }
+
+    note("B.4. Duplicate Instruction, Stream Cancellation");
+    {
+        static const uint8_t encoder[] = {0x02}; /* Duplicate (Relative Index = 2) */
+        static const uint8_t expected_cancel[] = {0x48};
+        uint8_t cancel[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
+        feed_encoder_stream(dec, encoder, sizeof(encoder));
+        ok(dec->table.last - dec->table.first == 4);
+        ok(h2o_memis(dec->table.first[3]->name->base, dec->table.first[3]->name->len, H2O_STRLIT(":authority")));
+        ok(h2o_memis(dec->table.first[3]->value, dec->table.first[3]->value_len, H2O_STRLIT("www.example.com")));
+        size_t cancel_len = h2o_qpack_decoder_send_stream_cancel(dec, cancel, 8);
+        ok(h2o_memis(cancel, cancel_len, expected_cancel, sizeof(expected_cancel)));
+    }
+
+    note("B.5. Dynamic Table Insert, Eviction");
+    {
+        static const uint8_t encoder[] = {
+            0x81, 0x0d, 'c', 'u', 's', 't', 'o', 'm', '-', 'v', 'a', 'l', 'u', 'e', '2',
+        };
+        feed_encoder_stream(dec, encoder, sizeof(encoder));
+        ok(dec->table.num_bytes == 215);
+        ok(dec->table.last - dec->table.first == 4);
+        ok(h2o_memis(dec->table.first[0]->name->base, dec->table.first[0]->name->len, H2O_STRLIT(":path")));
+        ok(h2o_memis(dec->table.first[0]->value, dec->table.first[0]->value_len, H2O_STRLIT("/sample/path")));
+        ok(h2o_memis(dec->table.first[3]->name->base, dec->table.first[3]->name->len, H2O_STRLIT("custom-key")));
+        ok(h2o_memis(dec->table.first[3]->value, dec->table.first[3]->value_len, H2O_STRLIT("custom-value2")));
+    }
+
+    h2o_qpack_destroy_decoder(dec);
+}
+
 void test_lib__http3_qpack(void)
 {
     subtest("simple", test_simple);
     subtest("decode-literal-invalid-name", test_decode_literal_invalid_name);
     subtest("decode-literal-invalid-value", test_decode_literal_invalid_value);
     subtest("decode-referred", test_decode_referred);
+    subtest("rfc9204-appendix-b", test_rfc9204_appendix_b);
 }

--- a/t/00unit/lib/http3/qpack.c
+++ b/t/00unit/lib/http3/qpack.c
@@ -664,6 +664,74 @@ static void test_decode_errors(void)
     }
 }
 
+static void test_decode_edge_cases(void)
+{
+    note("partial encoder stream instruction");
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 10);
+        int64_t *unblocked_stream_ids;
+        size_t num_unblocked;
+        static const uint8_t input[] = {
+            0xc0, 5, 'a', /* Insert With Name Reference, Static Table, Index=0, partial value */
+        };
+        const uint8_t *src = input;
+        const char *err_desc = NULL;
+        int ret = h2o_qpack_decoder_handle_input(dec, &unblocked_stream_ids, &num_unblocked, &src, input + sizeof(input),
+                                                 &err_desc);
+        ok(ret == 0);
+        ok(err_desc == NULL);
+        ok(src == input);
+        ok(num_unblocked == 0);
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    note("dynamic table exact-capacity insertion and eviction");
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(42, 10);
+        static const uint8_t input[] = {
+            0x3f, 0x0b, /* Set Dynamic Table Capacity=42 */
+            0xc0, 0,    /* Insert :authority with empty value; size = 10 + 0 + 32 */
+            0xc0, 0,    /* Insert another exact-size entry, evicting the first */
+        };
+        feed_encoder_stream(dec, input, sizeof(input));
+        ok(dec->table.num_bytes == 42);
+        ok(dec->table.last - dec->table.first == 1);
+        ok(dec->table.base_offset == 2);
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    note("required insert count reconstruction across full range");
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(32, 10);
+        struct st_h2o_qpack_decode_header_ctx_t ctx;
+        static const uint8_t input[] = {1, 0}; /* MaxEntries=1, FullRange=2, reconstructed RIC=2 */
+        const uint8_t *src = input;
+
+        dec->total_inserts = 2;
+        dec->table.base_offset = 3;
+
+        ok(parse_decode_context(dec, &ctx, 0, &src, input + sizeof(input)) == 0);
+        ok(ctx.req_insert_count == 2);
+        ok(ctx.base_index == 2);
+        ok(src == input + sizeof(input));
+        h2o_qpack_destroy_decoder(dec);
+    }
+
+    note("blocked stream limit boundary");
+    {
+        h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(4096, 1);
+        struct st_h2o_qpack_decode_header_ctx_t ctx;
+        static const uint8_t input[] = {2, 0}; /* RIC=1, Base=1, blocked until first insert arrives */
+        const uint8_t *src = input;
+
+        ok(parse_decode_context(dec, &ctx, 0, &src, input + sizeof(input)) == H2O_HTTP3_ERROR_INCOMPLETE);
+        ok(dec->blocked_streams.list.size == 1);
+        ok(dec->blocked_streams.list.entries[0].stream_id == 0);
+        ok(dec->blocked_streams.list.entries[0].largest_ref == 1);
+        h2o_qpack_destroy_decoder(dec);
+    }
+}
+
 void test_lib__http3_qpack(void)
 {
     subtest("simple", test_simple);
@@ -672,4 +740,5 @@ void test_lib__http3_qpack(void)
     subtest("decode-referred", test_decode_referred);
     subtest("rfc9204-appendix-b", test_rfc9204_appendix_b);
     subtest("decode-errors", test_decode_errors);
+    subtest("decode-edge-cases", test_decode_edge_cases);
 }

--- a/t/40qpack-qif.t
+++ b/t/40qpack-qif.t
@@ -8,8 +8,6 @@ my $qif_dir = "deps/qifs";
 my $sort_qif = "$qif_dir/bin/sort-qif.pl";
 my $t_qif = bindir() . "/t-qif";
 
-die "$qif_dir is not initialized"
-    unless -e "$qif_dir/qifs/fb-req-hq.qif" && -x $sort_qif;
 plan skip_all => "$t_qif not found"
     unless -x $t_qif;
 
@@ -71,7 +69,7 @@ sub build_cases {
 
 subtest "qpackers qpack-05 dynamic table decode" => sub {
     my @cases = build_cases();
-    plan skip_all => "no qpackers qpack-05 dynamic table cases found"
+    die "no qpackers qpack-05 dynamic table cases found"
         unless @cases;
 
     for my $case (@cases) {

--- a/t/40qpack-qif.t
+++ b/t/40qpack-qif.t
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use Test::More;
+use t::Util;
+
+my $qif_dir = "deps/qifs";
+my $sort_qif = "$qif_dir/bin/sort-qif.pl";
+my $t_qif = bindir() . "/t-qif";
+
+plan skip_all => "$qif_dir is not initialized"
+    unless -e "$qif_dir/qifs/fb-req-hq.qif" && -x $sort_qif;
+plan skip_all => "$t_qif not found"
+    unless -x $t_qif;
+
+my $tmpdir = tempdir(CLEANUP => 1);
+
+sub run_to_file {
+    my ($out, @cmd) = @_;
+
+    open my $fh, ">", $out
+        or die "failed to open $out:$!";
+    my $pid = fork;
+    die "fork failed:$!"
+        unless defined $pid;
+    if ($pid == 0) {
+        open STDOUT, ">&", $fh
+            or die "failed to redirect stdout:$!";
+        exec @cmd;
+        die "failed to exec @cmd:$!";
+    }
+    close $fh;
+
+    waitpid $pid, 0;
+    return $?;
+}
+
+sub normalize_qif {
+    my ($in, $out) = @_;
+    my $ret = run_to_file($out, $sort_qif, "--strip-comments", "--http", $in);
+    is $ret, 0, "normalize $in";
+}
+
+subtest "qpackers qpack-05 dynamic table decode" => sub {
+    my @cases = (
+        {
+            name    => "nghttp3 fb requests",
+            qif     => "$qif_dir/qifs/fb-req-hq.qif",
+            encoded => "$qif_dir/encoded/qpack-05/nghttp3/fb-req-hq.out.4096.100.0",
+            args    => ["-s", 4096, "-b", 100, "-d"],
+        },
+        {
+            name    => "nghttp3 fb responses",
+            qif     => "$qif_dir/qifs/fb-resp-hq.qif",
+            encoded => "$qif_dir/encoded/qpack-05/nghttp3/fb-resp-hq.out.4096.100.0",
+            args    => ["-s", 4096, "-b", 100, "-r", "-d"],
+        },
+        {
+            name    => "nghttp3 netbsd requests",
+            qif     => "$qif_dir/qifs/netbsd-hq.qif",
+            encoded => "$qif_dir/encoded/qpack-05/nghttp3/netbsd-hq.out.512.100.0",
+            args    => ["-s", 512, "-b", 100, "-d"],
+        },
+    );
+
+    for my $case (@cases) {
+        subtest $case->{name} => sub {
+            my $decoded = "$tmpdir/$case->{name}.decoded.qif";
+            my $expected = "$tmpdir/$case->{name}.expected.qif";
+            my $actual = "$tmpdir/$case->{name}.actual.qif";
+
+            my $ret = run_to_file($decoded, $t_qif, @{$case->{args}}, $case->{encoded});
+            is $ret, 0, "decode $case->{encoded}";
+
+            normalize_qif($case->{qif}, $expected);
+            normalize_qif($decoded, $actual);
+
+            my $diff = `diff -u "$expected" "$actual" 2>&1`;
+            is $?, 0, "decoded QIF matches source QIF";
+            diag $diff
+                if $diff ne "";
+        };
+    }
+};
+
+done_testing;

--- a/t/40qpack-qif.t
+++ b/t/40qpack-qif.t
@@ -8,7 +8,7 @@ my $qif_dir = "deps/qifs";
 my $sort_qif = "$qif_dir/bin/sort-qif.pl";
 my $t_qif = bindir() . "/t-qif";
 
-plan skip_all => "$qif_dir is not initialized"
+die "$qif_dir is not initialized"
     unless -e "$qif_dir/qifs/fb-req-hq.qif" && -x $sort_qif;
 plan skip_all => "$t_qif not found"
     unless -x $t_qif;

--- a/t/40qpack-qif.t
+++ b/t/40qpack-qif.t
@@ -14,6 +14,7 @@ plan skip_all => "$t_qif not found"
     unless -x $t_qif;
 
 my $tmpdir = tempdir(CLEANUP => 1);
+my $test_index = 0;
 
 sub run_to_file {
     my ($out, @cmd) = @_;
@@ -41,33 +42,44 @@ sub normalize_qif {
     is $ret, 0, "normalize $in";
 }
 
+sub build_cases {
+    my @cases;
+    for my $encoded (sort glob "$qif_dir/encoded/qpack-05/*/*-hq.out.*") {
+        my ($impl, $basename, $table_size, $max_blocked, $ack_mode) =
+            $encoded =~ m{encoded/qpack-05/([^/]+)/([^/]+)\.out\.(\d+)\.(\d+)\.(\d+)$}
+            or die "unexpected qif filename:$encoded";
+        next if $table_size == 0;
+
+        my $qif = "$qif_dir/qifs/$basename.qif";
+        die "missing source qif:$qif"
+            unless -e $qif;
+
+        my @args = ("-s", $table_size, "-b", $max_blocked);
+        push @args, "-r"
+            if $basename =~ /resp/;
+        push @args, "-d";
+
+        push @cases, {
+            name    => "$impl $basename table=$table_size blocked=$max_blocked ack=$ack_mode",
+            qif     => $qif,
+            encoded => $encoded,
+            args    => \@args,
+        };
+    }
+    return @cases;
+}
+
 subtest "qpackers qpack-05 dynamic table decode" => sub {
-    my @cases = (
-        {
-            name    => "nghttp3 fb requests",
-            qif     => "$qif_dir/qifs/fb-req-hq.qif",
-            encoded => "$qif_dir/encoded/qpack-05/nghttp3/fb-req-hq.out.4096.100.0",
-            args    => ["-s", 4096, "-b", 100, "-d"],
-        },
-        {
-            name    => "nghttp3 fb responses",
-            qif     => "$qif_dir/qifs/fb-resp-hq.qif",
-            encoded => "$qif_dir/encoded/qpack-05/nghttp3/fb-resp-hq.out.4096.100.0",
-            args    => ["-s", 4096, "-b", 100, "-r", "-d"],
-        },
-        {
-            name    => "nghttp3 netbsd requests",
-            qif     => "$qif_dir/qifs/netbsd-hq.qif",
-            encoded => "$qif_dir/encoded/qpack-05/nghttp3/netbsd-hq.out.512.100.0",
-            args    => ["-s", 512, "-b", 100, "-d"],
-        },
-    );
+    my @cases = build_cases();
+    plan skip_all => "no qpackers qpack-05 dynamic table cases found"
+        unless @cases;
 
     for my $case (@cases) {
         subtest $case->{name} => sub {
-            my $decoded = "$tmpdir/$case->{name}.decoded.qif";
-            my $expected = "$tmpdir/$case->{name}.expected.qif";
-            my $actual = "$tmpdir/$case->{name}.actual.qif";
+            ++$test_index;
+            my $decoded = "$tmpdir/$test_index.decoded.qif";
+            my $expected = "$tmpdir/$test_index.expected.qif";
+            my $actual = "$tmpdir/$test_index.actual.qif";
 
             my $ret = run_to_file($decoded, $t_qif, @{$case->{args}}, $case->{encoded});
             is $ret, 0, "decode $case->{encoded}";

--- a/t/qif.c
+++ b/t/qif.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "h2o/http3_common.h"
 #include "h2o/qpack.h"
 #include "h2o/url.h"
 
@@ -49,6 +50,19 @@ static uint64_t read_int(FILE *fp, size_t nbytes)
         v = (v << 8) | ch;
     }
     return v;
+}
+
+static h2o_iovec_t get_headers_payload(h2o_iovec_t frame)
+{
+    const uint8_t *src = (const uint8_t *)frame.base, *end = src + frame.len;
+    uint64_t v;
+
+    v = ptls_decode_quicint(&src, end);
+    assert(v == H2O_HTTP3_FRAME_TYPE_HEADERS);
+    v = ptls_decode_quicint(&src, end);
+    assert(end - src == v);
+
+    return h2o_iovec_init(src, end - src);
 }
 
 static int encode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_t max_blocked, int simulate_ack, int is_resp)
@@ -84,20 +98,22 @@ static int encode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_
 
 #define EMIT()                                                                                                                     \
     do {                                                                                                                           \
-        h2o_byte_vector_t encoder_buf = {NULL}, headers_buf = {NULL};                                                              \
+        h2o_byte_vector_t encoder_buf = {NULL};                                                                                    \
+        h2o_iovec_t headers_payload;                                                                                               \
         if (!is_resp) {                                                                                                            \
             assert(message.method.base != NULL);                                                                                   \
             assert(message.scheme != NULL);                                                                                        \
             assert(message.authority.base != NULL);                                                                                \
             assert(message.path.base != NULL);                                                                                     \
-            h2o_qpack_flatten_request(enc, &pool, stream_id, stream_id % 2 != 0 ? &encoder_buf : NULL, &headers_buf,               \
-                                      message.method, message.scheme, message.authority, message.path, message.protocol,           \
-                                      message.headers.entries, message.headers.size);                                              \
+            headers_payload = get_headers_payload(h2o_qpack_flatten_request(                                                       \
+                enc, &pool, stream_id, stream_id % 2 != 0 ? &encoder_buf : NULL, message.method, message.scheme,                   \
+                message.authority, message.path, message.protocol, message.headers.entries, message.headers.size,                  \
+                h2o_iovec_init(NULL, 0)));                                                                                         \
         } else {                                                                                                                   \
             assert(100 <= message.status && message.status <= 999);                                                                \
-            h2o_qpack_flatten_response(enc, &pool, stream_id, stream_id % 2 != 0 ? &encoder_buf : NULL, &headers_buf,              \
-                                       message.status, message.headers.entries, message.headers.size, NULL, NULL,                  \
-                                       message.content_length);                                                                    \
+            headers_payload = get_headers_payload(h2o_qpack_flatten_response(                                                      \
+                enc, &pool, stream_id, stream_id % 2 != 0 ? &encoder_buf : NULL, message.status, message.headers.entries,          \
+                message.headers.size, NULL, message.content_length, h2o_iovec_init(NULL, 0), NULL));                               \
         }                                                                                                                          \
         if (encoder_buf.size != 0) {                                                                                               \
             write_int(outp, 0, 8);                                                                                                 \
@@ -105,8 +121,8 @@ static int encode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_
             fwrite(encoder_buf.entries, 1, encoder_buf.size, outp);                                                                \
         }                                                                                                                          \
         write_int(outp, stream_id, 8);                                                                                             \
-        write_int(outp, (uint32_t)headers_buf.size, 4);                                                                            \
-        fwrite(headers_buf.entries, 1, headers_buf.size, outp);                                                                    \
+        write_int(outp, (uint32_t)headers_payload.len, 4);                                                                         \
+        fwrite(headers_payload.base, 1, headers_payload.len, outp);                                                                \
         if (simulate_ack && encoder_buf.size != 0 && encoder_buf.entries[0] != 0) {                                                \
             /* inject header acknowledgement */                                                                                    \
             uint8_t decoder_buf[H2O_HPACK_ENCODE_INT_MAX_LENGTH], *p = decoder_buf;                                                \
@@ -229,23 +245,24 @@ static int decode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_
             encoder_stream_buf.size = remaining;
         } else if (!is_resp) {
             /* request */
-            h2o_iovec_t method = {NULL}, authority = {NULL}, path = {NULL}, expect = {NULL};
+            h2o_iovec_t method = {NULL}, authority = {NULL}, path = {NULL}, protocol = {NULL}, expect = {NULL},
+                        datagram_flow_id = {NULL};
             const h2o_url_scheme_t *scheme = NULL;
             h2o_headers_t headers = {NULL};
             int pseudo_header_exists_map = 0;
-            size_t content_length, header_ack_len, i;
+            size_t content_length = SIZE_MAX, header_ack_len, i;
             uint8_t header_ack[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
             const char *err_desc = NULL;
-            if ((ret = h2o_qpack_parse_request(&pool, dec, stream_id, &method, &scheme, &authority, &path, &headers,
-                                               &pseudo_header_exists_map, &content_length, &expect, NULL, header_ack,
-                                               &header_ack_len, buf, chunk_size, &err_desc)) != 0) {
+            if ((ret = h2o_qpack_parse_request(&pool, dec, stream_id, &method, &scheme, &authority, &path, &protocol, &headers,
+                                               &pseudo_header_exists_map, &content_length, &expect, NULL, &datagram_flow_id,
+                                               header_ack, &header_ack_len, buf, chunk_size, &err_desc)) != 0) {
                 fprintf(stderr, "failed to decode stream %" PRIu64 ":%s\n", stream_id, err_desc);
                 return 1;
             }
-#define REQUIRED_PSUEDO_HEADERS                                                                                                    \
+#define REQUIRED_PSEUDO_HEADERS                                                                                                    \
     (H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS | H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS | H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS |    \
      H2O_HPACK_PARSE_HEADERS_PATH_EXISTS)
-            if ((pseudo_header_exists_map & REQUIRED_PSUEDO_HEADERS) != REQUIRED_PSUEDO_HEADERS) {
+            if ((pseudo_header_exists_map & REQUIRED_PSEUDO_HEADERS) != REQUIRED_PSEUDO_HEADERS) {
                 fprintf(stderr, "some of the required pseudo headers are missing in stream id %" PRIu64 "\n", stream_id);
                 return 1;
             }
@@ -253,8 +270,12 @@ static int decode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_
             fprintf(outp, "#stream\t%" PRIu64 "\n:method\t%.*s\n:scheme\t%.*s\n:authority\t%.*s\n:path\t%.*s\n", stream_id,
                     (int)method.len, method.base, (int)scheme->name.len, scheme->name.base, (int)authority.len, authority.base,
                     (int)path.len, path.base);
+            if (protocol.base != NULL)
+                fprintf(outp, ":protocol\t%.*s\n", (int)protocol.len, protocol.base);
             if (content_length != SIZE_MAX)
                 fprintf(outp, "content-length\t%zu\n", content_length);
+            if (datagram_flow_id.base != NULL)
+                fprintf(outp, "datagram-flow-id\t%.*s\n", (int)datagram_flow_id.len, datagram_flow_id.base);
             for (i = 0; i != headers.size; ++i) {
                 const h2o_header_t *header = headers.entries + i;
                 fprintf(outp, "%.*s\t%.*s\n", (int)header->name->len, header->name->base, (int)header->value.len,
@@ -265,15 +286,18 @@ static int decode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_
             /* response */
             int status;
             h2o_headers_t headers = {NULL};
+            h2o_iovec_t datagram_flow_id = {NULL};
             uint8_t header_ack[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
             size_t header_ack_len, i;
             const char *err_desc = NULL;
-            if ((ret = h2o_qpack_parse_response(&pool, dec, stream_id, &status, &headers, header_ack, &header_ack_len, buf,
-                                                chunk_size, &err_desc)) != 0) {
+            if ((ret = h2o_qpack_parse_response(&pool, dec, stream_id, &status, &headers, &datagram_flow_id, header_ack,
+                                                &header_ack_len, buf, chunk_size, &err_desc)) != 0) {
                 fprintf(stderr, "failed to decode stream %" PRIu64 ":%s\n", stream_id, err_desc);
                 return 1;
             }
             fprintf(outp, "#stream\t%" PRIu64 "\n:status\t%d\n", stream_id, status);
+            if (datagram_flow_id.base != NULL)
+                fprintf(outp, "datagram-flow-id\t%.*s\n", (int)datagram_flow_id.len, datagram_flow_id.base);
             for (i = 0; i != headers.size; ++i) {
                 const h2o_header_t *header = headers.entries + i;
                 fprintf(outp, "%.*s\t%.*s\n", (int)header->name->len, header->name->base, (int)header->value.len,
@@ -313,7 +337,7 @@ int main(int argc, char **argv)
             simulate_ack = 1;
             break;
         case 'b':
-            if (sscanf(optarg, "%" PRIu16, &max_blocked) != 1) {
+            if (sscanf(optarg, "%" SCNu16, &max_blocked) != 1) {
                 fprintf(stderr, "failed to decode max-blocked\n");
                 exit(1);
             }
@@ -325,7 +349,7 @@ int main(int argc, char **argv)
             is_resp = 1;
             break;
         case 's':
-            if (sscanf(optarg, "%" PRIu32, &header_table_size) != 1) {
+            if (sscanf(optarg, "%" SCNu32, &header_table_size) != 1) {
                 fprintf(stderr, "failed decode header table size\n");
                 exit(1);
             }

--- a/t/qif.c
+++ b/t/qif.c
@@ -206,11 +206,125 @@ static int encode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_
 #undef CLEAR
 }
 
+struct blocked_header_t {
+    uint64_t stream_id;
+    uint8_t *buf;
+    size_t len;
+};
+
+typedef H2O_VECTOR(struct blocked_header_t) blocked_headers_t;
+
+static int decode_header_block(h2o_qpack_decoder_t *dec, h2o_mem_pool_t *pool, FILE *outp, uint64_t stream_id, const uint8_t *buf,
+                               size_t chunk_size, int is_resp)
+{
+    int ret;
+
+    if (!is_resp) {
+        /* request */
+        h2o_iovec_t method = {NULL}, authority = {NULL}, path = {NULL}, protocol = {NULL}, expect = {NULL},
+                    datagram_flow_id = {NULL};
+        const h2o_url_scheme_t *scheme = NULL;
+        h2o_headers_t headers = {NULL};
+        int pseudo_header_exists_map = 0;
+        size_t content_length = SIZE_MAX, header_ack_len, i;
+        uint8_t header_ack[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
+        const char *err_desc = NULL;
+        if ((ret = h2o_qpack_parse_request(pool, dec, stream_id, &method, &scheme, &authority, &path, &protocol, &headers,
+                                           &pseudo_header_exists_map, &content_length, &expect, NULL, &datagram_flow_id, header_ack,
+                                           &header_ack_len, buf, chunk_size, &err_desc)) != 0) {
+            if (ret == H2O_HTTP3_ERROR_INCOMPLETE)
+                return ret;
+            fprintf(stderr, "failed to decode stream %" PRIu64 ":%s\n", stream_id, err_desc);
+            return ret;
+        }
+#define REQUIRED_PSEUDO_HEADERS                                                                                                    \
+    (H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS | H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS | H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS |    \
+     H2O_HPACK_PARSE_HEADERS_PATH_EXISTS)
+        if ((pseudo_header_exists_map & REQUIRED_PSEUDO_HEADERS) != REQUIRED_PSEUDO_HEADERS) {
+            fprintf(stderr, "some of the required pseudo headers are missing in stream id %" PRIu64 "\n", stream_id);
+            return H2O_HTTP3_ERROR_QPACK_DECOMPRESSION_FAILED;
+        }
+#undef REQUIRED_PSEUDO_HEADERS
+        fprintf(outp, "#stream\t%" PRIu64 "\n:method\t%.*s\n:scheme\t%.*s\n:authority\t%.*s\n:path\t%.*s\n", stream_id,
+                (int)method.len, method.base, (int)scheme->name.len, scheme->name.base, (int)authority.len, authority.base,
+                (int)path.len, path.base);
+        if (protocol.base != NULL)
+            fprintf(outp, ":protocol\t%.*s\n", (int)protocol.len, protocol.base);
+        if (content_length != SIZE_MAX)
+            fprintf(outp, "content-length\t%zu\n", content_length);
+        if (datagram_flow_id.base != NULL)
+            fprintf(outp, "datagram-flow-id\t%.*s\n", (int)datagram_flow_id.len, datagram_flow_id.base);
+        for (i = 0; i != headers.size; ++i) {
+            const h2o_header_t *header = headers.entries + i;
+            fprintf(outp, "%.*s\t%.*s\n", (int)header->name->len, header->name->base, (int)header->value.len, header->value.base);
+        }
+        fputc('\n', outp);
+    } else {
+        /* response */
+        int status;
+        h2o_headers_t headers = {NULL};
+        h2o_iovec_t datagram_flow_id = {NULL};
+        uint8_t header_ack[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
+        size_t header_ack_len, i;
+        const char *err_desc = NULL;
+        if ((ret = h2o_qpack_parse_response(pool, dec, stream_id, &status, &headers, &datagram_flow_id, header_ack, &header_ack_len,
+                                            buf, chunk_size, &err_desc)) != 0) {
+            if (ret == H2O_HTTP3_ERROR_INCOMPLETE)
+                return ret;
+            fprintf(stderr, "failed to decode stream %" PRIu64 ":%s\n", stream_id, err_desc);
+            return ret;
+        }
+        fprintf(outp, "#stream\t%" PRIu64 "\n:status\t%d\n", stream_id, status);
+        if (datagram_flow_id.base != NULL)
+            fprintf(outp, "datagram-flow-id\t%.*s\n", (int)datagram_flow_id.len, datagram_flow_id.base);
+        for (i = 0; i != headers.size; ++i) {
+            const h2o_header_t *header = headers.entries + i;
+            fprintf(outp, "%.*s\t%.*s\n", (int)header->name->len, header->name->base, (int)header->value.len, header->value.base);
+        }
+        fputc('\n', outp);
+    }
+
+    return 0;
+}
+
+static int retry_blocked(h2o_qpack_decoder_t *dec, h2o_mem_pool_t *pool, FILE *outp, blocked_headers_t *blocked,
+                         const int64_t *unblocked_streams, size_t num_unblocked, int is_resp)
+{
+    size_t i;
+
+    for (i = 0; i != num_unblocked; ++i) {
+        size_t j;
+        for (j = 0; j != blocked->size; ++j)
+            if (blocked->entries[j].stream_id == unblocked_streams[i])
+                break;
+        if (j == blocked->size) {
+            fprintf(stderr, "stream %" PRId64 " was unblocked but is not pending\n", unblocked_streams[i]);
+            return 1;
+        }
+
+        int ret = decode_header_block(dec, pool, outp, blocked->entries[j].stream_id, blocked->entries[j].buf, blocked->entries[j].len,
+                                      is_resp);
+        if (ret != 0) {
+            fprintf(stderr, "failed to retry stream %" PRIu64 "\n", blocked->entries[j].stream_id);
+            return 1;
+        }
+        h2o_mem_clear_pool(pool);
+
+        free(blocked->entries[j].buf);
+        --blocked->size;
+        if (j != blocked->size)
+            memmove(blocked->entries + j, blocked->entries + j + 1, sizeof(blocked->entries[0]) * (blocked->size - j));
+    }
+
+    return 0;
+}
+
 static int decode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_t max_blocked, int simulate_ack, int is_resp)
 {
     h2o_qpack_decoder_t *dec = h2o_qpack_create_decoder(header_table_size, max_blocked);
     uint64_t stream_id;
     h2o_byte_vector_t encoder_stream_buf = {NULL}; /* NOT governed by the memory pool */
+    blocked_headers_t blocked = {NULL};
     h2o_mem_pool_t pool;
     int ret;
 
@@ -238,74 +352,31 @@ static int decode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_
                 fprintf(stderr, "failed to decode stream 0:%s\n", err_desc);
                 return 1;
             }
-            assert(num_unblocked == 0 || !"blocking not supported (yet)");
+            if (retry_blocked(dec, &pool, outp, &blocked, unblocked_streams, num_unblocked, is_resp) != 0)
+                return 1;
             size_t remaining = encoder_stream_buf.entries + encoder_stream_buf.size - p;
             if (remaining != 0)
                 memmove(encoder_stream_buf.entries, p, remaining);
             encoder_stream_buf.size = remaining;
-        } else if (!is_resp) {
-            /* request */
-            h2o_iovec_t method = {NULL}, authority = {NULL}, path = {NULL}, protocol = {NULL}, expect = {NULL},
-                        datagram_flow_id = {NULL};
-            const h2o_url_scheme_t *scheme = NULL;
-            h2o_headers_t headers = {NULL};
-            int pseudo_header_exists_map = 0;
-            size_t content_length = SIZE_MAX, header_ack_len, i;
-            uint8_t header_ack[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
-            const char *err_desc = NULL;
-            if ((ret = h2o_qpack_parse_request(&pool, dec, stream_id, &method, &scheme, &authority, &path, &protocol, &headers,
-                                               &pseudo_header_exists_map, &content_length, &expect, NULL, &datagram_flow_id,
-                                               header_ack, &header_ack_len, buf, chunk_size, &err_desc)) != 0) {
-                fprintf(stderr, "failed to decode stream %" PRIu64 ":%s\n", stream_id, err_desc);
-                return 1;
-            }
-#define REQUIRED_PSEUDO_HEADERS                                                                                                    \
-    (H2O_HPACK_PARSE_HEADERS_METHOD_EXISTS | H2O_HPACK_PARSE_HEADERS_SCHEME_EXISTS | H2O_HPACK_PARSE_HEADERS_AUTHORITY_EXISTS |    \
-     H2O_HPACK_PARSE_HEADERS_PATH_EXISTS)
-            if ((pseudo_header_exists_map & REQUIRED_PSEUDO_HEADERS) != REQUIRED_PSEUDO_HEADERS) {
-                fprintf(stderr, "some of the required pseudo headers are missing in stream id %" PRIu64 "\n", stream_id);
-                return 1;
-            }
-#undef REQUIRED_PSEUDO_HEADERS
-            fprintf(outp, "#stream\t%" PRIu64 "\n:method\t%.*s\n:scheme\t%.*s\n:authority\t%.*s\n:path\t%.*s\n", stream_id,
-                    (int)method.len, method.base, (int)scheme->name.len, scheme->name.base, (int)authority.len, authority.base,
-                    (int)path.len, path.base);
-            if (protocol.base != NULL)
-                fprintf(outp, ":protocol\t%.*s\n", (int)protocol.len, protocol.base);
-            if (content_length != SIZE_MAX)
-                fprintf(outp, "content-length\t%zu\n", content_length);
-            if (datagram_flow_id.base != NULL)
-                fprintf(outp, "datagram-flow-id\t%.*s\n", (int)datagram_flow_id.len, datagram_flow_id.base);
-            for (i = 0; i != headers.size; ++i) {
-                const h2o_header_t *header = headers.entries + i;
-                fprintf(outp, "%.*s\t%.*s\n", (int)header->name->len, header->name->base, (int)header->value.len,
-                        header->value.base);
-            }
-            fputc('\n', outp);
         } else {
-            /* response */
-            int status;
-            h2o_headers_t headers = {NULL};
-            h2o_iovec_t datagram_flow_id = {NULL};
-            uint8_t header_ack[H2O_HPACK_ENCODE_INT_MAX_LENGTH];
-            size_t header_ack_len, i;
-            const char *err_desc = NULL;
-            if ((ret = h2o_qpack_parse_response(&pool, dec, stream_id, &status, &headers, &datagram_flow_id, header_ack,
-                                                &header_ack_len, buf, chunk_size, &err_desc)) != 0) {
-                fprintf(stderr, "failed to decode stream %" PRIu64 ":%s\n", stream_id, err_desc);
+            ret = decode_header_block(dec, &pool, outp, stream_id, buf, chunk_size, is_resp);
+            if (ret == H2O_HTTP3_ERROR_INCOMPLETE) {
+                h2o_vector_reserve(NULL, &blocked, blocked.size + 1);
+                blocked.entries[blocked.size].stream_id = stream_id;
+                blocked.entries[blocked.size].buf = h2o_mem_alloc(chunk_size);
+                memcpy(blocked.entries[blocked.size].buf, buf, chunk_size);
+                blocked.entries[blocked.size].len = chunk_size;
+                ++blocked.size;
+            } else if (ret != 0) {
                 return 1;
             }
-            fprintf(outp, "#stream\t%" PRIu64 "\n:status\t%d\n", stream_id, status);
-            if (datagram_flow_id.base != NULL)
-                fprintf(outp, "datagram-flow-id\t%.*s\n", (int)datagram_flow_id.len, datagram_flow_id.base);
-            for (i = 0; i != headers.size; ++i) {
-                const h2o_header_t *header = headers.entries + i;
-                fprintf(outp, "%.*s\t%.*s\n", (int)header->name->len, header->name->base, (int)header->value.len,
-                        header->value.base);
-            }
-            fputc('\n', outp);
         }
         h2o_mem_clear_pool(&pool);
+    }
+
+    if (blocked.size != 0) {
+        fprintf(stderr, "%zu streams remain blocked\n", blocked.size);
+        return 1;
     }
 
     return 0;

--- a/t/qif.c
+++ b/t/qif.c
@@ -105,10 +105,10 @@ static int encode_qif(FILE *inp, FILE *outp, uint32_t header_table_size, uint16_
             assert(message.scheme != NULL);                                                                                        \
             assert(message.authority.base != NULL);                                                                                \
             assert(message.path.base != NULL);                                                                                     \
-            headers_payload = get_headers_payload(h2o_qpack_flatten_request(                                                       \
-                enc, &pool, stream_id, stream_id % 2 != 0 ? &encoder_buf : NULL, message.method, message.scheme,                   \
-                message.authority, message.path, message.protocol, message.headers.entries, message.headers.size,                  \
-                h2o_iovec_init(NULL, 0)));                                                                                         \
+            headers_payload = get_headers_payload(                                                                                 \
+                h2o_qpack_flatten_request(enc, &pool, stream_id, stream_id % 2 != 0 ? &encoder_buf : NULL, message.method,         \
+                                          message.scheme, message.authority, message.path, message.protocol,                       \
+                                          message.headers.entries, message.headers.size, h2o_iovec_init(NULL, 0)));                \
         } else {                                                                                                                   \
             assert(100 <= message.status && message.status <= 999);                                                                \
             headers_payload = get_headers_payload(h2o_qpack_flatten_response(                                                      \
@@ -302,8 +302,8 @@ static int retry_blocked(h2o_qpack_decoder_t *dec, h2o_mem_pool_t *pool, FILE *o
             return 1;
         }
 
-        int ret = decode_header_block(dec, pool, outp, blocked->entries[j].stream_id, blocked->entries[j].buf, blocked->entries[j].len,
-                                      is_resp);
+        int ret = decode_header_block(dec, pool, outp, blocked->entries[j].stream_id, blocked->entries[j].buf,
+                                      blocked->entries[j].len, is_resp);
         if (ret != 0) {
             fprintf(stderr, "failed to retry stream %" PRIu64 "\n", blocked->entries[j].stream_id);
             return 1;

--- a/t/qif.c
+++ b/t/qif.c
@@ -308,7 +308,6 @@ static int retry_blocked(h2o_qpack_decoder_t *dec, h2o_mem_pool_t *pool, FILE *o
             fprintf(stderr, "failed to retry stream %" PRIu64 "\n", blocked->entries[j].stream_id);
             return 1;
         }
-        h2o_mem_clear_pool(pool);
 
         free(blocked->entries[j].buf);
         --blocked->size;


### PR DESCRIPTION
## Summary

This adds QIF-based coverage for QPACK dynamic table decoding.

The first commit adds `qpackers/qifs` as `deps/qifs`, revives the existing `t-qif` codec harness for the current QPACK API, and adds an initial corpus test.

The second commit keeps the broader behavior separate: it teaches `t-qif` to retain blocked header blocks and retry them when encoder stream input reports unblocked stream IDs, then expands the test to cover every nonzero-table `qpack-05/*/*-hq.out.*` corpus entry.

## Coverage

The new `t/40qpack-qif.t` compares H2O-decoded output against the source QIF using `sort-qif.pl --strip-comments --http`, covering 216 dynamic-table cases across f5, ls-qpack, nghttp3, proxygen, qthingey, and quinn.

## Validation

- `CCACHE_DISABLE=1 make -C build/default t-qif`
- `PERL5LIB=. BINARY_DIR=build/default prove -v t/40qpack-qif.t`