### PR TITLE
new mitigations for HTTP/2 state amplification

### DIFF
--- a/include/h2o.h
+++ b/include/h2o.h
@@ -60,13 +60,6 @@ extern "C" {
 #define H2O_USE_BROTLI 0
 #endif
 
-#ifndef H2O_MAX_HEADERS
-#define H2O_MAX_HEADERS 100
-#endif
-#ifndef H2O_MAX_REQLEN
-#define H2O_MAX_REQLEN (8192 + 4096 * (H2O_MAX_HEADERS))
-#endif
-
 #ifndef H2O_SOMAXCONN
 /* simply use a large value, and let the kernel clip it to the internal max */
 #define H2O_SOMAXCONN 65535

--- a/include/h2o/header.h
+++ b/include/h2o/header.h
@@ -29,6 +29,13 @@
 extern "C" {
 #endif
 
+#ifndef H2O_MAX_HEADERS
+#define H2O_MAX_HEADERS 100
+#endif
+#ifndef H2O_MAX_REQLEN
+#define H2O_MAX_REQLEN (8192 + 4096 * (H2O_MAX_HEADERS))
+#endif
+
 typedef struct st_h2o_header_flags_t {
     unsigned char dont_compress : 1;
 } h2o_header_flags_t;

--- a/include/h2o/header.h
+++ b/include/h2o/header.h
@@ -30,9 +30,18 @@ extern "C" {
 #endif
 
 #ifndef H2O_MAX_HEADERS
+/**
+ * Maximum number of fields expected in a field section. This is a soft target for processing input. Functions must be prepared for
+ * processing field sections that have more fields than H2O_MAX_HEADERS.
+ */
 #define H2O_MAX_HEADERS 100
 #endif
+
 #ifndef H2O_MAX_REQLEN
+/**
+ * Maximum size of an encoded field section in bytes. This is a soft target for processing input. Functions must be prepared for
+ * processing field sections that is larger than this (consider huffman decompression in HPACK).
+ */
 #define H2O_MAX_REQLEN (8192 + 4096 * (H2O_MAX_HEADERS))
 #endif
 

--- a/include/h2o/hpack.h
+++ b/include/h2o/hpack.h
@@ -45,6 +45,7 @@ extern const char h2o_hpack_err_unexpected_connection_specific_header[];
 extern const char h2o_hpack_err_invalid_content_length_header[];
 extern const char h2o_hpack_soft_err_found_invalid_char_in_header_name[];
 extern const char h2o_hpack_soft_err_found_invalid_char_in_header_value[];
+extern const char h2o_hpack_soft_err_headers_too_long[];
 
 #define H2O_HPACK_SOFT_ERROR_BIT_INVALID_NAME 0x1
 #define H2O_HPACK_SOFT_ERROR_BIT_INVALID_VALUE 0x2

--- a/include/h2o/hpack.h
+++ b/include/h2o/hpack.h
@@ -28,6 +28,14 @@
 #include "h2o/url.h"
 #include "h2o/cache_digests.h"
 
+#ifndef H2O_HPACK_MAX_HEADERS_HARD_LIMIT
+/**
+ * When the number of fields within a field section exceeds this value, the HPACK decoder raises a hard error that leads to closing
+ * the connection. H2O_MAX_HEADERS is the soft limit.
+ */
+#define H2O_HPACK_MAX_HEADERS_HARD_LIMIT 1000
+#endif
+
 #define H2O_HPACK_ENCODE_INT_MAX_LENGTH 10 /* first byte + 9 bytes (7*9==63 bits to hold positive numbers of int64_t) */
 
 extern const char h2o_hpack_err_missing_mandatory_pseudo_header[];

--- a/include/h2o/hpack.h
+++ b/include/h2o/hpack.h
@@ -45,7 +45,7 @@ extern const char h2o_hpack_err_unexpected_connection_specific_header[];
 extern const char h2o_hpack_err_invalid_content_length_header[];
 extern const char h2o_hpack_soft_err_found_invalid_char_in_header_name[];
 extern const char h2o_hpack_soft_err_found_invalid_char_in_header_value[];
-extern const char h2o_hpack_soft_err_headers_too_long[];
+extern const char h2o_hpack_err_headers_too_long[]; /* can either be a hard error or a soft error */
 
 #define H2O_HPACK_SOFT_ERROR_BIT_INVALID_NAME 0x1
 #define H2O_HPACK_SOFT_ERROR_BIT_INVALID_VALUE 0x2

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -105,7 +105,7 @@ const char h2o_hpack_err_unexpected_connection_specific_header[] = "found an une
 const char h2o_hpack_err_invalid_content_length_header[] = "invalid content-length header";
 const char h2o_hpack_soft_err_found_invalid_char_in_header_name[] = "found an invalid character in header name";
 const char h2o_hpack_soft_err_found_invalid_char_in_header_value[] = "found an invalid character in header value";
-const char h2o_hpack_soft_err_headers_too_long[] = "headers too long";
+const char h2o_hpack_err_headers_too_long[] = "headers too long";
 
 static int header_value_valid_as_whole(const char *s, size_t len)
 {
@@ -527,7 +527,7 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
         }
         ++num_headers_decoded;
         if (num_headers_decoded > H2O_HPACK_MAX_HEADERS_HARD_LIMIT) {
-            *err_desc = h2o_hpack_soft_err_headers_too_long;
+            *err_desc = h2o_hpack_err_headers_too_long;
             return H2O_HTTP2_ERROR_COMPRESSION;
         }
         if (name->base[0] == ':') {
@@ -621,13 +621,13 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                 if (headers->size < H2O_MAX_HEADERS) {
                     h2o_add_header(pool, headers, token, NULL, value.base, value.len);
                 } else if (*err_desc == NULL) {
-                    *err_desc = h2o_hpack_soft_err_headers_too_long;
+                    *err_desc = h2o_hpack_err_headers_too_long;
                 }
             } else {
                 if (headers->size < H2O_MAX_HEADERS) {
                     h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
                 } else if (*err_desc == NULL) {
-                    *err_desc = h2o_hpack_soft_err_headers_too_long;
+                    *err_desc = h2o_hpack_err_headers_too_long;
                 }
             }
         }
@@ -672,7 +672,7 @@ int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb de
         }
         ++num_headers_decoded;
         if (num_headers_decoded > H2O_HPACK_MAX_HEADERS_HARD_LIMIT) {
-            *err_desc = h2o_hpack_soft_err_headers_too_long;
+            *err_desc = h2o_hpack_err_headers_too_long;
             return H2O_HTTP2_ERROR_COMPRESSION;
         }
         if (name->base[0] == ':') {
@@ -730,13 +730,13 @@ int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb de
                 if (headers->size < H2O_MAX_HEADERS) {
                     h2o_add_header(pool, headers, token, NULL, value.base, value.len);
                 } else if (*err_desc == NULL) {
-                    *err_desc = h2o_hpack_soft_err_headers_too_long;
+                    *err_desc = h2o_hpack_err_headers_too_long;
                 }
             } else {
                 if (headers->size < H2O_MAX_HEADERS) {
                     h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
                 } else if (*err_desc == NULL) {
-                    *err_desc = h2o_hpack_soft_err_headers_too_long;
+                    *err_desc = h2o_hpack_err_headers_too_long;
                 }
             }
         }

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -506,6 +506,7 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                             const char **err_desc)
 {
     const uint8_t *src_end = src + len;
+    size_t num_headers_decoded = 0;
 
     *content_length = SIZE_MAX;
 
@@ -523,6 +524,11 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                 *err_desc = decode_err;
                 return ret;
             }
