### PR TITLE
add support for cross-layer tracing

### DIFF
--- a/deps/picotls/include/picotls.h
+++ b/deps/picotls/include/picotls.h
@@ -1466,6 +1466,9 @@ typedef struct st_ptls_log_getsni_t {
             break;                                                                                                                 \
         PTLS_LOG__DO_LOG(picotls, name, conn_state, ptls_log_getsni_ptls(_tls), 1, {                                               \
             PTLS_LOG_ELEMENT_PTR(tls, _tls);                                                                                       \
+            if (conn_state->conn_id != 0) {                                                                                        \
+                PTLS_LOG_ELEMENT_UNSIGNED(conn_id, conn_state->conn_id);                                                           \
+            }                                                                                                                      \
             do {                                                                                                                   \
                 block                                                                                                              \
             } while (0);                                                                                                           \
@@ -1550,6 +1553,10 @@ typedef struct st_ptls_log_conn_state_t {
      * represents the peer address using ipv6; ipv4 addresses are stored using the mapped form (::ffff:192.0.2.1)
      */
     uint8_t address[16];
+    /**
+     * application-supplied identifier; emitted as `conn_id` if set to a non-zero value
+     */
+    uint64_t conn_id;
     struct st_ptls_log_state_t state;
 } ptls_log_conn_state_t;
 
@@ -1577,9 +1584,10 @@ extern struct st_ptls_log_t {
 } ptls_log;
 
 /**
- * initializes a ptls_log_conn_state_t
+ * initializes a ptls_log_conn_state_t. `conn_id` and `peeraddr` (of type struct sockaddr) are optional; pass 0 and NULL
+ * respectively when unavailable.
  */
-void ptls_log_init_conn_state(ptls_log_conn_state_t *state, void (*random_bytes)(void *, size_t));
+void ptls_log_init_conn_state(ptls_log_conn_state_t *state, void (*random_bytes)(void *, size_t), uint64_t conn_id, void *peeraddr);
 /**
  * forces recalculation of the log state (should be called when SNI is determined)
  */

--- a/deps/picotls/lib/picotls.c
+++ b/deps/picotls/lib/picotls.c
@@ -5203,7 +5203,7 @@ static ptls_t *new_instance(ptls_context_t *ctx, int is_server)
     if (ptls_log_conn_state_override != NULL) {
         tls->log_state = *ptls_log_conn_state_override;
     } else {
-        ptls_log_init_conn_state(&tls->log_state, ctx->random_bytes);
+        ptls_log_init_conn_state(&tls->log_state, ctx->random_bytes, 0, NULL);
     }
 #endif
 
@@ -7196,15 +7196,29 @@ int ptls_log__do_write_end(struct st_ptls_log_point_t *point, struct st_ptls_log
 
 #endif
 
-void ptls_log_init_conn_state(ptls_log_conn_state_t *state, void (*random_bytes)(void *, size_t))
+void ptls_log_init_conn_state(ptls_log_conn_state_t *state, void (*random_bytes)(void *, size_t), uint64_t conn_id, void *_peeraddr)
 {
+    struct sockaddr *peeraddr = _peeraddr;
     uint32_t r;
     random_bytes(&r, sizeof(r));
 
     *state = (ptls_log_conn_state_t){
         .random_ = (float)r / ((uint64_t)UINT32_MAX + 1), /* [0..1), so that any(r) < sample_ratio where sample_ratio is [0..1] */
         .address = {0}, /* inaddr6_any */
+        .conn_id = conn_id,
     };
+    if (peeraddr != NULL) {
+        switch (peeraddr->sa_family) {
+        case AF_INET: /* store as v6-mapped v4 address */
+            ptls_build_v4_mapped_v6_address(state->address, &((struct sockaddr_in *)peeraddr)->sin_addr);
+            break;
+        case AF_INET6:
+            memcpy(state->address, ((struct sockaddr_in6 *)peeraddr)->sin6_addr.s6_addr, sizeof(state->address));
+            break;
+        default:
+            break;
+        }
+    }
 }
 
 size_t ptls_log_num_lost(void)

--- a/deps/quicly/include/quicly.h
+++ b/deps/quicly/include/quicly.h
@@ -835,6 +835,8 @@ typedef struct st_quicly_stats_t {
     apply(cc.cwnd_minimum, "cc.cwnd-minimum")                                                                                      \
     apply(cc.cwnd_maximum, "cc.cwnd-maximum")                                                                                      \
     apply(cc.num_loss_episodes, "cc.num-loss-episodes")                                                                            \
+    apply(cc.num_loss_episodes_undone, "cc.num-loss-episodes-undone")                                                              \
+    apply(cc.num_loss_episodes_undone_in_startup, "cc.num-loss-episodes-undone-in-startup")                                        \
     apply(cc.num_ecn_loss_episodes, "cc.num-ecn-loss-episodes")                                                                    \
     apply(delivery_rate.latest, "delivery-rate.latest")                                                                            \
     apply(delivery_rate.smoothed, "delivery-rate.smoothed")                                                                        \
@@ -1611,6 +1613,9 @@ extern const quicly_stream_callbacks_t quicly_stream_noop_callbacks;
             if (_c->stash.now != 0)                                                                                                \
                 PTLS_LOG_ELEMENT_SIGNED(time, _c->stash.now);                                                                      \
             PTLS_LOG_ELEMENT_PTR(conn, _c);                                                                                        \
+            if (conn_state->conn_id != 0) {                                                                                        \
+                PTLS_LOG_ELEMENT_UNSIGNED(conn_id, conn_state->conn_id);                                                           \
+            }                                                                                                                      \
             do {                                                                                                                   \
                 _block                                                                                                             \
             } while (0);                                                                                                           \

--- a/deps/quicly/include/quicly/cc.h
+++ b/deps/quicly/include/quicly/cc.h
@@ -117,6 +117,19 @@ typedef struct st_quicly_cc_t {
              * Number of bytes required to be acked in order to increase CWND by 1 MTU.
              */
             uint32_t bytes_per_mtu_increase;
+            /**
+             * State to undo a recovery episode when all packets deemed lost are later acknowledged. The packet number range being
+             * tracked for undo is: start_pn <= pn < recovery_end. `num_packets_lost` counts packets in that range that were
+             * declared lost and have not yet been late-ACKed. Other fields retain the values to be restored when
+             * `num_packets_lost` becomes zero.
+             */
+            struct {
+                uint64_t start_pn;
+                uint32_t num_packets_lost;
+                uint32_t cwnd;
+                uint32_t ssthresh;
+                uint32_t bytes_per_mtu_increase;
+            } undo;
         } pico;
         /**
          * State information for CUBIC congestion control.
@@ -194,6 +207,14 @@ typedef struct st_quicly_cc_t {
      */
     uint32_t num_loss_episodes;
     /**
+     * Total number of loss episodes undone.
+     */
+    uint32_t num_loss_episodes_undone;
+    /**
+     * Total number of loss episodes undone that occurred during startup.
+     */
+    uint32_t num_loss_episodes_undone_in_startup;
+    /**
      * Total number of loss episodes that was reported only by ECN (hence no packet loss).
      */
     uint32_t num_ecn_loss_episodes;
@@ -232,6 +253,10 @@ struct st_quicly_cc_type_t {
      * Switches the underlying algorithm of `cc` to that of `cc_switch`, returning a boolean whether the operation was successful.
      */
     int (*cc_switch)(quicly_cc_t *cc);
+    /**
+     * [optional] Called when a packet previously detected as lost is later acknowledged.
+     */
+    void (*cc_on_late_ack)(quicly_cc_t *cc, uint64_t pn, int64_t now);
     /**
      * [optional] called by quicly to enter jumpstart.
      */

--- a/deps/quicly/include/quicly/loss.h
+++ b/deps/quicly/include/quicly/loss.h
@@ -126,6 +126,10 @@ typedef struct quicly_loss_t {
      */
     quicly_loss_thresholds_t thresholds;
     /**
+     * Minimum packet number of a late-acked packet that can relax reordering tolerance.
+     */
+    uint64_t min_pn_to_relax_reorder_tolerance;
+    /**
      * The number of consecutive PTOs (PTOs that have fired without receiving an ack).
      */
     int8_t pto_count;
@@ -179,8 +183,9 @@ static void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 /**
  * called when an ACK is received
  */
-static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, size_t epoch, int64_t now, int64_t sent_at,
-                                        uint64_t ack_delay_encoded, quicly_loss_ack_received_kind_t kind);
+static void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, uint64_t largest_late_acked, uint64_t next_pn,
+                                        size_t epoch, int64_t now, int64_t sent_at, uint64_t ack_delay_encoded,
+                                        quicly_loss_ack_received_kind_t kind);
 /* This function updates the loss detection timer and indicates to the caller how many packets should be sent.
  * After calling this function, app should:
  *  * send min_packets_to_send number of packets immediately. min_packets_to_send should never be 0.
@@ -256,6 +261,7 @@ inline void quicly_loss_init(quicly_loss_t *r, const quicly_loss_conf_t *conf, u
                          .max_ack_delay = max_ack_delay,
                          .ack_delay_exponent = ack_delay_exponent,
                          .thresholds = {.use_packet_based = 1, .time_based_percentile = 1024 / 8 /* start from 1/8 RTT */},
+                         .min_pn_to_relax_reorder_tolerance = 0,
                          .pto_count = 0,
                          .time_of_last_packet_sent = 0,
                          .largest_acked_packet_plus1 = {.per_epoch = {0}, .all_ = 0},
@@ -341,12 +347,25 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 #undef SET_ALARM
 }
 
-inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, size_t epoch, int64_t now, int64_t sent_at,
-                                        uint64_t ack_delay_encoded, quicly_loss_ack_received_kind_t kind)
+inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly_acked, uint64_t largest_late_acked,
+                                        uint64_t next_pn, size_t epoch, int64_t now, int64_t sent_at, uint64_t ack_delay_encoded,
+                                        quicly_loss_ack_received_kind_t kind)
 {
     /* Reset PTO count if anything is newly acked, and if sender is not speculatively probing at a tail */
     if (largest_newly_acked != UINT64_MAX && r->pto_count > 0)
         r->pto_count = 0;
+
+    /* Adjust loss detection thresholds when receiving a late ACK above the current relaxation threshold. */
+    if (kind == QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK && largest_late_acked != UINT64_MAX &&
+        r->min_pn_to_relax_reorder_tolerance <= largest_late_acked) {
+        if (r->thresholds.use_packet_based) {
+            r->thresholds.use_packet_based = 0;
+        } else {
+            if ((r->thresholds.time_based_percentile *= 2) > 1024)
+                r->thresholds.time_based_percentile = 1024;
+        }
+        r->min_pn_to_relax_reorder_tolerance = next_pn;
+    }
 
     /* If largest newly acked is not larger than before, skip RTT sample */
     if (largest_newly_acked == UINT64_MAX || r->largest_acked_packet_plus1.per_epoch[epoch] > largest_newly_acked)
@@ -368,16 +387,6 @@ inline void quicly_loss_on_ack_received(quicly_loss_t *r, uint64_t largest_newly
         ack_delay_millisecs = *r->max_ack_delay;
     quicly_rtt_update(&r->rtt, (uint32_t)(now - sent_at), ack_delay_millisecs);
 
-    /* Adjust loss detection thresholds when receiving a late ack. The strategy is, for each ACK carrying a late ack, first disable
-     * packet-based detection, then double the time-based threshold until it reaches 1 RTT. */
-    if (kind == QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK) {
-        if (r->thresholds.use_packet_based) {
-            r->thresholds.use_packet_based = 0;
-        } else {
-            if ((r->thresholds.time_based_percentile *= 2) > 1024)
-                r->thresholds.time_based_percentile = 1024;
-        }
-    }
 }
 
 inline quicly_error_t quicly_loss_on_alarm(quicly_loss_t *r, int64_t now, uint32_t max_ack_delay, int is_1rtt_only,

--- a/deps/quicly/lib/cc-cubic.c
+++ b/deps/quicly/lib/cc-cubic.c
@@ -206,7 +206,13 @@ static void cubic_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwn
     cubic_reset(cc, initcwnd);
 }
 
-quicly_cc_type_t quicly_cc_type_cubic = {"cubic",         &quicly_cc_cubic_init,          cubic_on_acked,
-                                         cubic_on_lost,   cubic_on_persistent_congestion, cubic_on_sent,
-                                         cubic_on_switch, quicly_cc_jumpstart_enter};
+quicly_cc_type_t quicly_cc_type_cubic = {"cubic",
+                                         &quicly_cc_cubic_init,
+                                         cubic_on_acked,
+                                         cubic_on_lost,
+                                         cubic_on_persistent_congestion,
+                                         cubic_on_sent,
+                                         cubic_on_switch,
+                                         NULL,
+                                         quicly_cc_jumpstart_enter};
 quicly_init_cc_t quicly_cc_cubic_init = {cubic_init};

--- a/deps/quicly/lib/cc-pico.c
+++ b/deps/quicly/lib/cc-pico.c
@@ -116,11 +116,30 @@ static void pico_on_lost(quicly_cc_t *cc, const quicly_loss_t *loss, uint32_t by
     /* Nothing to do if loss is in recovery window (modulo when exiting rapid start, in which case CWND is further reduced relative
      * to the number of bytes lost. */
     if (lost_pn < cc->recovery_end) {
+        if (bytes != 0 && cc->state.pico.undo.num_packets_lost != 0)
+            ++cc->state.pico.undo.num_packets_lost;
         if (cc->num_loss_episodes == 1 && quicly_cc_rapid_start_is_enabled(&cc->rapid_start)) {
             quicly_cc_rapid_start_on_recovery(&cc->rapid_start, &cc->cwnd, 0, bytes);
             goto ClampMinAndUpdateMetrics;
         }
         return;
+    }
+
+    /* Zero-byte congestion reports are ECN signals, not lost packets. They still enter recovery below, but cannot be undone by
+     * late ACKs because no packet was deemed lost. */
+    if (bytes != 0) {
+        cc->state.pico.undo.num_packets_lost = 1;
+        cc->state.pico.undo.start_pn = lost_pn;
+        cc->state.pico.undo.cwnd = cc->cwnd;
+        if (quicly_cc_in_jumpstart(cc)) {
+            cc->state.pico.undo.cwnd /= 2;
+            if (cc->state.pico.undo.cwnd < cc->cwnd_initial)
+                cc->state.pico.undo.cwnd = cc->cwnd_initial;
+        }
+        cc->state.pico.undo.ssthresh = cc->ssthresh;
+        cc->state.pico.undo.bytes_per_mtu_increase = cc->state.pico.bytes_per_mtu_increase;
+    } else {
+        cc->state.pico.undo.num_packets_lost = 0;
     }
 
     cc->recovery_end = next_pn;
@@ -180,6 +199,33 @@ ClampMinAndUpdateMetrics:
 
     if (cc->cwnd_minimum > cc->cwnd)
         cc->cwnd_minimum = cc->cwnd;
+}
+
+static void pico_on_late_ack(quicly_cc_t *cc, uint64_t pn, int64_t now)
+{
+    if (!(cc->state.pico.undo.start_pn <= pn && pn < cc->recovery_end))
+        return;
+    if (cc->state.pico.undo.num_packets_lost == 0)
+        return;
+
+    if (--cc->state.pico.undo.num_packets_lost != 0)
+        return;
+
+    int was_in_startup = cc->state.pico.undo.ssthresh == UINT32_MAX;
+    cc->cwnd = cc->state.pico.undo.cwnd;
+    cc->ssthresh = cc->state.pico.undo.ssthresh;
+    cc->state.pico.stash = 0;
+    cc->state.pico.bytes_per_mtu_increase = cc->state.pico.undo.bytes_per_mtu_increase;
+    cc->recovery_end = 0;
+    --cc->num_loss_episodes;
+    ++cc->num_loss_episodes_undone;
+    if (was_in_startup) {
+        ++cc->num_loss_episodes_undone_in_startup;
+        cc->cwnd_exiting_slow_start = 0;
+        cc->exit_slow_start_at = INT64_MAX;
+        quicly_cc_jumpstart_reset(cc);
+        cc->rapid_start.newest_rtt_sample_until = 0;
+    }
 }
 
 static void pico_on_persistent_congestion(quicly_cc_t *cc, const quicly_loss_t *loss, int64_t now)
@@ -246,7 +292,14 @@ static void pico_init(quicly_init_cc_t *self, quicly_cc_t *cc, uint32_t initcwnd
     pico_reset(cc, initcwnd);
 }
 
-quicly_cc_type_t quicly_cc_type_pico = {"pico",         &quicly_cc_pico_init,          pico_on_acked,
-                                        pico_on_lost,   pico_on_persistent_congestion, pico_on_sent,
-                                        pico_on_switch, quicly_cc_jumpstart_enter,     pico_enable_rapid_start};
+quicly_cc_type_t quicly_cc_type_pico = {"pico",
+                                        &quicly_cc_pico_init,
+                                        pico_on_acked,
+                                        pico_on_lost,
+                                        pico_on_persistent_congestion,
+                                        pico_on_sent,
+                                        pico_on_switch,
+                                        pico_on_late_ack,
+                                        quicly_cc_jumpstart_enter,
+                                        pico_enable_rapid_start};
 quicly_init_cc_t quicly_cc_pico_init = {pico_init};

--- a/deps/quicly/lib/cc-reno.c
+++ b/deps/quicly/lib/cc-reno.c
@@ -143,6 +143,7 @@ quicly_cc_type_t quicly_cc_type_reno = {"reno",
                                         quicly_cc_reno_on_persistent_congestion,
                                         quicly_cc_reno_on_sent,
                                         reno_on_switch,
+                                        NULL,
                                         quicly_cc_jumpstart_enter};
 quicly_init_cc_t quicly_cc_reno_init = {reno_init};
 

--- a/deps/quicly/lib/quicly.c
+++ b/deps/quicly/lib/quicly.c
@@ -2740,24 +2740,19 @@ static quicly_conn_t *create_connection(quicly_context_t *ctx, uint32_t protocol
     if (ctx->transport_params.max_datagram_frame_size != 0)
         assert(ctx->receive_datagram_frame != NULL);
 
-    /* build log state */
-    ptls_log_init_conn_state(&log_state_override, ctx->tls->random_bytes);
-    switch (remote_addr->sa_family) {
-    case AF_INET:
-        ptls_build_v4_mapped_v6_address(&log_state_override.address, &((struct sockaddr_in *)remote_addr)->sin_addr);
-        break;
-    case AF_INET6:
-        memcpy(log_state_override.address, ((struct sockaddr_in6 *)remote_addr)->sin6_addr.s6_addr,
-               sizeof(log_state_override.address));
-        break;
-    default:
-        break;
+    /* build log state and override, unless already set by the caller */
+    if (ptls_log_conn_state_override == NULL) {
+        ptls_log_init_conn_state(&log_state_override, ctx->tls->random_bytes, 0, remote_addr);
+        ptls_log_conn_state_override = &log_state_override;
     }
 
     /* create TLS context */
-    ptls_log_conn_state_override = &log_state_override;
     tls = ptls_new(ctx->tls, server_name == NULL);
-    ptls_log_conn_state_override = NULL;
+
+    /* clear the override if we had set our own */
+    if (ptls_log_conn_state_override == &log_state_override)
+        ptls_log_conn_state_override = NULL;
+
     if (tls == NULL)
         return NULL;
     if (server_name != NULL && ptls_set_server_name(tls, server_name, strlen(server_name)) != 0) {
@@ -6271,6 +6266,7 @@ static quicly_error_t handle_ack_frame(quicly_conn_t *conn, struct st_quicly_han
     } largest_newly_acked = {UINT64_MAX, INT64_MAX};
     size_t bytes_acked = 0;
     int includes_ack_eliciting = 0, includes_late_ack = 0;
+    uint64_t largest_late_acked = UINT64_MAX;
     quicly_error_t ret;
 
     /* The flow is considered CC-limited if the packet was sent while `inflight >= 1/2 * CNWD` or acked under the same condition.
@@ -6339,7 +6335,10 @@ static quicly_error_t handle_ack_frame(quicly_conn_t *conn, struct st_quicly_han
                 if (sent->cc_bytes_in_flight == 0) {
                     is_late_ack = 1;
                     includes_late_ack = 1;
+                    largest_late_acked = pn_acked;
                     ++conn->super.stats.num_packets.late_acked;
+                    if (conn->egress.pn_path_start <= pn_acked && conn->egress.cc.type->cc_on_late_ack != NULL)
+                        conn->egress.cc.type->cc_on_late_ack(&conn->egress.cc, pn_acked, conn->stash.now);
                 }
             }
             ++conn->super.stats.num_packets.ack_received;
@@ -6394,8 +6393,8 @@ static quicly_error_t handle_ack_frame(quicly_conn_t *conn, struct st_quicly_han
 
     /* Update loss detection engine on ack. The function uses ack_delay only when the largest_newly_acked is also the largest acked
      * so far. So, it does not matter if the ack_delay being passed in does not apply to the largest_newly_acked. */
-    quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.pn, state->epoch, conn->stash.now,
-                                largest_newly_acked.sent_at, frame.ack_delay,
+    quicly_loss_on_ack_received(&conn->egress.loss, largest_newly_acked.pn, largest_late_acked, conn->egress.packet_number,
+                                state->epoch, conn->stash.now, largest_newly_acked.sent_at, frame.ack_delay,
                                 includes_ack_eliciting ? includes_late_ack ? QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK
                                                                            : QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING
                                                        : QUICLY_LOSS_ACK_RECEIVED_KIND_NON_ACK_ELICITING);

--- a/deps/quicly/t/cc.c
+++ b/deps/quicly/t/cc.c
@@ -19,8 +19,123 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-#include "quicly/cc.h"
+#include "quicly.h"
 #include "test.h"
+
+static void test_pico_undo_loss(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+    uint32_t bytes_per_mtu_increase = cc.state.pico.bytes_per_mtu_increase;
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.recovery_end == 20);
+    ok(cc.num_loss_episodes == 1);
+    ok(cc.state.pico.undo.num_packets_lost == 1);
+    ok(cc.cwnd < initcwnd);
+    ok(cc.ssthresh == cc.cwnd);
+    ok(cc.cwnd_exiting_slow_start == initcwnd);
+    ok(cc.exit_slow_start_at == 1000);
+
+    cc.type->cc_on_late_ack(&cc, 10, 1100);
+    ok(cc.recovery_end == 0);
+    ok(cc.num_loss_episodes == 0);
+    ok(cc.num_loss_episodes_undone == 1);
+    ok(cc.num_loss_episodes_undone_in_startup == 1);
+    ok(cc.state.pico.undo.num_packets_lost == 0);
+    ok(cc.cwnd == initcwnd);
+    ok(cc.ssthresh == UINT32_MAX);
+    ok(cc.state.pico.bytes_per_mtu_increase == bytes_per_mtu_increase);
+    ok(cc.cwnd_exiting_slow_start == 0);
+    ok(cc.exit_slow_start_at == INT64_MAX);
+}
+
+static void test_pico_undo_multiple_losses(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    uint32_t reduced_cwnd = cc.cwnd;
+    cc.type->cc_on_lost(&cc, &loss, mtu, 11, 20, 1001, mtu);
+    ok(cc.state.pico.undo.num_packets_lost == 2);
+
+    cc.type->cc_on_late_ack(&cc, 9, 1099);
+    ok(cc.state.pico.undo.num_packets_lost == 2);
+    ok(cc.recovery_end == 20);
+
+    cc.type->cc_on_late_ack(&cc, 10, 1100);
+    ok(cc.state.pico.undo.num_packets_lost == 1);
+    ok(cc.recovery_end == 20);
+    ok(cc.cwnd == reduced_cwnd);
+    ok(cc.num_loss_episodes == 1);
+
+    cc.type->cc_on_late_ack(&cc, 11, 1101);
+    ok(cc.state.pico.undo.num_packets_lost == 0);
+    ok(cc.recovery_end == 0);
+    ok(cc.cwnd == initcwnd);
+    ok(cc.ssthresh == UINT32_MAX);
+    ok(cc.num_loss_episodes == 0);
+    ok(cc.num_loss_episodes_undone == 1);
+    ok(cc.num_loss_episodes_undone_in_startup == 1);
+}
+
+static void test_pico_undo_rapid_start_loss(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+    cc.type->enable_rapid_start(&cc, 900);
+    ok(quicly_cc_rapid_start_is_enabled(&cc.rapid_start));
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.rapid_start.newest_rtt_sample_until == -1);
+
+    cc.type->cc_on_late_ack(&cc, 10, 1100);
+    ok(cc.rapid_start.newest_rtt_sample_until == 0);
+    ok(cc.recovery_end == 0);
+    ok(cc.cwnd == initcwnd);
+    ok(cc.ssthresh == UINT32_MAX);
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 20, 30, 1200, mtu);
+    ok(cc.cwnd == initcwnd / 2);
+    ok(cc.ssthresh == cc.cwnd);
+}
+
+static void test_pico_undo_jumpstart_loss(void)
+{
+    quicly_cc_t cc;
+    quicly_loss_t loss = {.rtt = {.latest = 100, .smoothed = 100, .minimum = 100, .variance = 0}};
+    uint32_t mtu = 1200, initcwnd = 10 * mtu, jumpcwnd = 24 * mtu;
+
+    quicly_cc_pico_init.cb(&quicly_cc_pico_init, &cc, initcwnd, 0);
+    cc.type->cc_jumpstart(&cc, jumpcwnd, 10);
+    ok(quicly_cc_in_jumpstart(&cc));
+    ok(cc.cwnd == jumpcwnd);
+
+    cc.type->cc_on_lost(&cc, &loss, mtu, 10, 20, 1000, mtu);
+    ok(cc.state.pico.undo.cwnd == jumpcwnd / 2);
+    ok(cc.cwnd < jumpcwnd);
+    ok(!quicly_cc_in_jumpstart(&cc));
+
+    cc.type->cc_on_late_ack(&cc, 10, 1100);
+    ok(cc.recovery_end == 0);
+    ok(cc.cwnd == jumpcwnd / 2);
+    ok(cc.ssthresh == UINT32_MAX);
+
+    cc.type->cc_on_acked(&cc, &loss, mtu, 11, 18 * mtu, 1, 20, 1200, mtu);
+    ok(cc.cwnd != 18 * mtu);
+    ok(cc.cwnd_exiting_jumpstart == 0);
+    ok(!quicly_cc_in_jumpstart(&cc));
+}
 
 static void test_rapid_start(void)
 {
@@ -58,4 +173,8 @@ static void test_rapid_start(void)
 void test_cc(void)
 {
     subtest("rapid-start", test_rapid_start);
+    subtest("pico-undo-loss", test_pico_undo_loss);
+    subtest("pico-undo-multiple-losses", test_pico_undo_multiple_losses);
+    subtest("pico-undo-rapid-start-loss", test_pico_undo_rapid_start_loss);
+    subtest("pico-undo-jumpstart-loss", test_pico_undo_jumpstart_loss);
 }

--- a/deps/quicly/t/loss.c
+++ b/deps/quicly/t/loss.c
@@ -44,7 +44,8 @@ static void acked(quicly_loss_t *loss, uint64_t pn, size_t epoch)
     int64_t sent_at = sent->sent_at;
     ok(quicly_sentmap_update(&loss->sentmap, &iter, QUICLY_SENTMAP_EVENT_ACKED) == 0);
 
-    quicly_loss_on_ack_received(loss, pn, epoch, now, sent_at, 0, 1);
+    quicly_loss_on_ack_received(loss, pn, UINT64_MAX, pn + 1, epoch, now, sent_at, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING);
 }
 
 static void test_time_detection(void)
@@ -184,9 +185,50 @@ static void test_slow_cert_verify(void)
     quicly_loss_dispose(&loss);
 }
 
+static void test_late_ack_threshold_adjustment(void)
+{
+    quicly_loss_t loss;
+
+    now = 0;
+
+    quicly_loss_init(&loss, &quicly_spec_context.loss, 20, &quicly_spec_context.transport_params.max_ack_delay,
+                     &quicly_spec_context.transport_params.ack_delay_exponent);
+
+    ok(loss.min_pn_to_relax_reorder_tolerance == 0);
+    ok(loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 8);
+
+    quicly_loss_on_ack_received(&loss, 100, 100, 200, QUICLY_EPOCH_1RTT, now, now - 20, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK);
+    ok(loss.min_pn_to_relax_reorder_tolerance == 200);
+    ok(!loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 8);
+
+    quicly_loss_on_ack_received(&loss, 101, 101, 200, QUICLY_EPOCH_1RTT, now, now - 20, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK);
+    ok(loss.min_pn_to_relax_reorder_tolerance == 200);
+    ok(!loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 8);
+
+    quicly_loss_on_ack_received(&loss, 250, 199, 300, QUICLY_EPOCH_1RTT, now, now - 20, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK);
+    ok(loss.min_pn_to_relax_reorder_tolerance == 200);
+    ok(!loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 8);
+
+    quicly_loss_on_ack_received(&loss, 200, 200, 300, QUICLY_EPOCH_1RTT, now, now - 20, 0,
+                                QUICLY_LOSS_ACK_RECEIVED_KIND_ACK_ELICITING_LATE_ACK);
+    ok(loss.min_pn_to_relax_reorder_tolerance == 300);
+    ok(!loss.thresholds.use_packet_based);
+    ok(loss.thresholds.time_based_percentile == 1024 / 4);
+
+    quicly_loss_dispose(&loss);
+}
+
 void test_loss(void)
 {
     subtest("time-detection", test_time_detection);
     subtest("pn-detection", test_pn_detection);
     subtest("slow-cert-verify", test_slow_cert_verify);
+    subtest("late-ack-threshold-adjustment", test_late_ack_threshold_adjustment);
 }

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -728,17 +728,7 @@ h2o_socket_t *h2o_evloop_socket_accept(h2o_socket_t *_listener)
      * https://github.com/h2o/h2o/pull/2542#issuecomment-760700859 */
     set_nodelay_if_likely_tcp(fd, &peeraddr.sa);
 
-    ptls_log_init_conn_state(&sock->_log_state, ptls_openssl_random_bytes);
-    switch (peeraddr.sa.sa_family) {
-    case AF_INET: /* store as v6-mapped v4 address */
-        ptls_build_v4_mapped_v6_address(&sock->_log_state.address, &peeraddr.sin4.sin_addr);
-        break;
-    case AF_INET6:
-        memcpy(sock->_log_state.address, peeraddr.sin6.sin6_addr.s6_addr, sizeof(sock->_log_state.address));
-        break;
-    default:
-        break;
-    }
+    ptls_log_init_conn_state(&sock->_log_state, ptls_openssl_random_bytes, 0, &peeraddr.sa);
 
     return sock;
 }

