### PR TITLE
t: undef $server instance to avoid deadlock

### DIFF
--- a/t/80hpack-bomb.t
+++ b/t/80hpack-bomb.t
@@ -25,6 +25,8 @@ subtest "decoded header count soft limit" => sub {
     like $body, qr{headers too long}, "soft error is reported";
 };
 
+undef $server;
+
 done_testing;
 
 sub get_with_headers {


### PR DESCRIPTION
On Ubuntu 24.04, with perl libraries from the system, there appears to be a deadlock on destruction, something like:

* `get_with_headers` captures `$server`.
* `$server` is therefore not destroyed when the script finishes.
* perl waits for child processes to die, but the h2o child processes is still alive because of the above.

Applying the same solution as b24bb47c19b07("undef instances to avoid deadlock in global destruction") fixes the issue.

This is not a big deal, since other tests do not work with perl libraries from the system, we need Net::DNS::Nameserver from CPAN, which seems to make the issue disappear.