+        }
+        ++num_headers_decoded;
+        if (num_headers_decoded > H2O_HPACK_MAX_HEADERS_HARD_LIMIT) {
+            *err_desc = h2o_hpack_soft_err_too_many_headers;
+            return H2O_HTTP2_ERROR_COMPRESSION;
         }
         if (name->base[0] == ':') {
             if (pseudo_header_exists_map != NULL) {
@@ -641,6 +647,7 @@ int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb de
         *status = 0;
 
     const uint8_t *src_end = src + len;
+    size_t num_headers_decoded = 0;
 
     /* the response MUST contain a :status header as the first element */
     if (status != NULL && src == src_end) {
@@ -662,6 +669,11 @@ int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb de
                 *err_desc = decode_err;
                 return ret;
             }
+        }
+        ++num_headers_decoded;
+        if (num_headers_decoded > H2O_HPACK_MAX_HEADERS_HARD_LIMIT) {
+            *err_desc = h2o_hpack_soft_err_too_many_headers;
+            return H2O_HTTP2_ERROR_COMPRESSION;
         }
         if (name->base[0] == ':') {
             if (status == NULL) {

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -105,7 +105,7 @@ const char h2o_hpack_err_unexpected_connection_specific_header[] = "found an une
 const char h2o_hpack_err_invalid_content_length_header[] = "invalid content-length header";
 const char h2o_hpack_soft_err_found_invalid_char_in_header_name[] = "found an invalid character in header name";
 const char h2o_hpack_soft_err_found_invalid_char_in_header_value[] = "found an invalid character in header value";
-const char h2o_hpack_soft_err_too_many_headers[] = "too many headers";
+const char h2o_hpack_soft_err_headers_too_long[] = "headers too long";
 
 static int header_value_valid_as_whole(const char *s, size_t len)
 {
@@ -527,7 +527,7 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
         }
         ++num_headers_decoded;
         if (num_headers_decoded > H2O_HPACK_MAX_HEADERS_HARD_LIMIT) {
-            *err_desc = h2o_hpack_soft_err_too_many_headers;
+            *err_desc = h2o_hpack_soft_err_headers_too_long;
             return H2O_HTTP2_ERROR_COMPRESSION;
         }
         if (name->base[0] == ':') {
@@ -621,13 +621,13 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                 if (headers->size < H2O_MAX_HEADERS) {
                     h2o_add_header(pool, headers, token, NULL, value.base, value.len);
                 } else if (*err_desc == NULL) {
-                    *err_desc = h2o_hpack_soft_err_too_many_headers;
+                    *err_desc = h2o_hpack_soft_err_headers_too_long;
                 }
             } else {
                 if (headers->size < H2O_MAX_HEADERS) {
                     h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
                 } else if (*err_desc == NULL) {
-                    *err_desc = h2o_hpack_soft_err_too_many_headers;
+                    *err_desc = h2o_hpack_soft_err_headers_too_long;
                 }
             }
         }
@@ -672,7 +672,7 @@ int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb de
         }
         ++num_headers_decoded;
         if (num_headers_decoded > H2O_HPACK_MAX_HEADERS_HARD_LIMIT) {
-            *err_desc = h2o_hpack_soft_err_too_many_headers;
+            *err_desc = h2o_hpack_soft_err_headers_too_long;
             return H2O_HTTP2_ERROR_COMPRESSION;
         }
         if (name->base[0] == ':') {
@@ -730,13 +730,13 @@ int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb de
                 if (headers->size < H2O_MAX_HEADERS) {
                     h2o_add_header(pool, headers, token, NULL, value.base, value.len);
                 } else if (*err_desc == NULL) {
-                    *err_desc = h2o_hpack_soft_err_too_many_headers;
+                    *err_desc = h2o_hpack_soft_err_headers_too_long;
                 }
             } else {
                 if (headers->size < H2O_MAX_HEADERS) {
                     h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
                 } else if (*err_desc == NULL) {
-                    *err_desc = h2o_hpack_soft_err_too_many_headers;
+                    *err_desc = h2o_hpack_soft_err_headers_too_long;
                 }
             }
         }

