### PR TITLE
`lib/handler/connect.c`: Allocate room for the sockaddr aligned to accommodate sockaddr_in or sockaddr_in6.

### DIFF
--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -408,10 +408,7 @@ static int store_server_addresses(struct st_connect_generator_t *self, struct ad
         assert(self->server_addresses.size < PTLS_ELEMENTSOF(self->server_addresses.list));
         if (h2o_connect_lookup_acl(self->handler->acl.entries, self->handler->acl.count, res->ai_addr)) {
             struct st_server_address_t *dst = self->server_addresses.list + self->server_addresses.size++;
-            static const size_t alignment = H2O_ALIGNOF(struct sockaddr_in) > H2O_ALIGNOF(struct sockaddr_in6)
-                                                ? H2O_ALIGNOF(struct sockaddr_in)
-                                                : H2O_ALIGNOF(struct sockaddr_in6);
-            dst->sa = h2o_mem_alloc_pool_aligned(&self->src_req->pool, alignment, res->ai_addrlen);
+            dst->sa = h2o_mem_alloc_pool_aligned(&self->src_req->pool, H2O_ALIGNOF(struct sockaddr_storage), res->ai_addrlen);
             memcpy(dst->sa, res->ai_addr, res->ai_addrlen);
             dst->salen = res->ai_addrlen;
             ++num_added;

--- a/lib/handler/connect.c
+++ b/lib/handler/connect.c
@@ -408,7 +408,10 @@ static int store_server_addresses(struct st_connect_generator_t *self, struct ad
         assert(self->server_addresses.size < PTLS_ELEMENTSOF(self->server_addresses.list));
         if (h2o_connect_lookup_acl(self->handler->acl.entries, self->handler->acl.count, res->ai_addr)) {
             struct st_server_address_t *dst = self->server_addresses.list + self->server_addresses.size++;
-            dst->sa = h2o_mem_alloc_pool_aligned(&self->src_req->pool, H2O_ALIGNOF(struct sockaddr), res->ai_addrlen);
+            static const size_t alignment = H2O_ALIGNOF(struct sockaddr_in) > H2O_ALIGNOF(struct sockaddr_in6)
+                                                ? H2O_ALIGNOF(struct sockaddr_in)
+                                                : H2O_ALIGNOF(struct sockaddr_in6);
+            dst->sa = h2o_mem_alloc_pool_aligned(&self->src_req->pool, alignment, res->ai_addrlen);
             memcpy(dst->sa, res->ai_addr, res->ai_addrlen);
             dst->salen = res->ai_addrlen;
             ++num_added;


### PR DESCRIPTION
In `lib/handler/connect.c` when allocating room for the sockaddr, use the alignment requirements of `struct sockaddr_storage` (~max of the alignment requirements of `struct sockaddr_in` and `struct sockaddr_in6`~), because the alignment requirement of the bare `struct sockaddr` is smaller than that of `struct sockaddr_in` and `struct sockaddr_in6`.

On 64-bit Linux, I am finding:
```
__alignof__(struct sockaddr) = 2
__alignof__(struct sockaddr_un) = 2
__alignof__(struct sockaddr_in) = 4
__alignof__(struct sockaddr_in6) = 4
__alignof__(struct sockaddr_storage) = 8
```

The misaligned allocation tickles the UndefinedBehaviorSanitizer later when the pointer is cast to the concrete type and dereferenced.