### PR TITLE
[CI] avoid skipping tests siliently on CI

### DIFF
--- a/misc/docker-ci/check.mk
+++ b/misc/docker-ci/check.mk
@@ -5,6 +5,7 @@ CMAKE_ARGS=
 BUILD_ARGS=
 TEST_ENV=
 FUZZ_ASAN=ASAN_OPTIONS=detect_leaks=0
+SERVER_FEATURES_UBUNTU2404=capabilities,dtrace,fusion,io_uring,ktls,libaegis,mruby,ssl-zerocopy
 DOCKER_RUN_OPTS=--privileged \
 	--ulimit memlock=-1 \
 	-v `pwd`:$(SRC_DIR):ro \
@@ -45,7 +46,7 @@ ossl3.0:
 		make -f $(SRC_DIR)/misc/docker-ci/check.mk _check \
 		CMAKE_ARGS='-DCMAKE_C_FLAGS=-Werror=format' \
 		BUILD_ARGS='$(BUILD_ARGS)' \
-		TEST_ENV='SKIP_PROG_EXISTS=1 $(TEST_ENV)' \
+		TEST_ENV='SKIP_PROG_EXISTS=1 EXPECTED_SERVER_FEATURES=$(SERVER_FEATURES_UBUNTU2404) $(TEST_ENV)' \
 		TMP_SIZE='$(TMP_SIZE)'
 
 boringssl:
@@ -53,7 +54,7 @@ boringssl:
 		make -f $(SRC_DIR)/misc/docker-ci/check.mk _check \
 		CMAKE_ARGS='-DOPENSSL_ROOT_DIR=/opt/boringssl -DEXTERNALPROJECT_SSL_ROOT_DIR=/usr' \
 		BUILD_ARGS='$(BUILD_ARGS)' \
-		TEST_ENV='SKIP_PROG_EXISTS=1 $(TEST_ENV)' \
+		TEST_ENV='SKIP_PROG_EXISTS=1 EXPECTED_SERVER_FEATURES=$(SERVER_FEATURES_UBUNTU2404) $(TEST_ENV)' \
 		TMP_SIZE='$(TMP_SIZE)'
 
 asan:
@@ -61,7 +62,7 @@ asan:
 		make -f $(SRC_DIR)/misc/docker-ci/check.mk _check \
 		CMAKE_ARGS='-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS=-fsanitize=address -DCMAKE_CXX_FLAGS=-fsanitize=address' \
 		BUILD_ARGS='$(BUILD_ARGS)' \
-		TEST_ENV='ASAN_OPTIONS=detect_leaks=0:alloc_dealloc_mismatch=0 $(TEST_ENV)' \
+		TEST_ENV='ASAN_OPTIONS=detect_leaks=0:alloc_dealloc_mismatch=0 EXPECTED_SERVER_FEATURES=$(SERVER_FEATURES_UBUNTU2404) $(TEST_ENV)' \
 		TMP_SIZE='$(TMP_SIZE)'
 
 # https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
@@ -70,7 +71,7 @@ coverage:
 		make -f $(SRC_DIR)/misc/docker-ci/check.mk _check _coverage_report \
 		CMAKE_ARGS='-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping -mllvm -runtime-counter-relocation" -DCMAKE_CXX_FLAGS= -DCMAKE_BUILD_TYPE=Debug -DWITH_H2OLOG=OFF' \
 		BUILD_ARGS='$(BUILD_ARGS)' \
-		TEST_ENV='SKIP_PROG_EXISTS=1 LLVM_PROFILE_FILE=/home/ci/profraw/%c%p-%m.profraw $(TEST_ENV)' \
+		TEST_ENV='SKIP_PROG_EXISTS=1 EXPECTED_SERVER_FEATURES=$(SERVER_FEATURES_UBUNTU2404) LLVM_PROFILE_FILE=/home/ci/profraw/%c%p-%m.profraw $(TEST_ENV)' \
 		TMP_SIZE='$(TMP_SIZE)'
 
 _coverage_report:

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -87,9 +87,28 @@ sub server_features {
     open my $fh, "-|", bindir() . "/h2o", "--version"
         or die "failed to invoke: h2o --version:$!";
     <$fh>; # skip h2o version
-    +{
-        map { chomp($_); split /:/, $_, 2 } <$fh>
-    };
+
+    my %features;
+    while (my $line = <$fh>) {
+        chomp $line;
+        my ($name, $value) = split/\s*:\s*/, $line, 2;
+        $features{$name} = $value;
+    }
+
+    # In CI, EXPECTED_SERVER_FEATURES pins the set of features that the build should advertise. It is an exact match over `*: YES`
+    # lines, so that both missing coverage and newly-added feature gates require an explicit CI expectation update, instead of
+    # silently changing which tests can be skipped.
+    if ($ENV{EXPECTED_SERVER_FEATURES}) {
+        my $expected = join ", ", sort split /\s*,\s*/, $ENV{EXPECTED_SERVER_FEATURES};
+        my $actual = join ", ", sort grep { $features{$_} eq "YES" } keys %features;
+        BAIL_OUT join "\n",
+            "h2o server feature set mismatch",
+            "  expected features: $expected",
+            "  actual features: $actual"
+            if $expected ne $actual;
+    }
+
+    \%features;
 }
 
 sub exec_unittest {


### PR DESCRIPTION
To determine which features should be enabled, the CI build relies on automatic detection of dependencies during configuration time.

The reliance is fine as it is a good way of testing automatic detection. However, the downside is that, if automatic detection failed and a feature was disabled, tests checking the availability of the feature would also be skipped. This leads to reduced coverage.

This pull request mitigates the problem by making the following changes:
* server_features() - the function used by tests to skip missing features - now recognize the EXPECTED_SERVER_FEATURES environment variable. If EXPECTED_SERVER_FEATURES is set to a different value than what is actually supported by the build, the function hard fails, resulting in test failures.
* For the CI flavors using Ubuntu 24.04 (i.e., the flavors that have the largest set of features enabled), EXPECTED_SERVER_FEATURES is set to those expected.

With these changes, if a feature becomes silently missing, the CI would fail. Similarly, if a feature is added without changing the expected list used by the CI, the CI would also fail. Together, these failures guarantee that the expected list would be kept in sync, and that we'd have expected coverage.