--- a/lib/http2/hpack.c
+++ b/lib/http2/hpack.c
@@ -105,6 +105,7 @@ const char h2o_hpack_err_unexpected_connection_specific_header[] = "found an une
 const char h2o_hpack_err_invalid_content_length_header[] = "invalid content-length header";
 const char h2o_hpack_soft_err_found_invalid_char_in_header_name[] = "found an invalid character in header name";
 const char h2o_hpack_soft_err_found_invalid_char_in_header_value[] = "found an invalid character in header value";
+const char h2o_hpack_soft_err_too_many_headers[] = "too many headers";
 
 static int header_value_valid_as_whole(const char *s, size_t len)
 {
@@ -611,9 +612,17 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     }
                 }
-                h2o_add_header(pool, headers, token, NULL, value.base, value.len);
+                if (headers->size < H2O_MAX_HEADERS) {
+                    h2o_add_header(pool, headers, token, NULL, value.base, value.len);
+                } else if (*err_desc == NULL) {
+                    *err_desc = h2o_hpack_soft_err_too_many_headers;
+                }
             } else {
-                h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
+                if (headers->size < H2O_MAX_HEADERS) {
+                    h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
+                } else if (*err_desc == NULL) {
+                    *err_desc = h2o_hpack_soft_err_too_many_headers;
+                }
             }
         }
     Next:;
