### PR TITLE
Keep HTTP/1 write timeout alive on sendvec progress

### DIFF
--- a/include/h2o/socket.h
+++ b/include/h2o/socket.h
@@ -111,6 +111,12 @@ typedef struct st_h2o_socket_t h2o_socket_t;
 
 typedef void (*h2o_socket_cb)(h2o_socket_t *sock, const char *err);
 
+/**
+ * When set, successful write progress may be reported by invoking the write callback with
+ * h2o_socket_error_write_progress. The write remains inflight until the callback is invoked with NULL or an error.
+ */
+#define H2O_SOCKET_SENDVEC_FLAG_REPORT_PROGRESS 0x1
+
 /* used by probes */
 struct st_h2o_io_uring_cmd_t;
 
@@ -201,6 +207,7 @@ struct st_h2o_socket_t {
     struct {
         h2o_socket_cb read;
         h2o_socket_cb write;
+        unsigned write_flags;
     } _cb;
     struct st_h2o_socket_addr_t *_peername;
     struct st_h2o_socket_addr_t *_sockname;
@@ -280,6 +287,7 @@ extern const char h2o_socket_error_ssl_cert_invalid[];
 extern const char h2o_socket_error_ssl_cert_name_mismatch[];
 extern const char h2o_socket_error_ssl_decode[];
 extern const char h2o_socket_error_ssl_handshake[];
+extern const char h2o_socket_error_write_progress[];
 
 /**
  * returns the loop
@@ -337,7 +345,15 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
 /**
  *
  */
-void h2o_socket_sendvec(h2o_socket_t *sock, h2o_sendvec_t *bufs, size_t bufcnt, h2o_socket_cb cb);
+/**
+ * writes given sendvecs to socket
+ * @param sock the socket
+ * @param bufs an array of sendvecs
+ * @param bufcnt length of the sendvec array
+ * @param flags optional H2O_SOCKET_SENDVEC_FLAG_* flags
+ * @param cb callback to be called when write is complete
+ */
+void h2o_socket_sendvec(h2o_socket_t *sock, h2o_sendvec_t *bufs, size_t bufcnt, unsigned flags, h2o_socket_cb cb);
 /**
  * starts polling on the socket (for read) and calls given callback when data arrives
  * @param sock the socket

--- a/lib/common/socket.c
+++ b/lib/common/socket.c
@@ -211,6 +211,7 @@ const char h2o_socket_error_ssl_cert_invalid[] = "invalid certificate";
 const char h2o_socket_error_ssl_cert_name_mismatch[] = "certificate name mismatch";
 const char h2o_socket_error_ssl_decode[] = "SSL decode error";
 const char h2o_socket_error_ssl_handshake[] = "ssl handshake failure";
+const char h2o_socket_error_write_progress[] = "write progress";
 
 static void (*resumption_get_async)(h2o_socket_t *sock, h2o_iovec_t session_id);
 static void (*resumption_new)(h2o_socket_t *sock, h2o_iovec_t session_id, h2o_iovec_t session_data);
@@ -920,6 +921,7 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
     });
 
     assert(sock->_cb.write == NULL);
+    assert(sock->_cb.write_flags == 0);
     sock->_cb.write = cb;
 
     for (size_t i = 0; i != bufcnt; ++i) {
@@ -933,12 +935,14 @@ void h2o_socket_write(h2o_socket_t *sock, h2o_iovec_t *bufs, size_t bufcnt, h2o_
     do_write(sock, bufs, bufcnt);
 }
 
-void h2o_socket_sendvec(h2o_socket_t *sock, h2o_sendvec_t *vecs, size_t cnt, h2o_socket_cb cb)
+void h2o_socket_sendvec(h2o_socket_t *sock, h2o_sendvec_t *vecs, size_t cnt, unsigned flags, h2o_socket_cb cb)
 {
     assert(sock->_cb.write == NULL);
+    assert(sock->_cb.write_flags == 0);
     assert(sock->_write_buf.flattened == NULL);
 
     sock->_cb.write = cb;
+    sock->_cb.write_flags = flags;
 
     if (cnt == 0)
         return do_write(sock, NULL, 0);
@@ -987,6 +991,7 @@ void on_write_complete(h2o_socket_t *sock, const char *err)
 
     cb = sock->_cb.write;
     sock->_cb.write = NULL;
+    sock->_cb.write_flags = 0;
     cb(sock, err);
 }
 

--- a/lib/common/socket/evloop.c.h
+++ b/lib/common/socket/evloop.c.h
@@ -71,6 +71,12 @@ static h2o_evloop_t *create_evloop(size_t sz);
 static void update_now(h2o_evloop_t *loop);
 static int32_t adjust_max_wait(h2o_evloop_t *loop, int32_t max_wait);
 
+static void notify_write_progress(struct st_h2o_evloop_socket_t *sock)
+{
+    if ((sock->super._cb.write_flags & H2O_SOCKET_SENDVEC_FLAG_REPORT_PROGRESS) != 0)
+        sock->super._cb.write(&sock->super, h2o_socket_error_write_progress);
+}
+
 /* functions to be defined in the backends */
 static int evloop_do_proceed(h2o_evloop_t *loop, int32_t max_wait);
 static void evloop_do_dispose(h2o_evloop_t *loop);
@@ -181,6 +187,8 @@ static size_t write_vecs(struct st_h2o_evloop_socket_t *sock, h2o_iovec_t **bufs
 
         if (wret == -1)
             return errno == EAGAIN ? 0 : SIZE_MAX;
+        if (wret != 0)
+            notify_write_progress(sock);
 
         /* adjust the buffer, doing the write once again only if all IOV_MAX buffers being supplied were fully written */
         while ((*bufs)->len <= wret) {
@@ -291,6 +299,8 @@ static int sendvec_core(struct st_h2o_evloop_socket_t *sock)
     /* send, and return an error if failed */
     if ((bytes_sent = sock->sendvec.callbacks->send_(&sock->sendvec, sock->fd, sock->sendvec.len)) == SIZE_MAX)
         return 0;
+    if (bytes_sent != 0)
+        notify_write_progress(sock);
 
     /* update offset, and return if we are not done yet */
     if (sock->sendvec.len != 0)
@@ -814,6 +824,7 @@ void h2o_socket_notify_write(h2o_socket_t *_sock, h2o_socket_cb cb)
 {
     struct st_h2o_evloop_socket_t *sock = (struct st_h2o_evloop_socket_t *)_sock;
     assert(sock->super._cb.write == NULL);
+    assert(sock->super._cb.write_flags == 0);
     assert(sock->super._write_buf.cnt == 0);
     assert(!has_pending_ssl_bytes(sock->super.ssl));
 

--- a/lib/http1.c
+++ b/lib/http1.c
@@ -841,6 +841,11 @@ static void on_send_next(h2o_socket_t *sock, const char *err)
 {
     struct st_h2o_http1_conn_t *conn = sock->data;
 
+    if (err == h2o_socket_error_write_progress) {
+        set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, req_io_on_timeout);
+        return;
+    }
+
     if (err != NULL)
         close_connection(conn, 1);
     else
@@ -862,6 +867,11 @@ static void on_send_complete_post_trailers(h2o_socket_t *sock, const char *err)
 static void on_send_complete(h2o_socket_t *sock, const char *err)
 {
     struct st_h2o_http1_conn_t *conn = sock->data;
+
+    if (err == h2o_socket_error_write_progress) {
+        set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, req_io_on_timeout);
+        return;
+    }
 
     if (err == NULL) {
         if (conn->req._ostr_top != &conn->_ostr_final.super) {
@@ -1100,7 +1110,8 @@ void finalostream_send(h2o_ostream_t *_self, h2o_req_t *_req, h2o_sendvec_t *inb
     if (bufcnt != 0)
         set_req_io_timeout(conn, conn->super.ctx->globalconf->http1.req_io_timeout, req_io_on_timeout);
 
-    h2o_socket_sendvec(conn->sock, bufs, bufcnt, h2o_send_state_is_in_progress(send_state) ? on_send_next : on_send_complete);
+    h2o_socket_sendvec(conn->sock, bufs, bufcnt, H2O_SOCKET_SENDVEC_FLAG_REPORT_PROGRESS,
+                       h2o_send_state_is_in_progress(send_state) ? on_send_next : on_send_complete);
 }
 
 static void on_send_informational_complete(h2o_socket_t *sock, const char *err);

--- a/t/50reverse-proxy-slow-client.t
+++ b/t/50reverse-proxy-slow-client.t
@@ -5,6 +5,7 @@ use IO::Socket::SSL;
 use IO::Socket::UNIX;
 use File::Temp qw(tempdir);
 use POSIX qw(WNOHANG);
+use Socket qw(SOL_SOCKET SO_RCVBUF);
 use Test::More;
 use Time::HiRes qw(sleep time);
 use t::Util;
@@ -68,13 +69,15 @@ sub run_slow_client {
         Proto    => "tcp",
     );
     die "failed to connect to h2o:$!" unless $sock;
+    setsockopt($sock, SOL_SOCKET, SO_RCVBUF, pack("i", 64 * 1024))
+        or die "failed to set SO_RCVBUF:$!";
 
     print $sock "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
 
     my $received = "";
     my @sleep_at;
-    my $bytes_per_sec = $ENV{SLOW_CLIENT_BYTES_PER_SEC} || 1024 * 1024;
-    my $read_unit = $ENV{SLOW_CLIENT_READ_UNIT} || 65536;
+    my $bytes_per_sec = 1024 * 1024;
+    my $read_unit = 8192;
     my $start_at = time;
     READ:
     while (1) {
@@ -85,7 +88,7 @@ sub run_slow_client {
             $received .= $buf;
         } while (length($received) < int((time - $start_at) * $bytes_per_sec));
         push @sleep_at, length($received);
-        sleep $read_unit / $bytes_per_sec;
+        sleep 0.01;
     }
     my $elapsed = time - $start_at;
 

--- a/t/50reverse-proxy-slow-client.t
+++ b/t/50reverse-proxy-slow-client.t
@@ -103,9 +103,20 @@ my $tempdir = tempdir(CLEANUP => 1);
 my $upstream_socket = "$tempdir/upstream.sock";
 my $upstream_guard = spawn_large_response_upstream($upstream_socket, $body_size);
 
-my $server = spawn_h2o(<< "EOT");
+my ($port, $tls_port) = empty_ports(2, { host => "0.0.0.0" });
+my $server = spawn_h2o_raw(<< "EOT", [{ port => $port, proto => "tcp" }, { port => $tls_port, proto => "tcp" }]);
 http1-request-io-timeout: 1
 proxy.zerocopy: OFF
+listen:
+  - host: 0.0.0.0
+    port: $port
+    sndbuf: 65536
+  - host: 0.0.0.0
+    port: $tls_port
+    sndbuf: 65536
+    ssl:
+      key-file: examples/h2o/server.key
+      certificate-file: examples/h2o/server.crt
 hosts:
   default:
     paths:
@@ -113,6 +124,8 @@ hosts:
         proxy.reverse.url: http://[unix:$upstream_socket]/
         proxy.timeout.io: 1000000
 EOT
+$server->{port} = $port;
+$server->{tls_port} = $tls_port;
 
 subtest "http" => sub {
     run_slow_client("http", $server->{port});

--- a/t/50reverse-proxy-slow-client.t
+++ b/t/50reverse-proxy-slow-client.t
@@ -72,21 +72,27 @@ sub run_slow_client {
     print $sock "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
 
     my $received = "";
-    my $start_at = time;
+    my @sleep_at;
     my $bytes_per_sec = $ENV{SLOW_CLIENT_BYTES_PER_SEC} || 1024 * 1024;
+    my $read_unit = $ENV{SLOW_CLIENT_READ_UNIT} || 65536;
+    my $start_at = time;
+    READ:
     while (1) {
-        my $r = sysread $sock, my $buf, 8192;
-        last unless $r;
-        $received .= $buf;
-        my $target_elapsed = length($received) / $bytes_per_sec;
-        my $sleep_for = $target_elapsed - (time - $start_at);
-        sleep $sleep_for if $sleep_for > 0;
+        do {
+            my $buf = "";
+            my $r = sysread $sock, $buf, $read_unit;
+            last READ unless $r;
+            $received .= $buf;
+        } while (length($received) < int((time - $start_at) * $bytes_per_sec));
+        push @sleep_at, length($received);
+        sleep $read_unit / $bytes_per_sec;
     }
     my $elapsed = time - $start_at;
 
     like $received, qr{^HTTP/1\.1 200\b}s, "$proto: received response headers";
     my ($headers, $body) = split /\r\n\r\n/, $received, 2;
     diag "$proto: received @{[ length($body) ]} of $body_size bytes in ${elapsed}s";
+    note "$proto: body bytes at sleep: @sleep_at";
     is length($body), $body_size, "$proto: response body was not truncated by http1 request I/O timeout";
 }
 

--- a/t/50reverse-proxy-slow-client.t
+++ b/t/50reverse-proxy-slow-client.t
@@ -1,0 +1,116 @@
+use strict;
+use warnings;
+use IO::Socket::INET;
+use IO::Socket::SSL;
+use IO::Socket::UNIX;
+use File::Temp qw(tempdir);
+use POSIX qw(WNOHANG);
+use Test::More;
+use Time::HiRes qw(sleep time);
+use t::Util;
+
+my $body_size = 20 * 1024 * 1024;
+
+sub spawn_large_response_upstream {
+    my ($socket_path, $body_size) = @_;
+    my $server = IO::Socket::UNIX->new(
+        Type   => SOCK_STREAM,
+        Local  => $socket_path,
+        Listen => 1,
+    ) or die "failed to listen to $socket_path:$!";
+
+    my $pid = fork;
+    die "fork failed:$!" unless defined $pid;
+
+    if ($pid != 0) {
+        close $server;
+        return make_guard(sub {
+            kill "KILL", $pid;
+            while (waitpid($pid, WNOHANG) != $pid) {}
+            unlink $socket_path;
+        });
+    }
+
+    $SIG{PIPE} = "IGNORE";
+    while (my $sock = $server->accept) {
+        my $req = "";
+        while ($req !~ /\r\n\r\n/s) {
+            my $r = sysread $sock, my $buf, 8192;
+            last unless $r;
+            $req .= $buf;
+        }
+
+        syswrite $sock, "HTTP/1.1 200 OK\r\nContent-Length: $body_size\r\nConnection: close\r\n\r\n";
+        my $chunk = "0" x 65536;
+        for (my $sent = 0; $sent < $body_size;) {
+            my $len = $body_size - $sent < length($chunk) ? $body_size - $sent : length($chunk);
+            my $w = syswrite $sock, $chunk, $len;
+            last unless defined $w && $w != 0;
+            $sent += $w;
+        }
+        close $sock;
+    }
+    exit 0;
+}
+
+sub run_slow_client {
+    my ($proto, $port) = @_;
+
+    my $sock = $proto eq "https" ? IO::Socket::SSL->new(
+        PeerHost => "127.0.0.1",
+        PeerPort => $port,
+        Proto    => "tcp",
+        SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
+        SSL_alpn_protocols => [ "http/1.1" ],
+    ) : IO::Socket::INET->new(
+        PeerHost => "127.0.0.1",
+        PeerPort => $port,
+        Proto    => "tcp",
+    );
+    die "failed to connect to h2o:$!" unless $sock;
+
+    print $sock "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+
+    my $received = "";
+    my $start_at = time;
+    my $bytes_per_sec = $ENV{SLOW_CLIENT_BYTES_PER_SEC} || 1024 * 1024;
+    while (1) {
+        my $r = sysread $sock, my $buf, 8192;
+        last unless $r;
+        $received .= $buf;
+        my $target_elapsed = length($received) / $bytes_per_sec;
+        my $sleep_for = $target_elapsed - (time - $start_at);
+        sleep $sleep_for if $sleep_for > 0;
+    }
+    my $elapsed = time - $start_at;
+
+    like $received, qr{^HTTP/1\.1 200\b}s, "$proto: received response headers";
+    my ($headers, $body) = split /\r\n\r\n/, $received, 2;
+    diag "$proto: received @{[ length($body) ]} of $body_size bytes in ${elapsed}s";
+    is length($body), $body_size, "$proto: response body was not truncated by http1 request I/O timeout";
+}
+
+my $tempdir = tempdir(CLEANUP => 1);
+my $upstream_socket = "$tempdir/upstream.sock";
+my $upstream_guard = spawn_large_response_upstream($upstream_socket, $body_size);
+
+my $server = spawn_h2o(<< "EOT");
+http1-request-io-timeout: 1
+proxy.zerocopy: OFF
+hosts:
+  default:
+    paths:
+      /:
+        proxy.reverse.url: http://[unix:$upstream_socket]/
+        proxy.timeout.io: 1000000
+EOT
+
+subtest "http" => sub {
+    run_slow_client("http", $server->{port});
+};
+
+subtest "https" => sub {
+    run_slow_client("https", $server->{tls_port});
+};
+
+done_testing();


### PR DESCRIPTION
## Why

HTTP/1 arms `http1-request-io-timeout` while writing a response, but `h2o_socket_sendvec` has historically called the write callback only when the entire sendvec is complete. That leaves HTTP/1 unable to rearm the timeout while a large sendvec is still making successful nonblocking write progress.

This affects responses that can be handed to HTTP/1 as a large buffered sendvec: for example a reverse-proxy response with no effective `proxy.max-buffer-size` limit and no pipe-backed send path. The common pipe path is different, because the pipe sender limits transfer units; likewise a configured `max-buffer-size` caps how large the buffered response chunk can become.

Under the default HTTP/1 request I/O timeout of 5 seconds, a tens-of-megabytes buffered response sent to a slow client can require many successful nonblocking writes over more than 5 seconds. Before this change, HTTP/1 would see no callback until the full sendvec completed, so the timeout could close the connection even though writes were advancing.

The failure fixed here appears when the response is buffered instead of pipe-backed and `proxy.max-buffer-size` does not cap the buffered chunk size.

This is a follow-up to the HTTP/1 I/O timeout mechanism introduced in #2293. That mechanism treats socket activity as progress and closes the connection when no progress is observed for `http1-request-io-timeout`. The missing piece was that HTTP/1 did not observe partial progress within one large sendvec write; it only heard about the write when the entire sendvec completed.

This issue is specific to HTTP/1.1. Write granularity of HTTP/2 is almost always below 80KB. HTTP/3 writes per-packet and the QUIC-level idle timeout detects zero progress. 

## What

Add an opt-in sendvec progress flag for the evloop backend. When enabled, successful partial writes invoke the write callback with `h2o_socket_error_write_progress`. HTTP/1 uses that progress notification to rearm `http1-request-io-timeout` without treating the sendvec as complete.

The libuv backend is left unchanged; progress reporting is optional.

## Tests

Added `t/50reverse-proxy-slow-client.t`, covering both clear HTTP and HTTPS with a 20 MiB reverse-proxy response, 1 MiB/s client reads, and `http1-request-io-timeout: 1`.

The test disables `proxy.zerocopy` so clear HTTP uses the buffered response path too; otherwise clear HTTP normally uses the pipe path and does not reproduce the large-sendvec case.

Local verification:

```
PERL5LIB=. BINARY_DIR=build/default H2O_ROOT=$PWD prove -v t/50reverse-proxy-slow-client.t
```

Before the fix, the test failed for both `http` and `https` after receiving about 4.5 MiB of the 20 MiB response. With the fix, both protocols receive the full response.