--- a/lib/common/socket/uv-binding.c.h
+++ b/lib/common/socket/uv-binding.c.h
@@ -377,7 +377,7 @@ h2o_socket_t *h2o_uv_socket_create(uv_handle_t *handle, uv_close_cb close_cb)
     sock->close_cb = close_cb;
     sock->handle->data = sock;
     h2o_timer_init(&sock->write_cb_timer, on_call_write_success);
-    ptls_log_init_conn_state(&sock->super._log_state, ptls_openssl_random_bytes);
+    ptls_log_init_conn_state(&sock->super._log_state, ptls_openssl_random_bytes, 0, NULL);
     return &sock->super;
 }
 

--- a/lib/http3/server.c
+++ b/lib/http3/server.c
@@ -2194,13 +2194,18 @@ h2o_http3_conn_t *h2o_http3_server_accept(h2o_http3_server_ctx_t *ctx, quicly_ad
         quicly_cc_calc_initial_cwnd(ctx->super.quic->initcwnd_packets, ctx->super.quic->transport_params.max_udp_payload_size) *
         4; /* sending jumpstart token is meaningless until CWND has grown 2x of IW, which translates to 4x data being sent */
 
-    /* accept connection */
     assert(ctx->super.next_cid != NULL && "to set next_cid, h2o_quic_set_context_identifier must be called");
+
+    /* accept connection */
+    ptls_log_conn_state_t log_state_override;
+    ptls_log_init_conn_state(&log_state_override, ctx->super.quic->tls->random_bytes, conn->super.id, &srcaddr->sa);
+    ptls_log_conn_state_override = &log_state_override;
     quicly_conn_t *qconn;
     quicly_error_t accept_ret = quicly_accept(
         &qconn, ctx->super.quic, &destaddr->sa, &srcaddr->sa, packet, address_token, ctx->super.next_cid,
         &conn->handshake_properties,
         &conn->h3 /* back pointer is set up here so that callbacks being called while parsing ClientHello can refer to `conn` */);
+    ptls_log_conn_state_override = NULL;
     if (accept_ret != 0) {
         h2o_http3_conn_t *ret = NULL;
         if (accept_ret == QUICLY_ERROR_DECRYPTION_FAILED)


### PR DESCRIPTION
Inject the connection identifier maintained by h2o to picotls and quicly, so that when using `h2olog` all events related to a connection can be grouped just by looking at the `conn_id` field.

Builds on top of https://github.com/h2o/picotls/pull/604 and https://github.com/h2o/quicly/pull/669.