@@ -625,8 +634,8 @@ int h2o_hpack_parse_request(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb dec
 }
 
 int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb decode_cb, void *decode_ctx, int *status,
-                             h2o_headers_t *headers, h2o_iovec_t *datagram_flow_id, const uint8_t *src, size_t len,
-                             const char **err_desc)
+                             h2o_headers_t *headers, h2o_iovec_t *datagram_flow_id, const uint8_t *src,
+                             size_t len, const char **err_desc)
 {
     if (status != NULL)
         *status = 0;
@@ -706,15 +715,23 @@ int h2o_hpack_parse_response(h2o_mem_pool_t *pool, h2o_hpack_decode_header_cb de
                         return H2O_HTTP2_ERROR_PROTOCOL;
                     }
                 }
-                h2o_add_header(pool, headers, token, NULL, value.base, value.len);
+                if (headers->size < H2O_MAX_HEADERS) {
+                    h2o_add_header(pool, headers, token, NULL, value.base, value.len);
+                } else if (*err_desc == NULL) {
+                    *err_desc = h2o_hpack_soft_err_too_many_headers;
+                }
             } else {
-                h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
+                if (headers->size < H2O_MAX_HEADERS) {
+                    h2o_add_header_by_str(pool, headers, name->base, name->len, 0, NULL, value.base, value.len);
+                } else if (*err_desc == NULL) {
+                    *err_desc = h2o_hpack_soft_err_too_many_headers;
+                }
             }
         }
     Next:;
     } while (src != src_end);
 
-    if (*err_desc) {
+    if (*err_desc != NULL) {
         return H2O_HTTP2_ERROR_INVALID_HEADER_CHAR;
     }
     return 0;

--- a/t/80hpack-bomb.t
+++ b/t/80hpack-bomb.t
@@ -22,7 +22,7 @@ subtest "decoded header count soft limit" => sub {
 
     ($headers, $body) = get_with_headers(101);
     like $headers, qr{^HTTP/2 400\s*$}m, "request exceeding the decoded header limit fails";
-    like $body, qr{too many headers}, "soft error is reported";
+    like $body, qr{headers too long}, "soft error is reported";
 };
 
 done_testing;

--- a/t/80hpack-bomb.t
+++ b/t/80hpack-bomb.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use t::Util;
+
+plan skip_all => 'curl not found'
+    unless prog_exists('curl');
+plan skip_all => 'curl does not support HTTP/2'
+    unless curl_supports_http2();
+
+my $server = spawn_h2o(<< "EOT");
+hosts:
+  default:
+    paths:
+      "/":
+        file.dir: @{[DOC_ROOT]}
+EOT
+
+subtest "decoded header count soft limit" => sub {
+    my ($headers, $body) = get_with_headers(95);
+    like $headers, qr{^HTTP/2 200\s*$}m, "request within the decoded header limit succeeds";
+
+    ($headers, $body) = get_with_headers(101);
+    like $headers, qr{^HTTP/2 400\s*$}m, "request exceeding the decoded header limit fails";
+    like $body, qr{too many headers}, "soft error is reported";
+};
+
+done_testing;
+
+sub get_with_headers {
+    my $num_headers = shift;
+    my $headers = join " ", map { "-H 'x-hpack-bomb-$_: v'" } 1..$num_headers;
+    return run_prog("curl --http2 --insecure --silent --show-error --dump-header /dev/stderr $headers https://127.0.0.1:$server->{tls_port}/");
+}

--- a/t/80issues595.t
+++ b/t/80issues595.t
@@ -28,9 +28,10 @@ subtest "trailing HEADERS with CONTINUATION" => sub {
     my $doit = sub {
         my ($proto, $opts, $port) = @_;
         my $cmd = "nghttp $opts -M 1 -m 3 -H ':method: GET' -d /dev/null";
+        my $value = "X" x 1024;
         $cmd .= join "", map {
-            " --trailer 'foo$_: 0123456789abcdef:$_'"
-        } 1..1000;
+            " --trailer 'foo$_: $value'"
+        } 1..20;
         $cmd .= " '$proto://127.0.0.1:$port/'";
         my $resp = `$cmd`;
         is $resp, "hello\n" x 3, $proto;


### PR DESCRIPTION
Specifically,
* Close the HTTP/2 or HTTP/3 connection if a request carries more than 1000 fields.
* Otherwise, send 400 error if a request carries more than 100 fields.