### PR TITLE
fix compile error on musl libc when _GNU_SOURCE is defined

### DIFF
--- a/lib/common/memory.c
+++ b/lib/common/memory.c
@@ -604,16 +604,13 @@ void h2o_append_to_null_terminated_list(void ***list, void *element)
 
 char *h2o_strerror_r(int err, char *buf, size_t len)
 {
-#if !(defined(_GNU_SOURCE) && defined(__gnu_linux__))
+#if defined(_GNU_SOURCE) && defined(__GLIBC__)
+    /* The GNU-specific strerror_r() returns a pointer to a string containing the error message. This may be either a pointer to a
+     * string that the function stores in  buf, or a pointer to some (immutable) static string (in which case buf is unused). */
+    return strerror_r(err, buf, len);
+#else
     strerror_r(err, buf, len);
     return buf;
-#else
-    /**
-     * The GNU-specific strerror_r() returns a pointer to a string containing the error message.
-     * This may be either a pointer to a string that the function stores in  buf,
-     * or a pointer to some (immutable) static string (in which case buf is unused)
-     */
-    return strerror_r(err, buf, len);
 #endif
 }
 


### PR DESCRIPTION
strerror_r of glibc behaves differently when _GNU_SOURCE is defined, so we need `#if` to handle it differently. However, the conditions checked for Linux rather than for glibc, and that led to musl libc being misdeteced as glibc.

This PR fixes the detection logic.