### PR TITLE
fix race condition inside the memcached-based session manager

### DIFF
--- a/lib/common/memcached.c
+++ b/lib/common/memcached.c
@@ -102,7 +102,6 @@ static void free_req(h2o_memcached_req_t *req)
     if (__sync_sub_and_fetch(&req->refcnt, 1) != 0)
         return;
 
-    assert(req->refcnt == 0);
     assert(!h2o_linklist_is_linked(&req->pending));
     switch (req->type) {
     case REQ_TYPE_GET:

--- a/lib/common/memcached.c
+++ b/lib/common/memcached.c
@@ -51,6 +51,7 @@ enum en_h2o_memcached_req_type_t { REQ_TYPE_GET, REQ_TYPE_SET, REQ_TYPE_DELETE }
 
 struct st_h2o_memcached_req_t {
     enum en_h2o_memcached_req_type_t type;
+    int refcnt;
     h2o_linklist_t pending;
     h2o_linklist_t inflight;
     union {
@@ -80,6 +81,7 @@ static h2o_memcached_req_t *create_req(h2o_memcached_context_t *ctx, enum en_h2o
     h2o_memcached_req_t *req = h2o_mem_alloc(offsetof(h2o_memcached_req_t, key.base) + ctx->prefix.len +
                                              (encode_key ? (key.len + 2) / 3 * 4 + 1 : key.len));
     req->type = type;
+    req->refcnt = 1;
     req->pending = (h2o_linklist_t){NULL};
     req->inflight = (h2o_linklist_t){NULL};
     memset(&req->data, 0, sizeof(req->data));
@@ -97,6 +99,10 @@ static h2o_memcached_req_t *create_req(h2o_memcached_context_t *ctx, enum en_h2o
 
 static void free_req(h2o_memcached_req_t *req)
 {
+    if (__sync_sub_and_fetch(&req->refcnt, 1) != 0)
+        return;
+
+    assert(req->refcnt == 0);
     assert(!h2o_linklist_is_linked(&req->pending));
     switch (req->type) {
     case REQ_TYPE_GET:
@@ -115,6 +121,11 @@ static void free_req(h2o_memcached_req_t *req)
         break;
     }
     free(req);
+}
+
+static void retain_req(h2o_memcached_req_t *req)
+{
+    __sync_add_and_fetch(&req->refcnt, 1);
 }
 
 static void discard_req(h2o_memcached_req_t *req)
@@ -179,30 +190,27 @@ static void *writer_main(void *_conn)
 
             switch (req->type) {
             case REQ_TYPE_GET:
+                retain_req(req);
                 pthread_mutex_lock(&conn->mutex);
                 h2o_linklist_insert(&conn->inflight, &req->inflight);
                 pthread_mutex_unlock(&conn->mutex);
-                if ((err = yrmcds_get(&conn->yrmcds, req->key.base, req->key.len, 0, &req->data.get.serial)) != YRMCDS_OK)
-                    goto Error;
+                err = yrmcds_get(&conn->yrmcds, req->key.base, req->key.len, 0, &req->data.get.serial);
                 break;
             case REQ_TYPE_SET:
                 err = yrmcds_set(&conn->yrmcds, req->key.base, req->key.len, req->data.set.value.base, req->data.set.value.len, 0,
                                  req->data.set.expiration, 0, !conn->yrmcds.text_mode, NULL);
-                discard_req(req);
-                if (err != YRMCDS_OK)
-                    goto Error;
                 break;
             case REQ_TYPE_DELETE:
                 err = yrmcds_remove(&conn->yrmcds, req->key.base, req->key.len, !conn->yrmcds.text_mode, NULL);
-                discard_req(req);
-                if (err != YRMCDS_OK)
-                    goto Error;
                 break;
             default:
                 h2o_error_printf("[lib/common/memcached.c] unknown type:%d\n", (int)req->type);
                 err = YRMCDS_NOT_IMPLEMENTED;
-                goto Error;
+                break;
             }
+            free_req(req);
+            if (err != YRMCDS_OK)
+                goto Error;
 
             pthread_mutex_lock(&conn->ctx->mutex);
         }


### PR DESCRIPTION
yrmcds_get assigns the request serial and writes the command within a single call. The caller cannot obtain the serial early enough to insert the request into the inflight list only after serial assignment but before the command can be answered. Therefore, writer_main must publish a GET request to the inflight list before calling yrmcds_get, so that the reader thread can match a response that arrives immediately.

That ordering means the request is visible to the reader while the writer is still inside yrmcds_get. If the reader enters teardown in that window, it can remove the request from inflight and enqueue callback delivery; the receiver can then free the request while the writer still needs it.

Therefore, hold a writer-side reference while the request is inflight, and release only that reference after the send attempt completes. The inflight/callback path keeps the remaining reference and performs the final release. SET and DELETE continue to be released on the writer side after their send attempts.

Full trace of the crash:
```
2026-06-16T04:53:25.2747758Z [0m[36m# t/40memcached-session-resumption.t --------------------------------
2026-06-16T04:53:25.2759156Z [0m  0.195886 # Subtest: binary
2026-06-16T04:53:25.2760336Z   0.299337 spawning memcached... done
2026-06-16T04:53:25.2761650Z   0.299943 Use of uninitialized value $listen_quic in concatenation (.) or string at t/Util.pm line 303.
2026-06-16T04:53:25.2763413Z   0.422171 spawning /home/ci/h2o... [INFO] raised RLIMIT_NOFILE to 1024
2026-06-16T04:53:25.2766721Z   0.430384 [lib/common/memcached.c] connected to memcached at 127.0.0.1:33115
2026-06-16T04:53:25.2767680Z   0.433105 h2o server (pid:13220) is ready to serve requests with 2 threads
2026-06-16T04:53:25.2774939Z   0.473069 fetch-ocsp-response (using OpenSSL 3.0.13 30 Jan 2024 (Library: OpenSSL 3.0.13 30 Jan 2024))
2026-06-16T04:53:25.2776140Z   0.496453 failed to extract ocsp URI from /tmp/fdF0WWr7nc/cert.crt
2026-06-16T04:53:25.2777171Z   0.497292 [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2026-06-16T04:53:25.2777965Z   0.502330 done
2026-06-16T04:53:25.2778917Z   1.503793     # run_openssl_client: openssl s_client -no_ticket -sess_out /tmp/cuksMvIGyw/session -connect 127.0.0.1:33119
2026-06-16T04:53:25.2780717Z   1.557538 ==13220==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
2026-06-16T04:53:25.2782173Z   3.511249     ok 1
2026-06-16T04:53:25.2784589Z   4.511656 killing /home/ci/h2o... received SIGTERM, gracefully shutting down
2026-06-16T04:53:25.2785509Z   4.611806 killed (got 0)
2026-06-16T04:53:25.2786405Z   4.612700 Use of uninitialized value $listen_quic in concatenation (.) or string at t/Util.pm line 303.
2026-06-16T04:53:25.2787553Z   4.693830 spawning /home/ci/h2o... [INFO] raised RLIMIT_NOFILE to 1024
2026-06-16T04:53:25.2788599Z   4.698183 [lib/common/memcached.c] connected to memcached at 127.0.0.1:33115
2026-06-16T04:53:25.2789622Z   4.699951 h2o server (pid:13405) is ready to serve requests with 2 threads
2026-06-16T04:53:25.2791025Z   4.715803 done
2026-06-16T04:53:25.2791843Z   4.743512 fetch-ocsp-response (using OpenSSL 3.0.13 30 Jan 2024 (Library: OpenSSL 3.0.13 30 Jan 2024))
2026-06-16T04:53:25.2792932Z   4.788903 failed to extract ocsp URI from /tmp/URv3Ie2Ps8/cert.crt
2026-06-16T04:53:25.2793883Z   4.789995 [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2026-06-16T04:53:25.2795159Z   5.716082     # run_openssl_client: openssl s_client -no_ticket -sess_in /tmp/cuksMvIGyw/session -connect 127.0.0.1:33123
2026-06-16T04:53:25.2796771Z   5.749224 ==13405==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
2026-06-16T04:53:25.2798043Z   5.753773 =================================================================
2026-06-16T04:53:25.2799372Z   5.753785 ==13405==ERROR: AddressSanitizer: heap-use-after-free on address 0x5100000083b8 at pc 0x55e7e3eb3118 bp 0x7fc3670d48a0 sp 0x7fc3670d4048
2026-06-16T04:53:25.2800799Z   5.753788 READ of size 65 at 0x5100000083b8 thread T5
2026-06-16T04:53:25.2802038Z   5.799684     #0 0x55e7e3eb3117 in read_iovec(void*, __sanitizer::__sanitizer_iovec*, unsigned long, unsigned long) asan_interceptors.cpp.o
2026-06-16T04:53:25.2803566Z   5.799696     #1 0x55e7e3eb2e51 in writev (/home/ci/h2o+0xf3e51) (BuildId: 315a30e3bf934153ff5f4cfcacd162daae1d239f)
2026-06-16T04:53:25.2804934Z   5.799698     #2 0x55e7e3f9b4c5 in send_command /h2o/deps/libyrmcds/send.c:94:21
2026-06-16T04:53:25.2805984Z   5.799700     #3 0x55e7e3f9b6fd in yrmcds_get /h2o/deps/libyrmcds/send.c:187:12
2026-06-16T04:53:25.2806994Z   5.799702     #4 0x55e7e40920e9 in writer_main /h2o/lib/common/memcached.c:185:28
2026-06-16T04:53:25.2808052Z   5.799704     #5 0x55e7e3f2c90c in asan_thread_start(void*) asan_interceptors.cpp.o
2026-06-16T04:53:25.2809348Z   5.799705     #6 0x7fc3707b4aa3  (/lib/x86_64-linux-gnu/libc.so.6+0x9caa3) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
2026-06-16T04:53:25.2811060Z   5.799707     #7 0x7fc370841c6b  (/lib/x86_64-linux-gnu/libc.so.6+0x129c6b) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
2026-06-16T04:53:25.2812070Z   5.799709 
2026-06-16T04:53:25.2812868Z   5.799756 0x5100000083b8 is located 120 bytes inside of 187-byte region [0x510000008340,0x5100000083fb)
2026-06-16T04:53:25.2813841Z   5.799848 freed by thread T4 here:
2026-06-16T04:53:25.2814828Z   5.799988     #0 0x55e7e3f2eb8a in free (/home/ci/h2o+0x16fb8a) (BuildId: 315a30e3bf934153ff5f4cfcacd162daae1d239f)
2026-06-16T04:53:25.2816109Z   5.799991     #1 0x55e7e408fffb in h2o_memcached_receiver /h2o/lib/common/memcached.c:352:9
2026-06-16T04:53:25.2816990Z   5.799993 
2026-06-16T04:53:25.2817538Z   5.800024 previously allocated by thread T4 here:
2026-06-16T04:53:25.2818623Z   5.800107     #0 0x55e7e3f2ee23 in malloc (/home/ci/h2o+0x16fe23) (BuildId: 315a30e3bf934153ff5f4cfcacd162daae1d239f)
2026-06-16T04:53:25.2819634Z   5.800111 
2026-06-16T04:53:25.2820389Z   5.800141 Thread T5 created by T2 here:
2026-06-16T04:53:25.2821413Z   5.800310     #0 0x55e7e3f14795 in pthread_create (/home/ci/h2o+0x155795) (BuildId: 315a30e3bf934153ff5f4cfcacd162daae1d239f)
2026-06-16T04:53:25.2822708Z   5.800314     #1 0x55e7e409146c in reader_main /h2o/lib/common/memcached.c:252:16
2026-06-16T04:53:25.2823712Z   5.800315     #2 0x55e7e409146c in thread_main /h2o/lib/common/memcached.c:319:9
2026-06-16T04:53:25.2824939Z   5.800317     #3 0x55e7e3f2c90c in asan_thread_start(void*) asan_interceptors.cpp.o
2026-06-16T04:53:25.2825772Z   5.800319 
2026-06-16T04:53:25.2826262Z   5.800350 Thread T2 created by T0 here:
2026-06-16T04:53:25.2827336Z   5.803334     #0 0x55e7e3f14795 in pthread_create (/home/ci/h2o+0x155795) (BuildId: 315a30e3bf934153ff5f4cfcacd162daae1d239f)
2026-06-16T04:53:25.2828755Z   5.803355     #1 0x55e7e4097025 in h2o_multithread_create_thread /h2o/lib/common/multithread.c:229:16
2026-06-16T04:53:25.2830096Z   5.803358     #2 0x55e7e4090fb4 in h2o_memcached_create_context /h2o/lib/common/memcached.c:425:13
2026-06-16T04:53:25.2831219Z   5.803360     #3 0x55e7e4301440 in setup_cache_memcached /h2o/src/ssl.c:157:9
2026-06-16T04:53:25.2832105Z   5.803363     #4 0x55e7e42e1d09 in main /h2o/src/main.c:5394:9
2026-06-16T04:53:25.2833276Z   5.803365     #5 0x7fc3707421c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
2026-06-16T04:53:25.2834920Z   5.803368     #6 0x7fc37074228a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
2026-06-16T04:53:25.2836489Z   5.803371     #7 0x55e7e3e93fd4 in _start (/home/ci/h2o+0xd4fd4) (BuildId: 315a30e3bf934153ff5f4cfcacd162daae1d239f)
2026-06-16T04:53:25.2837526Z   5.803373 
2026-06-16T04:53:25.2838012Z   5.803389 Thread T4 created by T0 here:
2026-06-16T04:53:25.2839056Z   5.803691     #0 0x55e7e3f14795 in pthread_create (/home/ci/h2o+0x155795) (BuildId: 315a30e3bf934153ff5f4cfcacd162daae1d239f)
2026-06-16T04:53:25.2840584Z   5.803694     #1 0x55e7e4097025 in h2o_multithread_create_thread /h2o/lib/common/multithread.c:229:16
2026-06-16T04:53:25.2841740Z   5.803696     #2 0x55e7e42e2686 in main /h2o/src/main.c:5440:9
2026-06-16T04:53:25.2842922Z   5.803698     #3 0x7fc3707421c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
2026-06-16T04:53:25.2844685Z   5.803700     #4 0x7fc37074228a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
2026-06-16T04:53:25.2846185Z   5.803702     #5 0x55e7e3e93fd4 in _start (/home/ci/h2o+0xd4fd4) (BuildId: 315a30e3bf934153ff5f4cfcacd162daae1d239f)
2026-06-16T04:53:25.2847135Z   5.803703 
2026-06-16T04:53:25.2848309Z   5.803797 SUMMARY: AddressSanitizer: heap-use-after-free asan_interceptors.cpp.o in read_iovec(void*, __sanitizer::__sanitizer_iovec*, unsigned long, unsigned long)
2026-06-16T04:53:25.2849713Z   5.804017 Shadow bytes around the buggy address:
2026-06-16T04:53:25.2850662Z   5.804021   0x510000008100: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
2026-06-16T04:53:25.2851649Z   5.804022   0x510000008180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
2026-06-16T04:53:25.2852526Z   5.804024   0x510000008200: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
2026-06-16T04:53:25.2853399Z   5.804026   0x510000008280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
2026-06-16T04:53:25.2854291Z   5.804027   0x510000008300: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
2026-06-16T04:53:25.2855194Z   5.804029 =>0x510000008380: fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd
2026-06-16T04:53:25.2856086Z   5.804030   0x510000008400: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
2026-06-16T04:53:25.2856942Z   5.804032   0x510000008480: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
2026-06-16T04:53:25.2857929Z   5.804033   0x510000008500: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
2026-06-16T04:53:25.2858808Z   5.804037   0x510000008580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
2026-06-16T04:53:25.2859689Z   5.804039   0x510000008600: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
2026-06-16T04:53:25.2860768Z   5.804041 Shadow byte legend (one shadow byte represents 8 application bytes):
2026-06-16T04:53:25.2861575Z   5.804043   Addressable:           00
2026-06-16T04:53:25.2862217Z   5.804046   Partially addressable: 01 02 03 04 05 06 07 
2026-06-16T04:53:25.2862886Z   5.804047   Heap left redzone:       fa
2026-06-16T04:53:25.2863652Z   5.804049   Freed heap region:       fd
2026-06-16T04:53:25.2864226Z   5.804051   Stack left redzone:      f1
2026-06-16T04:53:25.2864783Z   5.804052   Stack mid redzone:       f2
2026-06-16T04:53:25.2865328Z   5.804054   Stack right redzone:     f3
2026-06-16T04:53:25.2865917Z   5.804056   Stack after return:      f5
2026-06-16T04:53:25.2866455Z   5.804057   Stack use after scope:   f8
2026-06-16T04:53:25.2867046Z   5.804059   Global redzone:          f9
2026-06-16T04:53:25.2867620Z   5.804061   Global init order:       f6
2026-06-16T04:53:25.2868199Z   5.804062   Poisoned by user:        f7
2026-06-16T04:53:25.2868760Z   5.804064   Container overflow:      fc
2026-06-16T04:53:25.2869344Z   5.804066   Array cookie:            ac
2026-06-16T04:53:25.2869915Z   5.804068   Intra object redzone:    bb
2026-06-16T04:53:25.2870633Z   5.804069   ASan internal:           fe
2026-06-16T04:53:25.2871193Z   5.804071   Left alloca redzone:     ca
2026-06-16T04:53:25.2871798Z   5.804073   Right alloca redzone:    cb
2026-06-16T04:53:25.2872369Z   5.804105 ==13405==ABORTING
2026-06-16T04:53:25.2872850Z   5.818540     ok 2
2026-06-16T04:53:25.2873466Z   6.819144 killing /home/ci/h2o...     not ok 3 - server die with signal 256
2026-06-16T04:53:25.2874281Z   6.819229     #   Failed test 'server die with signal 256'
2026-06-16T04:53:25.2874945Z   6.819231     #   at t/Util.pm line 220.
2026-06-16T04:53:25.2875507Z   6.819256 killed (got 256)
2026-06-16T04:53:25.2876059Z   7.219791 killing memcached... killed (got 0)
2026-06-16T04:53:25.2876627Z   7.220182     1..3
2026-06-16T04:53:25.2877137Z   7.220297     # Looks like you failed 1 test of 3.
2026-06-16T04:53:25.2877758Z   7.220509 not ok 1 - binary
2026-06-16T04:53:25.2878270Z   7.220593 #   Failed test 'binary'
2026-06-16T04:53:25.2878927Z   7.220596 #   at t/40memcached-session-resumption.t line 59.
2026-06-16T04:53:25.2879611Z   7.220833 # Subtest: ascii
2026-06-16T04:53:25.2880238Z   7.325771 spawning memcached... done
2026-06-16T04:53:25.2881343Z   7.325787 Use of uninitialized value $listen_quic in concatenation (.) or string at t/Util.pm line 303.
2026-06-16T04:53:25.2882399Z   7.404255 spawning /home/ci/h2o... [INFO] raised RLIMIT_NOFILE to 1024
2026-06-16T04:53:25.2883299Z   7.412434 [lib/common/memcached.c] connected to memcached at 127.0.0.1:33125
2026-06-16T04:53:25.2884260Z   7.412480 h2o server (pid:13533) is ready to serve requests with 2 threads
2026-06-16T04:53:25.2885007Z   7.427618 done
2026-06-16T04:53:25.2885793Z   7.440236 fetch-ocsp-response (using OpenSSL 3.0.13 30 Jan 2024 (Library: OpenSSL 3.0.13 30 Jan 2024))
2026-06-16T04:53:25.2886859Z   7.466159 failed to extract ocsp URI from /tmp/_j57PDxOHz/cert.crt
2026-06-16T04:53:25.2887792Z   7.467878 [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2026-06-16T04:53:25.2889042Z   8.428144     # run_openssl_client: openssl s_client -no_ticket -sess_out /tmp/cuksMvIGyw/session -connect 127.0.0.1:33129
2026-06-16T04:53:25.2890733Z   8.454347 ==13533==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
2026-06-16T04:53:25.2891838Z  10.434515     ok 1
2026-06-16T04:53:25.2892500Z  11.434957 killing /home/ci/h2o... received SIGTERM, gracefully shutting down
2026-06-16T04:53:25.2893348Z  11.534979 killed (got 0)
2026-06-16T04:53:25.2894274Z  11.536182 Use of uninitialized value $listen_quic in concatenation (.) or string at t/Util.pm line 303.
2026-06-16T04:53:25.2895380Z  11.671775 spawning /home/ci/h2o... [INFO] raised RLIMIT_NOFILE to 1024
2026-06-16T04:53:25.2896363Z  11.678615 [lib/common/memcached.c] connected to memcached at 127.0.0.1:33125
2026-06-16T04:53:25.2897290Z  11.682657 h2o server (pid:13712) is ready to serve requests with 2 threads
2026-06-16T04:53:25.2898367Z  11.713624 fetch-ocsp-response (using OpenSSL 3.0.13 30 Jan 2024 (Library: OpenSSL 3.0.13 30 Jan 2024))
2026-06-16T04:53:25.2899263Z  11.740440 done
2026-06-16T04:53:25.2899810Z  11.757262 failed to extract ocsp URI from /tmp/hk4aGYoh9o/cert.crt
2026-06-16T04:53:25.2901070Z  11.759046 [OCSP Stapling] disabled for certificate file:examples/h2o/server.crt
2026-06-16T04:53:25.2902284Z  12.741008     # run_openssl_client: openssl s_client -no_ticket -sess_in /tmp/cuksMvIGyw/session -connect 127.0.0.1:33133
2026-06-16T04:53:25.2903863Z  12.769889 ==13712==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
2026-06-16T04:53:25.2904977Z  14.749051     ok 2
2026-06-16T04:53:25.2905607Z  15.749359 killing /home/ci/h2o... received SIGTERM, gracefully shutting down
2026-06-16T04:53:25.2906362Z  15.849480 killed (got 0)
2026-06-16T04:53:25.2906888Z  16.250005 killing memcached... killed (got 0)
2026-06-16T04:53:25.2907464Z  16.250444     1..2
2026-06-16T04:53:25.2907959Z  16.250721 ok 2 - ascii
2026-06-16T04:53:25.2920447Z  16.251066 1..2
2026-06-16T04:53:25.2920967Z  16.251479 # Looks like you failed 1 test of 2.
2026-06-16T04:53:25.2921643Z  16.257301 Command exited with non-zero status 1
2026-06-16T04:53:25.2922540Z  16.257316 0.79user 0.21system 0:16.25elapsed 6%CPU (0avgtext+0avgdata 57328maxresident)k
2026-06-16T04:53:25.2923520Z  16.257337 0inputs+0outputs (0major+56903minor)pagefaults 0swaps
2026-06-16T04:53:25.2924454Z [91m# t/40memcached-session-resumption.t failed
```