### PR TITLE
Remove assert that is checking the existence of index (3)

### DIFF
--- a/lib/http3/qpack.c
+++ b/lib/http3/qpack.c
@@ -1204,7 +1204,6 @@ static void flatten_known_header_with_static_lookup(struct st_h2o_qpack_flatten_
 {
     int is_exact;
     int32_t static_index = lookup_cb(value, &is_exact);
-    assert(index >= 0);
 
     do_flatten_header(ctx, static_index, is_exact, name->flags.likely_to_repeat, &name->buf, value, (h2o_header_flags_t){0});
 }


### PR DESCRIPTION
The lookup function might return -1 (not found) and `do_flatten_header` works appropriately when `static_index` of -1 is given; we should not assert the value of static_index. See how Datagram-Flow-ID is handled.